### PR TITLE
style: fix clippy::semicolon_if_nothing_returned

### DIFF
--- a/crates/fspy_shared_unix/src/exec/which.rs
+++ b/crates/fspy_shared_unix/src/exec/which.rs
@@ -115,12 +115,12 @@ mod tests {
         let file: &BStr = B("foo").as_bstr();
         let path: &BStr = B("/bin:/usr/bin").as_bstr();
         let access = mock_access(&["/bin/foo"], &[], &[]);
-        let res = which(&file, &path, access, |found| {
+        let res = which(file, path, access, |found| {
             *called.borrow_mut() = Some(found.to_owned());
             Ok(())
         });
         assert!(res.is_ok());
-        assert_eq!(&*called.borrow().as_ref().unwrap(), b"/bin/foo".as_bstr());
+        assert_eq!(called.borrow().as_ref().unwrap(), b"/bin/foo".as_bstr());
     }
 
     #[test]
@@ -128,7 +128,7 @@ mod tests {
         let file: &BStr = B("foo").as_bstr();
         let path: &BStr = B("/bin:/usr/bin").as_bstr();
         let access = mock_access(&[], &[], &[]);
-        let res = which(&file, &path, access, |_| Ok(()));
+        let res = which(file, path, access, |_| Ok(()));
         assert_eq!(res.unwrap_err(), nix::Error::ENOENT);
     }
 
@@ -137,7 +137,7 @@ mod tests {
         let file: &BStr = B("foo").as_bstr();
         let path: &BStr = B("/bin:/usr/bin").as_bstr();
         let access = mock_access(&[], &["/bin/foo", "/usr/bin/foo"], &[]);
-        let res = which(&file, &path, access, |_| Ok(()));
+        let res = which(file, path, access, |_| Ok(()));
         assert_eq!(res.unwrap_err(), nix::Error::EACCES);
     }
 
@@ -146,7 +146,7 @@ mod tests {
         let file: &BStr = B("foo").as_bstr();
         let path: &BStr = B("/usr/bin:/bin").as_bstr();
         let access = mock_access(&[], &[], &["/bin/foo"]);
-        let res = which(&file, &path, access, |_| Ok(()));
+        let res = which(file, path, access, |_| Ok(()));
         assert_eq!(res.unwrap_err(), nix::Error::ENOTDIR);
     }
 
@@ -156,12 +156,12 @@ mod tests {
         let file: &BStr = B("/usr/bin/foo").as_bstr();
         let path: &BStr = B("").as_bstr();
         let access = mock_access(&["/usr/bin/foo"], &[], &[]);
-        let res = which(&file, &path, access, |found| {
+        let res = which(file, path, access, |found| {
             *called.borrow_mut() = Some(found.to_owned());
             Ok(())
         });
         assert!(res.is_ok());
-        assert_eq!(&*called.borrow().as_ref().unwrap(), b"/usr/bin/foo".as_bstr());
+        assert_eq!(called.borrow().as_ref().unwrap(), b"/usr/bin/foo".as_bstr());
     }
 
     #[test]
@@ -169,7 +169,7 @@ mod tests {
         let file: &BStr = B("").as_bstr();
         let path: &BStr = B("/bin:/usr/bin").as_bstr();
         let access = mock_access(&[], &[], &[]);
-        let res = which(&file, &path, access, |_| Ok(()));
+        let res = which(file, path, access, |_| Ok(()));
         assert_eq!(res.unwrap_err(), nix::Error::ENOENT);
     }
 
@@ -179,7 +179,7 @@ mod tests {
         let file: &BStr = B(&long_name).as_bstr();
         let path: &BStr = B("/bin:/usr/bin").as_bstr();
         let access = mock_access(&[], &[], &[]);
-        let res = which(&file, &path, access, |_| Ok(()));
+        let res = which(file, path, access, |_| Ok(()));
         assert_eq!(res.unwrap_err(), nix::Error::ENAMETOOLONG);
     }
 
@@ -189,11 +189,11 @@ mod tests {
         let file: &BStr = B("foo").as_bstr();
         let path: &BStr = B(":/bin").as_bstr();
         let access = mock_access(&["foo"], &[], &[]);
-        let res = which(&file, &path, access, |found| {
+        let res = which(file, path, access, |found| {
             *called.borrow_mut() = Some(found.to_owned());
             Ok(())
         });
         assert!(res.is_ok());
-        assert_eq!(&*called.borrow().as_ref().unwrap(), b"foo".as_bstr());
+        assert_eq!(called.borrow().as_ref().unwrap(), b"foo".as_bstr());
     }
 }

--- a/crates/vite_package_manager/src/package_manager.rs
+++ b/crates/vite_package_manager/src/package_manager.rs
@@ -934,7 +934,7 @@ mod tests {
         let package_json_path = temp_dir.path().join("package.json");
         let package_json: serde_json::Value =
             serde_json::from_slice(&fs::read(&package_json_path).unwrap()).unwrap();
-        println!("package_json: {:?}", package_json);
+        println!("package_json: {package_json:?}");
         assert!(package_json["packageManager"].as_str().unwrap().starts_with("pnpm@"));
         // keep other fields
         assert_eq!(package_json["version"].as_str().unwrap(), "1.0.0");
@@ -967,7 +967,7 @@ mod tests {
         let package_json_path = temp_dir_path.join("package.json");
         let package_json: serde_json::Value =
             serde_json::from_slice(&fs::read(&package_json_path).unwrap()).unwrap();
-        println!("package_json: {:?}", package_json);
+        println!("package_json: {package_json:?}");
         assert!(package_json["packageManager"].as_str().unwrap().starts_with("yarn@"));
         // keep other fields
         assert_eq!(package_json["name"].as_str().unwrap(), "test-package");
@@ -993,12 +993,12 @@ mod tests {
 
         // check shim files
         let bin_prefix = result.get_bin_prefix();
-        assert!(is_exists_file(&bin_prefix.join("npm")).unwrap());
-        assert!(is_exists_file(&bin_prefix.join("npm.cmd")).unwrap());
-        assert!(is_exists_file(&bin_prefix.join("npm.ps1")).unwrap());
-        assert!(is_exists_file(&bin_prefix.join("npx")).unwrap());
-        assert!(is_exists_file(&bin_prefix.join("npx.cmd")).unwrap());
-        assert!(is_exists_file(&bin_prefix.join("npx.ps1")).unwrap());
+        assert!(is_exists_file(bin_prefix.join("npm")).unwrap());
+        assert!(is_exists_file(bin_prefix.join("npm.cmd")).unwrap());
+        assert!(is_exists_file(bin_prefix.join("npm.ps1")).unwrap());
+        assert!(is_exists_file(bin_prefix.join("npx")).unwrap());
+        assert!(is_exists_file(bin_prefix.join("npx.cmd")).unwrap());
+        assert!(is_exists_file(bin_prefix.join("npx.ps1")).unwrap());
 
         // run npm --version
         let mut paths =
@@ -1039,12 +1039,12 @@ mod tests {
 
         // check shim files
         let bin_prefix = result.get_bin_prefix();
-        assert!(is_exists_file(&bin_prefix.join("pnpm.cjs")).unwrap());
-        assert!(is_exists_file(&bin_prefix.join("pnpm.cmd")).unwrap());
-        assert!(is_exists_file(&bin_prefix.join("pnpm.ps1")).unwrap());
-        assert!(is_exists_file(&bin_prefix.join("pnpx.cjs")).unwrap());
-        assert!(is_exists_file(&bin_prefix.join("pnpx.cmd")).unwrap());
-        assert!(is_exists_file(&bin_prefix.join("pnpx.ps1")).unwrap());
+        assert!(is_exists_file(bin_prefix.join("pnpm.cjs")).unwrap());
+        assert!(is_exists_file(bin_prefix.join("pnpm.cmd")).unwrap());
+        assert!(is_exists_file(bin_prefix.join("pnpm.ps1")).unwrap());
+        assert!(is_exists_file(bin_prefix.join("pnpx.cjs")).unwrap());
+        assert!(is_exists_file(bin_prefix.join("pnpx.cmd")).unwrap());
+        assert!(is_exists_file(bin_prefix.join("pnpx.ps1")).unwrap());
 
         // run pnpm --version
         let mut paths =
@@ -1180,13 +1180,13 @@ mod tests {
 
         // check shim files
         let bin_prefix = result.get_bin_prefix();
-        assert!(is_exists_file(&bin_prefix.join("yarn.js")).unwrap());
-        assert!(is_exists_file(&bin_prefix.join("yarn")).unwrap());
-        assert!(is_exists_file(&bin_prefix.join("yarn.cmd")).unwrap());
-        assert!(is_exists_file(&bin_prefix.join("yarn.ps1")).unwrap());
-        assert!(is_exists_file(&bin_prefix.join("yarnpkg")).unwrap());
-        assert!(is_exists_file(&bin_prefix.join("yarnpkg.cmd")).unwrap());
-        assert!(is_exists_file(&bin_prefix.join("yarnpkg.ps1")).unwrap());
+        assert!(is_exists_file(bin_prefix.join("yarn.js")).unwrap());
+        assert!(is_exists_file(bin_prefix.join("yarn")).unwrap());
+        assert!(is_exists_file(bin_prefix.join("yarn.cmd")).unwrap());
+        assert!(is_exists_file(bin_prefix.join("yarn.ps1")).unwrap());
+        assert!(is_exists_file(bin_prefix.join("yarnpkg")).unwrap());
+        assert!(is_exists_file(bin_prefix.join("yarnpkg.cmd")).unwrap());
+        assert!(is_exists_file(bin_prefix.join("yarnpkg.ps1")).unwrap());
 
         // run pnpm --version
         let mut paths =
@@ -1280,13 +1280,13 @@ mod tests {
 
         // check shim files
         let bin_prefix = result.get_bin_prefix();
-        assert!(is_exists_file(&bin_prefix.join("yarn.js")).unwrap());
-        assert!(is_exists_file(&bin_prefix.join("yarn")).unwrap());
-        assert!(is_exists_file(&bin_prefix.join("yarn.cmd")).unwrap());
-        assert!(is_exists_file(&bin_prefix.join("yarn.ps1")).unwrap());
-        assert!(is_exists_file(&bin_prefix.join("yarnpkg")).unwrap());
-        assert!(is_exists_file(&bin_prefix.join("yarnpkg.cmd")).unwrap());
-        assert!(is_exists_file(&bin_prefix.join("yarnpkg.ps1")).unwrap());
+        assert!(is_exists_file(bin_prefix.join("yarn.js")).unwrap());
+        assert!(is_exists_file(bin_prefix.join("yarn")).unwrap());
+        assert!(is_exists_file(bin_prefix.join("yarn.cmd")).unwrap());
+        assert!(is_exists_file(bin_prefix.join("yarn.ps1")).unwrap());
+        assert!(is_exists_file(bin_prefix.join("yarnpkg")).unwrap());
+        assert!(is_exists_file(bin_prefix.join("yarnpkg.cmd")).unwrap());
+        assert!(is_exists_file(bin_prefix.join("yarnpkg.ps1")).unwrap());
 
         // run yarn --version
         let mut cmd = "yarn";
@@ -1346,13 +1346,13 @@ mod tests {
 
         let result = PackageManager::builder(temp_dir_path).build().await;
         assert!(result.is_err());
-        println!("result: {:?}", result);
+        println!("result: {result:?}");
         // Check if it's the expected error type
         if let Err(Error::PackageManagerVersionNotFound { name, version, .. }) = result {
             assert_eq!(name, "yarn");
             assert_eq!(version, "10000000000.0.0");
         } else {
-            panic!("Expected PackageManagerVersionNotFound error, got {:?}", result);
+            panic!("Expected PackageManagerVersionNotFound error, got {result:?}");
         }
     }
 
@@ -1365,7 +1365,7 @@ mod tests {
         create_package_json(&temp_dir_path, package_content);
 
         let result = PackageManager::builder(temp_dir_path).build().await;
-        println!("result: {:?}", result);
+        println!("result: {result:?}");
         assert!(result.is_err());
     }
 
@@ -1402,7 +1402,7 @@ mod tests {
         let result = PackageManager::builder(temp_dir_path).build().await;
         assert!(result.is_err());
         // Check if it's the expected error type
-        if let Err(Error::UnrecognizedPackageManager) = result {
+        if matches!(result, Err(Error::UnrecognizedPackageManager)) {
             // Expected error
         } else {
             panic!("Expected UnrecognizedPackageManager error");
@@ -1474,9 +1474,9 @@ mod tests {
                 .await;
         assert!(result.is_ok());
         let target_dir = result.unwrap();
-        println!("result: {:?}", target_dir);
-        assert!(is_exists_file(&target_dir.join("bin/yarn")).unwrap());
-        assert!(is_exists_file(&target_dir.join("bin/yarn.cmd")).unwrap());
+        println!("result: {target_dir:?}");
+        assert!(is_exists_file(target_dir.join("bin/yarn")).unwrap());
+        assert!(is_exists_file(target_dir.join("bin/yarn.cmd")).unwrap());
 
         // again should skip download
         let result =
@@ -1484,8 +1484,8 @@ mod tests {
                 .await;
         assert!(result.is_ok());
         let target_dir = result.unwrap();
-        assert!(is_exists_file(&target_dir.join("bin/yarn")).unwrap());
-        assert!(is_exists_file(&target_dir.join("bin/yarn.cmd")).unwrap());
+        assert!(is_exists_file(target_dir.join("bin/yarn")).unwrap());
+        assert!(is_exists_file(target_dir.join("bin/yarn.cmd")).unwrap());
 
         remove_dir_all_force(target_dir).await.unwrap();
     }
@@ -1683,7 +1683,7 @@ mod tests {
                 version: "1.0.0".into(),
                 hash: None,
                 bin_name: pm_type.to_string().into(),
-                workspace_root: temp_dir_path.clone(),
+                workspace_root: temp_dir_path,
                 install_dir,
             }
         }

--- a/crates/vite_package_manager/src/request.rs
+++ b/crates/vite_package_manager/src/request.rs
@@ -468,7 +468,7 @@ mod tests {
         let url = format!("{}/file.txt", server.base_url());
 
         let result = client.download_file(&url, &target_file).await;
-        assert!(result.is_ok(), "Failed to download file: {:?}", result);
+        assert!(result.is_ok(), "Failed to download file: {result:?}");
 
         // Verify file exists and has correct content
         assert!(target_file.exists());
@@ -513,7 +513,7 @@ mod tests {
 
         let url = format!("{}/test-package.tgz", server.base_url());
         let result = download_and_extract_tgz_with_hash(&url, &target_dir, None).await;
-        assert!(result.is_ok(), "Failed to download and extract: {:?}", result);
+        assert!(result.is_ok(), "Failed to download and extract: {result:?}");
 
         assert!(target_dir.join("package/bin/yarn").exists());
         assert!(target_dir.join("package/bin/yarn.cmd").exists());

--- a/crates/vite_package_manager/src/shim.rs
+++ b/crates/vite_package_manager/src/shim.rs
@@ -116,7 +116,7 @@ mod tests {
     use super::*;
 
     fn format_shim(shim: &str) -> String {
-        shim.replace(" ", "·")
+        shim.replace(' ', "·")
     }
 
     #[test]
@@ -402,7 +402,7 @@ mod tests {
             assert!(ps1.contains(path));
 
             let cmd = cmd_shim(path);
-            let expected_cmd_path = path.replace("/", "\\");
+            let expected_cmd_path = path.replace('/', "\\");
             assert!(cmd.contains(&expected_cmd_path));
         }
     }

--- a/crates/vite_path/src/absolute.rs
+++ b/crates/vite_path/src/absolute.rs
@@ -206,7 +206,7 @@ mod tests {
 
     #[test]
     fn non_absolute() {
-        assert!(AbsolutePath::new(Path::new("foo/bar")).is_none())
+        assert!(AbsolutePath::new(Path::new("foo/bar")).is_none());
     }
 
     #[test]

--- a/crates/vite_path/src/relative.rs
+++ b/crates/vite_path/src/relative.rs
@@ -326,46 +326,46 @@ mod tests {
     #[test]
     fn normalize_dots() {
         let rel_path = RelativePathBuf::new("./foo/./bar/.").unwrap();
-        assert_eq!(rel_path.as_str(), "foo/bar")
+        assert_eq!(rel_path.as_str(), "foo/bar");
     }
 
     #[test]
     fn normalize_trailing_slashes() {
         let rel_path = RelativePathBuf::new("foo/bar//").unwrap();
-        assert_eq!(rel_path.as_str(), "foo/bar")
+        assert_eq!(rel_path.as_str(), "foo/bar");
     }
     #[test]
     fn preserve_double_dots() {
         let rel_path = RelativePathBuf::new("../foo/../bar/..").unwrap();
-        assert_eq!(rel_path.as_str(), "../foo/../bar/..")
+        assert_eq!(rel_path.as_str(), "../foo/../bar/..");
     }
 
     #[test]
     fn push() {
         let mut rel_path = RelativePathBuf::new("foo/bar").unwrap();
         rel_path.push(RelativePathBuf::new(Path::new("baz")).unwrap());
-        assert_eq!(rel_path.as_str(), "foo/bar/baz")
+        assert_eq!(rel_path.as_str(), "foo/bar/baz");
     }
 
     #[test]
     fn push_empty() {
         let mut rel_path = RelativePathBuf::new("foo/bar").unwrap();
         rel_path.push(RelativePathBuf::new("").unwrap());
-        assert_eq!(rel_path.as_str(), "foo/bar")
+        assert_eq!(rel_path.as_str(), "foo/bar");
     }
 
     #[test]
     fn join() {
         let rel_path = RelativePathBuf::new("foo/bar").unwrap();
         let joined_path = rel_path.as_relative_path().join(RelativePathBuf::new("baz").unwrap());
-        assert_eq!(joined_path.as_str(), "foo/bar/baz")
+        assert_eq!(joined_path.as_str(), "foo/bar/baz");
     }
 
     #[test]
     fn join_empty() {
         let rel_path = RelativePathBuf::new("").unwrap();
         let joined_path = rel_path.as_relative_path().join(RelativePathBuf::new("baz").unwrap());
-        assert_eq!(joined_path.as_str(), "baz")
+        assert_eq!(joined_path.as_str(), "baz");
     }
 
     #[test]
@@ -373,7 +373,7 @@ mod tests {
         let rel_path = RelativePathBuf::new("foo/bar/baz").unwrap();
         let prefix = RelativePathBuf::new("foo").unwrap();
         let stripped_path = rel_path.strip_prefix(prefix).unwrap();
-        assert_eq!(stripped_path.as_str(), "bar/baz")
+        assert_eq!(stripped_path.as_str(), "bar/baz");
     }
 
     #[test]

--- a/crates/vite_task/src/config/mod.rs
+++ b/crates/vite_task/src/config/mod.rs
@@ -307,7 +307,7 @@ mod tests {
 
             // Verify that all build tasks are included
             let task_names: Vec<_> =
-                task_graph.node_weights().map(|task| task.display_name()).collect();
+                task_graph.node_weights().map(super::ResolvedTask::display_name).collect();
 
             assert!(task_names.contains(&"@test/core#build".into()));
             assert!(task_names.contains(&"@test/utils#build".into()));
@@ -346,7 +346,7 @@ mod tests {
             //     !has_edge("@test/web#build", "@test/utils#build"),
             //     "Web should have edge to utils (It should be indirect via App)"
             // );
-        })
+        });
     }
 
     #[test]
@@ -476,7 +476,7 @@ mod tests {
 
             // Verify that all build tasks are included (recursive flag works)
             let task_names: Vec<_> =
-                task_graph.node_weights().map(|task| task.display_name()).collect();
+                task_graph.node_weights().map(super::ResolvedTask::display_name).collect();
 
             assert!(task_names.contains(&"@test/core#build".into()));
             assert!(task_names.contains(&"@test/utils#build".into()));
@@ -540,9 +540,7 @@ mod tests {
                 // With topological=true, there should be more edges due to implicit dependencies
                 assert!(
                     edge_count_true > edge_count_false,
-                    "Graph with topological=true ({}) should have more edges than topological=false ({})",
-                    edge_count_true,
-                    edge_count_false
+                    "Graph with topological=true ({edge_count_true}) should have more edges than topological=false ({edge_count_false})"
                 );
 
                 // Verify specific edge differences
@@ -584,7 +582,7 @@ mod tests {
 
             // Verify that all build tasks are included
             let task_names: Vec<_> =
-                task_graph.node_weights().map(|task| task.display_name()).collect();
+                task_graph.node_weights().map(super::ResolvedTask::display_name).collect();
 
             assert!(task_names.contains(&"@test/core#build".into()));
             assert!(task_names.contains(&"@test/utils#build".into()));
@@ -605,7 +603,7 @@ mod tests {
                 has_edge("@test/utils#build(subcommand 0)", "@test/core#build"),
                 "utils should have edge to core"
             );
-        })
+        });
     }
 
     #[test]
@@ -627,7 +625,7 @@ mod tests {
                 }
                 _ => panic!("Expected RecursiveRunWithScope error"),
             }
-        })
+        });
     }
 
     #[test]
@@ -645,7 +643,7 @@ mod tests {
 
             // @test/utils has compound commands (3 subtasks) plus dependencies on @test/core#build
             let all_tasks: Vec<_> =
-                task_graph.node_weights().map(|task| task.display_name()).collect();
+                task_graph.node_weights().map(super::ResolvedTask::display_name).collect();
 
             // Should include utils subtasks
             assert!(all_tasks.contains(&"@test/utils#build(subcommand 0)".into()));
@@ -654,7 +652,7 @@ mod tests {
 
             // Should also include dependency on core
             assert!(all_tasks.contains(&"@test/core#build".into()));
-        })
+        });
     }
 
     #[test]
@@ -672,7 +670,7 @@ mod tests {
 
             // Check all tasks including subcommands
             let all_tasks: Vec<_> =
-                task_graph.node_weights().map(|task| task.display_name()).collect();
+                task_graph.node_weights().map(super::ResolvedTask::display_name).collect();
 
             // Utils should have 3 subtasks (indices 0, 1, and None)
             assert!(all_tasks.contains(&"@test/utils#build(subcommand 0)".into()));
@@ -710,7 +708,7 @@ mod tests {
                 has_edge("@test/app#build", "@test/utils#build"),
                 "app should have edge to Utils' last subtask"
             );
-        })
+        });
     }
 
     #[test]
