### PR TITLE
fix(task): propagate task exit codes to CLI process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,9 @@ jobs:
 
   install-e2e-test:
     name: vite install E2E test
-    runs-on: ubuntu-latest
+    # FIXME: Error: spawnSync esbuild ENOTSOCK
+    # runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -177,8 +179,8 @@ jobs:
           # Test vt install on various repositories with different package managers
           repos=(
             # pnpm workspace
-            "vitejs/vite:vite"
             "pnpm/pnpm:pnpm"
+            "vitejs/vite:vite"
             # yarn workspace
             "napi-rs/napi-rs:napi-rs"
             "toeverything/AFFiNE:AFFiNE"
@@ -191,19 +193,12 @@ jobs:
             IFS=':' read -r repo dir_name <<< "$repo_info"
             echo "Testing vt install on $repo..."
             # remove the directory if it exists
-            if [ -d "/tmp/$dir_name" ]; then
-              rm -rf "/tmp/$dir_name"
+            if [ -d "tmp/$dir_name" ]; then
+              rm -rf "tmp/$dir_name"
             fi
-            git clone --depth 1 "https://github.com/$repo.git" "/tmp/$dir_name"
-            cd "/tmp/$dir_name"
-            # retry 3 times
-            for i in {1..3}; do
-              vt install
-              if [ $? -eq 0 ]; then
-                break
-              fi
-              rm -rf node_modules
-            done
+            git clone --depth 1 "https://github.com/$repo.git" "tmp/$dir_name"
+            cd "tmp/$dir_name"
+            vt install
             # run again to show install cache increase by time
             time vt install
             echo "✓ Successfully installed dependencies for $repo"

--- a/crates/vite_task/src/execute.rs
+++ b/crates/vite_task/src/execute.rs
@@ -428,10 +428,11 @@ pub async fn execute_task(
 
     let outputs = outputs.into_inner().unwrap();
     tracing::debug!(
-        "executed task finished, path_reads: {}, path_writes: {}, outputs: {}",
+        "executed task finished, path_reads: {}, path_writes: {}, outputs: {}, exit_status: {}",
         path_reads.len(),
         path_writes.len(),
-        outputs.len()
+        outputs.len(),
+        exit_status
     );
 
     // let input_paths = gather_inputs(task, base_dir)?;

--- a/crates/vite_task/src/fmt.rs
+++ b/crates/vite_task/src/fmt.rs
@@ -1,4 +1,4 @@
-use std::future::Future;
+use std::{future::Future, process::ExitStatus};
 
 use petgraph::stable_graph::StableGraph;
 
@@ -11,12 +11,11 @@ pub async fn fmt<Fmt: Future<Output = Result<ResolveCommandResult, Error>>, FmtF
     resolve_fmt_command: FmtFn,
     workspace: &mut Workspace,
     args: &Vec<String>,
-) -> Result<(), Error> {
+) -> Result<Option<ExitStatus>, Error> {
     let resolved_task =
         ResolvedTask::resolve_from_builtin(workspace, resolve_fmt_command, "fmt", args.iter())
             .await?;
     let mut task_graph: StableGraph<ResolvedTask, ()> = Default::default();
     task_graph.add_node(resolved_task);
-    ExecutionPlan::plan(task_graph, false)?.execute(workspace).await?;
-    Ok(())
+    ExecutionPlan::plan(task_graph, false)?.execute(workspace).await
 }

--- a/crates/vite_task/src/install.rs
+++ b/crates/vite_task/src/install.rs
@@ -2,6 +2,7 @@ use std::{
     env,
     io::{self, IsTerminal, Write},
     iter,
+    process::ExitStatus,
 };
 
 use crossterm::{
@@ -42,7 +43,7 @@ impl InstallCommand {
         InstallCommandBuilder::new(workspace_root)
     }
 
-    pub async fn execute(self, args: &Vec<String>) -> Result<(), Error> {
+    pub async fn execute(self, args: &Vec<String>) -> Result<Option<ExitStatus>, Error> {
         // Handle UnrecognizedPackageManager error and let user select a package manager
         let package_manager = match PackageManager::builder(&self.workspace_root).build().await {
             Ok(pm) => pm,
@@ -67,10 +68,10 @@ impl InstallCommand {
         )?;
         let mut task_graph: StableGraph<ResolvedTask, ()> = Default::default();
         task_graph.add_node(resolved_task);
-        ExecutionPlan::plan(task_graph, false)?.execute(&mut workspace).await?;
+        let exit_status = ExecutionPlan::plan(task_graph, false)?.execute(&mut workspace).await?;
         workspace.unload().await?;
 
-        Ok(())
+        Ok(exit_status)
     }
 }
 

--- a/crates/vite_task/src/lib.rs
+++ b/crates/vite_task/src/lib.rs
@@ -16,7 +16,7 @@ mod vite;
 #[cfg(test)]
 mod test_utils;
 
-use std::{collections::HashMap, pin::Pin, sync::Arc};
+use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc};
 
 use clap::{Parser, Subcommand};
 pub(crate) use vite_error::Error;
@@ -125,11 +125,12 @@ async fn auto_install(workspace_root: &AbsolutePathBuf) -> Result<(), Error> {
     }
 
     tracing::debug!("Running install automatically...");
-    crate::install::InstallCommand::builder(workspace_root.clone())
+    let _exit_status = crate::install::InstallCommand::builder(workspace_root.clone())
         .ignore_replay()
         .build()
         .execute(&vec![])
         .await?;
+    // For auto-install, we don't propagate exit failures to avoid breaking the main command
     Ok(())
 }
 
@@ -205,7 +206,7 @@ pub async fn main<
     cwd: AbsolutePathBuf,
     args: Args,
     options: Option<CliOptions<Lint, LintFn, Fmt, FmtFn, Vite, ViteFn, Test, TestFn>>,
-) -> Result<(), Error> {
+) -> Result<Option<std::process::ExitStatus>, Error> {
     // Auto-install dependencies if needed, but skip for install command itself, or if `VITE_DISABLE_AUTO_INSTALL=1` is set.
     if !matches!(args.commands, Some(Commands::Install { .. }))
         && std::env::var_os("VITE_DISABLE_AUTO_INSTALL") != Some("1".into())
@@ -244,38 +245,42 @@ pub async fn main<
         Some(Commands::Lint { args }) => {
             let mut workspace = Workspace::partial_load(cwd)?;
             if let Some(lint_fn) = options.map(|o| o.lint) {
-                lint::lint(lint_fn, &mut workspace, args).await?;
+                let exit_status = lint::lint(lint_fn, &mut workspace, args).await?;
                 workspace.unload().await?;
+                return Ok(exit_status);
             }
-            return Ok(());
+            return Ok(None);
         }
         Some(Commands::Fmt { args }) => {
             let mut workspace = Workspace::partial_load(cwd)?;
             if let Some(fmt_fn) = options.map(|o| o.fmt) {
-                fmt::fmt(fmt_fn, &mut workspace, args).await?;
+                let exit_status = fmt::fmt(fmt_fn, &mut workspace, args).await?;
                 workspace.unload().await?;
+                return Ok(exit_status);
             }
-            return Ok(());
+            return Ok(None);
         }
         Some(Commands::Build { args }) => {
             let mut workspace = Workspace::partial_load(cwd)?;
             if let Some(vite_fn) = options.map(|o| o.vite) {
-                vite::create_vite("build", vite_fn, &mut workspace, args).await?;
+                let exit_status = vite::create_vite("build", vite_fn, &mut workspace, args).await?;
                 workspace.unload().await?;
+                return Ok(exit_status);
             }
-            return Ok(());
+            return Ok(None);
         }
         Some(Commands::Test { args }) => {
             let mut workspace = Workspace::partial_load(cwd)?;
             if let Some(test_fn) = options.map(|o| o.test) {
-                test::test(test_fn, &mut workspace, args).await?;
+                let exit_status = test::test(test_fn, &mut workspace, args).await?;
                 workspace.unload().await?;
+                return Ok(exit_status);
             }
-            return Ok(());
+            return Ok(None);
         }
         Some(Commands::Install { args }) => {
-            install::InstallCommand::builder(cwd).build().execute(args).await?;
-            return Ok(());
+            let exit_status = install::InstallCommand::builder(cwd).build().execute(&args).await?;
+            return Ok(exit_status);
         }
         Some(Commands::Cache { subcmd }) => {
             let cache_path = Workspace::get_cache_path(&cwd)?;
@@ -288,13 +293,13 @@ pub async fn main<
                     cache.list(std::io::stdout()).await?;
                 }
             }
