### PR TITLE
chore(cli): temporarily fix pnpm install warnning messages

### DIFF
--- a/packages/global/src/new.ts
+++ b/packages/global/src/new.ts
@@ -814,12 +814,27 @@ async function fixPackageJsonForVitePlus(projectDir: string, selectedPackageMana
             ...pkg.pnpm?.overrides,
             vite: viteVersion,
           },
+          peerDependencyRules: {
+            ...pkg.pnpm?.peerDependencyRules,
+            allowAny: [
+              ...pkg.pnpm?.peerDependencyRules?.allowAny ?? [],
+              'vite',
+            ],
+          },
         };
       } else {
         pkg.resolutions = {
           ...pkg.resolutions,
           vite: viteVersion,
         };
+      }
+    } else {
+      // change deps version to catalog
+      const names = ['@types/node', 'bumpp', 'happy-dom', 'vitest', 'typescript', 'tsdown', 'vite'];
+      for (const name of names) {
+        if (pkg.devDependencies?.[name]) {
+          pkg.devDependencies[name] = `catalog:`;
+        }
       }
     }
     // fix vite dev command

--- a/packages/global/templates/monorepo/package.json
+++ b/packages/global/templates/monorepo/package.json
@@ -21,6 +21,11 @@
     "overrides": {
       "vite": "catalog:",
       "tsdown": "catalog:"
+    },
+    "peerDependencyRules": {
+      "allowAny": [
+        "vite"
+      ]
     }
   },
   "resolutions": {

--- a/packages/global/templates/monorepo/pnpm-workspace.yaml
+++ b/packages/global/templates/monorepo/pnpm-workspace.yaml
@@ -8,7 +8,7 @@ catalog:
   "@voidzero-dev/vite-plus": latest
   bumpp: ^10.1.0
   happy-dom: ^18.0.1
-  vite: npm:@voidzero-dev/vite-plus
+  vite: npm:@voidzero-dev/vite-plus@latest
   vitest: ^3.2.4
   typescript: ^5.9.2
   tsdown: ^0.15.1


### PR DESCRIPTION
### TL;DR

Added catalog versioning for dev dependencies and updated peer dependency rules for vite in monorepo templates.

### What changed?

- Modified `fixPackageJsonForVitePlus` function to use catalog versioning for common dev dependencies when not using Vite Plus
- Added catalog versioning for: `@types/node`, `bumpp`, `happy-dom`, `vitest`, `typescript`, `tsdown`, and `vite`
- Updated `pnpm-workspace.yaml` to include peer dependency rules that allow any version of vite

### How to test?

1. Create a new project without Vite Plus
2. Verify that the specified dev dependencies use catalog versioning in package.json
3. Create a new monorepo project and check that the pnpm-workspace.yaml contains the new peer dependency rules

### Why make this change?

This change improves dependency management in projects by leveraging catalog versioning for common dev dependencies, ensuring consistent versions across projects. The peer dependency rule for vite helps prevent version conflicts when different packages in the monorepo have different vite version requirements.