### PR TITLE
feat(tools): ignore pnpm install unstable output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,9 +119,12 @@ jobs:
       - name: Build CLI
         run: pnpm run bootstrap-cli
 
+      - name: Run CLI lint
+        run: pnpm lint
+
       - name: Run CLI E2E tests
         run: |
-          pnpm run --filter=@voidzero-dev/vite-plus --filter=@voidzero-dev/global test
+          pnpm test
           git diff --exit-code
 
   install-e2e-test:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "install-global-cli": "npm install -g ./packages/global",
     "typecheck": "tsc -b tsconfig.json",
     "lint": "vite lint",
-    "test": "pnpm -r test",
+    "test": "vite test && pnpm -r snap-test",
     "prepare": "husky"
   },
   "devDependencies": {
@@ -22,7 +22,8 @@
     "lint-staged": "^16.1.6",
     "oxfmt": "catalog:",
     "oxlint": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "lint-staged": {
     "*.@(js|ts|tsx|yml|yaml|md|json|html|toml)": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "build": "oxnode ./build.ts",
-    "test": "snap-test"
+    "snap-test": "snap-test"
   },
   "files": [
     "bin",

--- a/packages/global/package.json
+++ b/packages/global/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "build": "rolldown -c rolldown.config.ts",
-    "test": "snap-test"
+    "snap-test": "snap-test"
   },
   "dependencies": {
     "oxlint": "catalog:",

--- a/packages/tools/src/__tests__/__snapshots__/utils.spec.ts.snap
+++ b/packages/tools/src/__tests__/__snapshots__/utils.spec.ts.snap
@@ -1,0 +1,38 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`replaceUnstableOutput > replace unstable cwd 1`] = `"<cwd>/foo.txt"`;
+
+exports[`replaceUnstableOutput > replace unstable pnpm install output 1`] = `
+"Scope: all <variable> workspace projects
+Packages: +<variable>
++<repeat>
+Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
+
+devDependencies:
++ @voidzero-dev/vite-plus <semver>
++ vitest <semver>"
+`;
+
+exports[`replaceUnstableOutput > replace unstable pnpm install output 2`] = `
+"Scope: all <variable> workspace projects
+Lockfile is up to date, resolution step is skipped
+Already up to date
+
+╭ Warning ───────────────────────────────────────────────────────────────────────────────────╮
+│                                                                                            │
+│   Ignored build scripts: esbuild.                                                          │
+│   Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.   │
+│                                                                                            │
+╰────────────────────────────────────────────────────────────────────────────────────────────╯
+
+Done in <variable>ms using pnpm v<semver>"
+`;
+
+exports[`replaceUnstableOutput > replace unstable semver version 1`] = `
+"v1.0.0
+v1.0.0-beta.1
+v1.0.0-beta.1+build.1
+1.0.0
+1.0.0-beta.1
+1.0.0-beta.1+build.1"
+`;

--- a/packages/tools/src/__tests__/utils.spec.ts
+++ b/packages/tools/src/__tests__/utils.spec.ts
@@ -1,0 +1,61 @@
+import { tmpdir } from 'node:os';
+
+import { describe, expect, test } from 'vitest';
+
+import { replaceUnstableOutput } from '../utils.ts';
+
+describe('replaceUnstableOutput', () => {
+  test('replace unstable semver version', () => {
+    const output = `
+v1.0.0
+v1.0.0-beta.1
+v1.0.0-beta.1+build.1
+1.0.0
+1.0.0-beta.1
+1.0.0-beta.1+build.1
+    `;
+    expect(replaceUnstableOutput(output.trim())).toMatchSnapshot();
+  });
+
+  test('replace unstable pnpm install output', () => {
+    const outputs = [
+      `
+Scope: all 6 workspace projects
+Packages: +312
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Progress: resolved 1, reused 0, downloaded 0, added 0
+Progress: resolved 316, reused 316, downloaded 0, added 315
+WARN  Skip adding vite to the default catalog because it already exists as npm:@voidzero-dev/vite-plus. Please use \`pnpm update\` to update the catalogs.
+WARN  Skip adding vitest to the default catalog because it already exists as beta. Please use \`pnpm update\` to update the catalogs.
+Progress: resolved 316, reused 316, downloaded 0, added 316, done
+
+devDependencies:
++ @voidzero-dev/vite-plus 0.0.0-8a4f4936e0eca32dd57e1a503c2b09745953344d
++ vitest 3.2.4
+      `,
+      `
+Scope: all 2 workspace projects
+Lockfile is up to date, resolution step is skipped
+Already up to date
+
+╭ Warning ───────────────────────────────────────────────────────────────────────────────────╮
+│                                                                                            │
+│   Ignored build scripts: esbuild.                                                          │
+│   Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.   │
+│                                                                                            │
+╰────────────────────────────────────────────────────────────────────────────────────────────╯
+
+Done in 171ms using pnpm v10.16.1
+      `,
+    ];
+    for (const output of outputs) {
+      expect(replaceUnstableOutput(output.trim())).toMatchSnapshot();
+    }
+  });
+
+  test('replace unstable cwd', () => {
+    const cwd = tmpdir();
+    const output = `${cwd}/foo.txt`;
+    expect(replaceUnstableOutput(output.trim(), cwd)).toMatchSnapshot();
+  });
+});

--- a/packages/tools/src/snap-test.ts
+++ b/packages/tools/src/snap-test.ts
@@ -10,6 +10,8 @@ import { promisify } from 'node:util';
 
 const exec = promisify(cp.exec);
 
+import { replaceUnstableOutput } from './utils.ts';
+
 // Create a unique temporary directory for testing
 const tempTmpDir = `${tmpdir()}/vite-plus-test-${randomUUID()}`;
 fs.mkdirSync(tempTmpDir, { recursive: true });
@@ -65,19 +67,19 @@ async function runTestCase(name: string) {
       const { stdout, stderr } = await exec(command, { env, cwd: caseTmpDir, encoding: 'utf-8' });
       newSnap.push(`> ${command}`);
       if (stdout) {
-        newSnap.push(replaceUnstableOutput(stdout));
+        newSnap.push(replaceUnstableOutput(stdout, caseTmpDir));
       }
       if (stderr) {
-        newSnap.push(replaceUnstableOutput(stderr));
+        newSnap.push(replaceUnstableOutput(stderr, caseTmpDir));
       }
     } catch (error) {
       // add error exit code to the command
       newSnap.push(`[${error.code}]> ${command}`);
       if (error.stdout) {
-        newSnap.push(replaceUnstableOutput(error.stdout));
+        newSnap.push(replaceUnstableOutput(error.stdout, caseTmpDir));
       }
       if (error.stderr) {
-        newSnap.push(replaceUnstableOutput(error.stderr));
+        newSnap.push(replaceUnstableOutput(error.stderr, caseTmpDir));
       }
     }
   }
