### PR TITLE
style: fix clippy::enum_variant_names

### DIFF
--- a/crates/vite_error/src/lib.rs
+++ b/crates/vite_error/src/lib.rs
@@ -12,13 +12,13 @@ use vite_str::Str;
 #[derive(Error, Debug)]
 pub enum Error {
     #[error(transparent)]
-    SqliteError(#[from] rusqlite::Error),
+    Sqlite(#[from] rusqlite::Error),
 
     #[error(transparent)]
-    BincodeEncodeError(#[from] bincode::error::EncodeError),
+    BincodeEncode(#[from] bincode::error::EncodeError),
 
     #[error(transparent)]
-    BincodeDecodeError(#[from] bincode::error::DecodeError),
+    BincodeDecode(#[from] bincode::error::DecodeError),
 
     #[error("Unrecognized db version: {0}")]
     UnrecognizedDbVersion(u32),
@@ -34,10 +34,10 @@ pub enum Error {
 
     #[cfg(unix)]
     #[error(transparent)]
-    NixError(#[from] nix::Error),
+    Nix(#[from] nix::Error),
 
     #[error(transparent)]
-    SerdeError(#[from] serde_json::Error),
+    Serde(#[from] serde_json::Error),
 
     #[error("Env value is not valid unicode: {key} = {value:?}")]
     EnvValueIsNotValidUnicode { key: Str, value: OsString },
@@ -54,10 +54,10 @@ pub enum Error {
     Utf8Error(#[from] bstr::Utf8Error),
 
     #[error(transparent)]
-    WaxBuildError(#[from] wax::BuildError),
+    WaxBuild(#[from] wax::BuildError),
 
     #[error(transparent)]
-    WaxWalkError(#[from] wax::WalkError),
+    WaxWalk(#[from] wax::WalkError),
 
     #[error("Duplicated task name: {0}")]
     DuplicatedTask(Str),
@@ -66,7 +66,7 @@ pub enum Error {
     DuplicatedPackageName { name: Str, path1: RelativePathBuf, path2: RelativePathBuf },
 
     #[error("Circular dependency found : {0:?}")]
-    CycleDependenciesError(petgraph::algo::Cycle<NodeIndex>),
+    CycleDependencies(petgraph::algo::Cycle<NodeIndex>),
 
     #[error("The package.json name is empty at {0:?}/package.json")]
     EmptyPackageName(AbsolutePathBuf),
@@ -93,7 +93,7 @@ pub enum Error {
     RecursiveRunWithScope(Str),
 
     #[error(transparent)]
-    SerdeYmlError(#[from] serde_yml::Error),
+    SerdeYml(#[from] serde_yml::Error),
 
     #[error("Lint failed, reason: {reason}")]
     LintFailed { status: Str, reason: Str },
@@ -102,7 +102,7 @@ pub enum Error {
     FmtFailed { status: Str, reason: Str },
 
     #[error("Vite failed")]
-    ViteError { status: Str, reason: Str },
+    Vite { status: Str, reason: Str },
 
     #[error("Test failed")]
     TestFailed { status: Str, reason: Str },
@@ -119,7 +119,7 @@ pub enum Error {
     #[error(
         "The stripped path ({stripped_path:?}) is not a valid relative path because: {invalid_path_data_error}"
     )]
-    StripPathError { stripped_path: Box<Path>, invalid_path_data_error: InvalidPathDataError },
+    StripPath { stripped_path: Box<Path>, invalid_path_data_error: InvalidPathDataError },
 
     #[error("The path ({path:?}) is not a valid relative path because: {reason}")]
     InvalidRelativePath { path: Box<Path>, reason: FromPathError },
@@ -142,10 +142,10 @@ pub enum Error {
     PackageManagerVersionNotFound { name: Str, version: Str, url: Str },
 
     #[error(transparent)]
-    SemverError(#[from] semver::Error),
+    Semver(#[from] semver::Error),
 
     #[error(transparent)]
-    ReqwestError(#[from] reqwest::Error),
+    Reqwest(#[from] reqwest::Error),
 
     #[error(transparent)]
     JoinError(#[from] tokio::task::JoinError),
@@ -163,12 +163,12 @@ pub enum Error {
     UnsupportedHashAlgorithm(Str),
 
     #[error(transparent)]
-    AnyhowError(#[from] anyhow::Error),
+    Anyhow(#[from] anyhow::Error),
 }
 
 impl From<StripPrefixError<'_>> for Error {
     fn from(value: StripPrefixError<'_>) -> Self {
-        Self::StripPathError {
+        Self::StripPath {
             stripped_path: Box::from(value.stripped_path),
             invalid_path_data_error: value.invalid_path_data_error,
         }

--- a/crates/vite_package_manager/src/package_manager.rs
+++ b/crates/vite_package_manager/src/package_manager.rs
@@ -469,7 +469,7 @@ async fn download_package_manager(
     download_and_extract_tgz_with_hash(&tgz_url, &target_dir_tmp, expected_hash).await.map_err(
         |err| {
             // status 404 means the version is not found, convert to PackageManagerVersionNotFound error
-            if let Error::ReqwestError(e) = &err
+            if let Error::Reqwest(e) = &err
                 && let Some(status) = e.status()
                 && status == reqwest::StatusCode::NOT_FOUND
             {

--- a/crates/vite_task/src/schedule.rs
+++ b/crates/vite_task/src/schedule.rs
@@ -104,7 +104,7 @@ impl ExecutionPlan {
         // or the task dependencies declaration is meaningless
         let node_indices = match toposort(&task_graph, None) {
             Ok(ok) => ok,
-            Err(err) => return Err(Error::CycleDependenciesError(err)),
+            Err(err) => return Err(Error::CycleDependencies(err)),
         };
 
         // TODO: implement parallel execution grouping

--- a/packages/cli/binding/src/lib.rs
+++ b/packages/cli/binding/src/lib.rs
@@ -225,7 +225,7 @@ fn js_error_to_fmt_error(err: napi::Error) -> Error {
 
 /// Convert JavaScript errors to Rust vite errors
 fn js_error_to_vite_error(err: napi::Error) -> Error {
-    Error::ViteError { status: err.status.to_string().into(), reason: err.to_string().into() }
+    Error::Vite { status: err.status.to_string().into(), reason: err.to_string().into() }
 }
 
 /// Convert JavaScript errors to Rust test errors


### PR DESCRIPTION
Rename Error enum variants to remove redundant 'Error' suffix:
- BincodeEncodeError -> BincodeEncode
- BincodeDecodeError -> BincodeDecode
- NixError -> Nix
- SerdeError -> Serde
- WaxBuildError -> WaxBuild
- WaxWalkError -> WaxWalk
- CycleDependenciesError -> CycleDependencies
- SerdeYmlError -> SerdeYml
- ViteError -> Vite
- StripPathError -> StripPath
- SemverError -> Semver
- ReqwestError -> Reqwest
- AnyhowError -> Anyhow
- SqliteError -> Sqlite

Also updated all usages in:
- packages/cli/binding/src/lib.rs
- crates/vite_package_manager/src/package_manager.rs
- crates/vite_task/src/schedule.rs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>