### PR TITLE
perf: lazily import resolveConfig

### DIFF
--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -12,7 +12,6 @@
 import { run } from '../binding/index.js';
 import { doc } from './doc.js';
 import { fmt } from './fmt.js';
-import { resolveConfig } from './index.js';
 import { lib } from './lib.js';
 import { lint } from './lint.js';
 import { test } from './test.js';
@@ -22,7 +21,7 @@ async function resolveUniversalViteConfig(err: null | Error, viteConfigCwd: stri
   if (err) {
     throw err;
   }
-
+  const { resolveConfig } = await import('./index.js');
   const config = await resolveConfig({ root: viteConfigCwd }, 'build');
 
   return Promise.resolve(JSON.stringify({


### PR DESCRIPTION
### TL;DR

Dynamically import `resolveConfig` in the `resolveUniversalViteConfig` function instead of importing it at the top level.

`resolveConfig` imports `rolldown-vite` which takes nearly 100ms. It's not actually used if cache is hit. Lazily importing it improves the startup time.



### Before:

![image.png](https://app.graphite.dev/user-attachments/assets/fe0bd5bf-0cee-43cd-bae3-936d0dcf4c00.png)

### After:

![image.png](https://app.graphite.dev/user-attachments/assets/84bb820e-d2c7-4f30-9fd2-fc55bf5bf141.png)

