### PR TITLE
fix(cli): set OXLINT_TSGOLINT_PATH env to let oxlint find the real tsgolint bin

### DIFF
--- a/crates/vite_error/src/lib.rs
+++ b/crates/vite_error/src/lib.rs
@@ -95,7 +95,7 @@ pub enum Error {
     #[error(transparent)]
     SerdeYmlError(#[from] serde_yml::Error),
 
-    #[error("Lint failed")]
+    #[error("Lint failed, reason: {reason}")]
     LintFailed { status: Str, reason: Str },
 
     #[error("Fmt failed")]

--- a/crates/vite_task/src/execute.rs
+++ b/crates/vite_task/src/execute.rs
@@ -208,6 +208,8 @@ const DEFAULT_PASSTHROUGH_ENVS: &[&str] = &[
     "COMPOSE_*",
     // Token patterns
     "*_TOKEN",
+    // oxc specific
+    "OXLINT_*",
 ];
 
 const SENSITIVE_PATTERNS: &[&str] = &[
@@ -605,6 +607,7 @@ mod tests {
             std::env::set_var("APP1_NAME", "app1_value");
             std::env::set_var("APP2_NAME", "app2_value");
             std::env::set_var("APP1_PASSWORD", "app1_password");
+            std::env::set_var("OXLINT_TSGOLINT_PATH", "/path/to/oxlint_tsgolint");
         }
 
         // Resolve envs multiple times
@@ -654,6 +657,7 @@ mod tests {
         assert!(all_envs.contains_key("APP1_PASSWORD"));
         assert!(all_envs.contains_key("APP1_TOKEN"));
         assert!(all_envs.contains_key("APP2_TOKEN"));
+        assert!(all_envs.contains_key("OXLINT_TSGOLINT_PATH"));
 
         // VITE_TASK_EXECUTION_ENV should always be added automatically
         assert!(all_envs.contains_key("VITE_TASK_EXECUTION_ENV"));
@@ -674,6 +678,7 @@ mod tests {
             std::env::remove_var("APP1_PASSWORD");
             std::env::remove_var("APP1_TOKEN");
             std::env::remove_var("APP2_TOKEN");
+            std::env::remove_var("OXLINT_TSGOLINT_PATH");
         }
     }
 

--- a/packages/cli/snap-tests/check-oxlint-env/check.js
+++ b/packages/cli/snap-tests/check-oxlint-env/check.js
@@ -1,0 +1,1 @@
+console.log('OXLINT_TSGOLINT_PATH=%s', process.env.OXLINT_TSGOLINT_PATH);

--- a/packages/cli/snap-tests/check-oxlint-env/package.json
+++ b/packages/cli/snap-tests/check-oxlint-env/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "check-oxlint-env",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "check": "node check.js",
+    "check-nested": "vite run check"
+  }
+}

--- a/packages/cli/snap-tests/check-oxlint-env/snap.txt
+++ b/packages/cli/snap-tests/check-oxlint-env/snap.txt
@@ -1,0 +1,51 @@
+> OXLINT_TSGOLINT_PATH=/path/to/oxlint_tsgolint1 vite run check # get OXLINT_TSGOLINT_PATH env
+$ node check.js
+OXLINT_TSGOLINT_PATH=/path/to/oxlint_tsgolint1
+
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    Vite+ Task Runner • Execution Summary
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Statistics:  1 tasks • 0 cache hits • 1 cache misses 
+Performance:  0% cache hit rate
+
+Task Details:
+────────────────────────────────────────────────
+  [1] check-oxlint-env#check ✓
+      → Cache miss: no previous cache entry found
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+> rm -rf node_modules # clean cache
+> OXLINT_TSGOLINT_PATH=/path/to/oxlint_tsgolint2 vite run check-nested # get OXLINT_TSGOLINT_PATH env in nested task
+$ vite run check
+$ node check.js
+OXLINT_TSGOLINT_PATH=/path/to/oxlint_tsgolint2
+
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    Vite+ Task Runner • Execution Summary
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Statistics:  1 tasks • 0 cache hits • 1 cache misses 
+Performance:  0% cache hit rate
+
+Task Details:
+────────────────────────────────────────────────
+  [1] check-oxlint-env#check ✓
+      → Cache miss: no previous cache entry found
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    Vite+ Task Runner • Execution Summary
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Statistics:  1 tasks • 0 cache hits • 1 cache misses 
+Performance:  0% cache hit rate
+
+Task Details:
+────────────────────────────────────────────────
+  [1] check-oxlint-env#check-nested ✓
+      → Cache miss: no previous cache entry found
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/packages/cli/snap-tests/check-oxlint-env/steps.json
+++ b/packages/cli/snap-tests/check-oxlint-env/steps.json
@@ -1,0 +1,10 @@
+{
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": [
+    "OXLINT_TSGOLINT_PATH=/path/to/oxlint_tsgolint1 vite run check # get OXLINT_TSGOLINT_PATH env",
+    "rm -rf node_modules # clean cache",
+    "OXLINT_TSGOLINT_PATH=/path/to/oxlint_tsgolint2 vite run check-nested # get OXLINT_TSGOLINT_PATH env in nested task"
+  ]
+}

--- a/packages/cli/src/lint.ts
+++ b/packages/cli/src/lint.ts
@@ -31,9 +31,10 @@ export async function lint(): Promise<{
   binPath: string;
   envs: Record<string, string>;
 }> {
+  const paths = [process.cwd(), dirname(fileURLToPath(import.meta.url))];
   // Resolve the oxlint binary directly (it's a native executable)
   const binPath = require.resolve('oxlint/bin/oxlint', {
-    paths: [process.cwd(), dirname(fileURLToPath(import.meta.url))],
+    paths,
   });
 
   return {
@@ -45,6 +46,9 @@ export async function lint(): Promise<{
       JS_RUNTIME_NAME: process.release.name,
       // Indicate that vite-plus is the package manager invoking oxlint
       NODE_PACKAGE_MANAGER: 'vite-plus',
+      OXLINT_TSGOLINT_PATH: require.resolve('oxlint-tsgolint/bin/tsgolint.js', {
+        paths,
+      }),
     },
   };
 }


### PR DESCRIPTION
### TL;DR

Added support for oxlint environment variables and improved error messaging for lint failures.

Fix `Failed to find tsgolint executable` error on vite+ local cli release package.

### What changed?

- Enhanced the `LintFailed` error message to include the reason for failure
- Added `OXLINT_*` to the list of default passthrough environment variables
- Created a new `vite` executable script in the CLI package
- Added `OXLINT_TSGOLINT_PATH` environment variable support in the lint function
- Created a new snap test to verify that oxlint environment variables are properly passed through

### How to test?

Run the new snap test to verify that oxlint environment variables are correctly passed:

```bash
cd packages/cli/snap-tests/check-oxlint-env
OXLINT_TSGOLINT_PATH=/path/to/oxlint_tsgolint vite run check
```

The test should show that the environment variable is properly passed to the task.

### Why make this change?

This change improves the developer experience when using oxlint with Vite+:

1. Better error messages make it easier to debug lint failures
2. Passing through oxlint-specific environment variables allows for more flexible configuration
3. The new executable script provides a more convenient way to run Vite+ commands