### PR TITLE
chore: make snapshot testing run in parallel

### DIFF
--- a/packages/cli/snap-tests/associate-existing-cache/snap.txt
+++ b/packages/cli/snap-tests/associate-existing-cache/snap.txt
@@ -7,7 +7,6 @@ Cache hit, replaying
 hello
 
 > json-edit package.json '_.scripts.script2 = "echo world"' # update the command of script2
-
 > vite-plus run script2 # should report cache miss due to command mismatch with the cache associated in step 2
 Cache miss: Command fingerprint changed: CommandFingerprintDiff { cwd: None, command: Parsed(TaskParsedCommandDiff { envs: BTreeMapDiff { altered: {}, removed: {} }, program: None, args: [Altered { index: 0, changes: [Some("hello")] }] }), envs_without_pass_through: BTreeMapDiff { altered: {}, removed: {} }, pass_through_envs: BTreeSetDiff { added: {}, removed: {} } }
 world

--- a/packages/cli/snap-tests/builtin-different-cwd/snap.txt
+++ b/packages/cli/snap-tests/builtin-different-cwd/snap.txt
@@ -9,7 +9,6 @@ Found 0 warnings and 0 errors.
 Finished in <variable>ms on 1 file with <variable> rules using <variable> threads.
 
 > echo 'console.log(1);' > folder2/a.js
-
 > cd folder1 && vite-plus lint
 Cache hit, replaying
 Found 0 warnings and 0 errors.

--- a/packages/cli/snap-tests/cache-clean/snap.txt
+++ b/packages/cli/snap-tests/cache-clean/snap.txt
@@ -7,13 +7,11 @@ Cache hit, replaying
 hello
 
 > vite-plus cache clean # clean the cache
-
 > vite-plus run hello # cache miss after clean
 Cache not found
 hello
 
 > cd subfolder && vite-plus cache clean # cache can be located and cleaned from subfolder
-
 > vite-plus run hello # cache miss after clean
 Cache not found
 hello

--- a/packages/cli/snap-tests/cache-miss-command-change/snap.txt
+++ b/packages/cli/snap-tests/cache-miss-command-change/snap.txt
@@ -5,7 +5,6 @@ Cache not found
 bar
 
 > json-edit package.json '_.scripts.hello = "echo baz && echo bar"' # update the first subcommand
-
 > vite-plus run hello # should report cache miss of the first subcommand, and hit cache of the second subcommand
 Cache miss: Command fingerprint changed: CommandFingerprintDiff { cwd: None, command: Parsed(TaskParsedCommandDiff { envs: BTreeMapDiff { altered: {}, removed: {} }, program: None, args: [Altered { index: 0, changes: [Some("foo")] }] }), envs_without_pass_through: BTreeMapDiff { altered: {}, removed: {} }, pass_through_envs: BTreeSetDiff { added: {}, removed: {} } }
 baz
@@ -13,7 +12,6 @@ Cache hit, replaying
 bar
 
 > json-edit package.json '_.scripts.hello = "echo bar"' # remove the first subcommand, now the second subcommand becomes the first
-
 > vite-plus run hello # can still hit cache even the subcommand index changed
 Cache hit, replaying
 bar

--- a/packages/cli/snap-tests/change-passthrough-env-config/snap.txt
+++ b/packages/cli/snap-tests/change-passthrough-env-config/snap.txt
@@ -7,7 +7,6 @@ Cache hit, replaying
 1
 
 > json-edit vite-task.json '_.tasks.hello.passThroughEnvs.push("MY_ENV2")' # add a new pass through env
-
 > MY_ENV=2 vite-plus run hello # cache should be invalidated because passThroughEnvs config changed
 Cache miss: Command fingerprint changed: CommandFingerprintDiff { cwd: None, command: NoChange, envs_without_pass_through: BTreeMapDiff { altered: {}, removed: {} }, pass_through_envs: BTreeSetDiff { added: {}, removed: {"MY_ENV2"} } }
 2

--- a/packages/cli/snap-tests/same-name-as-builtin/snap.txt
+++ b/packages/cli/snap-tests/same-name-as-builtin/snap.txt
@@ -8,7 +8,6 @@ Cache not found
 lint script
 
 > echo 'console.log(1);' > a.js
-
 > vite-plus lint
 Cache miss: a.js content changed
 Found 0 warnings and 0 errors.

--- a/packages/cli/snap-tests/shared-caching-inputs/snap.txt
+++ b/packages/cli/snap-tests/shared-caching-inputs/snap.txt
@@ -7,7 +7,6 @@ Cache hit, replaying
 bar
 
 > echo baz > foo.txt # change the input file to invalidate the cache
-
 > vite-plus run script2 # script2 should report a cache miss, and update the cache
 Cache miss: foo.txt content changed
 baz

