### PR TITLE
perf(cli): enable Node.js compile cache

### DIFF
--- a/packages/cli/bin/vite
+++ b/packages/cli/bin/vite
@@ -1,3 +1,7 @@
 #!/usr/bin/env node
 
+import module from 'node:module'
+if (module.enableCompileCache) {
+  module.enableCompileCache()
+}
 import '../dist/bin.js'

--- a/packages/global/bin/vp
+++ b/packages/global/bin/vp
@@ -1,2 +1,7 @@
 #!/usr/bin/env node
+
+import module from 'node:module';
+if (module.enableCompileCache) {
+  module.enableCompileCache();
+}
 import "../dist/index.js";


### PR DESCRIPTION
Before

```bash
hyperfine --warmup 3 'node /Users/fengmk2/git/github.com/voidzero-dev/vite-plus/packages/global/bin/vp lint'

Benchmark 1: node /Users/fengmk2/git/github.com/voidzero-dev/vite-plus/packages/global/bin/vp lint
  Time (mean ± σ):     129.9 ms ±   1.6 ms    [User: 121.1 ms, System: 156.8 ms]
  Range (min … max):   128.1 ms … 133.8 ms    22 runs
```

After

```bash
hyperfine --warmup 3 'node /Users/fengmk2/git/github.com/voidzero-dev/vite-plus/packages/global/bin/vp lint'

Benchmark 1: node /Users/fengmk2/git/github.com/voidzero-dev/vite-plus/packages/global/bin/vp lint
  Time (mean ± σ):     101.9 ms ±   2.0 ms    [User: 92.5 ms, System: 157.0 ms]
  Range (min … max):    99.6 ms … 110.1 ms    28 runs
```