### PR TITLE
refactor: don't print builtin command

### DIFF
--- a/crates/vite_task/src/config/mod.rs
+++ b/crates/vite_task/src/config/mod.rs
@@ -65,6 +65,7 @@ pub struct ResolvedTask {
     pub args: Arc<[Str]>,
     pub resolved_config: ResolvedTaskConfig,
     pub resolved_command: ResolvedTaskCommand,
+    pub is_builtin: bool,
     /// If true, the task will not be replayed from the cache.
     /// This is useful for tasks that should not be replayed, like auto run install command.
     /// TODO: this is a temporary solution, we should find a better way to handle this.
@@ -162,6 +163,7 @@ impl ResolvedTask {
             args: args.map(|arg| arg.as_ref().into()).collect(),
             resolved_config: resolved_task_config,
             resolved_command,
+            is_builtin: true,
             ignore_replay,
         })
     }

--- a/crates/vite_task/src/config/workspace.rs
+++ b/crates/vite_task/src/config/workspace.rs
@@ -229,6 +229,7 @@ impl Workspace {
             args: task_args,
             resolved_command,
             resolved_config,
+            is_builtin: false,
             ignore_replay: false,
         })
     }

--- a/crates/vite_task/src/schedule.rs
+++ b/crates/vite_task/src/schedule.rs
@@ -82,7 +82,8 @@ impl ExecutionPlan {
 
         let command = step.resolved_command.fingerprint.command.clone();
         let cwd = step.resolved_command.fingerprint.cwd.clone();
-        let pretty_command = format!("~/{}$ {}", cwd, command);
+        let display_command: Option<String> =
+            if step.is_builtin { None } else { Some(format!("~/{}$ {}", cwd, command)) };
         let ignore_replay = step.ignore_replay;
 
         // Check cache and prepare execution
@@ -98,28 +99,34 @@ impl ExecutionPlan {
         match cache_miss {
             Some(CacheMiss::NotFound) => {
                 tracing::debug!("{}", "Cache not found".style(Style::new().yellow()));
-                println!(
-                    "{} {}",
-                    "►".style(Style::new().bright_blue()),
-                    pretty_command.style(Style::new().cyan())
-                );
+                if let Some(display_command) = display_command {
+                    println!(
+                        "{} {}",
+                        "►".style(Style::new().bright_blue()),
+                        display_command.style(Style::new().cyan())
+                    );
+                }
             }
             Some(CacheMiss::FingerprintMismatch(mismatch)) => {
                 println!("{}: {}", "Cache miss".style(Style::new().yellow()), mismatch);
-                println!(
-                    "{} {}",
-                    "►".style(Style::new().bright_blue()),
-                    pretty_command.style(Style::new().cyan())
-                );
+                if let Some(display_command) = display_command {
+                    println!(
+                        "{} {}",
+                        "►".style(Style::new().bright_blue()),
+                        display_command.style(Style::new().cyan())
+                    );
+                }
             }
             None => {
                 if !ignore_replay {
-                    println!(
-                        "{} {} {}",
-                        "►".style(Style::new().bright_green()),
-                        pretty_command.style(Style::new().dimmed()),
-                        "(Cache hit, replaying)".style(Style::new().green())
-                    );
+                    println!("{}", "Cache hit, replaying".style(Style::new().green()));
+                    if let Some(display_command) = display_command {
+                        println!(
+                            "{} {}",
+                            "►".style(Style::new().bright_green()),
+                            display_command.style(Style::new().dimmed())
+                        );
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Hide command display for built-in tasks

### TL;DR

Added a flag to distinguish between built-in and user-defined tasks, and modified the command display logic to hide commands for built-in tasks.

### What changed?

- Added an `is_builtin` boolean field to the `ResolvedTask` struct
- Set `is_builtin` to `true` for built-in tasks and `false` for user-defined tasks
- Modified the command display logic in `schedule.rs` to only show commands for non-built-in tasks
- Improved the cache hit message formatting to be more concise

### How to test?

Run both built-in tasks (like auto-install) and user-defined tasks to verify:
1. Built-in task commands are no longer displayed in the console
2. User-defined task commands are still properly displayed
3. Cache hit/miss messages are displayed correctly for both types of tasks

### Why make this change?

This change improves the user experience by reducing console noise from internal/built-in commands that users don't need to see. It keeps the output focused on user-defined tasks while still providing necessary information about execution status.