### PR TITLE
feat(pm): add vite install command with package manager support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,3 +115,60 @@ jobs:
           vite-plus lint -h
           vite-plus test -h
           vite-plus build -h
+
+  e2e-test:
+    name: E2E test
+    runs-on: blaze/macos-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
+        env:
+          CARGO_INCREMENTAL: "1"
+
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: .node-version
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build vt
+        run: cargo build --bin vt --release
+
+      - name: Run vt install
+        run: |
+          export PATH=$PWD/target/release:$PATH
+
+          # Test vt install on various repositories with different package managers
+          repos=(
+            # pnpm workspace
+            "vitejs/vite:vite"
+            "pnpm/pnpm:pnpm"
+            # yarn workspace
+            "napi-rs/napi-rs:napi-rs"
+            "toeverything/AFFiNE:AFFiNE"
+            # npm workspace
+            "npm/cli:npm"
+            "redhat-developer/vscode-extension-tester:vscode-extension-tester"
+          )
+
+          for repo_info in "${repos[@]}"; do
+            IFS=':' read -r repo dir_name <<< "$repo_info"
+            echo "Testing vt install on $repo..."
+            # remove the directory if it exists
+            if [ -d "/tmp/$dir_name" ]; then
+              rm -rf "/tmp/$dir_name"
+            fi
+            git clone --depth 1 "https://github.com/$repo.git" "/tmp/$dir_name"
+            cd "/tmp/$dir_name"
+            vt install
+            # run again to show install cache increase by time
+            time vt install
+            echo "✓ Successfully installed dependencies for $repo"
+            echo ""
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 dist
 .claude/settings.local.json
 *.tsbuildinfo
