### PR TITLE
feat(vite_task): proxy and skip cache for vite dev

### DIFF
--- a/crates/vite_task/src/config/task_command.rs
+++ b/crates/vite_task/src/config/task_command.rs
@@ -41,8 +41,8 @@ impl From<TaskCommand> for TaskConfig {
 }
 
 impl TaskCommand {
-    pub fn is_vite(&self) -> bool {
-        matches!(self, Self::Parsed(parsed_command) if parsed_command.program == "vite")
+    pub fn need_skip_cache(&self) -> bool {
+        matches!(self, Self::Parsed(parsed_command) if parsed_command.program == "vite" || (parsed_command.program.ends_with("vite.js") && parsed_command.args.first() == Some(&("dev".into()))))
     }
 }
 

--- a/crates/vite_task/src/execute.rs
+++ b/crates/vite_task/src/execute.rs
@@ -335,8 +335,8 @@ pub async fn execute_task(
             cmd
         }
         TaskCommand::Parsed(task_parsed_command) => {
-            if resolved_command.fingerprint.command.is_vite() {
-                let mut child = tokio::process::Command::new("vite")
+            if resolved_command.fingerprint.command.need_skip_cache() {
+                let mut child = tokio::process::Command::new(&task_parsed_command.program)
                     .args(&task_parsed_command.args)
                     .envs(&resolved_command.all_envs)
                     .envs(&task_parsed_command.envs)

--- a/crates/vite_task/src/lib.rs
+++ b/crates/vite_task/src/lib.rs
@@ -96,6 +96,11 @@ pub enum Commands {
         /// Arguments to pass to vite install
         args: Vec<String>,
     },
+    Dev {
+        #[clap(last = true)]
+        /// Arguments to pass to vite dev
+        args: Vec<String>,
+    },
     /// Manage the task cache
     Cache {
         #[clap(subcommand)]
@@ -334,6 +339,15 @@ pub async fn main<
             let exit_status = install::InstallCommand::builder(cwd).build().execute(args).await?;
             return Ok(exit_status);
         }
+        Some(Commands::Dev { args }) => {
+            let mut workspace = Workspace::partial_load(cwd)?;
+            if let Some(vite_fn) = options.map(|o| o.vite) {
+                let exit_status = vite::create_vite("dev", vite_fn, &mut workspace, args).await?;
+                workspace.unload().await?;
+                return Ok(exit_status);
+            }
+            return Ok(None);
+        }
         Some(Commands::Cache { subcmd }) => {
             let cache_path = Workspace::get_cache_path(&cwd)?;
             match subcmd {
@@ -472,8 +486,8 @@ mod tests {
     fn test_args_with_task_args() {
         // Now "test" is a dedicated command, so let's use a different task name for implicit mode
         let args =
-            Args::try_parse_from(&["vite-plus", "dev", "--", "--watch", "--verbose"]).unwrap();
-        assert_eq!(args.task, Some("dev".into()));
+            Args::try_parse_from(&["vite-plus", "develop", "--", "--watch", "--verbose"]).unwrap();
+        assert_eq!(args.task, Some("develop".into()));
         assert_eq!(args.task_args, vec!["--watch", "--verbose"]);
         assert!(args.commands.is_none());
         assert!(!args.debug);

--- a/crates/vite_task/src/schedule.rs
+++ b/crates/vite_task/src/schedule.rs
@@ -205,10 +205,10 @@ async fn get_cached_or_execute<'a>(
         Err(cache_miss) => (
             Some(cache_miss),
             async move {
-                let is_vite = task.resolved_command.fingerprint.command.is_vite();
+                let skip_cache = task.resolved_command.fingerprint.command.need_skip_cache();
                 let executed_task = execute_task(&task.resolved_command, base_dir).await?;
                 let exit_status = executed_task.exit_status;
-                if !is_vite && exit_status.success() {
+                if !skip_cache && exit_status.success() {
                     let cached_task = CommandCacheValue::create(executed_task, fs, base_dir)?;
                     cache.update(&task, cached_task).await?;
                 }


### PR DESCRIPTION
This is still a temporary workaround. The final implementation requires a task-aware runner.