### PR TITLE
feat(install): add install shortcut command

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,3 +1,8 @@
 [default.extend-words]
 ratatui = "ratatui"
 PUNICODE = "PUNICODE"
+
+[files]
+extend-exclude = [
+  "**/snap-tests/**/snap.txt",
+]

--- a/crates/vite_task/src/lib.rs
+++ b/crates/vite_task/src/lib.rs
@@ -91,9 +91,12 @@ pub enum Commands {
         /// Arguments to pass to vite test
         args: Vec<String>,
     },
+    /// Install command.
+    /// It will be passed to the package manager's install command currently.
+    #[command(disable_help_flag = true, alias = "i")]
     Install {
-        #[clap(last = true)]
         /// Arguments to pass to vite install
+        #[arg(allow_hyphen_values = true, trailing_var_arg = true)]
         args: Vec<String>,
     },
     Dev {

--- a/packages/cli/snap-tests/command-install-shortcut/package.json
+++ b/packages/cli/snap-tests/command-install-shortcut/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "command-install-shortcut",
+  "version": "1.0.0",
+  "private": true,
+  "packageManager": "pnpm@10.15.1",
+  "dependencies": {
+    "tslib": "2.8.1"
+  }
+}

--- a/packages/cli/snap-tests/command-install-shortcut/snap.txt
+++ b/packages/cli/snap-tests/command-install-shortcut/snap.txt
@@ -1,0 +1,32 @@
+> vite-plus i # install shortcut
+Cache not found
+Packages: +<variable>
++<repeat>
+Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
+
+dependencies:
++ tslib <semver>
+
+Done in <variable>ms using pnpm v<semver>
+
+> vite-plus i # install shortcut hit cache
+Cache hit, replaying
+Packages: +<variable>
++<repeat>
+Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
+
+dependencies:
++ tslib <semver>
+
+Done in <variable>ms using pnpm v<semver>
+
+> vite-plus install # install command still hit cache
+Cache hit, replaying
+Packages: +<variable>
++<repeat>
+Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
+
+dependencies:
++ tslib <semver>
+
+Done in <variable>ms using pnpm v<semver>

--- a/packages/cli/snap-tests/command-install-shortcut/steps.json
+++ b/packages/cli/snap-tests/command-install-shortcut/steps.json
@@ -1,0 +1,10 @@
+{
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": [
+    "vite-plus i # install shortcut",
+    "vite-plus i # install shortcut hit cache",
+    "vite-plus install # install command still hit cache"
+  ]
+}

--- a/packages/cli/snap-tests/npm-install-with-options/package.json
+++ b/packages/cli/snap-tests/npm-install-with-options/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "npm-install-with-options",
+  "version": "1.0.0",
+  "private": true,
+  "packageManager": "npm@10.9.0",
+  "dependencies": {
+    "tslib": "2.8.1"
+  },
+  "devDependencies": {
+    "oxlint": "latest"
+  }
+}

--- a/packages/cli/snap-tests/npm-install-with-options/snap.txt
+++ b/packages/cli/snap-tests/npm-install-with-options/snap.txt
@@ -1,0 +1,44 @@
+> vite-plus install --help # print help message
+Cache not found
+Install a package
+
+Usage:
+npm install [<package-spec> ...]
+
+Options:
+[-S|--save|--no-save|--save-prod|--save-dev|--save-optional|--save-peer|--save-bundle]
+[-E|--save-exact] [-g|--global]
+[--install-strategy <hoisted|nested|shallow|linked>] [--legacy-bundling]
+[--global-style] [--omit <dev|optional|peer> [--omit <dev|optional|peer> ...]]
+[--include <prod|dev|optional|peer> [--include <prod|dev|optional|peer> ...]]
+[--strict-peer-deps] [--prefer-dedupe] [--no-package-lock] [--package-lock-only]
+[--foreground-scripts] [--ignore-scripts] [--no-audit] [--no-bin-links]
+[--no-fund] [--dry-run] [--cpu <cpu>] [--os <os>] [--libc <libc>]
+[-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
+[-ws|--workspaces] [--include-workspace-root] [--install-links]
+
+aliases: add, i, in, ins, inst, insta, instal, isnt, isnta, isntal, isntall
+
+Run "npm help install" for more info
+
+> vite-plus install --production # https://docs.npmjs.com/cli/v10/commands/npm-install
+Cache not found
+
+added 1 package, and audited 2 packages in <variable>ms
+
+found 0 vulnerabilities
+
+npm warn config production Use `--omit=dev` instead.
+
+> ls node_modules
+@oxlint
+tslib
+
+> vite-plus install --production # install again hit cache
+Cache hit, replaying
+
+added 1 package, and audited 2 packages in <variable>ms
+
+found 0 vulnerabilities
+
+npm warn config production Use `--omit=dev` instead.

--- a/packages/cli/snap-tests/npm-install-with-options/steps.json
+++ b/packages/cli/snap-tests/npm-install-with-options/steps.json
@@ -1,0 +1,11 @@
+{
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": [
+    "vite-plus install --help # print help message",
+    "vite-plus install --production # https://docs.npmjs.com/cli/v10/commands/npm-install",
+    "ls node_modules",
+    "vite-plus install --production # install again hit cache"
+  ]
+}