+.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "assert2"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,14 +167,223 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59051ec02907378a67b0ba1b8631121f5388c8dbbb3cec8c749d8f93c2c3c211"
 
 [[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca"
+dependencies = [
+ "async-lock",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.0.8",
+ "slab",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-object-pool"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333c456b97c3f2d50604e8b2624253b7f787208cb72eb75e64b0ad11b221652c"
+dependencies = [
+ "async-std",
+]
+
+[[package]]
+name = "async-process"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65daa13722ad51e6ab1a1b9c01299142bc75135b337923cfa10e79bbbd669f00"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.1",
+ "futures-lite",
+ "rustix 1.0.8",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f567af260ef69e1d52c2b560ce0ea230763e6fbb9214a85d768760a920e3e3c1"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.0.8",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-attributes",
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "attohttpc"
 version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48404d931ab11b3a7a5267291b3b8f3590f09b86181381f8e82a7e562ed832c0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "flate2",
- "http",
+ "http 1.3.1",
  "log",
  "native-tls",
  "url",
@@ -166,6 +394,17 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "backon"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "592277618714fbcecda9a02ba7a8781f319d26532a88553bbacc77ba5d2b3a8d"
+dependencies = [
+ "fastrand",
+ "gloo-timers",
+ "tokio",
+]
 
 [[package]]
 name = "backtrace"
@@ -184,9 +423,26 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "basic-cookies"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67bd8fd42c16bdb08688243dc5f0cc117a3ca9efeeaba3a345a18a6159ad96f7"
+dependencies = [
+ "lalrpop",
+ "lalrpop-util",
+ "regex",
+]
 
 [[package]]
 name = "bincode"
@@ -229,6 +485,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,6 +519,19 @@ checksum = "e669f146bb8b2327006ed94c69cf78c8ec81c100192564654230a40b4f091d82"
 dependencies = [
  "allocator-api2",
  "parking_lot",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -525,6 +809,15 @@ dependencies = [
  "ryu",
  "serde",
  "static_assertions",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -875,6 +1168,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -882,8 +1185,19 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -965,6 +1279,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55dd888a213fc57e957abf2aa305ee3e8a28dbe05687a251f33b637cd46b0070"
 
 [[package]]
+name = "ena"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,6 +1328,33 @@ checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.1",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1072,6 +1422,12 @@ name = "find-msvc-tools"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fixedbitset"
@@ -1255,7 +1611,7 @@ name = "fspy_shared"
 version = "0.0.0"
 dependencies = [
  "allocator-api2",
- "base64",
+ "base64 0.22.1",
  "bincode",
  "bstr",
  "bytemuck",
@@ -1273,7 +1629,7 @@ name = "fspy_shared_unix"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "bincode",
  "bstr",
  "elf",
@@ -1334,6 +1690,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1381,8 +1750,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1392,9 +1763,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.4+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1408,6 +1781,18 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "half"
@@ -1458,12 +1843,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "home"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
 ]
 
 [[package]]
@@ -1475,6 +1877,165 @@ dependencies = [
  "bytes",
  "fnv",
  "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.3.1",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "httpmock"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ec9586ee0910472dec1a1f0f8acf52f0fdde93aea74d70d4a3107b4be0fd5b"
+dependencies = [
+ "assert-json-diff",
+ "async-object-pool",
+ "async-std",
+ "async-trait",
+ "base64 0.21.7",
+ "basic-cookies",
+ "crossbeam-utils",
+ "form_urlencoded",
+ "futures-util",
+ "hyper 0.14.32",
+ "lazy_static",
+ "levenshtein",
+ "log",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_regex",
+ "similar",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec 1.15.1",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http 1.3.1",
+ "hyper 1.7.0",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.7.0",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2 0.6.0",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1637,6 +2198,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1707,10 +2284,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+dependencies = [
+ "ascii-canvas",
+ "bit-set",
+ "ena",
+ "itertools 0.11.0",
+ "lalrpop-util",
+ "petgraph 0.6.5",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "levenshtein"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
@@ -1808,6 +2431,9 @@ name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "lru"
@@ -1817,6 +2443,12 @@ checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.5",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -1963,6 +2595,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
@@ -2204,6 +2842,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2262,6 +2906,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
 name = "peg"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2296,11 +2946,21 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset 0.4.2",
+ "indexmap",
+]
+
+[[package]]
+name = "petgraph"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54acf3a685220b533e437e264e4d932cfbdc4cc7ec0cd232ed73c08d03b8a7ca"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.5.7",
  "hashbrown 0.15.5",
  "indexmap",
  "serde",
@@ -2350,6 +3010,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2360,6 +3026,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
 
 [[package]]
 name = "pkg-config"
@@ -2393,6 +3070,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "polling"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5bd19146350fe804f7cb2669c851c03d69da628803dab0d98018142aaa5d829"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.0.8",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2444,6 +3135,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2473,6 +3170,61 @@ dependencies = [
  "syn 2.0.106",
  "version_check",
  "yansi",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases 0.2.1",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.0",
+ "thiserror 2.0.16",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.3",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.16",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases 0.2.1",
+ "libc",
+ "once_cell",
+ "socket2 0.6.0",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2586,6 +3338,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -2643,6 +3406,61 @@ name = "regex-syntax"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+
+[[package]]
+name = "reqwest"
+version = "0.12.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "rusqlite"
@@ -2715,6 +3533,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2736,6 +3589,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2749,6 +3611,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "seccompiler"
@@ -2828,9 +3696,20 @@ version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
  "serde",
 ]
 
@@ -2840,6 +3719,18 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 
@@ -2867,6 +3758,31 @@ dependencies = [
  "cfg-if",
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2937,6 +3853,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3003,6 +3925,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3029,6 +3963,12 @@ dependencies = [
  "rustversion",
  "syn 2.0.106",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "supports-color"
@@ -3059,6 +3999,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -3100,6 +4049,17 @@ dependencies = [
  "once_cell",
  "rustix 1.0.8",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
 ]
 
 [[package]]
@@ -3174,6 +4134,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3192,6 +4161,21 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -3225,6 +4209,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-seqpacket"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3244,6 +4238,19 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -3297,6 +4304,51 @@ name = "toml_writer"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags 2.9.4",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -3371,6 +4423,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "tui-term"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3431,6 +4489,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "unty"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3474,6 +4538,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "value-bag"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
 
 [[package]]
 name = "vcpkg"
@@ -3523,11 +4593,15 @@ dependencies = [
  "bincode",
  "bstr",
  "nix 0.30.1",
- "petgraph",
+ "petgraph 0.8.2",
+ "reqwest",
  "rusqlite",
+ "semver 1.0.26",
+ "serde",
  "serde_json",
  "serde_yml",
  "thiserror 2.0.16",
+ "tokio",
  "vite_path",
  "vite_str",
  "wax",
@@ -3538,12 +4612,27 @@ name = "vite_package_manager"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "petgraph",
+ "backon",
+ "directories",
+ "flate2",
+ "futures-util",
+ "httpmock",
+ "indoc",
+ "pathdiff",
+ "petgraph 0.8.2",
+ "reqwest",
  "rustc-hash",
+ "semver 1.0.26",
  "serde",
  "serde_json",
  "serde_yml",
+ "tar",
  "tempfile",
+ "test-log",
+ "tokio",
+ "tokio-test",
+ "tracing",
+ "tracing-subscriber",
  "vite_error",
  "vite_path",
  "vite_str",
@@ -3583,6 +4672,7 @@ dependencies = [
  "bstr",
  "clap",
  "compact_str 0.9.0",
+ "crossterm 0.29.0",
  "dashmap",
  "diff-struct",
  "edit",
@@ -3592,14 +4682,16 @@ dependencies = [
  "itertools 0.14.0",
  "nix 0.30.1",
  "owo-colors",
- "petgraph",
+ "petgraph 0.8.2",
  "rayon",
  "rusqlite",
  "serde",
  "serde_json",
+ "serial_test",
  "shell-escape",
  "supports-color",
  "tempfile",
+ "test-log",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3675,6 +4767,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3717,6 +4818,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca85039a9b469b38336411d6d6ced91f3fc87109a2a27b0c197663f5144dffe"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3746,6 +4860,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -3781,6 +4908,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4152,6 +5288,12 @@ dependencies = [
  "syn 2.0.106",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ cargo_common_metadata = "allow"
 
 [workspace.dependencies]
 anyhow = "1.0.98"
+backon = "1.3.0"
 bincode = "2.0.1"
 brush-parser = "0.2.18"
 bstr = "1.12.0"
@@ -45,6 +46,7 @@ dashmap = "6.1.0"
 diff-struct = "0.5.3"
 directories = "6.0.0"
 edit = "0.1.5"
+flate2 = "1.0.35"
 fspy = { path = "crates/fspy" }
 fspy_preload_unix = { path = "crates/fspy_preload_unix", artifact = "cdylib" }
 fspy_preload_windows = { path = "crates/fspy_preload_windows", artifact = "cdylib" }
@@ -54,25 +56,34 @@ fspy_shared_unix = { path = "crates/fspy_shared_unix" }
 futures = "0.3.31"
 futures-core = "0.3.31"
 futures-util = "0.3.31"
+httpmock = "0.7"
+indoc = "2.0.5"
 itertools = "0.14.0"
 nix = { version = "0.30.1", features = ["dir"] }
 owo-colors = "4.1.0"
 passfd = { git = "https://github.com/polachok/passfd", rev = "d55881752c16aced1a49a75f9c428d38d3767213", default-features = false }
+pathdiff = "0.2.3"
 petgraph = "0.8.2"
 portable-pty = "0.9.0"
 ratatui = "0.29.0"
 rayon = "1.10.0"
 ref-cast = "1.0.24"
+reqwest = { version = "0.12", features = ["stream", "rustls-tls", "json"], default-features = false }
 rusqlite = "0.37.0"
 rustc-hash = "2.1.1"
+semver = "1.0.26"
 serde = "1.0.219"
 serde_json = "1.0.140"
 serde_yml = "0.0.12"
+serial_test = "3.2.0"
 shell-escape = "0.1.5"
 supports-color = "3.0.1"
+tar = "0.4.43"
 tempfile = "3.14.0"
+test-log = { version = "0.2.18", features = ["trace"] }
 thiserror = "2"
 tokio = "1.46.1"
+tokio-test = "0.4.4"
 tokio-util = "0.7.15"
 tracing = "0.1.41"
 tracing-error = "0.2.1"

--- a/crates/vite_error/Cargo.toml
+++ b/crates/vite_error/Cargo.toml
@@ -13,10 +13,14 @@ bincode = { workspace = true }
 bstr = { workspace = true }
 nix = { workspace = true }
 petgraph = { workspace = true }
+reqwest = { workspace = true }
 rusqlite = { workspace = true }
+semver = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yml = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
+wax = { workspace = true }
 vite_path = { workspace = true }
 vite_str = { workspace = true }
-wax = { workspace = true }

--- a/crates/vite_error/src/lib.rs
+++ b/crates/vite_error/src/lib.rs
@@ -107,6 +107,32 @@ pub enum Error {
     #[error("The package at {package_path:?} is outside the workspace at {workspace_root:?}")]
     PackageOutsideWorkspace { package_path: AbsolutePathBuf, workspace_root: AbsolutePathBuf },
 
+    #[error("Unsupported package manager: {0}")]
+    UnsupportedPackageManager(Str),
+
+    #[error("Unrecognized any package manager, please specify the package manager")]
+    UnrecognizedPackageManager,
+
+    #[error(
+        "Package manager {name}@{version} in {package_json_path:?} is invalid, expected format: 'package-manager-name@major.minor.patch'"
+    )]
+    PackageManagerVersionInvalid { name: Str, version: Str, package_json_path: AbsolutePathBuf },
+
+    #[error("Package manager {name}@{version} not found on {url}")]
+    PackageManagerVersionNotFound { name: Str, version: Str, url: Str },
+
+    #[error(transparent)]
+    SemverError(#[from] semver::Error),
+
+    #[error(transparent)]
+    ReqwestError(#[from] reqwest::Error),
+
+    #[error(transparent)]
+    JoinError(#[from] tokio::task::JoinError),
+
+    #[error("User cancelled by Ctrl+C")]
+    UserCancelled,
+
     #[error(transparent)]
     AnyhowError(#[from] anyhow::Error),
 }

--- a/crates/vite_package_manager/Cargo.toml
+++ b/crates/vite_package_manager/Cargo.toml
@@ -9,18 +9,35 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-vite_str = { workspace = true }
-vite_path = { workspace = true }
+backon = { workspace = true }
+directories = { workspace = true }
+flate2 = { workspace = true }
+futures-util = { workspace = true }
+indoc = { workspace = true }
+pathdiff = { workspace = true }
 petgraph = { workspace = true, features = ["serde-1"] }
+reqwest = { workspace = true }
 rustc-hash = { workspace = true }
+semver = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
+# use `preserve_order` feature to preserve the order of the fields in `package.json`
+serde_json = { workspace = true, features = ["preserve_order"] }
 serde_yml = { workspace = true }
+tar = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 vite_error = { workspace = true }
+vite_path = { workspace = true }
+vite_str = { workspace = true }
 wax = { workspace = true }
 
 [dev-dependencies]
+httpmock = { workspace = true }
 tempfile = { workspace = true }
+test-log = { workspace = true }
+tokio-test = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/vite_package_manager/src/config.rs
+++ b/crates/vite_package_manager/src/config.rs
@@ -1,0 +1,64 @@
+use std::env;
+use std::sync::LazyLock;
+
+use directories::BaseDirs;
+
+use vite_error::Error;
+use vite_path::{AbsolutePathBuf, current_dir};
+
+pub static NPM_REGISTRY: LazyLock<String> = LazyLock::new(|| {
+    env::var("npm_config_registry")
+        .or_else(|_| env::var("NPM_CONFIG_REGISTRY"))
+        .unwrap_or_else(|_| "https://registry.npmjs.org".into())
+});
+
+/// Get the tgz url of a npm package
+pub fn get_npm_package_tgz_url(name: &str, version: &str) -> String {
+    // convert `@scope/name` to `name`
+    let filename = name.split('/').last().unwrap_or(name);
+    format!("{}/{}/-/{}-{}.tgz", NPM_REGISTRY.clone(), name, filename, version)
+}
+
+pub fn get_npm_package_version_url(name: &str, version_or_tag: &str) -> String {
+    format!("{}/{}/{}", NPM_REGISTRY.clone(), name, version_or_tag)
+}
+
+/// Cache directory
+///
+/// It will use the cache directory of the operating system if available,
+/// otherwise it will use the current directory.
+pub fn get_cache_dir() -> Result<AbsolutePathBuf, Error> {
+    let cache_dir = match BaseDirs::new() {
+        Some(dirs) => AbsolutePathBuf::new(dirs.cache_dir().to_path_buf()).unwrap(),
+        None => current_dir()?.join(".cache"),
+    };
+    Ok(cache_dir.join("vite"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_npm_registry() {
+        assert_eq!(NPM_REGISTRY.clone(), "https://registry.npmjs.org");
+    }
+
+    #[test]
+    fn test_npm_tgz_url() {
+        assert_eq!(
+            get_npm_package_tgz_url("vite", "7.1.3"),
+            "https://registry.npmjs.org/vite/-/vite-7.1.3.tgz"
+        );
+        assert_eq!(
+            get_npm_package_tgz_url("@vitejs/release-scripts", "1.6.0"),
+            "https://registry.npmjs.org/@vitejs/release-scripts/-/release-scripts-1.6.0.tgz"
+        );
+    }
+
+    #[test]
+    fn test_get_cache_dir() {
+        let cache_dir = get_cache_dir().unwrap();
+        assert!(cache_dir.ends_with("vite"));
+    }
+}

--- a/crates/vite_package_manager/src/lib.rs
+++ b/crates/vite_package_manager/src/lib.rs
@@ -1,4 +1,7 @@
+mod config;
 pub mod package_manager;
+mod request;
+mod shim;
 
 use std::{fs, io};
 

--- a/crates/vite_package_manager/src/main.rs
+++ b/crates/vite_package_manager/src/main.rs
@@ -1,0 +1,15 @@
+use vite_error::Error;
+use vite_package_manager::package_manager::PackageManager;
+use vite_path::current_dir;
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let current_dir = current_dir()?;
+    let package_manager = PackageManager::builder(&current_dir).build().await?;
+    println!("Package manager: {:#?} for {:?}", package_manager, current_dir);
+
+    let resolve_command = package_manager.resolve_command();
+    println!("Resolve command: {:#?}", resolve_command);
+
+    Ok(())
+}

--- a/crates/vite_package_manager/src/package_manager.rs
+++ b/crates/vite_package_manager/src/package_manager.rs
@@ -1,9 +1,144 @@
-use std::fs::File;
+use std::collections::HashMap;
+use std::fs::{self, File};
 use std::io::{BufReader, Seek, SeekFrom};
 use std::path::Path;
+use std::{env, fmt};
 
+use semver::{Version, VersionReq};
+use serde::{Deserialize, Serialize};
+use tokio::fs::remove_dir_all;
+
+use crate::config::{get_cache_dir, get_npm_package_tgz_url, get_npm_package_version_url};
+use crate::request::{HttpClient, download_and_extract_tgz};
+use crate::shim;
 use vite_error::Error;
-use vite_path::{AbsolutePath, RelativePathBuf};
+use vite_path::{AbsolutePath, AbsolutePathBuf, RelativePathBuf};
+use vite_str::Str;
+
+#[derive(Serialize, Deserialize, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+struct PackageJson {
+    #[serde(default)]
+    pub version: Str,
+    #[serde(default)]
+    pub package_manager: Str,
+}
+
+/// The package manager type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PackageManagerType {
+    Pnpm,
+    Yarn,
+    Npm,
+}
+
+impl fmt::Display for PackageManagerType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PackageManagerType::Pnpm => write!(f, "pnpm"),
+            PackageManagerType::Yarn => write!(f, "yarn"),
+            PackageManagerType::Npm => write!(f, "npm"),
+        }
+    }
+}
+
+// TODO(@fengmk2): should move ResolveCommandResult to vite-common crate
+#[derive(Debug)]
+pub struct ResolveCommandResult {
+    pub bin_path: String,
+    pub envs: HashMap<String, String>,
+}
+
+/// The package manager.
+/// Use `PackageManager::builder()` to create a package manager.
+/// Then use `PackageManager::resolve_command()` to resolve the command result.
+#[derive(Debug)]
+pub struct PackageManager {
+    pub package_manager_type: PackageManagerType,
+    pub package_name: Str,
+    pub version: Str,
+    pub bin_name: Str,
+    pub workspace_root: AbsolutePathBuf,
+    pub install_dir: AbsolutePathBuf,
+}
+
+#[derive(Debug)]
+pub struct PackageManagerBuilder {
+    package_manager_type: Option<PackageManagerType>,
+    cwd: AbsolutePathBuf,
+}
+
+impl PackageManagerBuilder {
+    pub fn new(cwd: impl AsRef<AbsolutePath>) -> Self {
+        Self { package_manager_type: None, cwd: cwd.as_ref().to_absolute_path_buf() }
+    }
+
+    pub fn package_manager_type(mut self, package_manager_type: PackageManagerType) -> Self {
+        self.package_manager_type = Some(package_manager_type);
+        self
+    }
+
+    /// Build the package manager.
+    /// Detect the package manager from the current working directory.
+    pub async fn build(self) -> Result<PackageManager, Error> {
+        let workspace_root = find_workspace_root(&self.cwd)?;
+        let (package_manager_type, mut version) =
+            get_package_manager_type_and_version(&workspace_root, self.package_manager_type)?;
+
+        let mut package_name = package_manager_type.to_string();
+        let mut should_update_package_manager_field = false;
+
+        if version == "latest" {
+            version = get_latest_version(package_manager_type).await?;
+            should_update_package_manager_field = true;
+        }
+
+        // handle yarn >= 2.0.0 to use `@yarnpkg/cli-dist` as package name
+        // @see https://github.com/nodejs/corepack/blob/main/config.json#L135
+        if matches!(package_manager_type, PackageManagerType::Yarn) {
+            let version_req = VersionReq::parse(">=2.0.0")?;
+            if version_req.matches(&Version::parse(&version)?) {
+                package_name = "@yarnpkg/cli-dist".to_string();
+            }
+        }
+
+        // only download the package manager if it's not already downloaded
+        let install_dir =
+            download_package_manager(package_manager_type, &package_name, &version).await?;
+
+        if should_update_package_manager_field {
+            // auto set `packageManager` field in package.json
+            let package_json_path = workspace_root.path.join("package.json");
+            set_package_manager_field(&package_json_path, package_manager_type, &version).await?;
+        }
+
+        Ok(PackageManager {
+            package_manager_type,
+            package_name: package_name.into(),
+            version,
+            bin_name: package_manager_type.to_string().into(),
+            workspace_root: workspace_root.path.to_absolute_path_buf(),
+            install_dir,
+        })
+    }
+}
+
+impl PackageManager {
+    pub fn builder(workspace_root: impl AsRef<AbsolutePath>) -> PackageManagerBuilder {
+        PackageManagerBuilder::new(workspace_root)
+    }
+
+    pub fn get_bin_prefix(&self) -> AbsolutePathBuf {
+        self.install_dir.join("bin")
+    }
+
+    pub fn resolve_command(&self) -> ResolveCommandResult {
+        ResolveCommandResult {
+            bin_path: self.bin_name.to_string(),
+            envs: HashMap::from([("PATH".to_string(), format_path_env(self.get_bin_prefix()))]),
+        }
+    }
+}
 
 /// The package root directory and its package.json file.
 #[derive(Debug)]
@@ -116,6 +251,83 @@ pub fn find_workspace_root<'a>(original_cwd: &'a AbsolutePath) -> Result<Workspa
     }
 }
 
+/// Get the package manager name and version from the workspace root.
+fn get_package_manager_type_and_version(
+    workspace_root: &WorkspaceRoot,
+    default: Option<PackageManagerType>,
+) -> Result<(PackageManagerType, Str), Error> {
+    // check packageManager field in package.json
+    let package_json_path = workspace_root.path.join("package.json");
+    if let Some(file) = open_exists_file(&package_json_path)? {
+        let package_json: PackageJson = serde_json::from_reader(BufReader::new(&file))?;
+        if !package_json.package_manager.is_empty() {
+            if let Some((name, version)) = package_json.package_manager.split_once('@') {
+                // check if the version is a valid semver
+                semver::Version::parse(version).map_err(|_| {
+                    Error::PackageManagerVersionInvalid {
+                        name: name.into(),
+                        version: version.into(),
+                        package_json_path: package_json_path.to_absolute_path_buf(),
+                    }
+                })?;
+                match name {
+                    "pnpm" => return Ok((PackageManagerType::Pnpm, version.into())),
+                    "yarn" => return Ok((PackageManagerType::Yarn, version.into())),
+                    "npm" => return Ok((PackageManagerType::Npm, version.into())),
+                    _ => return Err(Error::UnsupportedPackageManager(name.into())),
+                }
+            }
+        }
+    }
+
+    // TODO(@fengmk2): check devEngines.packageManager field in package.json
+
+    let version = Str::from("latest");
+    // if pnpm-workspace.yaml exists, use pnpm@latest
+    if matches!(workspace_root.workspace_file, WorkspaceFile::PnpmWorkspaceYaml(_)) {
+        return Ok((PackageManagerType::Pnpm, version));
+    }
+
+    // if pnpm-lock.yaml exists, use pnpm@latest
+    let pnpm_lock_yaml_path = workspace_root.path.join("pnpm-lock.yaml");
+    if is_exists_file(&pnpm_lock_yaml_path)? {
+        return Ok((PackageManagerType::Pnpm, version));
+    }
+
+    // if yarn.lock or .yarnrc.yml exists, use yarn@latest
+    let yarn_lock_path = workspace_root.path.join("yarn.lock");
+    let yarnrc_yml_path = workspace_root.path.join(".yarnrc.yml");
+    if is_exists_file(&yarn_lock_path)? || is_exists_file(&yarnrc_yml_path)? {
+        return Ok((PackageManagerType::Yarn, version));
+    }
+
+    // if package-lock.json exists, use npm@latest
+    let package_lock_json_path = workspace_root.path.join("package-lock.json");
+    if is_exists_file(&package_lock_json_path)? {
+        return Ok((PackageManagerType::Npm, version));
+    }
+
+    // if pnpmfile.cjs exists, use pnpm@latest
+    let pnpmfile_cjs_path = workspace_root.path.join("pnpmfile.cjs");
+    if is_exists_file(&pnpmfile_cjs_path)? {
+        return Ok((PackageManagerType::Pnpm, version));
+    }
+
+    // if yarn.config.cjs exists, use yarn@latest (yarn 2.0+)
+    let yarn_config_cjs_path = workspace_root.path.join("yarn.config.cjs");
+    if is_exists_file(&yarn_config_cjs_path)? {
+        return Ok((PackageManagerType::Yarn, version));
+    }
+
+    // if default is specified, use it
+    if let Some(default) = default {
+        return Ok((default, version));
+    }
+
+    // unrecognized package manager, let user specify the package manager
+    Err(Error::UnrecognizedPackageManager)
+}
+
 /// Open the file if it exists, otherwise return None.
 fn open_exists_file(path: impl AsRef<Path>) -> Result<Option<File>, Error> {
     match File::open(path) {
@@ -126,16 +338,223 @@ fn open_exists_file(path: impl AsRef<Path>) -> Result<Option<File>, Error> {
     }
 }
 
+/// Check if the file exists.
+fn is_exists_file(path: impl AsRef<Path>) -> Result<bool, Error> {
+    match fs::metadata(path) {
+        Ok(metadata) => Ok(metadata.is_file()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(e.into()),
+    }
+}
+
+async fn get_latest_version(package_manager_type: PackageManagerType) -> Result<Str, Error> {
+    let package_name = if matches!(package_manager_type, PackageManagerType::Yarn) {
+        // yarn latest version should use `@yarnpkg/cli-dist` as package name
+        "@yarnpkg/cli-dist".to_string()
+    } else {
+        package_manager_type.to_string()
+    };
+    let url = get_npm_package_version_url(&package_name, "latest");
+    let package_json: PackageJson = HttpClient::new().get_json(&url).await?;
+    Ok(package_json.version)
+}
+
+/// Download the package manager and extract it to the cache directory.
+/// Return the install directory, e.g. $CACHE_DIR/vite/package_manager/pnpm/10.0.0/pnpm
+async fn download_package_manager(
+    package_manager_type: PackageManagerType,
+    package_name: &str,
+    version: &str,
+) -> Result<AbsolutePathBuf, Error> {
+    let tgz_url = get_npm_package_tgz_url(package_name, version);
+    let cache_dir = get_cache_dir()?;
+    let bin_name = package_manager_type.to_string();
+    // $CACHE_DIR/vite/package_manager/pnpm/10.0.0
+    let target_dir = cache_dir.join(format!("package_manager/{}/{}", bin_name, version));
+    let install_dir = target_dir.join(&bin_name);
+
+    // If all shims are already exists, return the target directory
+    // $CACHE_DIR/vite/package_manager/pnpm/10.0.0/pnpm/bin/(pnpm|pnpm.cmd|pnpm.ps1)
+    let bin_prefix = install_dir.join("bin");
+    let bin_file = bin_prefix.join(&bin_name);
+    if is_exists_file(&bin_file)?
+        && is_exists_file(&bin_file.with_extension("cmd"))?
+        && is_exists_file(&bin_file.with_extension("ps1"))?
+    {
+        return Ok(install_dir);
+    }
+
+    // $CACHE_DIR/vite/package_manager/pnpm/{tmp_name}
+    // Use tempfile::TempDir for robust temporary directory creation
+    let parent_dir = target_dir.parent().unwrap();
+    tokio::fs::create_dir_all(parent_dir).await?;
+    let target_dir_tmp = tempfile::tempdir_in(parent_dir)?.path().to_path_buf();
+
+    download_and_extract_tgz(&tgz_url, &target_dir_tmp).await.map_err(|err| {
+        // status 404 means the version is not found, convert to PackageManagerVersionNotFound error
+        if let Error::ReqwestError(e) = &err
+            && let Some(status) = e.status()
+            && status == reqwest::StatusCode::NOT_FOUND
+        {
+            Error::PackageManagerVersionNotFound {
+                name: package_manager_type.to_string().into(),
+                version: version.into(),
+                url: tgz_url.into(),
+            }
+        } else {
+            err
+        }
+    })?;
+
+    // rename $target_dir_tmp/package to $target_dir_tmp/{bin_name}
+    tracing::debug!("Rename package dir to {}", bin_name);
+    tokio::fs::rename(&target_dir_tmp.join("package"), &target_dir_tmp.join(&bin_name)).await?;
+
+    // check bin_file again, for the concurrent download cases
+    if is_exists_file(&bin_file)? {
+        tracing::debug!("bin_file already exists, skip rename");
+        return Ok(install_dir);
+    }
+
+    // rename $target_dir_tmp to $target_dir
+    tracing::debug!("Rename {:?} to {:?}", target_dir_tmp, target_dir);
+    remove_dir_all_force(&target_dir).await?;
+    tokio::fs::rename(&target_dir_tmp, &target_dir).await?;
+
+    // create shim file
+    tracing::debug!("Create shim files for {}", bin_name);
+    create_shim_files(package_manager_type, &bin_prefix).await?;
+
+    Ok(install_dir)
+}
+
+/// Remove the directory and all its contents.
+/// Ignore the error if the directory is not found.
+async fn remove_dir_all_force(path: impl AsRef<Path>) -> Result<(), std::io::Error> {
+    match remove_dir_all(path).await {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                Ok(())
+            } else {
+                Err(e)
+            }
+        }
+    }
+}
+
+/// Create shim files for the package manager.
+///
+/// Will automatically create `{cli_name}.cjs`, `{cli_name}.cmd`, `{cli_name}.ps1` files for the package manager.
+/// Example:
+/// - $bin_prefix/pnpm -> $bin_prefix/pnpm.cjs
+/// - $bin_prefix/pnpm.cmd -> $bin_prefix/pnpm.cjs
+/// - $bin_prefix/pnpm.ps1 -> $bin_prefix/pnpm.cjs
+/// - $bin_prefix/pnpx -> $bin_prefix/pnpx.cjs
+/// - $bin_prefix/pnpx.cmd -> $bin_prefix/pnpx.cjs
+/// - $bin_prefix/pnpx.ps1 -> $bin_prefix/pnpx.cjs
+async fn create_shim_files(
+    package_manager_type: PackageManagerType,
+    bin_prefix: impl AsRef<AbsolutePath>,
+) -> Result<(), Error> {
+    let mut bin_names: Vec<(&str, &str)> = Vec::new();
+
+    match package_manager_type {
+        PackageManagerType::Pnpm => {
+            bin_names.push(("pnpm", "pnpm"));
+            bin_names.push(("pnpx", "pnpx"));
+        }
+        PackageManagerType::Yarn => {
+            // yarn don't have the `npx` like cli, so we don't need to create shim files for it
+            bin_names.push(("yarn", "yarn"));
+            // but it has alias `yarnpkg`
+            bin_names.push(("yarnpkg", "yarn"));
+        }
+        PackageManagerType::Npm => {
+            // npm has two cli: bin/npm-cli.js and bin/npx-cli.js
+            bin_names.push(("npm", "npm-cli"));
+            bin_names.push(("npx", "npx-cli"));
+        }
+    }
+
+    let bin_prefix = bin_prefix.as_ref();
+    for (bin_name, js_bin_basename) in bin_names {
+        // try .cjs first
+        let mut js_bin_name = format!("{}.cjs", js_bin_basename);
+        if !is_exists_file(&bin_prefix.join(&js_bin_name))? {
+            // fallback to .js
+            js_bin_name = format!("{}.js", js_bin_basename);
+            if !is_exists_file(&bin_prefix.join(&js_bin_name))? {
+                continue;
+            }
+        }
+
+        let source_file = bin_prefix.join(js_bin_name);
+        let to_bin = bin_prefix.join(bin_name);
+        shim::write_shims(&source_file, &to_bin).await?;
+    }
+    Ok(())
+}
+
+async fn set_package_manager_field(
+    package_json_path: impl AsRef<AbsolutePath>,
+    package_manager_type: PackageManagerType,
+    version: &str,
+) -> Result<(), Error> {
+    let package_json_path = package_json_path.as_ref();
+    let package_manager_value = format!("{}@{}", package_manager_type, version);
+    let mut package_json = if is_exists_file(package_json_path)? {
+        let content = tokio::fs::read(&package_json_path).await?;
+        serde_json::from_slice(&content)?
+    } else {
+        serde_json::json!({})
+    };
+    // use IndexMap to preserve the order of the fields
+    if let Some(package_json) = package_json.as_object_mut() {
+        package_json.insert("packageManager".into(), serde_json::json!(package_manager_value));
+    }
+    let json_string = serde_json::to_string_pretty(&package_json)?;
+    tokio::fs::write(&package_json_path, json_string).await?;
+    tracing::debug!(
+        "set_package_manager_field: {:?} to {:?}",
+        package_json_path,
+        package_manager_value
+    );
+    Ok(())
+}
+
+fn format_path_env(bin_prefix: impl AsRef<Path>) -> String {
+    let mut paths = env::split_paths(&env::var_os("PATH").unwrap_or_default()).collect::<Vec<_>>();
+    paths.insert(0, bin_prefix.as_ref().to_path_buf());
+    env::join_paths(paths).unwrap().to_string_lossy().to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs::{self, File};
-    use tempfile::TempDir;
+    use std::env;
+    use std::fs;
+    use std::process::Command;
+
+    use tempfile::{TempDir, tempdir};
+
+    fn create_temp_dir() -> TempDir {
+        tempdir().expect("Failed to create temp directory")
+    }
+
+    fn create_package_json(dir: &AbsolutePath, content: &str) {
+        fs::write(dir.join("package.json"), content).expect("Failed to write package.json");
+    }
+
+    fn create_pnpm_workspace_yaml(dir: &AbsolutePath, content: &str) {
+        fs::write(dir.join("pnpm-workspace.yaml"), content)
+            .expect("Failed to write pnpm-workspace.yaml");
+    }
 
     #[test]
     fn test_find_package_root() {
-        let temp_dir = TempDir::new().unwrap();
-        let temp_dir_path = AbsolutePath::new(temp_dir.path()).unwrap();
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
         let nested_dir = temp_dir_path.join("a").join("b").join("c");
         fs::create_dir_all(&nested_dir).unwrap();
 
@@ -163,14 +582,14 @@ mod tests {
 
     #[test]
     fn test_find_workspace_root_with_pnpm() {
-        let temp_dir = TempDir::new().unwrap();
+        let temp_dir = create_temp_dir();
 
-        let temp_dir_path = AbsolutePath::new(temp_dir.path()).unwrap();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
         let nested_dir = temp_dir_path.join("packages").join("app");
         fs::create_dir_all(&nested_dir).unwrap();
 
         // Create pnpm-workspace.yaml at root
-        File::create(temp_dir.path().join("pnpm-workspace.yaml")).unwrap();
+        File::create(temp_dir_path.join("pnpm-workspace.yaml")).unwrap();
 
         // Should find workspace root
         let found = find_workspace_root(&nested_dir).unwrap();
@@ -180,14 +599,14 @@ mod tests {
 
     #[test]
     fn test_find_workspace_root_with_npm_workspaces() {
-        let temp_dir = TempDir::new().unwrap();
-        let temp_dir_path = AbsolutePath::new(temp_dir.path()).unwrap();
-        let nested_dir = temp_dir.path().join("packages").join("app");
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let nested_dir = temp_dir_path.join("packages").join("app");
         fs::create_dir_all(&nested_dir).unwrap();
 
         // Create package.json with workspaces field
         let package_json = r#"{"workspaces": ["packages/*"]}"#;
-        fs::write(temp_dir.path().join("package.json"), package_json).unwrap();
+        fs::write(temp_dir_path.join("package.json"), package_json).unwrap();
 
         // Should find workspace root
         let found = find_workspace_root(&temp_dir_path).unwrap();
@@ -197,28 +616,28 @@ mod tests {
 
     #[test]
     fn test_find_workspace_root_fallback_to_package_root() {
-        let temp_dir = TempDir::new().unwrap();
-        let temp_dir_path = AbsolutePath::new(temp_dir.path()).unwrap();
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
         let nested_dir = temp_dir_path.join("src");
         fs::create_dir_all(&nested_dir).unwrap();
 
         // Create package.json without workspaces field
         let package_json = r#"{"name": "test"}"#;
-        fs::write(temp_dir.path().join("package.json"), package_json).unwrap();
+        fs::write(temp_dir_path.join("package.json"), package_json).unwrap();
 
         // Should fallback to package root
         let found = find_workspace_root(&nested_dir).unwrap();
         assert_eq!(found.path, temp_dir_path);
         assert!(matches!(found.workspace_file, WorkspaceFile::NonWorkspacePackage(_)));
-        let package_root = find_package_root(temp_dir_path).unwrap();
+        let package_root = find_package_root(&temp_dir_path).unwrap();
         // equal to workspace root
         assert_eq!(package_root.path, found.path);
     }
 
     #[test]
     fn test_find_workspace_root_with_package_json_not_found() {
-        let temp_dir = TempDir::new().unwrap();
-        let temp_dir_path = AbsolutePath::new(temp_dir.path()).unwrap();
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
         let nested_dir = temp_dir_path.join("src");
         fs::create_dir_all(&nested_dir).unwrap();
 
@@ -226,5 +645,734 @@ mod tests {
         let found = find_workspace_root(&nested_dir);
         let err = found.unwrap_err();
         assert!(matches!(err, Error::PackageJsonNotFound(_)));
+    }
+
+    #[test]
+    fn test_find_package_root_with_package_json_in_current_dir() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let package_content = r#"{"name": "test-package"}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        let result = find_package_root(&temp_dir_path).unwrap();
+        assert_eq!(result.path, temp_dir_path);
+    }
+
+    #[test]
+    fn test_find_package_root_with_package_json_in_parent_dir() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let package_content = r#"{"name": "test-package"}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        let sub_dir = temp_dir_path.join("subdir");
+        fs::create_dir(&sub_dir).expect("Failed to create subdirectory");
+
+        let result = find_package_root(&sub_dir).unwrap();
+        assert_eq!(result.path, temp_dir_path);
+    }
+
+    #[test]
+    fn test_find_package_root_with_package_json_in_grandparent_dir() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let package_content = r#"{"name": "test-package"}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        let sub_dir = temp_dir_path.join("subdir").join("nested");
+        fs::create_dir_all(&sub_dir).expect("Failed to create nested directories");
+
+        let result = find_package_root(&sub_dir).unwrap();
+        assert_eq!(result.path, temp_dir_path);
+    }
+
+    #[test]
+    fn test_find_workspace_root_with_pnpm_workspace_yaml() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let workspace_content = "packages:\n  - 'packages/*'";
+        create_pnpm_workspace_yaml(&temp_dir_path, workspace_content);
+
+        let result = find_workspace_root(&temp_dir_path).expect("Should find workspace root");
+        assert_eq!(result.path, temp_dir_path);
+    }
+
+    #[test]
+    fn test_find_workspace_root_with_pnpm_workspace_yaml_in_parent_dir() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let workspace_content = "packages:\n  - 'packages/*'";
+        create_pnpm_workspace_yaml(&temp_dir_path, workspace_content);
+
+        let sub_dir = temp_dir_path.join("subdir");
+        fs::create_dir(&sub_dir).expect("Failed to create subdirectory");
+
+        let result = find_workspace_root(&sub_dir).expect("Should find workspace root");
+        assert_eq!(result.path, temp_dir_path);
+    }
+
+    #[test]
+    fn test_find_workspace_root_with_package_json_workspaces() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let package_content = r#"{"name": "test-workspace", "workspaces": ["packages/*"]}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        let result = find_workspace_root(&temp_dir_path).unwrap();
+        assert_eq!(result.path, temp_dir_path);
+        assert!(matches!(result.workspace_file, WorkspaceFile::NpmWorkspaceJson(_)));
+    }
+
+    #[test]
+    fn test_find_workspace_root_with_package_json_workspaces_in_parent_dir() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let package_content = r#"{"name": "test-workspace", "workspaces": ["packages/*"]}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        let sub_dir = temp_dir_path.join("subdir");
+        fs::create_dir(&sub_dir).expect("Failed to create subdirectory");
+
+        let result = find_workspace_root(&sub_dir).unwrap();
+        assert_eq!(result.path, temp_dir_path);
+        assert!(matches!(result.workspace_file, WorkspaceFile::NpmWorkspaceJson(_)));
+    }
+
+    #[test]
+    fn test_find_workspace_root_prioritizes_pnpm_workspace_over_package_json() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+
+        // Create package.json with workspaces first
+        let package_content = r#"{"name": "test-workspace", "workspaces": ["packages/*"]}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        // Then create pnpm-workspace.yaml (should take precedence)
+        let workspace_content = "packages:\n  - 'packages/*'";
+        create_pnpm_workspace_yaml(&temp_dir_path, workspace_content);
+
+        let result = find_workspace_root(&temp_dir_path).expect("Should find workspace root");
+        assert_eq!(result.path, temp_dir_path);
+    }
+
+    #[test]
+    fn test_find_workspace_root_falls_back_to_package_root_when_no_workspace_found() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let package_content = r#"{"name": "test-package"}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        let sub_dir = temp_dir_path.join("subdir");
+        fs::create_dir(&sub_dir).expect("Failed to create subdirectory");
+
+        let result = find_workspace_root(&sub_dir).expect("Should fall back to package root");
+        assert_eq!(result.path, temp_dir_path);
+    }
+
+    #[test]
+    fn test_find_workspace_root_with_nested_structure() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let workspace_content = "packages:\n  - 'packages/*'";
+        create_pnpm_workspace_yaml(&temp_dir_path, workspace_content);
+
+        let nested_dir = temp_dir_path.join("packages").join("app").join("src");
+        fs::create_dir_all(&nested_dir).expect("Failed to create nested directories");
+
+        let result = find_workspace_root(&nested_dir).expect("Should find workspace root");
+        assert_eq!(result.path, temp_dir_path);
+    }
+
+    #[test]
+    fn test_find_workspace_root_without_workspace_files_returns_package_root() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let package_content = r#"{"name": "test-package"}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        let result = find_workspace_root(&temp_dir_path).expect("Should return package root");
+        assert_eq!(result.path, temp_dir_path);
+    }
+
+    #[test]
+    fn test_find_workspace_root_with_invalid_package_json_handles_error() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let invalid_package_content = "{ invalid json content";
+        create_package_json(&temp_dir_path, invalid_package_content);
+
+        let result = find_workspace_root(&temp_dir_path);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_find_workspace_root_with_mixed_structure() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        // Create a package.json without workspaces
+        let package_content = r#"{"name": "test-package"}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        // Create a subdirectory with its own package.json
+        let sub_dir = temp_dir_path.join("subdir");
+        fs::create_dir(&sub_dir).expect("Failed to create subdirectory");
+        let sub_package_content = r#"{"name": "sub-package"}"#;
+        create_package_json(&sub_dir, sub_package_content);
+
+        // Should find the subdirectory package.json since find_package_root searches upward from original_cwd
+        let workspace_root =
+            find_workspace_root(&sub_dir).expect("Should find subdirectory package");
+        assert_eq!(workspace_root.path, sub_dir);
+        assert!(matches!(workspace_root.workspace_file, WorkspaceFile::NonWorkspacePackage(_)));
+    }
+
+    #[tokio::test]
+    async fn test_detect_package_manager_with_pnpm_workspace_yaml() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let workspace_content = "packages:\n  - 'packages/*'";
+        create_pnpm_workspace_yaml(&temp_dir_path, workspace_content);
+
+        let result =
+            PackageManager::builder(temp_dir_path).build().await.expect("Should detect pnpm");
+        assert_eq!(result.bin_name, "pnpm");
+    }
+
+    #[tokio::test]
+    async fn test_detect_package_manager_with_pnpm_lock_yaml() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let package_content = r#"{"name": "test-package", "version": "1.0.0"}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        // Create pnpm-lock.yaml
+        fs::write(temp_dir_path.join("pnpm-lock.yaml"), "lockfileVersion: '6.0'")
+            .expect("Failed to write pnpm-lock.yaml");
+
+        let result =
+            PackageManager::builder(temp_dir_path).build().await.expect("Should detect pnpm");
+        assert_eq!(result.bin_name, "pnpm");
+
+        // check if the package.json file has the `packageManager` field
+        let package_json_path = temp_dir.path().join("package.json");
+        let package_json: serde_json::Value =
+            serde_json::from_slice(&fs::read(&package_json_path).unwrap()).unwrap();
+        println!("package_json: {:?}", package_json);
+        assert!(package_json["packageManager"].as_str().unwrap().starts_with("pnpm@"));
+        // keep other fields
+        assert_eq!(package_json["version"].as_str().unwrap(), "1.0.0");
+        assert_eq!(package_json["name"].as_str().unwrap(), "test-package");
+    }
+
+    #[tokio::test]
+    async fn test_detect_package_manager_with_yarn_lock() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let package_content = r#"{"name": "test-package"}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        // Create yarn.lock
+        fs::write(temp_dir_path.join("yarn.lock"), "# yarn lockfile v1")
+            .expect("Failed to write yarn.lock");
+
+        let result = PackageManager::builder(temp_dir_path.to_absolute_path_buf())
+            .build()
+            .await
+            .expect("Should detect yarn");
+        assert_eq!(result.bin_name, "yarn");
+        assert_eq!(result.workspace_root, temp_dir_path);
+        assert!(
+            result.get_bin_prefix().ends_with("yarn/bin"),
+            "bin_prefix should end with yarn/bin, but got {:?}",
+            result.get_bin_prefix()
+        );
+        // package.json should have the `packageManager` field
+        let package_json_path = temp_dir_path.join("package.json");
+        let package_json: serde_json::Value =
+            serde_json::from_slice(&fs::read(&package_json_path).unwrap()).unwrap();
+        println!("package_json: {:?}", package_json);
+        assert!(package_json["packageManager"].as_str().unwrap().starts_with("yarn@"));
+        // keep other fields
+        assert_eq!(package_json["name"].as_str().unwrap(), "test-package");
+    }
+
+    #[tokio::test]
+    async fn test_detect_package_manager_with_package_lock_json() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let package_content = r#"{"name": "test-package"}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        // Create package-lock.json
+        fs::write(temp_dir_path.join("package-lock.json"), r#"{"lockfileVersion": 2}"#)
+            .expect("Failed to write package-lock.json");
+
+        let result =
+            PackageManager::builder(temp_dir_path).build().await.expect("Should detect npm");
+        assert_eq!(result.bin_name, "npm");
+
+        // check shim files
+        let bin_prefix = result.get_bin_prefix();
+        assert!(is_exists_file(&bin_prefix.join("npm")).unwrap());
+        assert!(is_exists_file(&bin_prefix.join("npm.cmd")).unwrap());
+        assert!(is_exists_file(&bin_prefix.join("npm.ps1")).unwrap());
+        assert!(is_exists_file(&bin_prefix.join("npx")).unwrap());
+        assert!(is_exists_file(&bin_prefix.join("npx.cmd")).unwrap());
+        assert!(is_exists_file(&bin_prefix.join("npx.ps1")).unwrap());
+
+        // run npm --version
+        let mut paths =
+            env::split_paths(&env::var_os("PATH").unwrap_or_default()).collect::<Vec<_>>();
+        paths.insert(0, bin_prefix.into_path_buf());
+        let output = Command::new("npm")
+            .arg("--version")
+            .env("PATH", env::join_paths(&paths).unwrap())
+            .output()
+            .expect("Failed to run npm");
+        assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+        // println!("npm --version: {:?}", String::from_utf8_lossy(&output.stdout));
+
+        // run npx --version
+        let output = Command::new("npx")
+            .arg("--version")
+            .env("PATH", env::join_paths(&paths).unwrap())
+            .output()
+            .expect("Failed to run npx");
+        assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+    }
+
+    #[tokio::test]
+    async fn test_detect_package_manager_with_package_manager_field() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let package_content = r#"{"name": "test-package", "packageManager": "pnpm@8.15.0"}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        let result = PackageManager::builder(temp_dir_path)
+            .build()
+            .await
+            .expect("Should detect pnpm with version");
+        assert_eq!(result.bin_name, "pnpm");
+
+        // check shim files
+        let bin_prefix = result.get_bin_prefix();
+        assert!(is_exists_file(&bin_prefix.join("pnpm.cjs")).unwrap());
+        assert!(is_exists_file(&bin_prefix.join("pnpm.cmd")).unwrap());
+        assert!(is_exists_file(&bin_prefix.join("pnpm.ps1")).unwrap());
+        assert!(is_exists_file(&bin_prefix.join("pnpx.cjs")).unwrap());
+        assert!(is_exists_file(&bin_prefix.join("pnpx.cmd")).unwrap());
+        assert!(is_exists_file(&bin_prefix.join("pnpx.ps1")).unwrap());
+
+        // run pnpm --version
+        let mut paths =
+            env::split_paths(&env::var_os("PATH").unwrap_or_default()).collect::<Vec<_>>();
+        paths.insert(0, bin_prefix.into_path_buf());
+        let output = Command::new("pnpm")
+            .arg("--version")
+            .env("PATH", env::join_paths(paths).unwrap())
+            .output()
+            .expect("Failed to run pnpm");
+        // println!("pnpm --version: {:?}", output);
+        assert!(output.status.success());
+        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "8.15.0");
+    }
+
+    #[tokio::test]
+    async fn test_detect_package_manager_with_yarn_package_manager_field() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let package_content = r#"{"name": "test-package", "packageManager": "yarn@4.0.0"}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        let result = PackageManager::builder(temp_dir_path.clone())
+            .build()
+            .await
+            .expect("Should detect yarn with version");
+        assert_eq!(result.bin_name, "yarn");
+
+        assert_eq!(result.version, "4.0.0");
+        assert_eq!(result.workspace_root, temp_dir_path);
+        assert!(
+            result.get_bin_prefix().ends_with("yarn/bin"),
+            "bin_prefix should end with yarn/bin, but got {:?}",
+            result.get_bin_prefix()
+        );
+
+        // check shim files
+        let bin_prefix = result.get_bin_prefix();
+        assert!(is_exists_file(&bin_prefix.join("yarn.js")).unwrap());
+        assert!(is_exists_file(&bin_prefix.join("yarn")).unwrap());
+        assert!(is_exists_file(&bin_prefix.join("yarn.cmd")).unwrap());
+        assert!(is_exists_file(&bin_prefix.join("yarn.ps1")).unwrap());
+        assert!(is_exists_file(&bin_prefix.join("yarnpkg")).unwrap());
+        assert!(is_exists_file(&bin_prefix.join("yarnpkg.cmd")).unwrap());
+        assert!(is_exists_file(&bin_prefix.join("yarnpkg.ps1")).unwrap());
+
+        // run yarn --version
+        let output = Command::new(bin_prefix.join("yarn").into_path_buf())
+            .arg("--version")
+            .output()
+            .expect("Failed to run yarn");
+        assert!(output.status.success());
+        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "4.0.0");
+    }
+
+    #[tokio::test]
+    async fn test_detect_package_manager_with_npm_package_manager_field() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let package_content = r#"{"name": "test-package", "packageManager": "npm@10.0.0"}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        let result = PackageManager::builder(temp_dir_path)
+            .build()
+            .await
+            .expect("Should detect npm with version");
+        assert_eq!(result.bin_name, "npm");
+    }
+
+    #[tokio::test]
+    async fn test_detect_package_manager_with_invalid_package_manager_field() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let package_content = r#"{"name": "test-package", "packageManager": "invalid@1.0.0"}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        let result = PackageManager::builder(temp_dir_path).build().await;
+        assert!(result.is_err());
+        // Check if it's the expected error type
+        if let Err(Error::UnsupportedPackageManager(name)) = result {
+            assert_eq!(name, "invalid");
+        } else {
+            panic!("Expected UnsupportedPackageManager error");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_detect_package_manager_with_not_exists_version_in_package_manager_field() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let package_content =
+            r#"{"name": "test-package", "packageManager": "yarn@10000000000.0.0"}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        let result = PackageManager::builder(temp_dir_path).build().await;
+        assert!(result.is_err());
+        println!("result: {:?}", result);
+        // Check if it's the expected error type
+        if let Err(Error::PackageManagerVersionNotFound { name, version, .. }) = result {
+            assert_eq!(name, "yarn");
+            assert_eq!(version, "10000000000.0.0");
+        } else {
+            panic!("Expected PackageManagerVersionNotFound error, got {:?}", result);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_detect_package_manager_with_invalid_semver() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let package_content =
+            r#"{"name": "test-package", "packageManager": "pnpm@invalid-version"}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        let result = PackageManager::builder(temp_dir_path).build().await;
+        println!("result: {:?}", result);
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_detect_package_manager_with_default_fallback() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let package_content = r#"{"name": "test-package"}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        let result = PackageManager::builder(temp_dir_path.clone())
+            .package_manager_type(PackageManagerType::Yarn)
+            .build()
+            .await
+            .expect("Should use default");
+        assert_eq!(result.bin_name, "yarn");
+        // package.json should have the `packageManager` field
+        let package_json_path = temp_dir_path.join("package.json");
+        let package_json: serde_json::Value =
+            serde_json::from_slice(&fs::read(&package_json_path).unwrap()).unwrap();
+        // println!("package_json: {:?}", package_json);
+        assert!(package_json["packageManager"].as_str().unwrap().starts_with("yarn@"));
+        // keep other fields
+        assert_eq!(package_json["name"].as_str().unwrap(), "test-package");
+    }
+
+    #[tokio::test]
+    async fn test_detect_package_manager_without_any_indicators() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let package_content = r#"{"name": "test-package"}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        let result = PackageManager::builder(temp_dir_path).build().await;
+        assert!(result.is_err());
+        // Check if it's the expected error type
+        if let Err(Error::UnrecognizedPackageManager) = result {
+            // Expected error
+        } else {
+            panic!("Expected UnrecognizedPackageManager error");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_detect_package_manager_prioritizes_package_manager_field_over_lock_files() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let package_content = r#"{"name": "test-package", "packageManager": "yarn@4.0.0"}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        // Create pnpm-lock.yaml (should be ignored due to packageManager field)
+        fs::write(temp_dir_path.join("pnpm-lock.yaml"), "lockfileVersion: '6.0'")
+            .expect("Failed to write pnpm-lock.yaml");
+
+        let result = PackageManager::builder(temp_dir_path)
+            .build()
+            .await
+            .expect("Should detect yarn from packageManager field");
+        assert_eq!(result.bin_name, "yarn");
+    }
+
+    #[tokio::test]
+    async fn test_detect_package_manager_prioritizes_pnpm_workspace_over_lock_files() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let package_content = r#"{"name": "test-package"}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        // Create yarn.lock (should be ignored due to pnpm-workspace.yaml)
+        fs::write(temp_dir_path.join("yarn.lock"), "# yarn lockfile v1")
+            .expect("Failed to write yarn.lock");
+
+        // Create pnpm-workspace.yaml (should take precedence)
+        let workspace_content = "packages:\n  - 'packages/*'";
+        create_pnpm_workspace_yaml(&temp_dir_path, workspace_content);
+
+        let result = PackageManager::builder(temp_dir_path)
+            .build()
+            .await
+            .expect("Should detect pnpm from workspace file");
+        assert_eq!(result.bin_name, "pnpm");
+    }
+
+    #[tokio::test]
+    async fn test_detect_package_manager_from_subdirectory() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let workspace_content = "packages:\n  - 'packages/*'";
+        create_pnpm_workspace_yaml(&temp_dir_path, workspace_content);
+
+        let sub_dir = temp_dir_path.join("packages").join("app");
+        fs::create_dir_all(&sub_dir).expect("Failed to create subdirectory");
+
+        let result = PackageManager::builder(sub_dir)
+            .build()
+            .await
+            .expect("Should detect pnpm from parent workspace");
+        assert_eq!(result.bin_name, "pnpm");
+        assert!(result.get_bin_prefix().ends_with("pnpm/bin"));
+    }
+
+    #[tokio::test]
+    async fn test_download_package_manager() {
+        let result =
+            download_package_manager(PackageManagerType::Yarn, "@yarnpkg/cli-dist", "4.9.2").await;
+        assert!(result.is_ok());
+        let target_dir = result.unwrap();
+        println!("result: {:?}", target_dir);
+        assert!(is_exists_file(&target_dir.join("bin/yarn")).unwrap());
+        assert!(is_exists_file(&target_dir.join("bin/yarn.cmd")).unwrap());
+
+        // again should skip download
+        let result =
+            download_package_manager(PackageManagerType::Yarn, "@yarnpkg/cli-dist", "4.9.2").await;
+        assert!(result.is_ok());
+        let target_dir = result.unwrap();
+        assert!(is_exists_file(&target_dir.join("bin/yarn")).unwrap());
+        assert!(is_exists_file(&target_dir.join("bin/yarn.cmd")).unwrap());
+
+        remove_dir_all_force(target_dir).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_get_latest_version() {
+        let result = get_latest_version(PackageManagerType::Yarn).await;
+        assert!(result.is_ok());
+        let version = result.unwrap();
+        // println!("version: {:?}", version);
+        assert!(!version.is_empty());
+        // check version should >= 4.0.0
+        let version_req = VersionReq::parse(">=4.0.0");
+        assert!(version_req.is_ok());
+        let version_req = version_req.unwrap();
+        assert!(version_req.matches(&Version::parse(&version).unwrap()));
+    }
+
+    #[tokio::test]
+    async fn test_detect_package_manager_with_yarnrc_yml() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let package_content = r#"{"name": "test-package"}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        // Create .yarnrc.yml
+        fs::write(
+            temp_dir_path.join(".yarnrc.yml"),
+            "nodeLinker: node-modules\nyarnPath: .yarn/releases/yarn-4.0.0.cjs",
+        )
+        .expect("Failed to write .yarnrc.yml");
+
+        let result = PackageManager::builder(temp_dir_path.clone())
+            .build()
+            .await
+            .expect("Should detect yarn from .yarnrc.yml");
+        assert_eq!(result.bin_name, "yarn");
+        assert_eq!(result.workspace_root, temp_dir_path);
+        assert!(
+            result.get_bin_prefix().ends_with("yarn/bin"),
+            "bin_prefix should end with yarn/bin, but got {:?}",
+            result.get_bin_prefix()
+        );
+        // package.json should have the `packageManager` field
+        let package_json_path = temp_dir.path().join("package.json");
+        let package_json: serde_json::Value =
+            serde_json::from_slice(&fs::read(&package_json_path).unwrap()).unwrap();
+        assert!(package_json["packageManager"].as_str().unwrap().starts_with("yarn@"));
+        // keep other fields
+        assert_eq!(package_json["name"].as_str().unwrap(), "test-package");
+    }
+
+    #[tokio::test]
+    async fn test_detect_package_manager_with_pnpmfile_cjs() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let package_content = r#"{"name": "test-package"}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        // Create pnpmfile.cjs
+        fs::write(temp_dir_path.join("pnpmfile.cjs"), "module.exports = { hooks: {} }")
+            .expect("Failed to write pnpmfile.cjs");
+
+        let result = PackageManager::builder(temp_dir_path.clone())
+            .build()
+            .await
+            .expect("Should detect pnpm from pnpmfile.cjs");
+        assert_eq!(result.bin_name, "pnpm");
+        assert_eq!(result.workspace_root, temp_dir_path);
+        assert!(
+            result.get_bin_prefix().ends_with("pnpm/bin"),
+            "bin_prefix should end with pnpm/bin, but got {:?}",
+            result.get_bin_prefix()
+        );
+        // package.json should have the `packageManager` field
+        let package_json_path = temp_dir_path.join("package.json");
+        let package_json: serde_json::Value =
+            serde_json::from_slice(&fs::read(&package_json_path).unwrap()).unwrap();
+        assert!(package_json["packageManager"].as_str().unwrap().starts_with("pnpm@"));
+        // keep other fields
+        assert_eq!(package_json["name"].as_str().unwrap(), "test-package");
+    }
+
+    #[tokio::test]
+    async fn test_detect_package_manager_with_yarn_config_cjs() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let package_content = r#"{"name": "test-package"}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        // Create yarn.config.cjs
+        fs::write(
+            temp_dir_path.join("yarn.config.cjs"),
+            "module.exports = { nodeLinker: 'node-modules' }",
+        )
+        .expect("Failed to write yarn.config.cjs");
+
+        let result = PackageManager::builder(temp_dir_path.clone())
+            .build()
+            .await
+            .expect("Should detect yarn from yarn.config.cjs");
+        assert_eq!(result.bin_name, "yarn");
+        assert_eq!(result.workspace_root, temp_dir_path);
+        assert!(
+            result.get_bin_prefix().ends_with("yarn/bin"),
+            "bin_prefix should end with yarn/bin, but got {:?}",
+            result.get_bin_prefix()
+        );
+        // package.json should have the `packageManager` field
+        let package_json_path = temp_dir_path.join("package.json");
+        let package_json: serde_json::Value =
+            serde_json::from_slice(&fs::read(&package_json_path).unwrap()).unwrap();
+        assert!(package_json["packageManager"].as_str().unwrap().starts_with("yarn@"));
+        // keep other fields
+        assert_eq!(package_json["name"].as_str().unwrap(), "test-package");
+    }
+
+    #[tokio::test]
+    async fn test_detect_package_manager_priority_order_lock_over_config() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let package_content = r#"{"name": "test-package"}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        // Create multiple detection files to test priority order
+        // According to vite-install.md, pnpmfile.cjs and yarn.config.cjs are lower priority than lock files
+
+        // Create pnpmfile.cjs
+        fs::write(temp_dir_path.join("pnpmfile.cjs"), "module.exports = { hooks: {} }")
+            .expect("Failed to write pnpmfile.cjs");
+
+        // Create yarn.config.cjs
+        fs::write(
+            temp_dir_path.join("yarn.config.cjs"),
+            "module.exports = { nodeLinker: 'node-modules' }",
+        )
+        .expect("Failed to write yarn.config.cjs");
+
+        // Create package-lock.json (should take precedence over pnpmfile.cjs and yarn.config.cjs)
+        fs::write(temp_dir_path.join("package-lock.json"), r#"{"lockfileVersion": 3}"#)
+            .expect("Failed to write package-lock.json");
+
+        let result = PackageManager::builder(temp_dir_path)
+            .build()
+            .await
+            .expect("Should detect npm from package-lock.json");
+        assert_eq!(
+            result.bin_name, "npm",
+            "package-lock.json should take precedence over pnpmfile.cjs and yarn.config.cjs"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_detect_package_manager_pnpmfile_over_yarn_config() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let package_content = r#"{"name": "test-package"}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        // Create both pnpmfile.cjs and yarn.config.cjs
+        fs::write(temp_dir_path.join("pnpmfile.cjs"), "module.exports = { hooks: {} }")
+            .expect("Failed to write pnpmfile.cjs");
+
+        fs::write(
+            temp_dir_path.join("yarn.config.cjs"),
+            "module.exports = { nodeLinker: 'node-modules' }",
+        )
+        .expect("Failed to write yarn.config.cjs");
+
+        // pnpmfile.cjs should be detected first (before yarn.config.cjs)
+        let result = PackageManager::builder(temp_dir_path)
+            .build()
+            .await
+            .expect("Should detect pnpm from pnpmfile.cjs");
+        assert_eq!(
+            result.bin_name, "pnpm",
+            "pnpmfile.cjs should be detected before yarn.config.cjs"
+        );
     }
 }

