### PR TITLE
chore(ci): add read permissions and fix dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ permissions: {}
 jobs:
   build-rust:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -105,12 +107,6 @@ jobs:
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          path: packages/global/dist
-          pattern: bindings-*
-          merge-multiple: true
-
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
           path: packages/cli/dist
           pattern: bindings-*
           merge-multiple: true
@@ -121,7 +117,7 @@ jobs:
           sed -i 's/"version": "0.0.0"/"version": "0.0.0-${{ github.sha }}"/' packages/cli/package.json
 
       # Setup node correctly for publishing to github registry
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version-file: .node-version
           registry-url: "https://npm.pkg.github.com"

--- a/packages/global/package.json
+++ b/packages/global/package.json
@@ -22,12 +22,12 @@
     "snap-test": "snap-test"
   },
   "dependencies": {
+    "@voidzero-dev/vite-plus": "workspace:*",
     "oxlint": "catalog:",
     "rolldown-vite": "catalog:",
     "vitest": "catalog:"
   },
   "devDependencies": {
-    "@voidzero-dev/vite-plus": "workspace:*",
     "@voidzero-dev/vite-plus-tools": "workspace:",
     "rolldown": "catalog:"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
 
   packages/global:
     dependencies:
+      '@voidzero-dev/vite-plus':
+        specifier: workspace:*
+        version: link:../cli
       oxlint:
         specifier: 'catalog:'
         version: 1.15.0(oxlint-tsgolint@0.2.0)
@@ -145,9 +148,6 @@ importers:
         specifier: 'catalog:'
         version: 3.2.4(@types/node@24.4.0)(esbuild@0.25.8)(jiti@2.5.1)(yaml@2.8.1)
     devDependencies:
-      '@voidzero-dev/vite-plus':
-        specifier: workspace:*
-        version: link:../cli
       '@voidzero-dev/vite-plus-tools':
         specifier: 'workspace:'
         version: link:../tools


### PR DESCRIPTION
### TL;DR

Updated GitHub workflow permissions and fixed dependency configuration in the global package.

### What changed?

- Added explicit `contents: read` permission to the `build-rust` job in the release workflow
- Removed unnecessary artifact download step for bindings in the release workflow
- Pinned `actions/setup-node` to a specific commit hash instead of using a floating version
- Moved `@voidzero-dev/vite-plus` from devDependencies to dependencies in the global package

### How to test?

1. Verify the release workflow runs correctly with the updated permissions
2. Ensure the global package can properly access the vite-plus dependency at runtime

### Why make this change?

This PR addresses GitHub's upcoming changes to default permissions in GitHub Actions by explicitly setting the required permissions. It also fixes a dependency issue in the global package where vite-plus was incorrectly listed as a devDependency when it's needed at runtime. The workflow changes also improve security by pinning action versions to specific commit hashes.