### PR TITLE
style: fix clippy::redundant_closure_for_method_calls warnings

### DIFF
--- a/crates/fspy_preload_unix/src/interceptions/spawn/exec/with_argv.rs
+++ b/crates/fspy_preload_unix/src/interceptions/spawn/exec/with_argv.rs
@@ -16,7 +16,7 @@ pub unsafe fn with_argv(
     let argc = 1 + unsafe {
         va.with_copy(|mut copy| {
             core::iter::from_fn(|| Some(copy.arg::<*const c_char>()))
-                .position(|p| p.is_null())
+                .position(<*const i8>::is_null)
                 .unwrap()
         })
     };

--- a/crates/fspy_shared_unix/src/exec/which.rs
+++ b/crates/fspy_shared_unix/src/exec/which.rs
@@ -86,7 +86,7 @@ mod tests {
 
     #[test]
     fn test_concat() {
-        let s = concat(&["a".into(), "bc".into(), "".into(), "e".into()], |s| s.to_owned());
+        let s = concat(&["a".into(), "bc".into(), "".into(), "e".into()], BStr::to_owned);
         assert_eq!(s, "abce");
     }
 


### PR DESCRIPTION
Replace redundant closures with direct method references:
- with_argv.rs: Replace |p| p.is_null() with <*const i8>::is_null
- which.rs: Replace |s| s.to_owned() with BStr::to_owned

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>