@@ -728,7 +726,7 @@ mod tests {
 
             // Verify that all build tasks are included
             let task_names: Vec<_> =
-                task_graph.node_weights().map(|task| task.display_name()).collect();
+                task_graph.node_weights().map(super::ResolvedTask::display_name).collect();
 
             assert!(
                 task_names.contains(&"@test/a#build".into()),
@@ -754,7 +752,7 @@ mod tests {
                 has_edge("@test/a#build", "@test/c#build"),
                 "A should have edge to C (A depends on C transitively through B)"
             );
-        })
+        });
     }
 
     #[test]
@@ -771,7 +769,7 @@ mod tests {
                 .expect("Failed to resolve build tasks");
 
             let build_tasks: Vec<_> =
-                build_graph.node_weights().map(|task| task.display_name()).collect();
+                build_graph.node_weights().map(super::ResolvedTask::display_name).collect();
 
             // Verify all packages with build scripts are included
             assert!(build_tasks.contains(&"@test/shared#build".into()));
@@ -850,7 +848,7 @@ mod tests {
                 .expect("Failed to resolve test tasks");
 
             let test_tasks: Vec<_> =
-                test_graph.node_weights().map(|task| task.display_name()).collect();
+                test_graph.node_weights().map(super::ResolvedTask::display_name).collect();
 
             assert!(test_tasks.contains(&"@test/shared#test".into()));
             assert!(test_tasks.contains(&"@test/ui#test".into()));
@@ -874,7 +872,7 @@ mod tests {
                 .expect("Failed to resolve api build task");
 
             let api_deps: Vec<_> =
-                api_build_graph.node_weights().map(|task| task.display_name()).collect();
+                api_build_graph.node_weights().map(super::ResolvedTask::display_name).collect();
 
             // Should include api and its dependencies
             assert!(api_deps.contains(&"@test/api#build".into()));
@@ -883,7 +881,7 @@ mod tests {
             // Should not include app or ui
             assert!(!api_deps.contains(&"@test/app#build".into()));
             assert!(!api_deps.contains(&"@test/ui#build".into()));
-        })
+        });
     }
 
     #[test]
