### PR TITLE
chore(cli): use 'vite test' replace 'vitest' command

### DIFF
--- a/packages/cli/snap-tests/npm-install-with-options/snap.txt
+++ b/packages/cli/snap-tests/npm-install-with-options/snap.txt
@@ -21,25 +21,13 @@ aliases: add, i, in, ins, inst, insta, instal, isnt, isnta, isntal, isntall
 Run "npm help install" for more info
 
 
-> vite install --production # https://docs.npmjs.com/cli/v10/commands/npm-install
+> vite install --production --silent # https://docs.npmjs.com/cli/v10/commands/npm-install
 
-added 1 package, and audited 2 packages in <variable>ms
-
-found 0 vulnerabilities
-
-
-npm warn config production Use `--omit=dev` instead.
 
 > ls node_modules
 @oxlint
 tslib
 
-> vite install --production # install again hit cache
+> vite install --production --silent # install again hit cache
 ✓ cache hit, replaying
 
-added 1 package, and audited 2 packages in <variable>ms
-
-found 0 vulnerabilities
-
-
-npm warn config production Use `--omit=dev` instead.

--- a/packages/cli/snap-tests/npm-install-with-options/steps.json
+++ b/packages/cli/snap-tests/npm-install-with-options/steps.json
@@ -4,8 +4,8 @@
   },
   "commands": [
     "vite install --help # print help message",
-    "vite install --production # https://docs.npmjs.com/cli/v10/commands/npm-install",
+    "vite install --production --silent # https://docs.npmjs.com/cli/v10/commands/npm-install",
     "ls node_modules",
-    "vite install --production # install again hit cache"
+    "vite install --production --silent # install again hit cache"
   ]
 }

--- a/packages/global/snap-tests/new-monorepo/snap.txt
+++ b/packages/global/snap-tests/new-monorepo/snap.txt
@@ -67,11 +67,11 @@ vite.config.ts
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "ready": "vite fmt && vite run lint && vite run test && vite run prepublishOnly",
+    "ready": "vite fmt && vite run lint && vite run test:all && vite run build:all",
     "dev": "vite run website#dev",
     "lint": "vite lint --type-aware",
-    "test": "vite test --passWithNoTests",
-    "prepublishOnly": "vite run -r build"
+    "test:all": "vite run -r test",
+    "build:all": "vite run -r build"
   },
   "devDependencies": {
     "vite": "catalog:"
@@ -139,10 +139,65 @@ website
    vite run dev
 
 
-> cd hello-vite-plus && ls -a packages
+> cd hello-vite-plus && ls -a packages && cat packages/my-lib/package.json # check package.json
 .
 ..
 my-lib
+{
+  "name": "my-lib",
+  "version": "0.0.0",
+  "description": "A starter for creating a React component library.",
+  "type": "module",
+  "license": "MIT",
+  "homepage": "https://github.com/author/library#readme",
+  "bugs": {
+    "url": "https://github.com/author/library/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/author/library.git"
+  },
+  "author": "Author Name <author.name@mail.com>",
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "vite lib",
+    "dev": "vite lib --watch",
+    "playground": "vite --config playground/vite.config.ts",
+    "test": "vite test",
+    "typecheck": "tsc --noEmit",
+    "release": "bumpp && pnpm publish",
+    "prepublishOnly": "pnpm run build",
+    "ready": "vite fmt && vite lint --type-aware && vite run build && vite test --passWithNoTests"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@types/node": "catalog:",
+    "@types/react": "^19.1.3",
+    "@types/react-dom": "^19.1.4",
+    "@vitejs/plugin-react": "^4.4.1",
+    "bumpp": "catalog:",
+    "happy-dom": "catalog:",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  }
+}
 
 > cd hello-vite-plus && vp new --lib tools/my-tool --template default # add lib new not exists tools directory
 
@@ -167,7 +222,51 @@ my-lib
    vite run dev
 
 
-> cd hello-vite-plus && ls -a tools
+> cd hello-vite-plus && ls -a tools && cat tools/my-tool/package.json # check package.json
 .
 ..
 my-tool