@@ -85,9 +87,4 @@ async function runTestCase(name: string) {
 
   await fsPromises.writeFile(`${casesDir}/${name}/snap.txt`, newSnapContent);
   console.log('%s finished', name);
-}
-
-function replaceUnstableOutput(output: string) {
-  return output.replace(/\d+(?:\.\d+)?s|\d+ms/, '<variable>ms')
-    .replace(/with \d+ rules using \d+ threads/, 'with <variable> rules using <variable> threads');
 }

--- a/packages/tools/src/utils.ts
+++ b/packages/tools/src/utils.ts
@@ -1,0 +1,24 @@
+export function replaceUnstableOutput(output: string, cwd?: string) {
+  if (cwd) {
+    output = output.replaceAll(cwd, '<cwd>');
+  }
+  return output
+    // semver version
+    .replaceAll(/ (v)?\d+\.\d+\.\d+(?:-.*)?/g, ' $1<semver>')
+    // oxlint
+    .replaceAll(/\d+(?:\.\d+)?s|\d+ms/g, '<variable>ms')
+    .replaceAll(/with \d+ rules using \d+ threads/g, 'with <variable> rules using <variable> threads')
+    // pnpm
+    .replaceAll(/Packages: \+\d+/g, 'Packages: +<variable>')
+    // only keep done
+    .replaceAll(
+      /Progress: resolved \d+, reused \d+, downloaded \d+, added \d+, done/g,
+      'Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done',
+    )
+    // ignore pnpm progress
+    .replaceAll(/Progress: resolved \d+, reused \d+, downloaded \d+, added \d+\n/g, '')
+    // ignore pnpm warn
+    .replaceAll(/WARN\s+Skip\s+adding .+?\n/g, '')
+    .replaceAll(/Scope: all \d+ workspace projects/g, 'Scope: all <variable> workspace projects')
+    .replaceAll(/\++\n/g, '+<repeat>\n');
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.2
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.4(@types/node@24.4.0)(esbuild@0.25.8)(jiti@2.5.1)(yaml@2.8.1)
 
   docs:
     devDependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['**/__tests__/**/*.spec.ts'],
+    exclude: [
+      'packages/global/templates',
+      // ignore __tests__ at node_modules, e.g.: packages/cli/node_modules/@napi-rs/cli/src/utils/__tests__/typegen.spec.ts
+      '**/node_modules',
+    ],
+  },
+});


### PR DESCRIPTION
This PR adds Vitest for unit testing alongside the existing snapshot tests. Key changes:

1. Added a new `vitest.config.ts` file to configure test discovery
2. Created a utility function `replaceUnstableOutput` to normalize test output by replacing unstable values like:
    - Semver versions
    - Timestamps
    - File paths
    - PNPM output patterns
    - Current working directory
3. Renamed the existing snapshot test commands from `test` to `snap-test` in package.json files
4. Updated the CI workflow to use the new `snap-test` command
5. Modified the root `test` command to run both Vitest tests and snapshot tests

The PR includes a test case for the new utility function with appropriate snapshots.