@@ -898,7 +896,7 @@ mod tests {
             let result =
                 workspace.build_task_subgraph(&["test#integration".into()], Arc::default(), true);
             assert!(result.is_err(), "Recursive run with # in task name should fail");
-        })
+        });
     }
 
     #[test]
@@ -938,7 +936,7 @@ mod tests {
 
             // Verify all tasks are present
             let all_tasks: Vec<_> =
-                app_build_graph.node_weights().map(|task| task.display_name()).collect();
+                app_build_graph.node_weights().map(super::ResolvedTask::display_name).collect();
 
             // App should have 5 subtasks (indices: 0, 1, 2, 3, None)
             assert_eq!(
@@ -1042,7 +1040,7 @@ mod tests {
                 "@test/ui#build(subcommand 0)",
                 "@test/shared#build",
             ));
-        })
+        });
     }
 
     #[test]
@@ -1138,7 +1136,7 @@ mod tests {
                 task_a.resolved_command.fingerprint, task_c_subtask_0.resolved_command.fingerprint,
                 "Task 'a' and first subtask of 'c' should have identical fingerprints for cache sharing"
             );
-        })
+        });
     }
 
     #[test]
@@ -1162,12 +1160,11 @@ mod tests {
                 .expect("Failed to resolve build tasks recursively");
 
             let task_names: Vec<_> =
-                build_tasks.node_weights().map(|task| task.display_name()).collect();
+                build_tasks.node_weights().map(super::ResolvedTask::display_name).collect();
 
             assert!(
                 task_names.contains(&"build".into()),
-                "Should find empty-name package build task, found: {:?}",
-                task_names
+                "Should find empty-name package build task, found: {task_names:?}"
             );
             assert!(
                 task_names.contains(&"normal-package#build".into()),
@@ -1180,7 +1177,7 @@ mod tests {
                 .expect("Failed to resolve empty-name build");
 
             let empty_build_tasks: Vec<_> =
-                empty_build.node_weights().map(|task| task.display_name()).collect();
+                empty_build.node_weights().map(super::ResolvedTask::display_name).collect();
 
             assert!(empty_build_tasks.contains(&"build".into()), "Should have build task");
             assert!(
@@ -1203,7 +1200,7 @@ mod tests {
                 has_edge(&empty_build, "build", "test"),
                 "Empty-name build should depend on empty-name test (internal dependency)"
             );
-        })
+        });
     }
 
     #[test]