--- a/packages/cli/tests/cases/exit-code/snap.txt
+++ b/packages/cli/tests/cases/exit-code/snap.txt
@@ -10,8 +10,6 @@ success
 Cache not found
 failure
 
-
 [1]> vite-plus run script2 # script2 should be failure and not cache
 Cache not found
 failure
-

--- a/packages/tools/src/snap-test.ts
+++ b/packages/tools/src/snap-test.ts
@@ -3,8 +3,12 @@
 import cp from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { promisify } from 'node:util';
+
+const exec = promisify(cp.exec);
 
 // Create a unique temporary directory for testing
 const tempTmpDir = `${tmpdir()}/vite-plus-test-${randomUUID()}`;
@@ -17,24 +21,27 @@ const casesDir = path.resolve('snap-tests');
 
 const filter = process.argv[2] ?? ''; // Optional filter to run specific test cases
 
+const tasks: Promise<void>[] = [];
 for (const caseName of fs.readdirSync(casesDir)) {
   if (caseName.startsWith('.')) continue; // Skip hidden files like .DS_Store
   if (caseName.includes(filter)) {
-    console.log(caseName);
-    runTestCase(caseName);
+    tasks.push(runTestCase(caseName));
   }
 }
+
+await Promise.all(tasks);
 
 interface Steps {
   env: Record<string, string>;
   commands: string[];
 }
 
-function runTestCase(name: string) {
+async function runTestCase(name: string) {
+  console.log('%s started', name);
   const caseTmpDir = `${tempTmpDir}/${name}`;
-  fs.cpSync(`${casesDir}/${name}`, caseTmpDir, { recursive: true, errorOnExist: true });
+  await fsPromises.cp(`${casesDir}/${name}`, caseTmpDir, { recursive: true, errorOnExist: true });
 
-  const steps: Steps = JSON.parse(fs.readFileSync(`${caseTmpDir}/steps.json`, 'utf-8'));
+  const steps: Steps = JSON.parse(await fsPromises.readFile(`${caseTmpDir}/steps.json`, 'utf-8'));
 
   const env = {
     ...process.env,
@@ -52,18 +59,29 @@ function runTestCase(name: string) {
 
   for (const command of steps.commands) {
     try {
-      const output = cp.execSync(command, { env, cwd: caseTmpDir, encoding: 'utf-8' });
+      const { stdout, stderr } = await exec(command, { env, cwd: caseTmpDir, encoding: 'utf-8' });
       newSnap.push(`> ${command}`);
-      newSnap.push(replaceUnstableOutput(output));
+      if (stdout) {
+        newSnap.push(replaceUnstableOutput(stdout));
+      }
+      if (stderr) {
+        newSnap.push(replaceUnstableOutput(stderr));
+      }
     } catch (error) {
-      // add error status code to the command
-      newSnap.push(`[${error.status}]> ${command}`);
-      newSnap.push(error.output.filter((line: string | null) => line !== null).join('\n'));
+      // add error exit code to the command
+      newSnap.push(`[${error.code}]> ${command}`);
+      if (error.stdout) {
+        newSnap.push(replaceUnstableOutput(error.stdout));
+      }
+      if (error.stderr) {
+        newSnap.push(replaceUnstableOutput(error.stderr));
+      }
     }
   }
   const newSnapContent = newSnap.join('\n');
 
-  fs.writeFileSync(`${casesDir}/${name}/snap.txt`, newSnapContent);
+  await fsPromises.writeFile(`${casesDir}/${name}/snap.txt`, newSnapContent);
+  console.log('%s finished', name);
 }
 
 function replaceUnstableOutput(output: string) {


### PR DESCRIPTION
### TL;DR

Refactored the CLI test runner to use async/await pattern and cleaned up test snapshots by removing unnecessary blank lines.

### What changed?

- Converted the test runner from synchronous to asynchronous using `async/await`
- Replaced `fs` synchronous methods with `fs/promises` asynchronous alternatives
- Added parallel test execution with `Promise.all`
- Improved error handling to properly capture both stdout and stderr
- Cleaned up test case snapshots by removing unnecessary blank lines between commands
- Added better logging to show when tests start and finish

### How to test?

Run the CLI tests to verify they execute correctly:

```
cd packages/cli
npm test
```

All tests should run in parallel and complete successfully with the updated snapshots.

### Why make this change?

This change improves the test runner's performance by executing tests in parallel rather than sequentially. The async/await pattern provides better error handling and makes the code more maintainable. Removing unnecessary blank lines in the snapshots makes them cleaner and easier to read while maintaining the same functional test coverage.

## Bench

Before

```
pnpm test  2.04s user 0.95s system 83% cpu 3.555 total
```

After

```
pnpm test  2.24s user 1.76s system 241% cpu 1.656 total
```