### PR TITLE
feat: support color on task run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,6 +1609,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3028,6 +3034,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "supports-color"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+dependencies = [
+ "is_ci",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3579,6 +3594,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shell-escape",
+ "supports-color",
  "tempfile",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,18 +45,18 @@ dashmap = "6.1.0"
 diff-struct = "0.5.3"
 directories = "6.0.0"
 edit = "0.1.5"
-fspy_shared = { path = "crates/fspy_shared" }
 fspy = { path = "crates/fspy" }
-fspy_shared_unix = { path = "crates/fspy_shared_unix"}
-fspy_seccomp_unotify = { path = "crates/fspy_seccomp_unotify" }
 fspy_preload_unix = { path = "crates/fspy_preload_unix", artifact = "cdylib" }
 fspy_preload_windows = { path = "crates/fspy_preload_windows", artifact = "cdylib" }
-passfd = { git = "https://github.com/polachok/passfd", rev = "d55881752c16aced1a49a75f9c428d38d3767213", default-features = false }
+fspy_seccomp_unotify = { path = "crates/fspy_seccomp_unotify" }
+fspy_shared = { path = "crates/fspy_shared" }
+fspy_shared_unix = { path = "crates/fspy_shared_unix" }
 futures = "0.3.31"
 futures-core = "0.3.31"
 futures-util = "0.3.31"
 itertools = "0.14.0"
 nix = { version = "0.30.1", features = ["dir"] }
+passfd = { git = "https://github.com/polachok/passfd", rev = "d55881752c16aced1a49a75f9c428d38d3767213", default-features = false }
 petgraph = "0.8.2"
 portable-pty = "0.9.0"
 ratatui = "0.29.0"
@@ -69,6 +69,7 @@ serde = "1.0.219"
 serde_json = "1.0.140"
 serde_yml = "0.0.12"
 shell-escape = "0.1.5"
+supports-color = "3.0.1"
 tempfile = "3.14.0"
 thiserror = "2"
 tokio = "1.46.1"
@@ -80,9 +81,9 @@ tui-term = "0.2.0"
 twox-hash = "2.1.1"
 vite_error = { path = "crates/vite_error" }
 vite_package_manager = { path = "crates/vite_package_manager" }
-vite_task = { path = "crates/vite_task" }
-vite_str = { path = "crates/vite_str" }
 vite_path = { path = "crates/vite_path" }
+vite_str = { path = "crates/vite_str" }
+vite_task = { path = "crates/vite_task" }
 wax = "0.6.0"
 wildmatch = "2.4.0"
 

--- a/crates/vite_task/Cargo.toml
+++ b/crates/vite_task/Cargo.toml
@@ -36,6 +36,7 @@ rusqlite = { workspace = true, features = ["bundled"] }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
 shell-escape = { workspace = true }
+supports-color = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "io-std", "macros"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/vite_task/src/execute.rs
+++ b/crates/vite_task/src/execute.rs
@@ -11,6 +11,7 @@ use std::{
 use anyhow::Context;
 use bincode::{Decode, Encode};
 use fspy::{AccessMode, Spy, TrackedChild};
+use supports_color::{Stream, on};
 
 use futures_util::future::try_join4;
 use serde::{Deserialize, Serialize};
@@ -159,6 +160,7 @@ fn is_default_passthrough_env(name: &str) -> bool {
         "TERM",
         "TERM_PROGRAM",
         "DISPLAY",
+        "FORCE_COLOR",
         // Temporary directories
         "TMP",
         "TEMP",
@@ -244,6 +246,27 @@ impl TaskEnvs {
                 .chain(paths),
         )?
         .into();
+
+        // Automatically add FORCE_COLOR environment variable if not already set
+        // This enables color output in subprocesses when color is supported
+        // TODO: will remove this temporarily until we have a better solution
+        if !all_envs.contains_key("FORCE_COLOR") {
+            if let Some(support) = on(Stream::Stdout) {
+                let force_color_value = if support.has_16m {
+                    "3" // True color (16 million colors)
+                } else if support.has_256 {
+                    "2" // 256 colors
+                } else if support.has_basic {
+                    "1" // Basic ANSI colors
+                } else {
+                    "0" // No color support
+                };
+                all_envs.insert(
+                    "FORCE_COLOR".into(),
+                    Arc::<OsStr>::from(OsStr::new(force_color_value)),
+                );
+            }
+        }
 
         Ok(Self { all_envs, envs_without_pass_through })
     }
@@ -436,6 +459,9 @@ mod tests {
         assert!(!is_default_passthrough_env("RANDOM_ENV"));
         assert!(!is_default_passthrough_env("MY_SECRET"));
 
+        // Test FORCE_COLOR is a passthrough env
+        assert!(is_default_passthrough_env("FORCE_COLOR"));
+
         // Test edge cases
         assert!(!is_default_passthrough_env("VSCODE")); // Should not match without underscore
         assert!(!is_default_passthrough_env("DOCKER")); // Should not match without underscore
@@ -508,6 +534,62 @@ mod tests {
             std::env::remove_var("ALPHA_VAR");
             std::env::remove_var("MIDDLE_VAR");
             std::env::remove_var("BETA_VAR");
+        }
+    }
+
+    #[test]
+    fn test_force_color_auto_detection() {
+        use crate::collections::HashSet;
+        use crate::config::{ResolvedTaskConfig, TaskCommand, TaskConfig};
+        use std::path::Path;
+
+        let task_config = TaskConfig {
+            command: TaskCommand::ShellScript("echo test".into()),
+            cwd: ".".into(),
+            cacheable: true,
+            inputs: HashSet::new(),
+            envs: HashSet::new(),
+            pass_through_envs: HashSet::new(),
+        };
+
+        let resolved_task_config =
+            ResolvedTaskConfig { config_dir: ".".into(), config: task_config };
+
+        // Test when FORCE_COLOR is not already set
+        unsafe {
+            std::env::remove_var("FORCE_COLOR");
+        }
+
+        let result = TaskEnvs::resolve(Path::new("."), &resolved_task_config).unwrap();
+
+        // FORCE_COLOR should be automatically added if color is supported
+        // Note: This test might vary based on the test environment
+        let force_color_present = result.all_envs.contains_key("FORCE_COLOR");
+        if force_color_present {
+            let force_color_value = result.all_envs.get("FORCE_COLOR").unwrap();
+            let force_color_str = force_color_value.to_str().unwrap();
+            // Should be a valid FORCE_COLOR level
+            assert!(matches!(force_color_str, "0" | "1" | "2" | "3"));
+        }
+
+        // Test when FORCE_COLOR is already set - should not be overridden
+        unsafe {
+            std::env::set_var("FORCE_COLOR", "2");
+        }
+
+        let result2 = TaskEnvs::resolve(Path::new("."), &resolved_task_config).unwrap();
+
+        // Should contain the original FORCE_COLOR value
+        assert!(result2.all_envs.contains_key("FORCE_COLOR"));
+        let force_color_value = result2.all_envs.get("FORCE_COLOR").unwrap();
+        assert_eq!(force_color_value.to_str().unwrap(), "2");
+
+        // FORCE_COLOR should not be in envs_without_pass_through since it's a passthrough env
+        assert!(!result2.envs_without_pass_through.contains_key("FORCE_COLOR"));
+
+        // Clean up
+        unsafe {
+            std::env::remove_var("FORCE_COLOR");
         }
     }
 }


### PR DESCRIPTION
### TL;DR

Add automatic color support detection for subprocess output by adding the `supports-color` crate and setting the `FORCE_COLOR` environment variable.

### What changed?

- Added the `supports-color` crate as a dependency
- Added automatic detection of terminal color support capabilities
- Set the `FORCE_COLOR` environment variable for subprocesses based on detected color support level:
  - `3` for true color (16 million colors)
  - `2` for 256 colors
  - `1` for basic ANSI colors
  - `0` for no color support
- Added `FORCE_COLOR` to the default passthrough environment variables
- Added tests to verify the color detection and environment variable handling

### How to test?

1. Run a task that outputs colored text (like a test runner or linter)
2. Verify that the subprocess correctly displays colored output
3. Test with different terminal capabilities to ensure the correct color level is detected

### Why make this change?

Many CLI tools support colored output but disable it when running in a subprocess or CI environment. By automatically detecting color support and setting the `FORCE_COLOR` environment variable, we ensure that subprocess output maintains proper coloring, improving readability and user experience.