@@ -1229,15 +1226,14 @@ mod tests {
                 .expect("Failed to resolve build tasks recursively");
 
             let task_names: Vec<_> =
-                build_tasks.node_weights().map(|task| task.display_name()).collect();
+                build_tasks.node_weights().map(super::ResolvedTask::display_name).collect();
 
             // Count build tasks from nameless packages (they appear as just "build")
             let nameless_build_count = task_names.iter().filter(|name| *name == "build").count();
 
             assert_eq!(
                 nameless_build_count, 2,
-                "Should find 2 'build' tasks from nameless packages, found tasks: {:?}",
-                task_names
+                "Should find 2 'build' tasks from nameless packages, found tasks: {task_names:?}"
             );
 
             // Verify normal package build is also included
@@ -1253,7 +1249,7 @@ mod tests {
                 .expect("Failed to resolve deploy tasks");
 
             let deploy_task_names: Vec<_> =
-                deploy_tasks.node_weights().map(|task| task.display_name()).collect();
+                deploy_tasks.node_weights().map(super::ResolvedTask::display_name).collect();
 
             // Check that deploy task and its dependencies are resolved
             assert!(
@@ -1275,7 +1271,7 @@ mod tests {
                 .expect("Failed to resolve test tasks");
 
             let test_task_names: Vec<_> =
-                test_tasks.node_weights().map(|task| task.display_name()).collect();
+                test_tasks.node_weights().map(super::ResolvedTask::display_name).collect();
 
             // Should have test tasks from both nameless packages and normal-package
             let nameless_test_count = test_task_names.iter().filter(|name| *name == "test").count();
@@ -1315,7 +1311,7 @@ mod tests {
                     && has_edge(&build_graph, "build", "normal-package#test"),
                 "Should have dependency from normal-package to second nameless package due to topological ordering"
             );
-        })
+        });
     }
 
     #[test]
