### PR TITLE
style: fix clippy::uninlined_format_args warnings

### DIFF
--- a/crates/fspy/build.rs
+++ b/crates/fspy/build.rs
@@ -31,13 +31,13 @@ fn unpack_tar_gz(content: impl Read, path: &str) -> anyhow::Result<Vec<u8>> {
             return Ok(data);
         }
     }
-    bail!("Path {} not found in tar gz", path)
+    bail!("Path {path} not found in tar gz")
 }
 
 fn download_and_unpack_tar_gz(url: &str, path: &str) -> anyhow::Result<Vec<u8>> {
-    let resp = download(url).context(format!("Failed to get ok response from {}", url))?;
+    let resp = download(url).context(format!("Failed to get ok response from {url}"))?;
     let data = unpack_tar_gz(resp, path)
-        .context(format!("Failed to download or unpack {} out of {}", path, url))?;
+        .context(format!("Failed to download or unpack {path} out of {url}"))?;
     Ok(data)
 }
 
@@ -84,13 +84,13 @@ fn fetch_macos_binaries() -> anyhow::Result<()> {
     let downloads = MACOS_BINARY_DOWNLOADS
         .iter()
         .find(|(arch, _)| *arch == target_arch)
-        .context(format!("Unsupported macOS arch: {}", target_arch))?
+        .context(format!("Unsupported macOS arch: {target_arch}"))?
         .1;
     // let downloads = [(zsh_url.as_str(), "bin/zsh", zsh_hash)];
     for (url, path_in_targz, expected_hash) in downloads.iter().copied() {
         let filename = path_in_targz.split('/').next_back().unwrap();
         let download_path = out_dir.join(filename);
-        let hash_path = out_dir.join(format!("{}.hash", filename));
+        let hash_path = out_dir.join(format!("{filename}.hash"));
 
         let file_exists = matches!(fs::read(&download_path), Ok(existing_file_data) if xxh3_128(&existing_file_data) == expected_hash);
         if !file_exists {
@@ -102,11 +102,10 @@ fn fetch_macos_binaries() -> anyhow::Result<()> {
             let actual_hash = xxh3_128(&data);
             assert_eq!(
                 actual_hash, expected_hash,
-                "expected_hash of {} in {} needs to be updated",
-                path_in_targz, url
+                "expected_hash of {path_in_targz} in {url} needs to be updated"
             );
         }
-        fs::write(&hash_path, format!("{:x}", expected_hash))?;
+        fs::write(&hash_path, format!("{expected_hash:x}"))?;
     }
     Ok(())
     // let zsh_path = ensure_downloaded(&zsh_url);

--- a/crates/fspy/examples/cli.rs
+++ b/crates/fspy/examples/cli.rs
@@ -48,6 +48,6 @@ async fn main() -> io::Result<()> {
     csv_writer.flush().await?;
 
     let output = tokio_child.wait().await?;
-    eprintln!("\nfspy: {} paths accessed. {}", path_count, output);
+    eprintln!("\nfspy: {path_count} paths accessed. {output}");
     Ok(())
 }

--- a/crates/fspy_e2e/src/main.rs
+++ b/crates/fspy_e2e/src/main.rs
@@ -109,10 +109,10 @@ async fn main() {
         for access in accesses.iter() {
             collector.add(access);
         }
-        let snap_file = File::create(manifest_dir.join(format!("snaps/{}.txt", name))).unwrap();
+        let snap_file = File::create(manifest_dir.join(format!("snaps/{name}.txt"))).unwrap();
         let mut snap_writer = BufWriter::new(snap_file);
         for (path, mode) in collector.iter() {
-            writeln!(snap_writer, "{}: {:?}", path, mode).unwrap();
+            writeln!(snap_writer, "{path}: {mode:?}").unwrap();
         }
     }
 }

--- a/crates/fspy_preload_unix/src/client/mod.rs
+++ b/crates/fspy_preload_unix/src/client/mod.rs
@@ -127,8 +127,7 @@ impl Client {
                 *shm_buf = self.new_shm()?;
                 let buf = shm_buf.advance(len).with_context(|| {
                     format!(
-                        "The requested buf ({}) is greater than the shm chunk size ({})",
-                        len, SHM_CHUNK_SIZE
+                        "The requested buf ({len}) is greater than the shm chunk size ({SHM_CHUNK_SIZE})"
                     )
                 })?;
                 f(buf)
@@ -304,6 +303,6 @@ fn init_client() {
     CLIENT.set(Client::from_env()).unwrap();
     let ret = unsafe { pthread_atfork(None, None, Some(reset_shm_atfork)) };
     if ret != 0 {
-        panic!("pthread_atfork failed: {}", ret);
+        panic!("pthread_atfork failed: {ret}");
     }
 }

--- a/crates/fspy_shared_unix/src/payload.rs
+++ b/crates/fspy_shared_unix/src/payload.rs
@@ -48,7 +48,7 @@ pub fn encode_payload(payload: Payload) -> EncodedPayload {
 /// - The bincode deserialization fails
 pub fn decode_payload_from_env() -> anyhow::Result<EncodedPayload> {
     let Some(encoded_string) = std::env::var_os(PAYLOAD_ENV_NAME) else {
-        anyhow::bail!("Environment variable '{}' not found", PAYLOAD_ENV_NAME);
+        anyhow::bail!("Environment variable '{PAYLOAD_ENV_NAME}' not found");
     };
     decode_payload(encoded_string.into_vec().into())
 }


### PR DESCRIPTION
Use inline format args in format strings for better readability and
performance. Changed format!("{}", var) to format!("{var}").

Fixed 13 occurrences across:
- crates/fspy/build.rs (7 fixes)
- crates/fspy_shared_unix/src/payload.rs (1 fix)
- crates/fspy_preload_unix/src/client/mod.rs (2 fixes)
- crates/fspy/examples/cli.rs (1 fix)
- crates/fspy_e2e/src/main.rs (2 fixes)

All tests pass and clippy is clean with -D clippy::uninlined_format_args.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>