--- a/packages/cli/snap-tests/pnpm-install-with-options/package.json
+++ b/packages/cli/snap-tests/pnpm-install-with-options/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "pnpm-install-with-options",
+  "version": "1.0.0",
+  "private": true,
+  "packageManager": "pnpm@10.15.1",
+  "dependencies": {
+    "tslib": "2.8.1"
+  },
+  "devDependencies": {
+    "oxlint": "latest"
+  }
+}

--- a/packages/cli/snap-tests/pnpm-install-with-options/snap.txt
+++ b/packages/cli/snap-tests/pnpm-install-with-options/snap.txt
@@ -1,0 +1,50 @@
+> vite-plus install --help | head -n 20 # print help message
+Cache not found
+Version <semver> (compiled to binary; bundled Node.js v<semver>)
+Usage: pnpm install [options]
+
+Alias: i
+
+Installs all dependencies of the project in the current working directory. When executed inside a workspace, installs all dependencies of all projects.
+
+Options:
+      --[no-]color                      Controls colors in the output. By
+                                        default, output is always colored when
+                                        it goes directly to a terminal
+      --[no-]frozen-lockfile            Don't generate a lockfile and fail if an
+                                        update is needed. This setting is on by
+                                        default in CI environments, so use
+                                        --no-frozen-lockfile if you need to
+                                        disable it for some reason
+      --[no-]verify-store-integrity     If false, doesn't check whether packages
+                                        in the store were mutated
+      --aggregate-output                Aggregate output from child processes
+
+> vite-plus install --prod # https://pnpm.io/cli/install#--prod--p
+Cache not found
+Packages: +<variable>
++<repeat>
+Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
+
+dependencies:
++ tslib <semver>
+
+devDependencies: skipped
+
+Done in <variable>ms using pnpm v<semver>
+
+> ls node_modules
+tslib
+
+> vite-plus install --prod # install again hit cache
+Cache hit, replaying
+Packages: +<variable>
++<repeat>
+Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
+
+dependencies:
++ tslib <semver>
+
+devDependencies: skipped
+
+Done in <variable>ms using pnpm v<semver>

--- a/packages/cli/snap-tests/pnpm-install-with-options/steps.json
+++ b/packages/cli/snap-tests/pnpm-install-with-options/steps.json
@@ -1,0 +1,11 @@
+{
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": [
+    "vite-plus install --help | head -n 20 # print help message",
+    "vite-plus install --prod # https://pnpm.io/cli/install#--prod--p",
+    "ls node_modules",
+    "vite-plus install --prod # install again hit cache"
+  ]
+}

--- a/packages/cli/snap-tests/yarn-install-with-options/package.json
+++ b/packages/cli/snap-tests/yarn-install-with-options/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "yarn-install-with-options",
+  "version": "1.0.0",
+  "private": true,
+  "packageManager": "yarn@1.22.22",
+  "dependencies": {
+    "tslib": "2.8.1"
+  }
+}