-            return Ok(());
+            return Ok(None);
         }
         None => {
             let workspace = Workspace::load(cwd, false)?;
             // in implicit mode, vite-plus will run the task in the current package, replace the `pnpm/yarn/npm run` command.
             let Some(task) = args.task else {
-                return Ok(());
+                return Ok(None);
             };
             let name = &workspace.package_json.name;
             if name.is_empty() {
@@ -311,11 +316,10 @@ pub async fn main<
     let task_graph = workspace.build_task_subgraph(tasks, task_args.clone(), recursive_run)?;
 
     let plan = ExecutionPlan::plan(task_graph, parallel_run)?;
-    plan.execute(&mut workspace).await?;
+    let exit_status = plan.execute(&mut workspace).await?;
 
     workspace.unload().await?;
-
-    Ok(())
+    Ok(exit_status)
 }
 
 pub fn init_tracing() {

--- a/crates/vite_task/src/lint.rs
+++ b/crates/vite_task/src/lint.rs
@@ -1,4 +1,4 @@
-use std::future::Future;
+use std::{future::Future, process::ExitStatus};
 
 use petgraph::stable_graph::StableGraph;
 
@@ -14,12 +14,11 @@ pub async fn lint<
     resolve_lint_command: LintFn,
     workspace: &mut Workspace,
     args: &Vec<String>,
-) -> Result<(), Error> {
+) -> Result<Option<ExitStatus>, Error> {
     let resolved_task =
         ResolvedTask::resolve_from_builtin(workspace, resolve_lint_command, "lint", args.iter())
             .await?;
     let mut task_graph: StableGraph<ResolvedTask, ()> = Default::default();
     task_graph.add_node(resolved_task);
-    ExecutionPlan::plan(task_graph, false)?.execute(workspace).await?;
-    Ok(())
+    ExecutionPlan::plan(task_graph, false)?.execute(workspace).await
 }

--- a/crates/vite_task/src/main.rs
+++ b/crates/vite_task/src/main.rs
@@ -8,12 +8,22 @@ async fn main() -> Result<(), Error> {
     init_tracing();
 
     let args = Args::parse();
-    match vite_task::main(current_dir()?, args, None::<CliOptions>).await {
-        Ok(()) => Ok(()),
+    let result = vite_task::main(current_dir()?, args, None::<CliOptions>).await;
+
+    match result {
+        Ok(Some(exit_status)) => {
+            // Exit with the exit status of the first failed task
+            std::process::exit(exit_status.code().unwrap_or(1))
+        }
+        Ok(None) => {
+            // Success case - no failed tasks
+            Ok(())
+        }
         Err(err) => {
             tracing::error!("Error: {}", err);
             match err {
-                Error::UserCancelled => std::process::exit(130), // Standard exit code for Ctrl+C
+                // Standard exit code for Ctrl+C
+                Error::UserCancelled => std::process::exit(130),
                 _ => return Err(err),
             }
         }

--- a/crates/vite_task/src/schedule.rs
+++ b/crates/vite_task/src/schedule.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{process::ExitStatus, sync::Arc};
 
 use futures_core::future::BoxFuture;
 use futures_util::future::FutureExt as _;
@@ -66,18 +66,31 @@ impl ExecutionPlan {
     /// 1. Check if cached result exists and is valid
     /// 2. If cache hit: replay the cached output
     /// 3. If cache miss: execute the task and cache the result
+    ///
+    /// Returns:
+    /// - `Ok(None)` if all tasks succeeded
+    /// - `Ok(Some(exit_status))` if any task failed (contains the first failure's exit status)
+    /// - `Err(_)` for other errors (network, filesystem, etc.)
     #[tracing::instrument(skip(self, workspace))]
-    pub async fn execute(self, workspace: &mut Workspace) -> anyhow::Result<()> {
+    pub async fn execute(self, workspace: &mut Workspace) -> Result<Option<ExitStatus>, Error> {
+        let mut first_failed_exit_status = None;
         for step in self.steps {
-            Self::execute_resolved_task(step, workspace).await?;
+            let exit_status = Self::execute_resolved_task(step, workspace).await?;
+            if let Some(exit_status) = exit_status
+                && !exit_status.success()
+                && first_failed_exit_status.is_none()
+            {
+                first_failed_exit_status = Some(exit_status);
+            }
         }
-        Ok(())
+        // Return the exit status of the first failed task, or None if all succeeded
+        Ok(first_failed_exit_status)
     }
 
     pub async fn execute_resolved_task(
         step: ResolvedTask,
         workspace: &mut Workspace,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<Option<ExitStatus>> {
         tracing::debug!("Executing task {}", step.display_name());
 
         let command = step.resolved_command.fingerprint.command.clone();
@@ -145,8 +158,8 @@ impl ExecutionPlan {
         }
 
         // Execute or replay the task
-        execute_or_replay.await?;
-        Ok(())
+        let exit_status = execute_or_replay.await?;
+        Ok(exit_status)
     }
 }
 
@@ -157,14 +170,14 @@ async fn get_cached_or_execute<'a>(
     cache: &'a mut TaskCache,
     fs: &'a impl FileSystem,
     base_dir: &'a AbsolutePath,
-) -> Result<(Option<CacheMiss>, BoxFuture<'a, Result<(), Error>>), Error> {
+) -> Result<(Option<CacheMiss>, BoxFuture<'a, Result<Option<ExitStatus>, Error>>), Error> {
     Ok(match cache.try_hit(&task, fs, base_dir).await? {
         Ok(cache_task) => (
             None,
             ({
                 async move {
                     if task.ignore_replay {
-                        return Ok(());
+                        return Ok(None);
                     }
                     // replay
                     let std_outputs = Arc::clone(&cache_task.std_outputs);
@@ -184,7 +197,7 @@ async fn get_cached_or_execute<'a>(
                             }
                         }
                     }
-                    Ok(())
+                    Ok(None)
                 }
                 .boxed()
             }),
@@ -194,11 +207,12 @@ async fn get_cached_or_execute<'a>(
             async move {
                 let is_vite = task.resolved_command.fingerprint.command.is_vite();
                 let executed_task = execute_task(&task.resolved_command, base_dir).await?;
-                if !is_vite && executed_task.exit_status.success() {
+                let exit_status = executed_task.exit_status;
+                if !is_vite && exit_status.success() {
                     let cached_task = CommandCacheValue::create(executed_task, fs, base_dir)?;
                     cache.update(&task, cached_task).await?;
                 }
-                Ok(())
+                Ok(Some(exit_status))
             }
             .boxed(),
         ),

--- a/crates/vite_task/src/test.rs
+++ b/crates/vite_task/src/test.rs
@@ -1,4 +1,4 @@
-use std::{future::Future, iter};
+use std::{future::Future, iter, process::ExitStatus};
 
 use petgraph::stable_graph::StableGraph;
 
@@ -13,7 +13,7 @@ pub async fn test<
     resolve_test_command: TestFn,
     workspace: &mut Workspace,
     args: &Vec<String>,
-) -> Result<(), Error> {
+) -> Result<Option<ExitStatus>, Error> {
     let resolved_task = ResolvedTask::resolve_from_builtin(
         workspace,
         resolve_test_command,
@@ -23,6 +23,5 @@ pub async fn test<
     .await?;
     let mut task_graph: StableGraph<ResolvedTask, ()> = Default::default();
     task_graph.add_node(resolved_task);
-    ExecutionPlan::plan(task_graph, false)?.execute(workspace).await?;
-    Ok(())
+    ExecutionPlan::plan(task_graph, false)?.execute(workspace).await
 }

--- a/crates/vite_task/src/vite.rs
+++ b/crates/vite_task/src/vite.rs
@@ -1,4 +1,4 @@
-use std::{future::Future, iter};
+use std::{future::Future, iter, process::ExitStatus};
 
 use petgraph::stable_graph::StableGraph;
 
@@ -14,7 +14,7 @@ pub async fn create_vite<
     resolve_vite_command: ViteFn,
     workspace: &mut Workspace,
     args: &Vec<String>,
-) -> Result<(), Error> {
+) -> Result<Option<ExitStatus>, Error> {
     let resolved_task = ResolvedTask::resolve_from_builtin(
         workspace,
         resolve_vite_command,
@@ -24,6 +24,5 @@ pub async fn create_vite<
     .await?;
     let mut task_graph: StableGraph<ResolvedTask, ()> = Default::default();
     task_graph.add_node(resolved_task);
-    ExecutionPlan::plan(task_graph, false)?.execute(workspace).await?;
-    Ok(())
+    ExecutionPlan::plan(task_graph, false)?.execute(workspace).await
 }

--- a/packages/cli/binding/src/lib.rs
+++ b/packages/cli/binding/src/lib.rs
@@ -104,7 +104,7 @@ pub async fn run(options: CliOptions) -> Result<()> {
     let vite = options.vite;
     let test = options.test;
     // Call the Rust core with wrapped resolver functions
-    if let Err(e) = vite_task::main(
+    let result = vite_task::main(
         cwd,
         args,
         Some(ViteTaskCliOptions {
@@ -155,10 +155,27 @@ pub async fn run(options: CliOptions) -> Result<()> {
             },
         }),
     )
-    .await
-    {
-        // Convert Rust errors to NAPI errors for JavaScript
-        return Err(anyhow::Error::from(e).into());
+    .await;
+
+    match result {
+        Ok(Some(exit_status)) => {
+            // Exit with the exit status of the first failed task
+            std::process::exit(exit_status.code().unwrap_or(1))
+        }
+        Ok(None) => {
+            // Success case - no failed tasks
+            // Continue to Ok(()) return
+        }
+        Err(e) => {
+            match e {
+                // Standard exit code for Ctrl+C
+                Error::UserCancelled => std::process::exit(130),
+                _ => {
+                    // Convert Rust errors to NAPI errors for JavaScript
+                    return Err(anyhow::Error::from(e).into());
+                }
+            }
+        }
     }
     Ok(())
 }

--- a/packages/cli/tests/cases/exit-code/failure.js
+++ b/packages/cli/tests/cases/exit-code/failure.js
@@ -1,0 +1,2 @@
+console.log('failure');
+process.exit(1);

--- a/packages/cli/tests/cases/exit-code/package.json
+++ b/packages/cli/tests/cases/exit-code/package.json
@@ -1,0 +1,6 @@
+{
+  "scripts": {
+    "script1": "echo 'success'",
+    "script2": "node failure.js"
+  }
+}

--- a/packages/cli/tests/cases/exit-code/snap.txt
+++ b/packages/cli/tests/cases/exit-code/snap.txt
@@ -1,0 +1,17 @@
+> vite-plus run script1 # script1 run, create the cache and should be success
+Cache not found
+success
+
+> vite-plus run script1 # script1 should hit the updated cache
+Cache hit, replaying
+success
+
+[1]> vite-plus run script2 # script2 should be failure and not cache
+Cache not found
+failure
+
+
+[1]> vite-plus run script2 # script2 should be failure and not cache
+Cache not found
+failure
+

--- a/packages/cli/tests/cases/exit-code/steps.json
+++ b/packages/cli/tests/cases/exit-code/steps.json
@@ -1,0 +1,11 @@
+{
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": [
+    "vite-plus run script1 # script1 run, create the cache and should be success",
+    "vite-plus run script1 # script1 should hit the updated cache",
+    "vite-plus run script2 # script2 should be failure and not cache",
+    "vite-plus run script2 # script2 should be failure and not cache"
+  ]
+}

--- a/packages/tools/src/snap-test.ts
+++ b/packages/tools/src/snap-test.ts
@@ -51,9 +51,15 @@ function runTestCase(name: string) {
   const newSnap: string[] = [];
 
   for (const command of steps.commands) {
-    newSnap.push(`> ${command}`);
-    const output = cp.execSync(command, { env, cwd: caseTmpDir, encoding: 'utf-8' });
-    newSnap.push(replaceUnstableOutput(output));
+    try {
+      const output = cp.execSync(command, { env, cwd: caseTmpDir, encoding: 'utf-8' });
+      newSnap.push(`> ${command}`);
+      newSnap.push(replaceUnstableOutput(output));
+    } catch (error) {
+      // add error status code to the command
+      newSnap.push(`[${error.status}]> ${command}`);
+      newSnap.push(error.output.filter((line: string | null) => line !== null).join('\n'));
+    }
   }
   const newSnapContent = newSnap.join('\n');
 


### PR DESCRIPTION
### TL;DR

Propagate task execution exit codes to the CLI, ensuring failed tasks return appropriate error codes.

### What changed?

- Modified the execution flow to return exit status from tasks instead of just success/failure
- Updated all command handlers (lint, fmt, test, etc.) to propagate exit status
- Changed the main CLI entry point to exit with the appropriate code when tasks fail
- Added exit status to debug logs for better troubleshooting
- Created a new test case to verify exit code propagation behavior

### How to test?

1. Run a task that succeeds: `vite run script1` - should exit with code 0
2. Run a task that fails: `vite run script2` - should exit with the same code as the failed task
3. Try the new test case: `cd packages/cli/tests/cases/exit-code && vite-plus run script2` - should exit with code 1

### Why make this change?

Previously, when a task failed, the CLI would still exit with code 0, which is misleading for CI/CD pipelines and scripts that rely on exit codes to determine success or failure. This change ensures that the CLI properly propagates the exit code of failed tasks, making it more reliable for automation and consistent with standard CLI behavior.