+{
+  "name": "my-tool",
+  "version": "0.0.0",
+  "description": "A starter for creating a TypeScript package.",
+  "type": "module",
+  "license": "MIT",
+  "homepage": "https://github.com/author/library#readme",
+  "bugs": {
+    "url": "https://github.com/author/library/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/author/library.git"
+  },
+  "author": "Author Name <author.name@mail.com>",
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "vite lib",
+    "dev": "vite lib --watch",
+    "test": "vite test",
+    "typecheck": "tsc --noEmit",
+    "release": "bumpp && npm publish",
+    "ready": "vite fmt && vite lint --type-aware && vite run build && vite test --passWithNoTests"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "bumpp": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/global/snap-tests/new-monorepo/steps.json
+++ b/packages/global/snap-tests/new-monorepo/steps.json
@@ -7,8 +7,8 @@
     "cd hello-vite-plus && vp new --app --template vanilla-ts apps/my-app # add app",
     "cd hello-vite-plus && ls -a apps",
     "cd hello-vite-plus && vp new --lib packages/my-lib --template react # add lib",
-    "cd hello-vite-plus && ls -a packages",
+    "cd hello-vite-plus && ls -a packages && cat packages/my-lib/package.json # check package.json",
     "cd hello-vite-plus && vp new --lib tools/my-tool --template default # add lib new not exists tools directory",
-    "cd hello-vite-plus && ls -a tools"
+    "cd hello-vite-plus && ls -a tools && cat tools/my-tool/package.json # check package.json"
   ]
 }

--- a/packages/global/src/new.ts
+++ b/packages/global/src/new.ts
@@ -869,6 +869,9 @@ async function fixPackageJsonForVitePlus(projectDir: string, selectedPackageMana
     if (pkg.scripts?.dev === 'tsdown --watch') {
       pkg.scripts.dev = 'vite lib --watch';
     }
+    if (pkg.scripts?.test === 'vitest' || pkg.scripts?.test === 'vitest run') {
+      pkg.scripts.test = 'vite test';
+    }
     // try to add ready script
     if (!pkg.scripts?.ready) {
       pkg.scripts.ready = 'vite fmt && vite lint --type-aware && vite run build && vite test --passWithNoTests';

--- a/packages/global/templates/monorepo/package.json
+++ b/packages/global/templates/monorepo/package.json
@@ -8,11 +8,11 @@
     "tools/*"
   ],
   "scripts": {
-    "ready": "vite fmt && vite run lint && vite run test && vite run prepublishOnly",
+    "ready": "vite fmt && vite run lint && vite run test:all && vite run build:all",
     "dev": "vite run website#dev",
     "lint": "vite lint --type-aware",
-    "test": "vite test --passWithNoTests",
-    "prepublishOnly": "vite run -r build"
+    "test:all": "vite run -r test",
+    "build:all": "vite run -r build"
   },
   "devDependencies": {
     "vite": "catalog:"

--- a/packages/global/templates/monorepo/vite.config.ts
+++ b/packages/global/templates/monorepo/vite.config.ts
@@ -1,7 +1,3 @@
 import { defineConfig } from 'vite';
 
-export default defineConfig({
-  test: {
-    projects: ['apps/*', 'packages/*', 'tools/*'],
-  },
-});
+export default defineConfig({});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig } from '@voidzero-dev/vite-plus';
 
 export default defineConfig({
   test: {


### PR DESCRIPTION
### TL;DR

Improved monorepo template scripts and added silent flag to npm install tests.

### What changed?

- Updated monorepo template scripts in `package.json` to use more descriptive names:
  - Changed `prepublishOnly` to `build:all`
  - Changed `test` to `test:all`
  - Updated the `ready` script to use the new script names
- Added `--silent` flag to npm install commands in snap tests to reduce output verbosity
- Enhanced the `fixPackageJsonForVitePlus` function to properly update test scripts
- Simplified the monorepo template's `vite.config.ts` by replacing the test projects configuration with commented placeholders
- Updated snap tests to display package.json contents for better verification
- Changed vitest config import to use `@voidzero-dev/vite-plus`

### How to test?

1. Create a new monorepo project: `vp new my-monorepo --template monorepo`
2. Verify the root package.json has the updated script names
3. Add a new library: `vp new --lib packages/my-lib --template react`
4. Check that the library's package.json has the correct test script
5. Run the CLI snap tests: `vite test packages/cli/snap-tests/npm-install-with-options`

### Why make this change?

The script naming improvements make the monorepo template more intuitive and consistent. The `build:all` and `test:all` names better reflect their purpose of running these commands across all packages. Adding the silent flag to npm install tests reduces noise in test output, making it easier to focus on relevant information. The package.json display in snap tests provides better verification of template generation.