--- a/packages/cli/snap-tests/yarn-install-with-options/snap.txt
+++ b/packages/cli/snap-tests/yarn-install-with-options/snap.txt
@@ -1,0 +1,91 @@
+> vite-plus install --help # print help message
+Cache not found
+
+  Usage: yarn install [flags]
+
+  Yarn install is used to install all dependencies for a project.
+
+  Options:
+
+    -v, --version                       output the version number
+    --no-default-rc                     prevent Yarn from automatically detecting yarnrc and npmrc files
+    --use-yarnrc <path>                 specifies a yarnrc file that Yarn should use (.yarnrc only, not .npmrc) (default: )
+    --verbose                           output verbose messages on internal operations
+    --offline                           trigger an error if any required dependencies are not available in local cache
+    --prefer-offline                    use network only if dependencies are not available in local cache
+    --enable-pnp, --pnp                 enable the Plug'n'Play installation
+    --disable-pnp                       disable the Plug'n'Play installation
+    --strict-semver                     
+    --json                              format Yarn log messages as lines of JSON (see jsonlines.org)
+    --ignore-scripts                    don't run lifecycle scripts
+    --har                               save HAR output of network traffic
+    --ignore-platform                   ignore platform checks
+    --ignore-engines                    ignore engines check
+    --ignore-optional                   ignore optional dependencies
+    --force                             install and build packages even if they were built before, overwrite lockfile
+    --skip-integrity-check              run install without checking if node_modules is installed
+    --check-files                       install will verify file tree of packages for consistency
+    --no-bin-links                      don't generate bin links when setting up packages
+    --flat                              only allow one version of a package
+    --prod, --production [prod]         
+    --no-lockfile                       don't read or generate a lockfile
+    --pure-lockfile                     don't generate a lockfile
+    --frozen-lockfile                   don't generate a lockfile and fail if an update is needed
+    --update-checksums                  update package checksums from current repository
+    --link-duplicates                   create hardlinks to the repeated modules in node_modules
+    --link-folder <path>                specify a custom folder to store global links
+    --global-folder <path>              specify a custom folder to store global packages
+    --modules-folder <path>             rather than installing modules into the node_modules folder relative to the cwd, output them here
+    --preferred-cache-folder <path>     specify a custom folder to store the yarn cache if possible
+    --cache-folder <path>               specify a custom folder that must be used to store the yarn cache
+    --mutex <type>[:specifier]          use a mutex to ensure only one yarn instance is executing
+    --emoji [bool]                      enable emoji in output (default: true)
+    -s, --silent                        skip Yarn console logs, other types of logs (script output) will be printed
+    --cwd <cwd>                         working directory to use (default: /private<cwd>)
+    --proxy <host>                      
+    --https-proxy <host>                
+    --registry <url>                    override configuration registry
+    --no-progress                       disable progress bar
+    --network-concurrency <number>      maximum number of concurrent network requests
+    --network-timeout <milliseconds>    TCP timeout for network requests
+    --non-interactive                   do not show interactive prompts
+    --scripts-prepend-node-path [bool]  prepend the node executable dir to the PATH in scripts
+    --no-node-version-check             do not warn when using a potentially unsupported Node version
+    --focus                             Focus on a single workspace by installing remote copies of its sibling workspaces.
+    --otp <otpcode>                     one-time password for two factor authentication
+    -A, --audit                         Run vulnerability audit on installed packages
+    -g, --global                        DEPRECATED
+    -S, --save                          DEPRECATED - save package to your `dependencies`
+    -D, --save-dev                      DEPRECATED - save package to your `devDependencies`
+    -P, --save-peer                     DEPRECATED - save package to your `peerDependencies`
+    -O, --save-optional                 DEPRECATED - save package to your `optionalDependencies`
+    -E, --save-exact                    DEPRECATED
+    -T, --save-tilde                    DEPRECATED
+    -h, --help                          output usage information
+  Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
+
+
+> vite-plus install --prod # https://classic.yarnpkg.com/en/docs/cli/install#toc-yarn-install-production-true-false
+Cache not found
+yarn install v<semver>
+info No lockfile found.
+[1/4] Resolving packages...
+[2/4] Fetching packages...
+[3/4] Linking dependencies...
+[4/4] Building fresh packages...
+success Saved lockfile.
+Done in <variable>ms.
+
+> ls node_modules
+tslib
+
+> vite-plus install --prod # install again hit cache
+Cache hit, replaying
+yarn install v<semver>
+info No lockfile found.
+[1/4] Resolving packages...
+[2/4] Fetching packages...
+[3/4] Linking dependencies...
+[4/4] Building fresh packages...
+success Saved lockfile.
+Done in <variable>ms.

--- a/packages/cli/snap-tests/yarn-install-with-options/steps.json
+++ b/packages/cli/snap-tests/yarn-install-with-options/steps.json
@@ -1,0 +1,11 @@
+{
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": [
+    "vite-plus install --help # print help message",
+    "vite-plus install --prod # https://classic.yarnpkg.com/en/docs/cli/install#toc-yarn-install-production-true-false",
+    "ls node_modules",
+    "vite-plus install --prod # install again hit cache"
+  ]
+}


### PR DESCRIPTION
### TL;DR

Added an alias `i` for the `install` command and improved argument handling for hyphenated values.

### What changed?

- Enhanced the `install` command in `vite_task` crate:
  - Added documentation comments
  - Added `disable_help_flag = true` and an alias `i` for the command
  - Replaced `last = true` with `allow_hyphen_values = true` and `trailing_var_arg = true` to properly handle hyphenated arguments
- Added test cases for the `install` command:
  - Created a test for the `i` shortcut with pnpm
  - Added test for yarn package installation
  - Added snapshots to validate expected output

### How to test?

1. Run `vite-plus i` to verify the shortcut works
2. Run `vite-plus install -D tslib@2.8.1` to verify installing a package with flags works correctly
3. Test with different package managers (pnpm, yarn) to ensure compatibility

### Why make this change?

The previous implementation didn't properly handle hyphenated arguments for the install command, which prevented users from using common package manager flags like `-D` (for dev dependencies). This change ensures that all arguments are correctly passed to the underlying package manager and adds a convenient shortcut alias for the install command.