### PR TITLE
feat(cli): rename global cli to vite

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
           merge-multiple: true
 
       - name: Build
-        run: vp run @voidzero-dev/vite-plus#build:ts @voidzero-dev/global#build
+        run: vite run @voidzero-dev/vite-plus#build:ts @voidzero-dev/global#build
 
       # Download again because `@voidzero-dev/global#build` will cleanup the dist dir first
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/packages/global/package.json
+++ b/packages/global/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/voidzero-dev/vite-plus.git"
   },
   "bin": {
+    "vite": "./bin/vp",
     "vite-plus": "./bin/vp",
     "vp": "./bin/vp",
     "vite-plus-dev": "./bin/vp-dev"


### PR DESCRIPTION
### TL;DR

Added a `vite` binary alias to the global package and updated the release workflow to use it.

### What changed?

- Added a new binary alias `vite` in the `packages/global/package.json` file that points to the same executable as `vp` and `vite-plus`
- Updated the build command in the release workflow from `vp run` to `vite run`

### How to test?

1. Install the package globally
2. Verify that the `vite` command works and behaves the same as `vp` and `vite-plus`
3. Run a build using the new `vite run` command to ensure it functions correctly

### Why make this change?

This change provides a more intuitive command name for users who are familiar with Vite. By adding the `vite` alias, users can use a command that matches the package's purpose without having to remember the alternative commands (`vp` or `vite-plus`). This improves the developer experience and makes the tool more accessible.