@@ -1355,7 +1351,7 @@ mod tests {
                 }
             }
             assert!(found_app_test, "Should find @test/app#test task in graph");
-        })
+        });
     }
 
     #[test]
@@ -1379,9 +1375,9 @@ mod tests {
                     Error::AmbiguousTaskRequest { .. } => {
                         // This is the expected error
                     }
-                    _ => panic!("Expected TaskNameConflict error, but got: {:?}", e),
+                    _ => panic!("Expected TaskNameConflict error, but got: {e:?}"),
                 }
             }
-        })
+        });
     }
 }

--- a/crates/vite_task/src/execute.rs
+++ b/crates/vite_task/src/execute.rs
@@ -765,14 +765,17 @@ mod tests {
         );
 
         assert_eq!(
-            envs_without_pass_through.get("TEST_VAR").map(|s| s.as_str()),
+            envs_without_pass_through.get("TEST_VAR").map(vite_str::Str::as_str),
             Some("uppercase")
         );
         assert_eq!(
-            envs_without_pass_through.get("test_var").map(|s| s.as_str()),
+            envs_without_pass_through.get("test_var").map(vite_str::Str::as_str),
             Some("lowercase")
         );
-        assert_eq!(envs_without_pass_through.get("Test_Var").map(|s| s.as_str()), Some("mixed"));
+        assert_eq!(
+            envs_without_pass_through.get("Test_Var").map(vite_str::Str::as_str),
+            Some("mixed")
+        );
 
         // Clean up
         unsafe {

--- a/crates/vite_task/src/fingerprint.rs
+++ b/crates/vite_task/src/fingerprint.rs
@@ -160,7 +160,7 @@ mod tests {
 
         let fingerprint2 = CommandFingerprint {
             cwd: RelativePathBuf::default(),
-            command: TaskCommand::Parsed(parsed_cmd.clone()),
+            command: TaskCommand::Parsed(parsed_cmd),
             envs_without_pass_through: [
                 ("ENV_A".into(), "a".into()),
                 ("ENV_B".into(), "b".into()),
@@ -478,7 +478,11 @@ mod tests {
                 fingerprint.inputs.len(),
                 12,
                 "got {:?}",
-                fingerprint.inputs.keys().map(|k| k.to_string()).collect::<Vec<String>>()
+                fingerprint
+                    .inputs
+                    .keys()
+                    .map(std::string::ToString::to_string)
+                    .collect::<Vec<String>>()
             );
             assert!(
                 fingerprint.inputs.contains_key(&RelativePathBuf::new("src/index.js").unwrap())
@@ -696,7 +700,7 @@ mod tests {
 
         let fingerprint_without_ignores = CommandFingerprint {
             cwd: RelativePathBuf::default(),
-            command: TaskCommand::Parsed(parsed_cmd.clone()),
+            command: TaskCommand::Parsed(parsed_cmd),
             envs_without_pass_through: Default::default(),
             pass_through_envs: Default::default(),
             fingerprint_ignores: None,
@@ -739,7 +743,7 @@ mod tests {
 
         let fingerprint2 = CommandFingerprint {
             cwd: RelativePathBuf::default(),
-            command: TaskCommand::Parsed(parsed_cmd.clone()),
+            command: TaskCommand::Parsed(parsed_cmd),
             envs_without_pass_through: Default::default(),
             pass_through_envs: Default::default(),
             fingerprint_ignores: Some(vec![Str::from("!dist/public/**"), Str::from("dist/**/*")]),

--- a/crates/vite_task/src/fs.rs
+++ b/crates/vite_task/src/fs.rs
@@ -266,8 +266,7 @@ mod tests {
         // Create a test file with known content
         std::fs::write(&temp_file, "Hello, World!").unwrap();
 
-        let file_path =
-            Arc::<AbsolutePath>::from(AbsolutePathBuf::new(temp_file.to_path_buf()).unwrap());
+        let file_path = Arc::<AbsolutePath>::from(AbsolutePathBuf::new(temp_file).unwrap());
         let path_read = PathRead { read_dir_entries: false };
 
         let result = fs.fingerprint_path(&file_path, path_read).unwrap();
@@ -300,7 +299,7 @@ mod tests {
                 assert!(entries.contains_key("file2.txt"));
                 assert_eq!(entries.len(), 2);
             }
-            _ => panic!("Expected folder with entries, got: {:?}", result),
+            _ => panic!("Expected folder with entries, got: {result:?}"),
         }
 
         // Test without reading entries
@@ -311,10 +310,10 @@ mod tests {
                 // On Windows CI, temporary directories might have permission issues
                 // Skip the test if we get a permission denied error
                 if cfg!(windows) && err.to_string().contains("Access is denied") {
-                    eprintln!("Skipping test due to Windows permission issue: {}", err);
+                    eprintln!("Skipping test due to Windows permission issue: {err}");
                     return;
                 }
-                panic!("Unexpected error: {}", err);
+                panic!("Unexpected error: {err}");
             }
         };
         assert!(matches!(result_no_entries, PathFingerprint::Folder(None)));

--- a/crates/vite_task/src/install.rs
+++ b/crates/vite_task/src/install.rs
@@ -405,7 +405,7 @@ mod tests {
 
         let command = InstallCommandBuilder::new(workspace_root).build();
         let result = command.execute(&vec![]).await;
-        println!("result: {:?}", result);
+        println!("result: {result:?}");
         assert!(result.is_ok());
     }
 

--- a/crates/vite_task/src/lib.rs
+++ b/crates/vite_task/src/lib.rs
@@ -539,7 +539,7 @@ mod tests {
 
     #[test]
     fn test_args_basic_task() {
-        let args = Args::try_parse_from(&["vite-plus", "build"]).unwrap();
+        let args = Args::try_parse_from(["vite-plus", "build"]).unwrap();
         assert_eq!(args.task, None);
         assert!(args.task_args.is_empty());
         assert!(matches!(args.commands, Commands::Build { .. }));
@@ -548,7 +548,7 @@ mod tests {
 
     #[test]
     fn test_args_fmt_command() {
-        let args = Args::try_parse_from(&["vite-plus", "fmt"]).unwrap();
+        let args = Args::try_parse_from(["vite-plus", "fmt"]).unwrap();
         assert_eq!(args.task, None);
         assert!(args.task_args.is_empty());
         assert!(matches!(args.commands, Commands::Fmt { .. }));
@@ -557,7 +557,7 @@ mod tests {
 
     #[test]
     fn test_args_fmt_command_with_args() {
-        let args = Args::try_parse_from(&[
+        let args = Args::try_parse_from([
             "vite-plus",
             "fmt",
             "--",
@@ -580,7 +580,7 @@ mod tests {
 
     #[test]
     fn test_args_test_command() {
-        let args = Args::try_parse_from(&["vite-plus", "test"]).unwrap();
+        let args = Args::try_parse_from(["vite-plus", "test"]).unwrap();
         assert_eq!(args.task, None);
         assert!(args.task_args.is_empty());
         assert!(matches!(args.commands, Commands::Test { .. }));
@@ -590,7 +590,7 @@ mod tests {
     #[test]
     fn test_args_test_command_with_args() {
         let args =
-            Args::try_parse_from(&["vite-plus", "test", "--", "--watch", "--coverage"]).unwrap();
+            Args::try_parse_from(["vite-plus", "test", "--", "--watch", "--coverage"]).unwrap();
         assert_eq!(args.task, None);
         assert!(args.task_args.is_empty());
         if let Commands::Test { args } = &args.commands {
@@ -602,7 +602,7 @@ mod tests {
 
     #[test]
     fn test_args_lib_command() {
-        let args = Args::try_parse_from(&["vite-plus", "lib"]).unwrap();
+        let args = Args::try_parse_from(["vite-plus", "lib"]).unwrap();
         assert_eq!(args.task, None);
         assert!(args.task_args.is_empty());
         assert!(matches!(args.commands, Commands::Lib { .. }));
@@ -610,7 +610,7 @@ mod tests {
 
     #[test]
     fn test_args_lib_command_with_args() {
-        let args = Args::try_parse_from(&["vite-plus", "lib", "--", "--watch", "--outdir", "dist"])
+        let args = Args::try_parse_from(["vite-plus", "lib", "--", "--watch", "--outdir", "dist"])
             .unwrap();
         assert_eq!(args.task, None);
         assert!(args.task_args.is_empty());
@@ -626,7 +626,7 @@ mod tests {
 
     #[test]
     fn test_args_debug_flag() {
-        let args = Args::try_parse_from(&["vite-plus", "--debug", "build"]).unwrap();
+        let args = Args::try_parse_from(["vite-plus", "--debug", "build"]).unwrap();
         assert_eq!(args.task, None);
         assert!(matches!(args.commands, Commands::Build { .. }));
         assert!(args.debug);
@@ -634,7 +634,7 @@ mod tests {
 
     #[test]
     fn test_args_debug_flag_short() {
-        let args = Args::try_parse_from(&["vite-plus", "-d", "build"]).unwrap();
+        let args = Args::try_parse_from(["vite-plus", "-d", "build"]).unwrap();
         assert_eq!(args.task, None);
         assert!(matches!(args.commands, Commands::Build { .. }));
         assert!(args.debug);
@@ -643,49 +643,48 @@ mod tests {
     #[test]
     fn test_boolean_flag_negation() {
         // Test --no-debug alone
-        let args = Args::try_parse_from(&["vite-plus", "--no-debug", "build"]).unwrap();
+        let args = Args::try_parse_from(["vite-plus", "--no-debug", "build"]).unwrap();
         assert!(!args.debug);
         assert!(args.no_debug);
-        assert_eq!(resolve_bool_flag(args.debug, args.no_debug), false);
+        assert!(!resolve_bool_flag(args.debug, args.no_debug));
 
         // Test run command with --no-recursive
-        let args = Args::try_parse_from(&["vite-plus", "run", "--no-recursive", "build"]).unwrap();
+        let args = Args::try_parse_from(["vite-plus", "run", "--no-recursive", "build"]).unwrap();
         if let Commands::Run { recursive, no_recursive, .. } = args.commands {
             assert!(!recursive);
             assert!(no_recursive);
-            assert_eq!(resolve_bool_flag(recursive, no_recursive), false);
+            assert!(!resolve_bool_flag(recursive, no_recursive));
         } else {
             panic!("Expected Run command");
         }
 
         // Test run command with --no-parallel
-        let args = Args::try_parse_from(&["vite-plus", "run", "--no-parallel", "build"]).unwrap();
+        let args = Args::try_parse_from(["vite-plus", "run", "--no-parallel", "build"]).unwrap();
         if let Commands::Run { parallel, no_parallel, .. } = args.commands {
             assert!(!parallel);
             assert!(no_parallel);
-            assert_eq!(resolve_bool_flag(parallel, no_parallel), false);
+            assert!(!resolve_bool_flag(parallel, no_parallel));
         } else {
             panic!("Expected Run command");
         }
 
         // Test run command with --no-topological
-        let args =
-            Args::try_parse_from(&["vite-plus", "run", "--no-topological", "build"]).unwrap();
+        let args = Args::try_parse_from(["vite-plus", "run", "--no-topological", "build"]).unwrap();
         if let Commands::Run { topological, no_topological, .. } = args.commands {
             assert_eq!(topological, None);
             assert!(no_topological);
             // no_topological takes precedence
-            assert_eq!(no_topological, true);
+            assert!(no_topological);
         } else {
             panic!("Expected Run command");
         }
 
         // Test --debug vs --no-debug conflict (should fail)
-        let result = Args::try_parse_from(&["vite-plus", "--debug", "--no-debug", "build"]);
+        let result = Args::try_parse_from(["vite-plus", "--debug", "--no-debug", "build"]);
         assert!(result.is_err());
 
         // Test recursive with topological default behavior
-        let args = Args::try_parse_from(&["vite-plus", "run", "--recursive", "build"]).unwrap();
+        let args = Args::try_parse_from(["vite-plus", "run", "--recursive", "build"]).unwrap();
         if let Commands::Run { recursive, no_recursive, topological, no_topological, .. } =
             args.commands
         {
@@ -700,7 +699,7 @@ mod tests {
 
         // Test recursive with --no-topological
         let args =
-            Args::try_parse_from(&["vite-plus", "run", "--recursive", "--no-topological", "build"])
+            Args::try_parse_from(["vite-plus", "run", "--recursive", "--no-topological", "build"])
                 .unwrap();
         if let Commands::Run { recursive, no_recursive, topological, no_topological, .. } =
             args.commands
@@ -717,7 +716,7 @@ mod tests {
 
     #[test]
     fn test_args_run_command_basic() {
-        let args = Args::try_parse_from(&["vite-plus", "run", "build", "test"]).unwrap();
+        let args = Args::try_parse_from(["vite-plus", "run", "build", "test"]).unwrap();
         assert!(args.task.is_none());
 
         if let Commands::Run {
@@ -744,7 +743,7 @@ mod tests {
     #[test]
     fn test_args_run_command_with_flags() {
         let args =
-            Args::try_parse_from(&["vite-plus", "run", "--recursive", "--sequential", "build"])
+            Args::try_parse_from(["vite-plus", "run", "--recursive", "--sequential", "build"])
                 .unwrap();
 
         if let Commands::Run { tasks, recursive, sequential, parallel, .. } = args.commands {
@@ -760,7 +759,7 @@ mod tests {
     #[test]
     fn test_args_run_command_with_parallel_flag() {
         let args =
-            Args::try_parse_from(&["vite-plus", "run", "--parallel", "build", "test"]).unwrap();
+            Args::try_parse_from(["vite-plus", "run", "--parallel", "build", "test"]).unwrap();
 
         if let Commands::Run { tasks, parallel, sequential, .. } = args.commands {
             assert_eq!(tasks, vec!["build", "test"]);
@@ -773,7 +772,7 @@ mod tests {
 
     #[test]
     fn test_args_run_command_with_task_args() {
-        let args = Args::try_parse_from(&[
+        let args = Args::try_parse_from([
             "vite-plus",
             "run",
             "build",
@@ -794,7 +793,7 @@ mod tests {
 
     #[test]
     fn test_args_run_command_all_flags() {
-        let args = Args::try_parse_from(&[
+        let args = Args::try_parse_from([
             "vite-plus",
             "run",
             "--recursive",
@@ -816,7 +815,7 @@ mod tests {
 
     #[test]
     fn test_args_debug_with_run_command() {
-        let args = Args::try_parse_from(&["vite-plus", "--debug", "run", "build"]).unwrap();
+        let args = Args::try_parse_from(["vite-plus", "--debug", "run", "build"]).unwrap();
 
         assert!(args.debug);
         if let Commands::Run { tasks, .. } = args.commands {
@@ -828,7 +827,7 @@ mod tests {
 
     #[test]
     fn test_args_run_short_flags() {
-        let args = Args::try_parse_from(&["vite-plus", "run", "-r", "-s", "-p", "build"]).unwrap();
+        let args = Args::try_parse_from(["vite-plus", "run", "-r", "-s", "-p", "build"]).unwrap();
 
         if let Commands::Run { tasks, recursive, sequential, parallel, .. } = args.commands {
             assert_eq!(tasks, vec!["build"]);
@@ -842,7 +841,7 @@ mod tests {
 
     #[test]
     fn test_args_run_empty_tasks() {
-        let args = Args::try_parse_from(&["vite-plus", "run"]).unwrap();
+        let args = Args::try_parse_from(["vite-plus", "run"]).unwrap();
 
         if let Commands::Run { tasks, .. } = args.commands {
             assert!(tasks.is_empty(), "Tasks should be empty when none provided");
@@ -853,7 +852,7 @@ mod tests {
 
     #[test]
     fn test_args_doc_command() {
-        let args = Args::try_parse_from(&["vite-plus", "doc"]).unwrap();
+        let args = Args::try_parse_from(["vite-plus", "doc"]).unwrap();
         assert_eq!(args.task, None);
         assert!(args.task_args.is_empty());
         assert!(matches!(args.commands, Commands::Doc { .. }));
@@ -863,7 +862,7 @@ mod tests {
     #[test]
     fn test_args_doc_command_with_args() {
         let args =
-            Args::try_parse_from(&["vite-plus", "doc", "build", "--host", "0.0.0.0"]).unwrap();
+            Args::try_parse_from(["vite-plus", "doc", "build", "--host", "0.0.0.0"]).unwrap();
         assert_eq!(args.task, None);
         assert!(args.task_args.is_empty());
         if let Commands::Doc { args } = &args.commands {
@@ -878,7 +877,7 @@ mod tests {
 
     #[test]
     fn test_args_complex_task_args() {
-        let args = Args::try_parse_from(&[
+        let args = Args::try_parse_from([
             "vite-plus",
             "test",
             "--",
@@ -909,7 +908,7 @@ mod tests {
 
     #[test]
     fn test_args_run_complex_task_args() {
-        let args = Args::try_parse_from(&[
+        let args = Args::try_parse_from([
             "vite-plus",
             "run",
             "--recursive",
@@ -936,7 +935,7 @@ mod tests {
     fn test_run_command_uses_subcommand_task_args() {
         // This test verifies that the main function uses task_args from Commands::Run,
         // not from the top-level Args struct
-        let args1 = Args::try_parse_from(&[
+        let args1 = Args::try_parse_from([
             "vite-plus",
             "run",
             "build",
@@ -947,7 +946,7 @@ mod tests {
         .unwrap();
 
         let args2 =
-            Args::try_parse_from(&["vite-plus", "build", "--", "--watch", "--mode=development"])
+            Args::try_parse_from(["vite-plus", "build", "--", "--watch", "--mode=development"])
                 .unwrap();
 
         // Verify args1: explicit mode with run subcommand

--- a/crates/vite_task/src/schedule.rs
+++ b/crates/vite_task/src/schedule.rs
@@ -287,6 +287,6 @@ mod tests {
             assert_order(&plan, "@test/ui#build", "@test/app#build(subcommand 0)");
             assert_order(&plan, "@test/api#build", "@test/app#build(subcommand 0)");
             assert_order(&plan, "@test/shared#build", "@test/app#build(subcommand 0)");
-        })
+        });
     }
 }

--- a/crates/vite_task/src/test_utils.rs
+++ b/crates/vite_task/src/test_utils.rs
@@ -7,7 +7,7 @@ where
 {
     let temp_dir = tempfile::tempdir().expect("Failed to create temp directory");
     let cache_path =
-        AbsolutePath::new(temp_dir.path()).unwrap().join(&format!("vite-test-{}", test_name));
+        AbsolutePath::new(temp_dir.path()).unwrap().join(format!("vite-test-{}", test_name));
 
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(cache_path)));
 


### PR DESCRIPTION
Add missing semicolons to statements for consistent formatting across:
- Test assertions in vite_path
- Test closures in vite_task
- Various test functions in vite_package_manager and other modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>