--- a/crates/vite_package_manager/src/request.rs
+++ b/crates/vite_package_manager/src/request.rs
@@ -1,0 +1,499 @@
+use std::path::Path;
+use std::time::Duration;
+
+use backon::{ExponentialBuilder, Retryable};
+use flate2::read::GzDecoder;
+use futures_util::stream::StreamExt;
+use reqwest::Response;
+use serde::de::DeserializeOwned;
+use tar::Archive;
+use tokio::fs;
+use tokio::io::AsyncWriteExt;
+
+use crate::Error;
+
+/// HTTP client with built-in retry support
+#[derive(Clone)]
+pub struct HttpClient {
+    max_times: usize,
+    min_delay: u64,
+}
+
+impl Default for HttpClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HttpClient {
+    /// Create a new HTTP client with default settings (3 retries, 500ms min delay)
+    pub fn new() -> Self {
+        Self::with_config(3, 500)
+    }
+
+    /// Create a new HTTP client with custom retry configuration
+    ///
+    /// # Arguments
+    ///
+    /// * `max_times` - Maximum number of retry attempts
+    /// * `min_delay` - Minimum delay in milliseconds for exponential backoff
+    pub fn with_config(max_times: usize, min_delay: u64) -> Self {
+        Self { max_times, min_delay }
+    }
+
+    async fn get(&self, url: &str) -> Result<Response, Error> {
+        let response = (|| async { reqwest::get(url).await?.error_for_status() })
+            .retry(
+                ExponentialBuilder::default()
+                    .with_jitter()
+                    .with_min_delay(Duration::from_millis(self.min_delay))
+                    .with_max_times(self.max_times as usize),
+            )
+            .await?;
+
+        Ok(response)
+    }
+
+    /// Get JSON data from a URL
+    ///
+    /// # Arguments
+    ///
+    /// * `url` - The URL to fetch JSON from
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(T)` - Deserialized JSON data
+    /// * `Err(e)` - If the request fails or JSON deserialization fails
+    pub async fn get_json<T: DeserializeOwned>(&self, url: &str) -> Result<T, Error> {
+        tracing::debug!("Fetching JSON from: {}", url);
+
+        let response = self.get(url).await?;
+        let data = response.json::<T>().await?;
+        Ok(data)
+    }
+
+    /// Download a file to a specified path
+    ///
+    /// # Arguments
+    ///
+    /// * `url` - The URL of the file to download
+    /// * `target_path` - The path where the file will be saved
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(())` - If the file is downloaded successfully
+    /// * `Err(e)` - If the download fails
+    pub async fn download_file(
+        &self,
+        url: &str,
+        target_path: impl AsRef<Path>,
+    ) -> Result<(), Error> {
+        let target_path = target_path.as_ref();
+        tracing::debug!("Downloading {} to {:?}", url, target_path);
+
+        let response = self.get(url).await?;
+
+        self.write_response_to_file(response, target_path).await?;
+
+        tracing::debug!("Download completed: {:?}", target_path);
+        Ok(())
+    }
+
+    /// Internal helper to write response body to file
+    async fn write_response_to_file(
+        &self,
+        response: Response,
+        target_path: &Path,
+    ) -> Result<(), Error> {
+        // Create the target file
+        let mut file = fs::File::create(target_path).await?;
+
+        // Stream the response body to the file
+        let mut stream = response.bytes_stream();
+        while let Some(chunk_result) = stream.next().await {
+            let chunk = chunk_result?;
+            file.write_all(&chunk).await?;
+        }
+
+        file.flush().await?;
+        Ok(())
+    }
+}
+
+fn extract_tgz(tgz_file: impl AsRef<Path>, target_dir: impl AsRef<Path>) -> Result<(), Error> {
+    let tgz_file = tgz_file.as_ref();
+    let target_dir = target_dir.as_ref();
+    tracing::debug!("Extract tgz: {:?} to {:?}", tgz_file, target_dir);
+
+    let file = std::fs::File::open(&tgz_file)?;
+    let tar_stream = GzDecoder::new(file);
+    let mut archive = Archive::new(tar_stream);
+    archive.unpack(&target_dir)?;
+
+    tracing::debug!("Extract tgz finished");
+
+    Ok(())
+}
+
+/// Download tgz file from url and extract it to the target directory.
+///
+/// # Arguments
+///
+/// * `url` - The url of the tgz file.
+/// * `target_dir` - The directory to extract the tgz file to.
+///
+/// # Returns
+///
+/// * `Ok(())` - If the tgz file is downloaded and extracted successfully.
+/// * `Err(e)` - If the tgz file is not downloaded or extracted successfully.
+pub async fn download_and_extract_tgz(
+    url: &str,
+    target_dir: impl AsRef<Path>,
+) -> Result<(), Error> {
+    let target_dir = target_dir.as_ref().to_path_buf();
+    tracing::debug!("Start download and extract {} to {:?}", url, target_dir);
+
+    // Create target directory
+    fs::create_dir_all(&target_dir).await?;
+
+    // Download the tgz file with retry logic using HttpClient
+    let tgz_file = target_dir.join("package.tgz");
+    let client = HttpClient::new();
+    client.download_file(url, &tgz_file).await?;
+
+    // Extract the tgz file to the target directory
+    let tgz_file_for_extract = tgz_file.clone();
+    let target_dir_for_extract = target_dir.clone();
+    tokio::task::spawn_blocking(move || {
+        extract_tgz(&tgz_file_for_extract, &target_dir_for_extract)
+    })
+    .await??;
+
+    // Remove the temp file
+    fs::remove_file(&tgz_file).await?;
+
+    tracing::debug!("Download and extract finished");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    use httpmock::prelude::*;
+    use tempfile::TempDir;
+
+    /// Helper function to create a mock package tar.gz that mimics npm package structure
+    fn create_mock_package_tgz() -> Vec<u8> {
+        let mut tar_builder = tar::Builder::new(Vec::new());
+
+        // Add package.json
+        let package_json = br#"{"name":"test-package","version":"1.0.0"}"#;
+        let mut header = tar::Header::new_gnu();
+        header.set_size(package_json.len() as u64);
+        header.set_mode(0o644);
+        tar_builder
+            .append_data(&mut header, "package/package.json", std::io::Cursor::new(package_json))
+            .unwrap();
+
+        // Add bin/yarn mock file
+        let yarn_content = b"#!/usr/bin/env node\nconsole.log('mock yarn');";
+        let mut header = tar::Header::new_gnu();
+        header.set_size(yarn_content.len() as u64);
+        header.set_mode(0o755);
+        tar_builder
+            .append_data(&mut header, "package/bin/yarn", std::io::Cursor::new(yarn_content))
+            .unwrap();
+
+        // Add bin/yarn.cmd mock file
+        let yarn_cmd_content = b"@echo off\nnode yarn %*";
+        let mut header = tar::Header::new_gnu();
+        header.set_size(yarn_cmd_content.len() as u64);
+        header.set_mode(0o755);
+        tar_builder
+            .append_data(
+                &mut header,
+                "package/bin/yarn.cmd",
+                std::io::Cursor::new(yarn_cmd_content),
+            )
+            .unwrap();
+
+        let tar_data = tar_builder.into_inner().unwrap();
+
+        // Compress with gzip
+        let mut gz_data = Vec::new();
+        {
+            let mut encoder =
+                flate2::write::GzEncoder::new(&mut gz_data, flate2::Compression::default());
+            std::io::copy(&mut std::io::Cursor::new(tar_data), &mut encoder).unwrap();
+        }
+        gz_data
+    }
+
+    #[tokio::test]
+    #[test_log::test]
+    async fn test_extract_tgz_function() {
+        // Test the extract_tgz function directly
+        let temp_dir = TempDir::new().unwrap();
+        let target_dir = temp_dir.path().join("extracted");
+
+        // Create a simple tar.gz file content for testing
+        let test_content = b"test file content";
+        let mut tar_builder = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header.set_size(test_content.len() as u64);
+        tar_builder
+            .append_data(&mut header, "test.txt", std::io::Cursor::new(test_content))
+            .unwrap();
+        let tar_data = tar_builder.into_inner().unwrap();
+
+        // Compress with gzip
+        let mut gz_data = Vec::new();
+        {
+            let mut encoder =
+                flate2::write::GzEncoder::new(&mut gz_data, flate2::Compression::default());
+            std::io::copy(&mut std::io::Cursor::new(tar_data), &mut encoder).unwrap();
+        }
+
+        // Write the compressed data to a temporary file
+        let tgz_file = temp_dir.path().join("test.tgz");
+        fs::write(&tgz_file, gz_data).unwrap();
+
+        // Test extraction
+        let result = extract_tgz(&tgz_file, &target_dir);
+        assert!(result.is_ok());
+
+        // Verify the file was extracted
+        let extracted_file = target_dir.join("test.txt");
+        assert!(extracted_file.exists());
+
+        // Verify the content
+        let content = fs::read_to_string(extracted_file).unwrap();
+        assert_eq!(content, "test file content");
+    }
+
+    #[tokio::test]
+    async fn test_extract_tgz_large_file() {
+        // Test extraction with a larger file
+        let temp_dir = TempDir::new().unwrap();
+        let target_dir = temp_dir.path().join("extracted");
+
+        // Create a larger tar.gz file for testing
+        let large_content = vec![b'a'; 1024 * 1024]; // 1MB
+        let mut tar_builder = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header.set_size(large_content.len() as u64);
+        tar_builder
+            .append_data(&mut header, "large.txt", std::io::Cursor::new(&large_content))
+            .unwrap();
+        let tar_data = tar_builder.into_inner().unwrap();
+
+        // Compress with gzip
+        let mut gz_data = Vec::new();
+        {
+            let mut encoder =
+                flate2::write::GzEncoder::new(&mut gz_data, flate2::Compression::default());
+            std::io::copy(&mut std::io::Cursor::new(tar_data), &mut encoder).unwrap();
+        }
+
+        // Write the compressed data to a temporary file
+        let tgz_file = temp_dir.path().join("large.tgz");
+        fs::write(&tgz_file, gz_data).unwrap();
+
+        // Test extraction
+        let result = extract_tgz(&tgz_file, &target_dir);
+        assert!(result.is_ok());
+
+        // Verify the file was extracted
+        let extracted_file = target_dir.join("large.txt");
+        assert!(extracted_file.exists());
+
+        // Verify the content size
+        let content = fs::read(extracted_file).unwrap();
+        assert_eq!(content.len(), 1024 * 1024);
+    }
+
+    #[tokio::test]
+    async fn test_extract_tgz_invalid_file() {
+        // Test extraction with invalid tar.gz content
+        let temp_dir = TempDir::new().unwrap();
+        let target_dir = temp_dir.path().join("extracted");
+
+        // Create an invalid tar.gz file
+        let invalid_content = b"this is not a valid tar.gz file";
+        let tgz_file = temp_dir.path().join("invalid.tgz");
+        fs::write(&tgz_file, invalid_content).unwrap();
+
+        // Test extraction - should fail gracefully
+        let result = extract_tgz(&tgz_file, &target_dir);
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_extract_tgz_empty_file() {
+        // Test extraction with empty tar.gz
+        let temp_dir = TempDir::new().unwrap();
+        let target_dir = temp_dir.path().join("extracted");
+
+        // Create an empty tar.gz file
+        let tgz_file = temp_dir.path().join("empty.tgz");
+        fs::write(&tgz_file, Vec::<u8>::new()).unwrap();
+
+        // Test extraction - should handle empty file gracefully
+        let result = extract_tgz(&tgz_file, &target_dir);
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_http_client_get_json() {
+        let server = MockServer::start();
+
+        // Create mock JSON response
+        let mock_json = serde_json::json!({
+            "name": "test-package",
+            "version": "1.0.0",
+            "description": "A test package"
+        });
+
+        server.mock(|when, then| {
+            when.method(GET).path("/api/package.json");
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(mock_json.clone());
+        });
+
+        let client = HttpClient::new();
+        let url = format!("{}/api/package.json", server.base_url());
+
+        #[derive(serde::Deserialize, Debug, PartialEq)]
+        struct PackageInfo {
+            name: String,
+            version: String,
+            description: String,
+        }
+
+        let result: Result<PackageInfo, _> = client.get_json(&url).await;
+        assert!(result.is_ok());
+
+        let package_info = result.unwrap();
+        assert_eq!(package_info.name, "test-package");
+        assert_eq!(package_info.version, "1.0.0");
+        assert_eq!(package_info.description, "A test package");
+    }
+
+    #[tokio::test]
+    async fn test_http_client_download_file() {
+        let server = MockServer::start();
+        let temp_dir = TempDir::new().unwrap();
+        let target_file = temp_dir.path().join("downloaded.txt");
+
+        let mock_content = b"Hello, World! This is test content.";
+
+        server.mock(|when, then| {
+            when.method(GET).path("/file.txt");
+            then.status(200).header("content-type", "text/plain").body(mock_content);
+        });
+
+        let client = HttpClient::new();
+        let url = format!("{}/file.txt", server.base_url());
+
+        let result = client.download_file(&url, &target_file).await;
+        assert!(result.is_ok(), "Failed to download file: {:?}", result);
+
+        // Verify file exists and has correct content
+        assert!(target_file.exists());
+        let content = fs::read(&target_file).unwrap();
+        assert_eq!(content, mock_content);
+    }
+
+    #[tokio::test]
+    async fn test_http_client_retry_on_server_error() {
+        // Test that the client correctly retries on server errors
+        let server = MockServer::start();
+        let temp_dir = TempDir::new().unwrap();
+        let target_file = temp_dir.path().join("test.txt");
+
+        server.mock(|when, then| {
+            when.method(GET).path("/server_error");
+            then.status(500).body("Internal Server Error");
+        });
+
+        let client = HttpClient::with_config(2, 50); // 2 retries with 50ms base interval
+        let url = format!("{}/server_error", server.base_url());
+
+        // Should fail after retries
+        let result = client.download_file(&url, &target_file).await;
+        // println!("result: {:?}", result);
+        assert!(result.is_err(), "Expected download to fail with 500 after retries");
+    }
+
+    #[tokio::test]
+    async fn test_download_and_extract_tgz() {
+        // Start a mock server
+        let server = MockServer::start();
+        let temp_dir = TempDir::new().unwrap();
+        let target_dir = temp_dir.path().join("extracted");
+
+        // Create mock response with package tar.gz
+        let mock_tgz = create_mock_package_tgz();
+        server.mock(|when, then| {
+            when.method(GET).path("/test-package.tgz");
+            then.status(200).header("content-type", "application/octet-stream").body(mock_tgz);
+        });
+
+        let url = format!("{}/test-package.tgz", server.base_url());
+        let result = download_and_extract_tgz(&url, &target_dir).await;
+        assert!(result.is_ok(), "Failed to download and extract: {:?}", result);
+
+        assert!(target_dir.join("package/bin/yarn").exists());
+        assert!(target_dir.join("package/bin/yarn.cmd").exists());
+
+        // TempDir automatically cleans up when it goes out of scope
+    }
+
+    #[tokio::test]
+    async fn test_http_client_download_with_404_error() {
+        let server = MockServer::start();
+        let temp_dir = TempDir::new().unwrap();
+        let target_file = temp_dir.path().join("test.txt");
+
+        // Mock a 404 response
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/nonexistent");
+            then.status(404).body("Not Found");
+        });
+
+        let client = HttpClient::new();
+        let url = format!("{}/nonexistent", server.base_url());
+
+        // Should fail with 404
+        let result = client.download_file(&url, &target_file).await;
+        assert!(result.is_err(), "Expected download to fail with 404");
+
+        // Should try 4 times, 1 for first request, 3 for retries
+        mock.assert_hits(4);
+    }
+
+    #[tokio::test]
+    async fn test_http_client_json_with_invalid_response() {
+        let server = MockServer::start();
+
+        // Mock response with invalid JSON
+        server.mock(|when, then| {
+            when.method(GET).path("/invalid.json");
+            then.status(200).header("content-type", "application/json").body("not valid json");
+        });
+
+        let client = HttpClient::new();
+        let url = format!("{}/invalid.json", server.base_url());
+
+        #[derive(serde::Deserialize)]
+        struct TestData {
+            field: String,
+        }
+
+        let result: Result<TestData, _> = client.get_json(&url).await;
+        assert!(result.is_err(), "Expected JSON parsing to fail");
+    }
+}

