### PR TITLE
test: add auto install benchmark

### DIFF
--- a/bench/benches/auto_install.sh
+++ b/bench/benches/auto_install.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Benchmark script to compare performance with and without auto-install
+# Our implementation uses VITE_TASK_EXECUTION_ENV=1 to disable nested auto-install execution
+
+AUTO_INSTALL_CMD="node ./packages/cli/src/bin.ts lint"
+
+echo "=== Performance comparison: auto-install enabled vs disabled ==="
+echo ""
+
+# Test with auto-install enabled (default behavior)
+echo "Testing with auto-install enabled..."
+time ${AUTO_INSTALL_CMD}
+
+echo ""
+
+# Test with auto-install disabled (simulating nested execution)
+echo "Testing with auto-install disabled (nested execution simulation)..."
+time VITE_TASK_EXECUTION_ENV=1 ${AUTO_INSTALL_CMD}
+
+echo ""
+echo "=== Running detailed benchmark with hyperfine ==="
+
+# Run detailed benchmark comparison
+hyperfine -w 2 -r 5 -i \
+  -n "auto-install-enabled" "${AUTO_INSTALL_CMD}" \
+  -n "auto-install-disabled" "VITE_TASK_EXECUTION_ENV=1 ${AUTO_INSTALL_CMD}"

--- a/crates/vite_task/src/execute.rs
+++ b/crates/vite_task/src/execute.rs
@@ -396,6 +396,12 @@ pub async fn execute_task(
     .await?;
 
     let outputs = outputs.into_inner().unwrap();
+    tracing::debug!(
+        "executed task finished, path_reads: {}, path_writes: {}, outputs: {}",
+        path_reads.len(),
+        path_writes.len(),
+        outputs.len()
+    );
 
     // let input_paths = gather_inputs(task, base_dir)?;
 


### PR DESCRIPTION
```
./bench/benches/auto_install.sh

=== Running detailed benchmark with hyperfine ===
Benchmark 1: auto-install-enabled
  Time (mean ± σ):      68.8 ms ±   1.4 ms    [User: 60.1 ms, System: 126.7 ms]
  Range (min … max):    67.6 ms …  71.0 ms    5 runs
 
Benchmark 2: auto-install-disabled
  Time (mean ± σ):      67.6 ms ±   7.2 ms    [User: 57.0 ms, System: 119.4 ms]
  Range (min … max):    59.8 ms …  79.3 ms    5 runs
 
Summary
  auto-install-disabled ran
    1.02 ± 0.11 times faster than auto-install-enabled
```