### PR TITLE
feat(task): prevent nested auto-install execution

### DIFF
--- a/crates/vite_task/src/execute.rs
+++ b/crates/vite_task/src/execute.rs
@@ -272,6 +272,11 @@ impl TaskEnvs {
                 );
             }
         }
+
+        // Add VITE_TASK_EXECUTION_ENV to indicate we're running inside vite_task
+        // This prevents nested auto-install execution
+        all_envs.insert("VITE_TASK_EXECUTION_ENV".into(), Arc::<OsStr>::from(OsStr::new("1")));
+
         tracing::debug!("all_envs: {:?}", all_envs);
 
         Ok(Self { all_envs, envs_without_pass_through })
@@ -634,5 +639,39 @@ mod tests {
         unsafe {
             std::env::remove_var("FORCE_COLOR");
         }
+    }
+
+    #[test]
+    fn test_vite_task_execution_env_added() {
+        use crate::collections::HashSet;
+        use crate::config::{ResolvedTaskConfig, TaskCommand, TaskConfig};
+
+        let task_config = TaskConfig {
+            command: TaskCommand::ShellScript("echo test".into()),
+            cwd: RelativePathBuf::default(),
+            cacheable: true,
+            inputs: HashSet::new(),
+            envs: HashSet::new(),
+            pass_through_envs: HashSet::new(),
+        };
+
+        let resolved_task_config =
+            ResolvedTaskConfig { config_dir: RelativePathBuf::default(), config: task_config };
+
+        let base_dir = if cfg!(windows) {
+            AbsolutePath::new("C:\\workspace").unwrap()
+        } else {
+            AbsolutePath::new("/workspace").unwrap()
+        };
+
+        let result = TaskEnvs::resolve(base_dir, &resolved_task_config).unwrap();
+
+        // VITE_TASK_EXECUTION_ENV should always be added automatically
+        assert!(result.all_envs.contains_key("VITE_TASK_EXECUTION_ENV"));
+        let env_value = result.all_envs.get("VITE_TASK_EXECUTION_ENV").unwrap();
+        assert_eq!(env_value.to_str().unwrap(), "1");
+
+        // VITE_TASK_EXECUTION_ENV should not be in envs_without_pass_through since it's not declared
+        assert!(!result.envs_without_pass_through.contains_key("VITE_TASK_EXECUTION_ENV"));
     }
 }

--- a/crates/vite_task/src/lib.rs
+++ b/crates/vite_task/src/lib.rs
@@ -107,6 +107,12 @@ const fn resolve_bool_flag(positive: bool, negative: bool) -> bool {
 
 /// Automatically run install command
 async fn auto_install(workspace_root: &AbsolutePathBuf) -> Result<(), Error> {
+    // Skip if we're already running inside a vite_task execution to prevent nested installs
+    if std::env::var("VITE_TASK_EXECUTION_ENV").map_or(false, |v| v == "1") {
+        tracing::debug!("Skipping auto-install: already running inside vite_task execution");
+        return Ok(());
+    }
+
     tracing::debug!("Running install automatically...");
     crate::install::InstallCommand::builder(workspace_root.clone())
         .ignore_replay()
@@ -721,6 +727,47 @@ mod tests {
             assert_eq!(args, &vec!["--watch".to_string(), "--mode=development".to_string()]);
         } else {
             panic!("Expected Build command");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_auto_install_skipped_conditions() {
+        use vite_path::AbsolutePathBuf;
+
+        // Test auto_install function directly
+        let test_workspace = if cfg!(windows) {
+            AbsolutePathBuf::new("C:\\test-workspace-not-exists".into()).unwrap()
+        } else {
+            AbsolutePathBuf::new("/test-workspace-not-exists".into()).unwrap()
+        };
+
+        // Without the environment variable, auto_install should attempt to run
+        // (it may fail due to invalid workspace, but that's expected)
+        unsafe {
+            std::env::remove_var("VITE_TASK_EXECUTION_ENV");
+        }
+        let result_without_env = auto_install(&test_workspace).await;
+        // Should attempt to run (and likely fail with workspace error, which is fine)
+        assert!(result_without_env.is_err());
+
+        // With environment variable set to different value, auto_install should still attempt to run
+        unsafe {
+            std::env::set_var("VITE_TASK_EXECUTION_ENV", "0");
+        }
+        let result_with_wrong_value = auto_install(&test_workspace).await;
+        // Should attempt to run (and likely fail with workspace error, which is fine)
+        assert!(result_with_wrong_value.is_err());
+
+        // With environment variable set to "1", auto_install should be skipped (return Ok)
+        unsafe {
+            std::env::set_var("VITE_TASK_EXECUTION_ENV", "1");
+        }
+        let result_with_correct_value = auto_install(&test_workspace).await;
+        assert!(result_with_correct_value.is_ok());
+
+        // Clean up
+        unsafe {
+            std::env::remove_var("VITE_TASK_EXECUTION_ENV");
         }
     }
 }


### PR DESCRIPTION
### TL;DR

Prevent nested auto-install executions by adding an environment variable flag to task execution.

### What changed?

- Added `VITE_TASK_EXECUTION_ENV=1` environment variable to all task executions
- Modified the `auto_install` function to skip installation when this environment variable is present
- Added unit tests to verify both the environment variable is set correctly and that auto-install is skipped when appropriate

### How to test?

1. Run a task that would normally trigger auto-install
2. Verify that nested auto-install doesn't occur when a task is already running
3. Run the new unit tests:
   - `test_vite_task_execution_env_added`
   - `test_auto_install_skipped_conditions`

### Why make this change?

This change prevents recursive auto-install executions that could occur when a task runs another task. Without this protection, tasks could trigger infinite nested auto-install loops, causing performance issues and potential stack overflows. The environment variable flag provides a simple way to detect when we're already inside a task execution context.