--- a/crates/vite_package_manager/src/shim.rs
+++ b/crates/vite_package_manager/src/shim.rs
@@ -1,0 +1,408 @@
+use std::path::Path;
+use tokio::fs::write;
+
+use indoc::formatdoc;
+use pathdiff::diff_paths;
+
+use vite_error::Error;
+
+/// Write cmd/sh/pwsh shim files.
+pub async fn write_shims(
+    source_file: impl AsRef<Path>,
+    to_bin: impl AsRef<Path>,
+) -> Result<(), Error> {
+    let to_bin = to_bin.as_ref();
+    // source file `/foo/bar/pnpm.js` point to bin file `/foo/bin/npm`, the relative path is `../bar/pnpm.js`.
+    let relative_path = diff_paths(source_file, to_bin.parent().unwrap()).unwrap();
+    let relative_file = relative_path.to_str().unwrap();
+
+    // Referenced from pnpm/cmd-shim's TypeScript implementation:
+    // https://github.com/pnpm/cmd-shim/blob/main/src/index.ts
+    write(to_bin, sh_shim(relative_file)).await?;
+    write(to_bin.with_extension("cmd"), cmd_shim(relative_file)).await?;
+    write(to_bin.with_extension("ps1"), pwsh_shim(relative_file)).await?;
+
+    // set executable permission for unix
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        tokio::fs::set_permissions(to_bin, std::fs::Permissions::from_mode(0o755)).await?;
+    }
+    Ok(())
+}
+
+/// Unix shell shim.
+pub fn sh_shim(relative_file: &str) -> String {
+    formatdoc! {
+        r#"
+        #!/bin/sh
+        basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+        case `uname` in
+            *CYGWIN*|*MINGW*|*MSYS*)
+                if command -v cygpath > /dev/null 2>&1; then
+                    basedir=`cygpath -w "$basedir"`
+                fi
+            ;;
+        esac
+
+        if [ -x "$basedir/node" ]; then
+            exec "$basedir/node" "$basedir/{relative_file}" "$@"
+        else
+            exec node "$basedir/{relative_file}" "$@"
+        fi
+        "#
+    }
+}
+
+/// Windows Command Prompt shim.
+pub fn cmd_shim(relative_file: &str) -> String {
+    formatdoc! {
+        r#"
+        @SETLOCAL
+        @IF EXIST "%~dp0\node.exe" (
+            "%~dp0\node.exe" "%~dp0\{relative_file}" %*
+        ) ELSE (
+        @SET PATHEXT=%PATHEXT:;.JS;=;%
+            node "%~dp0\{relative_file}" %*
+        )
+        "#,
+        relative_file = relative_file.replace("/", "\\")
+    }
+    .replace("\n", "\r\n") // replace \n to \r\n for windows
+}
+
+/// PowerShell shim.
+pub fn pwsh_shim(relative_file: &str) -> String {
+    formatdoc! {
+        r#"
+        #!/usr/bin/env pwsh
+        $basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+        $exe=""
+        if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {{
+            # Fix case when both the Windows and Linux builds of Node
+            # are installed in the same directory
+            $exe=".exe"
+        }}
+        $ret=0
+        if (Test-Path "$basedir/node$exe") {{
+            # Support pipeline input
+            if ($MyInvocation.ExpectingInput) {{
+                $input | & "$basedir/node$exe" "$basedir/{relative_file}" $args
+            }} else {{
+                & "$basedir/node$exe" "$basedir/{relative_file}" $args
+            }}
+            $ret=$LASTEXITCODE
+        }} else {{
+            # Support pipeline input
+            if ($MyInvocation.ExpectingInput) {{
+                $input | & "node$exe" "$basedir/{relative_file}" $args
+            }} else {{
+                & "node$exe" "$basedir/{relative_file}" $args
+            }}
+            $ret=$LASTEXITCODE
+        }}
+        exit $ret
+        "#
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+    use tokio::fs::read_to_string;
+
+    fn format_shim(shim: &str) -> String {
+        shim.replace(" ", "·")
+    }
+
+    #[test]
+    fn test_sh_shim() {
+        let shim = sh_shim("pnpm.js");
+        // println!("{:#}", format_shim(&shim));
+        assert!(shim.contains("pnpm.js"), "{}", format_shim(&shim));
+    }
+
+    #[test]
+    fn test_cmd_shim() {
+        let shim = cmd_shim("yarn.js");
+        // println!("{:#?}", format_shim(&shim));
+        assert!(shim.contains("yarn.js"), "{}", format_shim(&shim));
+        assert!(
+            shim.contains("@SETLOCAL\r\n@IF EXIST \"%~dp0\\node.exe\" (\r\n"),
+            "{}",
+            format_shim(&shim)
+        );
+
+        let shim = cmd_shim("../../../../pnpm.js");
+        // println!("{:#}", format_shim(&shim));
+        assert!(
+            shim.contains("node \"%~dp0\\..\\..\\..\\..\\pnpm.js\" %*"),
+            "{}",
+            format_shim(&shim)
+        );
+        assert!(
+            shim.contains("@SETLOCAL\r\n@IF EXIST \"%~dp0\\node.exe\" (\r\n"),
+            "{}",
+            format_shim(&shim)
+        );
+    }
+
+    #[test]
+    fn test_pwsh_shim() {
+        let shim = pwsh_shim("pnpm.cjs");
+        // println!("{:#}", format_shim(&shim));
+        assert!(shim.contains("pnpm.cjs"), "{}", format_shim(&shim));
+    }
+
+    #[tokio::test]
+    async fn test_write_shims_basic() {
+        let temp_dir = TempDir::new().unwrap();
+        let source = temp_dir.path().join("node_modules").join(".bin").join("pnpm.js");
+        let target = temp_dir.path().join("bin").join("pnpm");
+
+        // Create parent directories
+        tokio::fs::create_dir_all(source.parent().unwrap()).await.unwrap();
+        tokio::fs::create_dir_all(target.parent().unwrap()).await.unwrap();
+
+        // Write shims
+        write_shims(&source, &target).await.unwrap();
+
+        // Verify base shim file was created (shell script)
+        assert!(target.exists());
+        let content = read_to_string(&target).await.unwrap();
+        assert!(content.contains("#!/bin/sh"));
+        assert!(content.contains("../node_modules/.bin/pnpm.js"));
+
+        // Verify .cmd file was created
+        let cmd_file = target.with_extension("cmd");
+        assert!(cmd_file.exists());
+        let cmd_content = read_to_string(&cmd_file).await.unwrap();
+        assert!(cmd_content.contains("@SETLOCAL"));
+        assert!(cmd_content.contains("..\\node_modules\\.bin\\pnpm.js"));
+
+        // Verify .ps1 file was created
+        let ps1_file = target.with_extension("ps1");
+        assert!(ps1_file.exists());
+        let ps1_content = read_to_string(&ps1_file).await.unwrap();
+        assert!(ps1_content.contains("#!/usr/bin/env pwsh"));
+        assert!(ps1_content.contains("../node_modules/.bin/pnpm.js"));
+    }
+
+    #[tokio::test]
+    async fn test_write_shims_relative_paths() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // Test case 1: Source is deeper than target
+        let source1 = temp_dir.path().join("deep").join("nested").join("path").join("script.js");
+        let target1 = temp_dir.path().join("bin").join("script");
+
+        tokio::fs::create_dir_all(source1.parent().unwrap()).await.unwrap();
+        tokio::fs::create_dir_all(target1.parent().unwrap()).await.unwrap();
+
+        write_shims(&source1, &target1).await.unwrap();
+
+        let content1 = read_to_string(&target1).await.unwrap();
+        assert!(content1.contains("../deep/nested/path/script.js"));
+
+        // Test case 2: Source and target at same level
+        let source2 = temp_dir.path().join("scripts").join("tool.js");
+        let target2 = temp_dir.path().join("bin").join("tool");
+
+        tokio::fs::create_dir_all(source2.parent().unwrap()).await.unwrap();
+        tokio::fs::create_dir_all(target2.parent().unwrap()).await.unwrap();
+
+        write_shims(&source2, &target2).await.unwrap();
+
+        let content2 = read_to_string(&target2).await.unwrap();
+        assert!(content2.contains("../scripts/tool.js"));
+    }
+
+    #[tokio::test]
+    async fn test_write_shims_windows_path_conversion() {
+        let temp_dir = TempDir::new().unwrap();
+        let source = temp_dir.path().join("node_modules").join("package").join("bin.js");
+        let target = temp_dir.path().join("bin").join("package");
+
+        tokio::fs::create_dir_all(source.parent().unwrap()).await.unwrap();
+        tokio::fs::create_dir_all(target.parent().unwrap()).await.unwrap();
+
+        write_shims(&source, &target).await.unwrap();
+
+        // Check base file (shell script) has forward slashes
+        let content = read_to_string(&target).await.unwrap();
+        assert!(content.contains("../node_modules/package/bin.js"));
+
+        // Check CMD file has backslashes
+        let cmd_file = target.with_extension("cmd");
+        let cmd_content = read_to_string(&cmd_file).await.unwrap();
+        assert!(cmd_content.contains("..\\node_modules\\package\\bin.js"));
+        assert!(!cmd_content.contains("../node_modules/package/bin.js"));
+
+        // Check PS1 file has forward slashes
+        let ps1_file = target.with_extension("ps1");
+        let ps1_content = read_to_string(&ps1_file).await.unwrap();
+        assert!(ps1_content.contains("../node_modules/package/bin.js"));
+        assert!(!ps1_content.contains("..\\node_modules\\"));
+    }
+
+    #[tokio::test]
+    async fn test_write_shims_overwrite_existing() {
+        let temp_dir = TempDir::new().unwrap();
+        let source = temp_dir.path().join("src").join("cli.js");
+        let target = temp_dir.path().join("bin").join("cli");
+
+        tokio::fs::create_dir_all(source.parent().unwrap()).await.unwrap();
+        tokio::fs::create_dir_all(target.parent().unwrap()).await.unwrap();
+
+        // Write initial content to files
+        tokio::fs::write(&target, "old content").await.unwrap();
+        tokio::fs::write(target.with_extension("cmd"), "old cmd content").await.unwrap();
+        tokio::fs::write(target.with_extension("ps1"), "old ps1 content").await.unwrap();
+
+        // Write shims (should overwrite)
+        write_shims(&source, &target).await.unwrap();
+
+        // Verify files were overwritten
+        let content = read_to_string(&target).await.unwrap();
+        assert!(!content.contains("old content"));
+        assert!(content.contains("../src/cli.js"));
+
+        let cmd_content = read_to_string(target.with_extension("cmd")).await.unwrap();
+        assert!(!cmd_content.contains("old cmd content"));
+        assert!(cmd_content.contains("@SETLOCAL"));
+
+        let ps1_content = read_to_string(target.with_extension("ps1")).await.unwrap();
+        assert!(!ps1_content.contains("old ps1 content"));
+        assert!(ps1_content.contains("#!/usr/bin/env pwsh"));
+    }
+
+    #[tokio::test]
+    async fn test_write_shims_complex_relative_path() {
+        let temp_dir = TempDir::new().unwrap();
+        let source = temp_dir.path().join("a").join("b").join("c").join("script.js");
+        let target = temp_dir.path().join("x").join("y").join("z").join("script");
+
+        tokio::fs::create_dir_all(source.parent().unwrap()).await.unwrap();
+        tokio::fs::create_dir_all(target.parent().unwrap()).await.unwrap();
+
+        write_shims(&source, &target).await.unwrap();
+
+        // Base file should be shell script with forward slashes
+        let content = read_to_string(&target).await.unwrap();
+        assert!(content.contains("#!/bin/sh"));
+        assert!(content.contains("../../a/b/c/script.js"));
+
+        // CMD file should have backslashes
+        let cmd_content = read_to_string(target.with_extension("cmd")).await.unwrap();
+        assert!(cmd_content.contains("..\\..\\a\\b\\c\\script.js"));
+    }
+
+    #[tokio::test]
+    async fn test_sh_shim_content_validation() {
+        let shim = sh_shim("lib/cli.js");
+
+        // Verify shebang
+        assert!(shim.starts_with("#!/bin/sh"));
+
+        // Verify CYGWIN/MINGW/MSYS handling
+        assert!(shim.contains("*CYGWIN*|*MINGW*|*MSYS*)"));
+        assert!(shim.contains("cygpath -w"));
+
+        // Verify node execution paths
+        assert!(shim.contains("if [ -x \"$basedir/node\" ]"));
+        assert!(shim.contains("exec \"$basedir/node\" \"$basedir/lib/cli.js\" \"$@\""));
+        assert!(shim.contains("exec node \"$basedir/lib/cli.js\" \"$@\""));
+    }
+
+    #[tokio::test]
+    async fn test_cmd_shim_content_validation() {
+        let shim = cmd_shim("lib/cli.js");
+
+        // Verify Windows batch commands
+        assert!(shim.starts_with("@SETLOCAL"));
+        assert!(shim.contains("@IF EXIST \"%~dp0\\node.exe\""));
+        assert!(shim.contains("\"%~dp0\\node.exe\" \"%~dp0\\lib\\cli.js\" %*"));
+        assert!(shim.contains("@SET PATHEXT=%PATHEXT:;.JS;=;%"));
+        assert!(shim.contains("node \"%~dp0\\lib\\cli.js\" %*"));
+
+        // Verify line endings are Windows-style
+        assert!(shim.contains("\r\n"));
+        assert!(!shim.contains("\n\n")); // No double Unix line endings
+    }
+
+    #[tokio::test]
+    async fn test_pwsh_shim_content_validation() {
+        let shim = pwsh_shim("lib/cli.js");
+
+        // Verify shebang
+        assert!(shim.starts_with("#!/usr/bin/env pwsh"));
+
+        // Verify PowerShell version handling
+        assert!(shim.contains("$PSVersionTable.PSVersion -lt \"6.0\""));
+        assert!(shim.contains("$IsWindows"));
+
+        // Verify execution paths
+        assert!(shim.contains("Test-Path \"$basedir/node$exe\""));
+        assert!(shim.contains("& \"$basedir/node$exe\" \"$basedir/lib/cli.js\" $args"));
+
+        // Verify pipeline input support
+        assert!(shim.contains("$MyInvocation.ExpectingInput"));
+        assert!(shim.contains("$input |"));
+
+        // Verify exit code handling
+        assert!(shim.contains("$ret=$LASTEXITCODE"));
+        assert!(shim.contains("exit $ret"));
+    }
+
+    #[tokio::test]
+    async fn test_write_shims_error_handling() {
+        // Test with invalid path (no parent directory)
+        let temp_dir = TempDir::new().unwrap();
+        let source = temp_dir.path().join("source.js");
+        let target = temp_dir.path().join("non").join("existent").join("path").join("target");
+
+        // This should fail because parent directory doesn't exist
+        let result = write_shims(&source, &target).await;
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_cmd_shim_path_separator_conversion() {
+        // Test forward slashes are converted to backslashes
+        let shim = cmd_shim("node_modules/.bin/tool.js");
+        assert!(shim.contains("node_modules\\.bin\\tool.js"));
+        assert!(!shim.contains("node_modules/.bin/tool.js"));
+
+        // Test multiple levels
+        let shim = cmd_shim("a/b/c/d.js");
+        assert!(shim.contains("a\\b\\c\\d.js"));
+        assert!(!shim.contains("a/b/c/d.js"));
+    }
+
+    #[test]
+    fn test_relative_path_formats() {
+        // Test various relative path formats work correctly
+        let paths = vec![
+            "../script.js",
+            "../../lib/cli.js",
+            "../../../node_modules/.bin/tool.js",
+            "script.js",
+            "./script.js",
+        ];
+
+        for path in paths {
+            let sh = sh_shim(path);
+            assert!(sh.contains(path));
+
+            let ps1 = pwsh_shim(path);
+            assert!(ps1.contains(path));
+
+            let cmd = cmd_shim(path);
+            let expected_cmd_path = path.replace("/", "\\");
+            assert!(cmd.contains(&expected_cmd_path));
+        }
+    }
+}

--- a/crates/vite_path/src/absolute.rs
+++ b/crates/vite_path/src/absolute.rs
@@ -1,5 +1,6 @@
 use ref_cast::{RefCastCustom, ref_cast_custom};
 use std::{
+    ffi::OsStr,
     fmt::Display,
     ops::Deref,
     path::{Path, PathBuf},
@@ -84,6 +85,17 @@ impl AbsolutePath {
     pub fn parent(&self) -> Option<&AbsolutePath> {
         let parent_path = self.0.parent()?;
         Some(unsafe { AbsolutePath::assume_absolute(parent_path) })
+    }
+
+    /// Creates an owned [`AbsolutePathBuf`] like `self` but with the extension added.
+    pub fn with_extension<S: AsRef<OsStr>>(&self, extension: S) -> AbsolutePathBuf {
+        let path = self.0.with_extension(extension);
+        unsafe { AbsolutePathBuf::assume_absolute(path) }
+    }
+
+    /// Returns true if `self` ends with `path`.
+    pub fn ends_with<P: AsRef<Path>>(&self, path: P) -> bool {
+        self.0.ends_with(path.as_ref())
     }
 }
 
@@ -262,5 +274,16 @@ mod tests {
 
         assert_eq!(err.stripped_path.as_os_str().as_bytes(), &[0xC0]);
         let_assert!(InvalidPathDataError::NonUtf8 = err.invalid_path_data_error);
+    }
+
+    #[test]
+    fn with_extension() {
+        let abs_path = AbsolutePath::new(Path::new("/home/foo/bar")).unwrap();
+        let abs_path_with_extension = abs_path.with_extension("txt");
+        assert_eq!(abs_path_with_extension.as_path().as_os_str(), "/home/foo/bar.txt");
+        let abs_path_with_extension = abs_path.with_extension("txt").with_extension("tgz");
+        assert_eq!(abs_path_with_extension.as_path().as_os_str(), "/home/foo/bar.tgz");
+        // abs_path is not changed
+        assert_eq!(abs_path.as_path().as_os_str(), "/home/foo/bar");
     }
 }

--- a/crates/vite_task/Cargo.toml
+++ b/crates/vite_task/Cargo.toml
@@ -22,6 +22,7 @@ brush-parser = { workspace = true }
 bstr = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 compact_str = { workspace = true, features = ["serde"] }
+crossterm = { workspace = true }
 dashmap = { workspace = true }
 diff-struct = { workspace = true }
 edit = { workspace = true }
@@ -53,4 +54,6 @@ vite_error = { workspace = true }
 nix = { workspace = true }
 
 [dev-dependencies]
+serial_test = { workspace = true }
 tempfile = { workspace = true }
+test-log = { workspace = true }

--- a/crates/vite_task/docs/vite-install.md
+++ b/crates/vite_task/docs/vite-install.md
@@ -1,0 +1,361 @@
+# `vite-plus install`
+
+## Overview
+
+`vite install` will automatically select the most suitable packageManager based on the current directory configuration, then run its install command, and generate a new fingerprint.
+
+Currently only pnpm, yarn, and npm are supported. More package managers like bun, [vlt](https://docs.vlt.sh/cli/commands/install), lerna*,* etc. will be considered in the future.
+
+> Assume the current running environment has at least `node` installed
+
+## Detect workspace root directory
+
+User maybe run `vite install` in a workspace subdirectory, we need to relocate to the workspace root directory to run.
+
+### monorepo
+
+Search for workspace information from the current directory. If not found, search in the parent directory, all the way up to the operating system root directory.
+
+Workspace root detection priority:
+
+- `pnpm-workspace.yaml` file exists
+- `package.json` file exists and `workspaces` field exists on it
+
+If no workspace identification information is found, it indicates that the current project is not a monorepo and should be treated as a normal repo.
+
+Examples
+
+/path/to/pnpm-worksapce.yaml
+
+```yaml
+packages:
+  - "packages/*"
+  - "apps/*"
+  - "!**/test/**"
+```
+
+/path/to/package.json
+
+```json
+{
+  "name": "my-monorepo",
+  "version": "1.0.0",
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ]
+}
+```
+
+### normal repo
+
+Starting from the current directory, recursively search upwards to find the directory containing the `package.json` file as the workspace root; if not found, use the current directory as the workspace root.
+
+## Detect package manager
+
+Package manager detection priority:
+
+- `packageManager` field in `package.json` , got `{pm}@{version}`
+- `devEngines.packageManager` field in `package.json` (WIP)
+- `pnpm-lock.yaml` or `pnpm-workspace.yaml` file exists ⇒ `pnpm@latest`
+- `yarn.lock` or `.yarnrc.yml` file exists ⇒ `yarn@latest`
+- `package-lock.json` exists ⇒ `npm@latest`
+- `pnpmfile.cjs` exists ⇒ `pnpm@latest`
+- `yarn.config.cjs` exists ⇒ `yarn@latest`, support in yarn 2.0+
+- List pnpm/yarn/npm to let user choice and recommend user to use `pnpm@latest` by default
+
+If `packageManager` filed not exists on package.json, it will auto filled correctly after install run.
+
+## Install package manager
+
+If the detected package manager does not exist, we will download and use it locally.
+
+We will install the package manager in a local directory without polluting the user's global installation.
+
+Also need to [make shims](https://github.com/nodejs/corepack/blob/main/mkshims.ts) like corepack does.
+
+## Run `pm install` and collect fingerprint
+
+When running `pm install`, it will use the same approach as vite task to collect fingerprints. Since the install process generates a huge node_modules, specific special filtering will be applied.
+
+The ignored paths are as follows:
+
+- All paths under the node_modules directory, but will retain the first-level filename list of node_modules as a fingerprint
+- Paths that are not within the `cwd` scope
+
+## Manual execution
+
+If the user want their modifications to be cleaned up by a fresh install, they should manually run `vite install`. It will ignore cache checks and re-execute `pm install`, generating a new fingerprint.
+
+## Auto execution
+
+The `vite install` task will be auto-executed or quickly skipped at the beginning of any other vite+ command, eliminating the need for the user to run it manually in most cases.
+
+### No replay when cache hit
+
+The auto-executed `vite install` task will not replay stdout after hitting the cache, to avoid interfering with the real execution of the command.
+
+## Architecture
+
+### Install Execution Flow
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                    Install Execution Flow                    │
+├──────────────────────────────────────────────────────────────┤
+│                                                              │
+│  1. Install Request                                          │
+│  ──────────────────                                          │
+│    vite install [args]                                       │
+│         │                                                    │
+│         ▼                                                    │
+│  2. Workspace Detection                                      │
+│  ──────────────────────                                      │
+│    • Check pnpm-workspace.yaml                               │
+│    • Check package.json#workspaces                           │
+│    • Search upward for package.json                          │
+│         │                                                    │
+│         ▼                                                    │
+│  3. Package Manager Detection                                │
+│  ────────────────────────────                                │
+│    ┌──────────────────────┬────────────────┐                 │
+│    │ packageManager field │   Lock Files   │                 │
+│    └──────────┬───────────┴────────┬───────┘                 │
+│               │                     │                        │
+│               ▼                     ▼                        │
+│  4a. Parse pm@version    4b. Infer from locks                │
+│  ────────────────────    ────────────────────                │
+│    • pnpm@8.15.0           • pnpm-lock.yaml → pnpm           │
+│    • yarn@4.0.0            • yarn.lock → yarn                │
+│    • npm@10.0.0            • package-lock.json → npm         │
+│               │                     │                        │
+│               └──────────┬──────────┘                        │
+│                          │                                   │
+│                          ▼                                   │
+│  5. Package Manager Installation                             │
+│  ────────────────────────────────                            │
+│    • Check local cache for pm@version                        │
+│    • Download if missing (with retry)                        │
+│    • Extract and create shims                                │
+│    • Update PATH environment                                 │
+│         │                                                    │
+│         ▼                                                    │
+│  6. Execute Install Command                                  │
+│  ──────────────────────────                                  │
+│    • Run: {pm} install [args]                                │
+│    • Monitor with fspy                                       │
+│    • Capture stdout/stderr                                   │
+│         │                                                    │
+│         ▼                                                    │
+│  7. Fingerprint Collection                                   │
+│  ─────────────────────────                                   │
+│    • Hash package.json                                       │
+│    • Hash lock file                                          │
+│    • List node_modules/* (names only)                        │
+│         │                                                    │
+│         ▼                                                    │
+│  8. Cache Storage                                            │
+│  ────────────────                                            │
+│    • Save fingerprint                                        │
+│    • Store outputs                                           │
+│    • Update packageManager field                             │
+│                                                              │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### Package Manager Resolution
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                 Package Manager Resolution                   │
+├──────────────────────────────────────────────────────────────┤
+│                                                              │
+│  Priority Order:                                             │
+│  ──────────────                                              │
+│    1. package.json#packageManager                            │
+│    2. pnpm-workspace.yaml exists                             │
+│    3. Lock file detection                                    │
+│    4. User selection (interactive)                           │
+│         │                                                    │
+│         ▼                                                    │
+│  Detection Flow:                                             │
+│  ──────────────                                              │
+│                                                              │
+│    package.json                                              │
+│         │                                                    │
+│         ├─► packageManager: "pnpm@8.15.0"                    │
+│         │   └─► Use exact version                            │
+│         │                                                    │
+│         └─► No packageManager field                          │
+│             │                                                │
+│             ├─► pnpm-workspace.yaml exists?                  │
+│             │   └─► pnpm@latest                              │
+│             │                                                │
+│             ├─► pnpm-lock.yaml exists?                       │
+│             │   └─► pnpm@latest                              │
+│             │                                                │
+│             ├─► yarn.lock exists?                            │
+│             │   └─► yarn@latest                              │
+│             │                                                │
+│             ├─► package-lock.json exists?                    │
+│             │   └─► npm@latest                               │
+│             │                                                │
+│             └─► No indicators found                          │
+│                 │                                            │
+│                 ├─► CI environment?                          │
+│                 │   └─► Auto-select pnpm                     │
+│                 │                                            │
+│                 ├─► Non-TTY?                                 │
+│                 │   └─► Auto-select pnpm                     │
+│                 │                                            │
+│                 └─► Interactive menu                         │
+│                     └─► User selects                         │
+│                                                              │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### Package Manager Download & Setup
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│              Package Manager Download & Setup                │
+├──────────────────────────────────────────────────────────────┤
+│                                                              │
+│  1. Cache Check                                              │
+│  ─────────────                                               │
+│    $CACHE_DIR/vite/package_manager/{pm}/{version}/          │
+│         │                                                    │
+│         ├─► Exists? → Use cached                             │
+│         │                                                    │
+│         └─► Missing? → Download                              │
+│                  │                                           │
+│                  ▼                                           │
+│  2. Download with Retry                                      │
+│  ──────────────────────                                      │
+│    GET https://registry.npmjs.org/{package}/-/              │
+│        {package}-{version}.tgz                               │
+│         │                                                    │
+│         ├─► Success → Extract                                │
+│         │                                                    │
+│         └─► Failed → Retry with backoff                      │
+│             • 1st retry: wait 1s                             │
+│             • 2nd retry: wait 2s                             │
+│             • 3rd retry: wait 4s                             │
+│                  │                                           │
+│                  ▼                                           │
+│  3. Extract & Setup                                          │
+│  ─────────────────                                           │
+│    • Extract tgz to temp dir                                 │
+│    • Rename package/ to {pm}/                                │
+│    • Atomic move to cache dir                                │
+│         │                                                    │
+│         ▼                                                    │
+│  4. Create Shims                                             │
+│  ──────────────                                              │
+│    For each binary:                                          │
+│    • Create Unix shell script (.sh)                          │
+│    • Create Windows batch (.cmd)                             │
+│    • Create PowerShell script (.ps1)                         │
+│         │                                                    │
+│         ▼                                                    │
+│  Shim Structure:                                             │
+│  ──────────────                                              │
+│    bin/                                                      │
+│    ├── pnpm         → ../pnpm.cjs                            │
+│    ├── pnpm.cmd     → ..\pnpm.cjs                            │
+│    ├── pnpm.ps1     → ../pnpm.cjs                            │
+│    ├── pnpx         → ../pnpx.cjs                            │
+│    ├── pnpx.cmd     → ..\pnpx.cjs                            │
+│    └── pnpx.ps1     → ../pnpx.cjs                            │
+│                                                              │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### Fingerprint Generation
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                   Fingerprint Generation                     │
+├──────────────────────────────────────────────────────────────┤
+│                                                              │
+│  Install Fingerprint Components:                             │
+│  ───────────────────────────────                             │
+│                                                              │
+│  1. Configuration Files                                      │
+│  ──────────────────────                                      │
+│    • package.json content hash                               │
+│    • Lock file content hash                                  │
+│    • .npmrc/.yarnrc/.pnpmfile (if exists)                    │
+│         │                                                    │
+│         ▼                                                    │
+│  2. Node Modules Structure                                   │
+│  ─────────────────────────                                   │
+│    Special handling for node_modules:                        │
+│    • Ignore file contents                                    │
+│    • Record first-level directory names only                 │
+│    • Example fingerprint:                                    │
+│      node_modules/                                           │
+│      ├── @types        (recorded)                            │
+│      ├── typescript    (recorded)                            │
+│      └── vite          (recorded)                            │
+│         │                                                    │
+│         ▼                                                    │
+│  3. Environment Context                                      │
+│  ─────────────────────                                       │
+│    • NODE_ENV value                                          │
+│    • Package manager version                                 │
+│    • Install command arguments                               │
+│         │                                                    │
+│         ▼                                                    │
+│  Fingerprint Hash:                                           │
+│  ────────────────                                            │
+│    xxHash3({                                                 │
+│      config_files + node_modules_list + env_context          │
+│    }) → 0xABCDEF123456789                                    │
+│                                                              │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### Cache Hit/Miss Behavior
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                  Cache Hit/Miss Behavior                     │
+├──────────────────────────────────────────────────────────────┤
+│                                                              │
+│  Auto-execution Mode:                                        │
+│  ───────────────────                                         │
+│                                                              │
+│    Cache Lookup                                              │
+│         │                                                    │
+│         ├─► Cache Hit                                        │
+│         │   • Skip execution                                 │
+│         │   • No output replay                               │
+│         │   • Continue to next task                          │
+│         │                                                    │
+│         └─► Cache Miss                                       │
+│             • Execute install                                │
+│             • Capture outputs                                │
+│             • Generate fingerprint                           │
+│                                                              │
+│  Manual Execution Mode (`vite install`):                     │
+│  ────────────────────────────────                            │
+│                                                              │
+│    Skip Cache                                                │
+│         │                                                    │
+│         └─► Always Execute                                   │
+│             • Run install command                            │
+│             • Generate fingerprint                           │
+│                                                              │
+│  Fingerprint Validation:                                     │
+│  ──────────────────────                                      │
+│                                                              │
+│    Compare Current vs Cached:                                │
+│    • package.json changed?        → Cache miss               │
+│    • Lock file changed?           → Cache miss               │
+│    • node_modules/* changed?      → Cache miss               │
+│    • Install args different?      → Cache miss               │
+│    • All match?                   → Cache hit                │
+│                                                              │
+└──────────────────────────────────────────────────────────────┘
+```

--- a/crates/vite_task/src/config/mod.rs
+++ b/crates/vite_task/src/config/mod.rs
@@ -114,6 +114,21 @@ impl ResolvedTask {
         args: impl Iterator<Item = impl AsRef<str>> + Clone,
     ) -> Result<Self, Error> {
         let ResolveCommandResult { bin_path, envs } = resolve_command().await?;
+        Self::resolve_from_builtin_with_command_result(
+            workspace,
+            task_name,
+            args,
+            ResolveCommandResult { bin_path, envs },
+        )
+    }
+
+    pub(crate) fn resolve_from_builtin_with_command_result(
+        workspace: &Workspace,
+        task_name: &str,
+        args: impl Iterator<Item = impl AsRef<str>> + Clone,
+        command_result: ResolveCommandResult,
+    ) -> Result<Self, Error> {
+        let ResolveCommandResult { bin_path, envs } = command_result;
         let builtin_task = TaskCommand::Parsed(TaskParsedCommand {
             args: args.clone().map(|arg| arg.as_ref().into()).collect(),
             envs: envs.into_iter().map(|(k, v)| (k.into(), v.into())).collect(),

--- a/crates/vite_task/src/install.rs
+++ b/crates/vite_task/src/install.rs
@@ -1,0 +1,421 @@
+use std::io::{self, IsTerminal, Write};
+use std::{env, iter};
+
+use crossterm::{
+    cursor,
+    event::{self, Event, KeyCode, KeyEvent},
+    execute,
+    style::{Color, Print, ResetColor, SetForegroundColor},
+    terminal,
+};
+use petgraph::stable_graph::StableGraph;
+
+use crate::config::ResolvedTask;
+use crate::schedule::ExecutionPlan;
+use crate::{Error, ResolveCommandResult, Workspace};
+use vite_package_manager::package_manager::{PackageManager, PackageManagerType};
+use vite_path::AbsolutePathBuf;
+
+/// Install command.
+///
+/// This is the command that will be executed by the `vite-plus install` command.
+///
+pub struct InstallCommand {
+    workspace_root: AbsolutePathBuf,
+}
+
+/// Install command builder.
+///
+/// This is a builder pattern for the `vite-plus install` command.
+///
+pub struct InstallCommandBuilder {
+    workspace_root: AbsolutePathBuf,
+}
+
+impl InstallCommand {
+    pub fn builder(workspace_root: AbsolutePathBuf) -> InstallCommandBuilder {
+        InstallCommandBuilder::new(workspace_root)
+    }
+
+    pub async fn execute(self, args: &Vec<String>) -> Result<(), Error> {
+        // Handle UnrecognizedPackageManager error and let user select a package manager
+        let package_manager = match PackageManager::builder(&self.workspace_root).build().await {
+            Ok(pm) => pm,
+            Err(Error::UnrecognizedPackageManager) => {
+                // Prompt user to select a package manager
+                let selected_type = prompt_package_manager_selection()?;
+                PackageManager::builder(&self.workspace_root)
+                    .package_manager_type(selected_type)
+                    .build()
+                    .await?
+            }
+            Err(e) => return Err(e),
+        };
+        let mut workspace = Workspace::partial_load(self.workspace_root)?;
+        let resolve_command = package_manager.resolve_command();
+        let resolved_task = ResolvedTask::resolve_from_builtin_with_command_result(
+            &workspace,
+            "install",
+            iter::once("install").chain(args.iter().map(String::as_str)),
+            ResolveCommandResult { bin_path: resolve_command.bin_path, envs: resolve_command.envs },
+        )?;
+        let mut task_graph: StableGraph<ResolvedTask, ()> = Default::default();
+        task_graph.add_node(resolved_task);
+        ExecutionPlan::plan(task_graph, false)?.execute(&mut workspace).await?;
+        workspace.unload().await?;
+
+        Ok(())
+    }
+}
+
+impl InstallCommandBuilder {
+    pub fn new(workspace_root: AbsolutePathBuf) -> Self {
+        Self { workspace_root }
+    }
+
+    pub fn build(self) -> InstallCommand {
+        InstallCommand { workspace_root: self.workspace_root }
+    }
+}
+
+/// Common CI environment variables
+const CI_ENV_VARS: &[&str] = &[
+    "CI",
+    "CONTINUOUS_INTEGRATION",
+    "GITHUB_ACTIONS",
+    "GITLAB_CI",
+    "CIRCLECI",
+    "TRAVIS",
+    "JENKINS_URL",
+    "BUILDKITE",
+    "DRONE",
+    "CODEBUILD_BUILD_ID", // AWS CodeBuild
+    "TF_BUILD",           // Azure Pipelines
+];
+
+/// Check if running in a CI environment
+fn is_ci_environment() -> bool {
+    CI_ENV_VARS.iter().any(|key| env::var(key).is_ok())
+}
+
+/// Interactive menu for selecting a package manager with keyboard navigation
+fn interactive_package_manager_menu() -> Result<PackageManagerType, Error> {
+    let options = vec![
+        ("pnpm (recommended)", PackageManagerType::Pnpm),
+        ("npm", PackageManagerType::Npm),
+        ("yarn", PackageManagerType::Yarn),
+    ];
+
+    let mut selected_index = 0;
+
+    // Print header and instructions with proper line breaks
+    println!("\n📦 No package manager detected. Please select one:");
+    println!(
+        "   Use ↑↓ arrows to navigate, Enter to select, 1-{} for quick selection",
+        options.len()
+    );
+    println!("   Press Esc, q, or Ctrl+C to cancel installation\n");
+
+    // Enable raw mode for keyboard input
+    terminal::enable_raw_mode()?;
+
+    // Clear the selection area and hide cursor
+    execute!(io::stdout(), cursor::Hide)?;
+
+    let result = loop {
+        // Display menu with current selection
+        for (i, (name, _)) in options.iter().enumerate() {
+            execute!(io::stdout(), cursor::MoveToColumn(2))?;
+
+            if i == selected_index {
+                // Highlight selected item
+                execute!(
+                    io::stdout(),
+                    SetForegroundColor(Color::Cyan),
+                    Print("▶ "),
+                    Print(format!("[{}] ", i + 1)),
+                    Print(name),
+                    ResetColor,
+                    Print(" ← ")
+                )?;
+            } else {
+                execute!(
+                    io::stdout(),
+                    Print("  "),
+                    SetForegroundColor(Color::DarkGrey),
+                    Print(format!("[{}] ", i + 1)),
+                    ResetColor,
+                    Print(name),
+                    Print("   ")
+                )?;
+            }
+
+            if i < options.len() - 1 {
+                execute!(io::stdout(), Print("\n"))?;
+            }
+        }
+
+        // Move cursor back up for next iteration
+        if options.len() > 1 {
+            execute!(io::stdout(), cursor::MoveUp((options.len() - 1) as u16))?;
+        }
+
+        // Read keyboard input
+        if let Event::Key(KeyEvent { code, modifiers, .. }) = event::read()? {
+            match code {
+                // Handle Ctrl+C for exit
+                KeyCode::Char('c') if modifiers.contains(event::KeyModifiers::CONTROL) => {
+                    // Clean up terminal before exiting
+                    terminal::disable_raw_mode()?;
+                    execute!(
+                        io::stdout(),
+                        cursor::Show,
+                        cursor::MoveDown(options.len() as u16),
+                        Print("\n\n"),
+                        SetForegroundColor(Color::Yellow),
+                        Print("⚠ Installation cancelled by user\n"),
+                        ResetColor
+                    )?;
+                    return Err(Error::UserCancelled);
+                }
+                KeyCode::Up => {
+                    if selected_index > 0 {
+                        selected_index -= 1;
+                    }
+                }
+                KeyCode::Down => {
+                    if selected_index < options.len() - 1 {
+                        selected_index += 1;
+                    }
+                }
+                KeyCode::Enter | KeyCode::Char(' ') => {
+                    break Ok(options[selected_index].1.clone());
+                }
+                KeyCode::Char('1') => {
+                    break Ok(options[0].1.clone());
+                }
+                KeyCode::Char('2') if options.len() > 1 => {
+                    break Ok(options[1].1.clone());
+                }
+                KeyCode::Char('3') if options.len() > 2 => {
+                    break Ok(options[2].1.clone());
+                }
+                KeyCode::Esc | KeyCode::Char('q') => {
+                    // Exit on escape/quit
+                    terminal::disable_raw_mode()?;
+                    execute!(
+                        io::stdout(),
+                        cursor::Show,
+                        cursor::MoveDown(options.len() as u16),
+                        Print("\n\n"),
+                        SetForegroundColor(Color::Yellow),
+                        Print("⚠ Installation cancelled by user\n"),
+                        ResetColor
+                    )?;
+                    return Err(Error::UserCancelled);
+                }
+                _ => {}
+            }
+        }
+    };
+
+    // Clean up: disable raw mode and show cursor
+    terminal::disable_raw_mode()?;
+    execute!(io::stdout(), cursor::Show, cursor::MoveDown(options.len() as u16), Print("\n"))?;
+
+    // Print selection confirmation
+    match &result {
+        Ok(pm) => {
+            let name = match pm {
+                PackageManagerType::Pnpm => "pnpm",
+                PackageManagerType::Npm => "npm",
+                PackageManagerType::Yarn => "yarn",
+            };
+            println!("\n✓ Selected package manager: {}\n", name);
+        }
+        Err(_) => {}
+    }
+
+    result
+}
+
+/// Prompt the user to select a package manager
+fn prompt_package_manager_selection() -> Result<PackageManagerType, Error> {
+    // In CI environment, automatically use pnpm without prompting
+    if is_ci_environment() {
+        println!("CI environment detected. Using default package manager: pnpm");
+        return Ok(PackageManagerType::Pnpm);
+    }
+
+    // Check if stdin is a TTY (terminal) - if not, use default
+    if !io::stdin().is_terminal() {
+        println!("Non-interactive environment detected. Using default package manager: pnpm");
+        return Ok(PackageManagerType::Pnpm);
+    }
+
+    // Try interactive menu first, fall back to simple prompt on error
+    match interactive_package_manager_menu() {
+        Ok(pm) => Ok(pm),
+        Err(err) => {
+            match err {
+                Error::UserCancelled => return Err(err),
+                // Fallback to simple text prompt if interactive menu fails
+                _ => simple_text_prompt(),
+            }
+        }
+    }
+}
+
+/// Simple text-based prompt as fallback
+fn simple_text_prompt() -> Result<PackageManagerType, Error> {
+    let managers = vec![
+        ("pnpm", PackageManagerType::Pnpm),
+        ("npm", PackageManagerType::Npm),
+        ("yarn", PackageManagerType::Yarn),
+    ];
+
+    println!("\nNo package manager detected. Please select one:");
+    println!("────────────────────────────────────────────────");
+
+    for (i, (name, _)) in managers.iter().enumerate() {
+        if i == 0 {
+            println!("  [{}] {} (recommended)", i + 1, name);
+        } else {
+            println!("  [{}] {}", i + 1, name);
+        }
+    }
+
+    print!("\nEnter your choice (1-{}) [default: 1]: ", managers.len());
+    io::stdout().flush()?;
+
+    let mut input = String::new();
+    io::stdin().read_line(&mut input)?;
+
+    let choice = input.trim();
+    let index = if choice.is_empty() {
+        0 // Default to pnpm
+    } else {
+        choice
+            .parse::<usize>()
+            .ok()
+            .and_then(|n| if n > 0 && n <= managers.len() { Some(n - 1) } else { None })
+            .unwrap_or(0) // Default to pnpm if invalid input
+    };
+
+    let (name, selected_type) = &managers[index];
+    println!("✓ Selected package manager: {}\n", name);
+
+    Ok(selected_type.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::{fs, path::PathBuf};
+    use tempfile::TempDir;
+
+    /// Helper struct to safely manage environment variables in tests
+    /// This struct ensures that environment variables are properly restored
+    /// after the test completes, even if the test panics.
+    struct EnvGuard {
+        key: String,
+        original_value: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn new(key: &str, value: &str) -> Self {
+            let original_value = env::var(key).ok();
+            // SAFETY: This is only used in tests which are run serially,
+            // preventing data races on environment variables
+            unsafe {
+                env::set_var(key, value);
+            }
+            Self { key: key.to_string(), original_value }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: This is only used in tests which are run serially,
+            // preventing data races on environment variables
+            unsafe {
+                match &self.original_value {
+                    Some(value) => env::set_var(&self.key, value),
+                    None => env::remove_var(&self.key),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_install_command_builder_build() {
+        let workspace_root = AbsolutePathBuf::new(PathBuf::from("/test/workspace")).unwrap();
+        let command = InstallCommandBuilder::new(workspace_root.clone()).build();
+
+        assert_eq!(command.workspace_root, workspace_root);
+    }
+
+    #[ignore = "skip this test for auto run, should be run manually, because it will prompt for user selection"]
+    #[tokio::test]
+    async fn test_install_command_with_package_json_without_package_manager() {
+        let temp_dir = TempDir::new().unwrap();
+        let workspace_root = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+
+        // Create a minimal package.json
+        let package_json = r#"{
+            "name": "test-package",
+            "version": "1.0.0"
+        }"#;
+        fs::write(workspace_root.join("package.json"), package_json).unwrap();
+
+        let command = InstallCommandBuilder::new(workspace_root).build();
+        assert!(command.execute(&vec![]).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_install_command_with_package_json_with_package_manager() {
+        let temp_dir = TempDir::new().unwrap();
+        let workspace_root = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+
+        // Create a minimal package.json
+        let package_json = r#"{
+            "name": "test-package",
+            "version": "1.0.0",
+            "packageManager": "pnpm@10.15.0"
+        }"#;
+        fs::write(workspace_root.join("package.json"), package_json).unwrap();
+
+        let command = InstallCommandBuilder::new(workspace_root).build();
+        let result = command.execute(&vec![]).await;
+        println!("result: {:?}", result);
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_install_command_execute_with_invalid_workspace() {
+        let temp_dir = TempDir::new().unwrap();
+        let workspace_root = AbsolutePathBuf::new(temp_dir.path().join("nonexistent")).unwrap();
+
+        let command = InstallCommandBuilder::new(workspace_root).build();
+        let args = vec![];
+
+        let result = command.execute(&args).await;
+        assert!(matches!(result.unwrap_err(), Error::PackageJsonNotFound(_)));
+    }
+
+    /// Test that in CI environment, we will use pnpm without prompting
+    #[test]
+    #[serial] // Run serially to avoid race conditions with environment variables
+    fn test_prompt_package_manager_in_ci() {
+        // Use EnvGuard to safely manage the CI environment variable
+        let _guard = EnvGuard::new("CI", "true");
+
+        // Should return pnpm without prompting
+        let result = prompt_package_manager_selection();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), PackageManagerType::Pnpm);
+
+        // EnvGuard will automatically restore the original value when dropped
+    }
+}

--- a/crates/vite_task/src/lib.rs
+++ b/crates/vite_task/src/lib.rs
@@ -5,6 +5,7 @@ mod config;
 mod execute;
 mod fingerprint;
 mod fs;
+mod install;
 mod lint;
 mod maybe_str;
 mod schedule;
@@ -88,6 +89,11 @@ pub enum Commands {
     Test {
         #[clap(last = true)]
         /// Arguments to pass to vite test
+        args: Vec<String>,
+    },
+    Install {
+        #[clap(last = true)]
+        /// Arguments to pass to vite install
         args: Vec<String>,
     },
 }
@@ -215,6 +221,10 @@ pub async fn main<
                 test::test(test_fn, &mut workspace, args).await?;
                 workspace.unload().await?;
             }
+            return Ok(());
+        }
+        Some(Commands::Install { args }) => {
+            install::InstallCommand::builder(cwd).build().execute(&args).await?;
             return Ok(());
         }
         None => {

--- a/crates/vite_task/src/main.rs
+++ b/crates/vite_task/src/main.rs
@@ -1,14 +1,23 @@
 use vite_path::current_dir;
 
 use clap::Parser as _;
-use vite_task::{Args, CliOptions, init_tracing};
 
 use vite_error::Error;
+use vite_task::{Args, CliOptions, init_tracing};
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     init_tracing();
 
     let args = Args::parse();
-    vite_task::main(current_dir()?, args, None::<CliOptions>).await
+    match vite_task::main(current_dir()?, args, None::<CliOptions>).await {
+        Ok(()) => Ok(()),
+        Err(err) => {
+            tracing::error!("Error: {}", err);
+            match err {
+                Error::UserCancelled => std::process::exit(130), // Standard exit code for Ctrl+C
+                _ => return Err(err),
+            }
+        }
+    }
 }


### PR DESCRIPTION
Implements a comprehensive package manager installation system that automatically detects and downloads the appropriate package manager (npm, yarn, pnpm) based on lockfiles, configuration files, and package.json settings.

Key features:
- Automatic package manager detection from multiple sources
- Support for pnpm, yarn (including v2+), and npm
- Intelligent version resolution with semver support
- Automatic shim generation for cross-platform compatibility
- HTTP client with automatic retry support using backon
- Workspace root and package root detection utilities
- Path filtering for cache optimization using gitignore-style patterns
- Comprehensive test coverage with mocked HTTP requests

Detection priority order:
1. packageManager field in package.json
2. pnpm-workspace.yaml
3. Lock files (pnpm-lock.yaml, yarn.lock, package-lock.json)
4. Config files (pnpmfile.cjs, yarn.config.cjs, .yarnrc.yml)

The implementation ensures consistent package manager usage across the monorepo and automatically updates the packageManager field when detecting from other sources.

🤖 Generated with [Claude Code](https://claude.ai/code)