### PR TITLE
chore(cli): use vite lib instead of tsdown build

### DIFF
--- a/packages/global/templates/monorepo-lib/README.md
+++ b/packages/global/templates/monorepo-lib/README.md
@@ -7,17 +7,17 @@ A starter for creating a TypeScript package.
 - Install dependencies:
 
 ```bash
-npm install
+vite install
 ```
 
 - Run the unit tests:
 
 ```bash
-npm run test
+vite run test
 ```
 
 - Build the library:
 
 ```bash
-npm run build
+vite run build
 ```

--- a/packages/global/templates/monorepo-lib/package.json
+++ b/packages/global/templates/monorepo-lib/package.json
@@ -29,8 +29,8 @@
   },
   "scripts": {
     "ready": "vite run build && vite run test",
-    "build": "tsdown",
-    "dev": "tsdown --watch",
+    "build": "vite lib",
+    "dev": "vite lib --watch",
     "test": "vite test",
     "typecheck": "tsc --noEmit",
     "release": "bumpp && npm publish"


### PR DESCRIPTION
### TL;DR

Updated build tooling from `tsdown` to `vite lib` and standardized CLI commands to use `vite` in the monorepo library template.

### What changed?

- Updated the README.md to replace `npm` commands with `vite` commands for installation, testing, and building
- Modified package.json scripts to use `vite lib` instead of `tsdown` for building the library
- Changed the development script from `tsdown --watch` to `vite lib --watch`
- Kept other scripts like test, typecheck, and release unchanged in their functionality

### How to test?

1. Create a new library using this template
2. Run the commands as specified in the README:
   ```bash
   vite install
   vite run test
   vite run build
   ```
3. Verify that the build process works correctly with the new `vite lib` command

### Why make this change?

This change standardizes the build tooling across the monorepo to use Vite consistently, replacing the previous `tsdown` tool. Using Vite for library building provides better consistency with other parts of the system and leverages Vite's optimized build process for libraries.