### PR TITLE
feat(pm): add update command for package dependencies

### DIFF
--- a/crates/vite_package_manager/src/commands/mod.rs
+++ b/crates/vite_package_manager/src/commands/mod.rs
@@ -1,0 +1,1 @@
+pub mod update;

--- a/crates/vite_package_manager/src/commands/update.rs
+++ b/crates/vite_package_manager/src/commands/update.rs
@@ -1,0 +1,595 @@
+use std::{collections::HashMap, process::ExitStatus};
+
+use vite_error::Error;
+use vite_path::AbsolutePath;
+
+use crate::package_manager::{
+    PackageManager, PackageManagerType, ResolveCommandResult, format_path_env, run_command,
+};
+
+/// Options for the update command.
+#[derive(Debug, Default)]
+pub struct UpdateCommandOptions<'a> {
+    pub packages: &'a [String],
+    pub latest: bool,
+    pub global: bool,
+    pub recursive: bool,
+    pub filters: Option<&'a [String]>,
+    pub workspace_root: bool,
+    pub dev: bool,
+    pub prod: bool,
+    pub interactive: bool,
+    pub no_optional: bool,
+    pub no_save: bool,
+    pub workspace_only: bool,
+    pub pass_through_args: Option<&'a [String]>,
+}
+
+impl PackageManager {
+    /// Run the update command with the package manager.
+    /// Return the exit status of the command.
+    #[must_use]
+    pub async fn run_update_command(
+        &self,
+        options: &UpdateCommandOptions<'_>,
+        cwd: impl AsRef<AbsolutePath>,
+    ) -> Result<ExitStatus, Error> {
+        let resolve_command = self.resolve_update_command(options);
+        run_command(&resolve_command.bin_path, &resolve_command.args, &resolve_command.envs, cwd)
+            .await
+    }
+
+    /// Resolve the update command.
+    #[must_use]
+    pub fn resolve_update_command(&self, options: &UpdateCommandOptions) -> ResolveCommandResult {
+        let bin_name: String;
+        let envs = HashMap::from([("PATH".to_string(), format_path_env(self.get_bin_prefix()))]);
+        let mut args: Vec<String> = Vec::new();
+
+        // global packages should use npm cli only
+        if options.global {
+            bin_name = "npm".into();
+            args.push("update".into());
+            args.push("--global".into());
+            if let Some(pass_through_args) = options.pass_through_args {
+                args.extend_from_slice(pass_through_args);
+            }
+            args.extend_from_slice(options.packages);
+
+            return ResolveCommandResult { bin_path: bin_name, args, envs };
+        }
+
+        match self.client {
+            PackageManagerType::Pnpm => {
+                bin_name = "pnpm".into();
+                // pnpm: --filter must come before command
+                if let Some(filters) = options.filters {
+                    for filter in filters {
+                        args.push("--filter".into());
+                        args.push(filter.clone());
+                    }
+                }
+                args.push("update".into());
+
+                if options.latest {
+                    args.push("--latest".into());
+                }
+                if options.workspace_root {
+                    args.push("--workspace-root".into());
+                }
+                if options.recursive {
+                    args.push("--recursive".into());
+                }
+                if options.dev {
+                    args.push("--dev".into());
+                }
+                if options.prod {
+                    args.push("--prod".into());
+                }
+                if options.interactive {
+                    args.push("--interactive".into());
+                }
+                if options.no_optional {
+                    args.push("--no-optional".into());
+                }
+                if options.no_save {
+                    args.push("--no-save".into());
+                }
+                if options.workspace_only {
+                    args.push("--workspace".into());
+                }
+            }
+            PackageManagerType::Yarn => {
+                bin_name = "yarn".into();
+
+                // Determine yarn version
+                let is_yarn_v1 = self.version.starts_with("1.");
+
+                if is_yarn_v1 {
+                    // yarn@1: yarn upgrade [--latest]
+                    if let Some(filters) = options.filters {
+                        args.push("workspace".into());
+                        args.push(filters[0].clone());
+                    }
+                    args.push("upgrade".into());
+                    if options.latest {
+                        args.push("--latest".into());
+                    }
+                } else {
+                    // yarn@2+: yarn up (already updates to latest by default)
+                    if let Some(filters) = options.filters {
+                        args.push("workspaces".into());
+                        args.push("foreach".into());
+                        args.push("--all".into());
+                        for filter in filters {
+                            args.push("--include".into());
+                            args.push(filter.clone());
+                        }
+                    }
+                    args.push("up".into());
+                    if options.recursive {
+                        args.push("--recursive".into());
+                    }
+                    if options.interactive {
+                        args.push("--interactive".into());
+                    }
+                }
+            }
+            PackageManagerType::Npm => {
+                bin_name = "npm".into();
+                args.push("update".into());
+
+                if let Some(filters) = options.filters {
+                    for filter in filters {
+                        args.push("--workspace".into());
+                        args.push(filter.clone());
+                    }
+                }
+                if options.workspace_root || options.recursive {
+                    args.push("--include-workspace-root".into());
+                }
+                if options.recursive {
+                    args.push("--workspaces".into());
+                }
+                if options.dev {
+                    args.push("--include=dev".into());
+                }
+                if options.prod {
+                    args.push("--include=prod".into());
+                }
+                if options.no_optional {
+                    args.push("--no-optional".into());
+                }
+                if options.no_save {
+                    args.push("--no-save".into());
+                }
+
+                // npm doesn't have --latest flag
+                // Warn user or handle differently
+                if options.latest {
+                    println!(
+                        "Warning: npm doesn't support --latest flag. Updating within semver range only."
+                    );
+                }
+
+                // npm doesn't support interactive mode
+                if options.interactive {
+                    println!(
+                        "Warning: npm doesn't support interactive mode. Running standard update."
+                    );
+                }
+            }
+        }
+
+        if let Some(pass_through_args) = options.pass_through_args {
+            args.extend_from_slice(pass_through_args);
+        }
+        args.extend_from_slice(options.packages);
+
+        ResolveCommandResult { bin_path: bin_name, args, envs }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::{TempDir, tempdir};
+    use vite_path::AbsolutePathBuf;
+    use vite_str::Str;
+
+    use super::*;
+
+    fn create_temp_dir() -> TempDir {
+        tempdir().expect("Failed to create temp directory")
+    }
+
+    fn create_mock_package_manager(pm_type: PackageManagerType, version: &str) -> PackageManager {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let install_dir = temp_dir_path.join("install");
+
+        PackageManager {
+            client: pm_type,
+            package_name: pm_type.to_string().into(),
+            version: Str::from(version),
+            hash: None,
+            bin_name: pm_type.to_string().into(),
+            workspace_root: temp_dir_path.clone(),
+            install_dir,
+        }
+    }
+
+    #[test]
+    fn test_pnpm_basic_update() {
+        let pm = create_mock_package_manager(PackageManagerType::Pnpm, "10.0.0");
+        let result = pm.resolve_update_command(&UpdateCommandOptions {
+            packages: &["react".to_string()],
+            latest: false,
+            global: false,
+            recursive: false,
+            filters: None,
+            workspace_root: false,
+            dev: false,
+            prod: false,
+            interactive: false,
+            no_optional: false,
+            no_save: false,
+            workspace_only: false,
+            pass_through_args: None,
+        });
+        assert_eq!(result.bin_path, "pnpm");
+        assert_eq!(result.args, vec!["update", "react"]);
+    }
+
+    #[test]
+    fn test_pnpm_update_latest() {
+        let pm = create_mock_package_manager(PackageManagerType::Pnpm, "10.0.0");
+        let result = pm.resolve_update_command(&UpdateCommandOptions {
+            packages: &["react".to_string()],
+            latest: true,
+            ..Default::default()
+        });
+        assert_eq!(result.bin_path, "pnpm");
+        assert_eq!(result.args, vec!["update", "--latest", "react"]);
+    }
+
+    #[test]
+    fn test_pnpm_update_all() {
+        let pm = create_mock_package_manager(PackageManagerType::Pnpm, "10.0.0");
+        let result = pm.resolve_update_command(&UpdateCommandOptions {
+            packages: &[],
+            latest: false,
+            ..Default::default()
+        });
+        assert_eq!(result.bin_path, "pnpm");
+        assert_eq!(result.args, vec!["update"]);
+    }
+
+    #[test]
+    fn test_pnpm_update_with_filter() {
+        let pm = create_mock_package_manager(PackageManagerType::Pnpm, "10.0.0");
+        let result = pm.resolve_update_command(&UpdateCommandOptions {
+            packages: &["react".to_string()],
+            filters: Some(&["app".to_string()]),
+            ..Default::default()
+        });
+        assert_eq!(result.args, vec!["--filter", "app", "update", "react"]);
+        assert_eq!(result.bin_path, "pnpm");
+    }
+
+    #[test]
+    fn test_pnpm_update_recursive() {
+        let pm = create_mock_package_manager(PackageManagerType::Pnpm, "10.0.0");
+        let result = pm.resolve_update_command(&UpdateCommandOptions {
+            packages: &[],
+            recursive: true,
+            ..Default::default()
+        });
+        assert_eq!(result.args, vec!["update", "--recursive"]);
+        assert_eq!(result.bin_path, "pnpm");
+    }
+
+    #[test]
+    fn test_pnpm_update_interactive() {
+        let pm = create_mock_package_manager(PackageManagerType::Pnpm, "10.0.0");
+        let result = pm.resolve_update_command(&UpdateCommandOptions {
+            packages: &[],
+            interactive: true,
+            ..Default::default()
+        });
+        assert_eq!(result.args, vec!["update", "--interactive"]);
+        assert_eq!(result.bin_path, "pnpm");
+    }
+
+    #[test]
+    fn test_pnpm_update_dev_only() {
+        let pm = create_mock_package_manager(PackageManagerType::Pnpm, "10.0.0");
+        let result = pm.resolve_update_command(&UpdateCommandOptions {
+            packages: &[],
+            dev: true,
+            ..Default::default()
+        });
+        assert_eq!(result.args, vec!["update", "--dev"]);
+        assert_eq!(result.bin_path, "pnpm");
+    }
+
+    #[test]
+    fn test_pnpm_update_no_optional() {
+        let pm = create_mock_package_manager(PackageManagerType::Pnpm, "10.0.0");
+        let result = pm.resolve_update_command(&UpdateCommandOptions {
+            packages: &[],
+            no_optional: true,
+            ..Default::default()
+        });
+        assert_eq!(result.args, vec!["update", "--no-optional"]);
+        assert_eq!(result.bin_path, "pnpm");
+    }
+
+    #[test]
+    fn test_pnpm_update_no_save() {
+        let pm = create_mock_package_manager(PackageManagerType::Pnpm, "10.0.0");
+        let result = pm.resolve_update_command(&UpdateCommandOptions {
+            packages: &["react".to_string()],
+            no_save: true,
+            ..Default::default()
+        });
+        assert_eq!(result.args, vec!["update", "--no-save", "react"]);
+        assert_eq!(result.bin_path, "pnpm");
+    }
+
+    #[test]
+    fn test_pnpm_update_workspace_only() {
+        let pm = create_mock_package_manager(PackageManagerType::Pnpm, "10.0.0");
+        let result = pm.resolve_update_command(&UpdateCommandOptions {
+            packages: &["@myorg/utils".to_string()],
+            workspace_only: true,
+            filters: Some(&["app".to_string()]),
+            ..Default::default()
+        });
+        assert_eq!(result.args, vec!["--filter", "app", "update", "--workspace", "@myorg/utils"]);
+        assert_eq!(result.bin_path, "pnpm");
+    }
+
+    #[test]
+    fn test_yarn_v1_basic_update() {
+        let pm = create_mock_package_manager(PackageManagerType::Yarn, "1.22.0");
+        let result = pm.resolve_update_command(&UpdateCommandOptions {
+            packages: &["react".to_string()],
+            ..Default::default()
+        });
+        assert_eq!(result.args, vec!["upgrade", "react"]);
+        assert_eq!(result.bin_path, "yarn");
+    }
+
+    #[test]
+    fn test_yarn_v1_update_latest() {
+        let pm = create_mock_package_manager(PackageManagerType::Yarn, "1.22.0");
+        let result = pm.resolve_update_command(&UpdateCommandOptions {
+            packages: &["react".to_string()],
+            latest: true,
+            ..Default::default()
+        });
+        assert_eq!(result.args, vec!["upgrade", "--latest", "react"]);
+        assert_eq!(result.bin_path, "yarn");
+    }
+
+    #[test]
+    fn test_yarn_v1_update_with_workspace() {
+        let pm = create_mock_package_manager(PackageManagerType::Yarn, "1.22.0");
+        let result = pm.resolve_update_command(&UpdateCommandOptions {
+            packages: &["react".to_string()],
+            filters: Some(&["app".to_string()]),
+            ..Default::default()
+        });
+        assert_eq!(result.args, vec!["workspace", "app", "upgrade", "react"]);
+        assert_eq!(result.bin_path, "yarn");
+    }
+
+    #[test]
+    fn test_yarn_v4_basic_update() {
+        let pm = create_mock_package_manager(PackageManagerType::Yarn, "4.0.0");
+        let result = pm.resolve_update_command(&UpdateCommandOptions {
+            packages: &["react".to_string()],
+            ..Default::default()
+        });
+        assert_eq!(result.args, vec!["up", "react"]);
+        assert_eq!(result.bin_path, "yarn");
+    }
+
+    #[test]
+    fn test_yarn_v4_update_interactive() {
+        let pm = create_mock_package_manager(PackageManagerType::Yarn, "4.0.0");
+        let result = pm.resolve_update_command(&UpdateCommandOptions {
+            packages: &[],
+            interactive: true,
+            ..Default::default()
+        });
+        assert_eq!(result.args, vec!["up", "--interactive"]);
+        assert_eq!(result.bin_path, "yarn");
+    }
+
+    #[test]
+    fn test_yarn_v4_update_with_filter() {
+        let pm = create_mock_package_manager(PackageManagerType::Yarn, "4.0.0");
+        let result = pm.resolve_update_command(&UpdateCommandOptions {
+            packages: &["react".to_string()],
+            filters: Some(&["app".to_string()]),
+            ..Default::default()
+        });
+        assert_eq!(
+            result.args,
+            vec!["workspaces", "foreach", "--all", "--include", "app", "up", "react"]
+        );
+        assert_eq!(result.bin_path, "yarn");
+    }
+
+    #[test]
+    fn test_yarn_v4_update_recursive() {
+        let pm = create_mock_package_manager(PackageManagerType::Yarn, "4.0.0");
+        let result = pm.resolve_update_command(&UpdateCommandOptions {
+            packages: &[],
+            recursive: true,
+            ..Default::default()
+        });
+        assert_eq!(result.args, vec!["up", "--recursive"]);
+        assert_eq!(result.bin_path, "yarn");
+    }
+
+    #[test]
+    fn test_npm_basic_update() {
+        let pm = create_mock_package_manager(PackageManagerType::Npm, "11.0.0");
+        let result = pm.resolve_update_command(&UpdateCommandOptions {
+            packages: &["react".to_string()],
+            ..Default::default()
+        });
+        assert_eq!(result.args, vec!["update", "react"]);
+        assert_eq!(result.bin_path, "npm");
+    }
+
+    #[test]
+    fn test_npm_update_all() {
+        let pm = create_mock_package_manager(PackageManagerType::Npm, "11.0.0");
+        let result = pm
+            .resolve_update_command(&UpdateCommandOptions { packages: &[], ..Default::default() });
+        assert_eq!(result.args, vec!["update"]);
+        assert_eq!(result.bin_path, "npm");
+    }
+
+    #[test]
+    fn test_npm_update_with_workspace() {
+        let pm = create_mock_package_manager(PackageManagerType::Npm, "11.0.0");
+        let result = pm.resolve_update_command(&UpdateCommandOptions {
+            packages: &["react".to_string()],
+            filters: Some(&["app".to_string()]),
+            ..Default::default()
+        });
+        assert_eq!(result.args, vec!["update", "--workspace", "app", "react"]);
+        assert_eq!(result.bin_path, "npm");
+    }
+
+    #[test]
+    fn test_npm_update_recursive() {
+        let pm = create_mock_package_manager(PackageManagerType::Npm, "11.0.0");
+        let result = pm.resolve_update_command(&UpdateCommandOptions {
+            packages: &[],
+            recursive: true,
+            ..Default::default()
+        });
+        assert_eq!(result.args, vec!["update", "--include-workspace-root", "--workspaces"]);
+        assert_eq!(result.bin_path, "npm");
+    }
+
+    #[test]
+    fn test_npm_update_dev_only() {
+        let pm = create_mock_package_manager(PackageManagerType::Npm, "11.0.0");
+        let result = pm.resolve_update_command(&UpdateCommandOptions {
+            packages: &[],
+            dev: true,
+            ..Default::default()
+        });
+        assert_eq!(result.args, vec!["update", "--include=dev"]);
+        assert_eq!(result.bin_path, "npm");
+    }
+
+    #[test]
+    fn test_npm_update_no_optional() {
+        let pm = create_mock_package_manager(PackageManagerType::Npm, "11.0.0");
+        let result = pm.resolve_update_command(&UpdateCommandOptions {
+            packages: &[],
+            no_optional: true,
+            ..Default::default()
+        });
+        assert_eq!(result.args, vec!["update", "--no-optional"]);
+        assert_eq!(result.bin_path, "npm");
+    }
+
+    #[test]
+    fn test_npm_update_no_save() {
+        let pm = create_mock_package_manager(PackageManagerType::Npm, "11.0.0");
+        let result = pm.resolve_update_command(&UpdateCommandOptions {
+            packages: &["react".to_string()],
+            no_save: true,
+            ..Default::default()
+        });
+        assert_eq!(result.args, vec!["update", "--no-save", "react"]);
+        assert_eq!(result.bin_path, "npm");
+    }
+
+    #[test]
+    fn test_global_update() {
+        let pm = create_mock_package_manager(PackageManagerType::Pnpm, "10.0.0");
+        let result = pm.resolve_update_command(&UpdateCommandOptions {
+            packages: &["typescript".to_string()],
+            global: true,
+            ..Default::default()
+        });
+        assert_eq!(result.args, vec!["update", "--global", "typescript"]);
+        assert_eq!(result.bin_path, "npm");
+    }
+
+    #[test]
+    fn test_pnpm_update_multiple_packages() {
+        let pm = create_mock_package_manager(PackageManagerType::Pnpm, "10.0.0");
+        let result = pm.resolve_update_command(&UpdateCommandOptions {
+            packages: &["react".to_string(), "react-dom".to_string(), "vite".to_string()],
+            latest: true,
+            ..Default::default()
+        });
+        assert_eq!(result.args, vec!["update", "--latest", "react", "react-dom", "vite"]);
+        assert_eq!(result.bin_path, "pnpm");
+    }
+
+    #[test]
+    fn test_pnpm_update_complex() {
+        let pm = create_mock_package_manager(PackageManagerType::Pnpm, "10.0.0");
+        let result = pm.resolve_update_command(&UpdateCommandOptions {
+            packages: &["react".to_string()],
+            latest: true,
+            recursive: true,
+            filters: Some(&["app".to_string(), "web".to_string()]),
+            dev: true,
+            interactive: true,
+            ..Default::default()
+        });
+        assert_eq!(
+            result.args,
+            vec![
+                "--filter",
+                "app",
+                "--filter",
+                "web",
+                "update",
+                "--latest",
+                "--recursive",
+                "--dev",
+                "--interactive",
+                "react"
+            ]
+        );
+        assert_eq!(result.bin_path, "pnpm");
+    }
+
+    #[test]
+    fn test_yarn_v4_update_multiple_filters() {
+        let pm = create_mock_package_manager(PackageManagerType::Yarn, "4.0.0");
+        let result = pm.resolve_update_command(&UpdateCommandOptions {
+            packages: &["lodash".to_string()],
+            filters: Some(&["app".to_string(), "web".to_string()]),
+            ..Default::default()
+        });
+        assert_eq!(
+            result.args,
+            vec![
+                "workspaces",
+                "foreach",
+                "--all",
+                "--include",
+                "app",
+                "--include",
+                "web",
+                "up",
+                "lodash"
+            ]
+        );
+        assert_eq!(result.bin_path, "yarn");
+    }
+}

--- a/crates/vite_package_manager/src/lib.rs
+++ b/crates/vite_package_manager/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod add;
+pub mod commands;
 mod config;
 mod install;
 pub mod package;

--- a/packages/cli/binding/src/cli.rs
+++ b/packages/cli/binding/src/cli.rs
@@ -26,6 +26,7 @@ use crate::commands::{
     lint::{LintConfig, lint},
     remove::RemoveCommand,
     test::test,
+    update::UpdateCommand,
     vite::vite as vite_cmd,
 };
 
@@ -215,6 +216,60 @@ pub enum Commands {
         global: bool,
 
         /// Packages to remove
+        packages: Vec<String>,
+
+        /// Additional arguments to pass through to the package manager
+        #[arg(last = true, allow_hyphen_values = true)]
+        pass_through_args: Option<Vec<String>>,
+    },
+    /// Update packages to their latest versions
+    #[command(alias = "up")]
+    Update {
+        /// Update to latest version (ignore semver range)
+        #[arg(short = 'L', long)]
+        latest: bool,
+
+        /// Update global packages
+        #[arg(short = 'g', long)]
+        global: bool,
+
+        /// Update recursively in all workspace packages
+        #[arg(short = 'r', long)]
+        recursive: bool,
+
+        /// Filter packages in monorepo (can be used multiple times)
+        #[arg(long, value_name = "PATTERN")]
+        filter: Option<Vec<String>>,
+
+        /// Include workspace root
+        #[arg(short = 'w', long)]
+        workspace_root: bool,
+
+        /// Update only devDependencies
+        #[arg(short = 'D', long)]
+        dev: bool,
+
+        /// Update only dependencies (production)
+        #[arg(short = 'P', long)]
+        prod: bool,
+
+        /// Interactive mode - show outdated packages and choose which to update
+        #[arg(short = 'i', long)]
+        interactive: bool,
+
+        /// Don't update optionalDependencies
+        #[arg(long)]
+        no_optional: bool,
+
+        /// Update lockfile only, don't modify package.json
+        #[arg(long)]
+        no_save: bool,
+
+        /// Only update if package exists in workspace (pnpm-specific)
+        #[arg(long)]
+        workspace: bool,
+
+        /// Packages to update (optional - updates all if omitted)
         packages: Vec<String>,
 
         /// Additional arguments to pass through to the package manager
@@ -609,6 +664,40 @@ pub async fn main<
                     *workspace_root,
                     *recursive,
                     *global,
+                    pass_through_args.as_deref(),
+                )
+                .await?;
+            return Ok(exit_status);
+        }
+        Commands::Update {
+            latest,
+            global,
+            recursive,
+            filter,
+            workspace_root,
+            dev,
+            prod,
+            interactive,
+            no_optional,
+            no_save,
+            workspace,
+            packages,
+            pass_through_args,
+        } => {
+            let exit_status = UpdateCommand::new(cwd)
+                .execute(
+                    packages,
+                    *latest,
+                    *global,
+                    *recursive,
+                    filter.as_deref(),
+                    *workspace_root,
+                    *dev,
+                    *prod,
+                    *interactive,
+                    *no_optional,
+                    *no_save,
+                    *workspace,
                     pass_through_args.as_deref(),
                 )
                 .await?;
@@ -1853,6 +1942,381 @@ mod tests {
                 assert_eq!(pass_through_args, &Some(vec!["--ignore-scripts".to_string()]));
             } else {
                 panic!("Expected Remove command");
+            }
+        }
+    }
+
+    mod update_command_tests {
+        use super::*;
+
+        #[test]
+        fn test_args_update_command_basic() {
+            let args = Args::try_parse_from(&["vite-plus", "update"]).unwrap();
+            if let Commands::Update {
+                latest,
+                global,
+                recursive,
+                filter,
+                workspace_root,
+                dev,
+                prod,
+                interactive,
+                no_optional,
+                no_save,
+                workspace,
+                packages,
+                ..
+            } = &args.commands
+            {
+                assert!(!latest);
+                assert!(!global);
+                assert!(!recursive);
+                assert!(filter.is_none());
+                assert!(!workspace_root);
+                assert!(!dev);
+                assert!(!prod);
+                assert!(!interactive);
+                assert!(!no_optional);
+                assert!(!no_save);
+                assert!(!workspace);
+                assert!(packages.is_empty());
+            } else {
+                panic!("Expected Update command");
+            }
+        }
+
+        #[test]
+        fn test_args_update_command_with_alias() {
+            let args = Args::try_parse_from(&["vite-plus", "up"]).unwrap();
+            assert!(matches!(args.commands, Commands::Update { .. }));
+        }
+
+        #[test]
+        fn test_args_update_command_with_packages() {
+            let args =
+                Args::try_parse_from(&["vite-plus", "update", "react", "react-dom"]).unwrap();
+            if let Commands::Update { packages, .. } = &args.commands {
+                assert_eq!(packages, &vec!["react", "react-dom"]);
+            } else {
+                panic!("Expected Update command");
+            }
+        }
+
+        #[test]
+        fn test_args_update_command_with_latest_flag() {
+            let args = Args::try_parse_from(&["vite-plus", "update", "-L", "react"]).unwrap();
+            if let Commands::Update { latest, packages, .. } = &args.commands {
+                assert!(latest);
+                assert_eq!(packages, &vec!["react"]);
+            } else {
+                panic!("Expected Update command");
+            }
+
+            let args = Args::try_parse_from(&["vite-plus", "update", "--latest", "react"]).unwrap();
+            if let Commands::Update { latest, packages, .. } = &args.commands {
+                assert!(latest);
+                assert_eq!(packages, &vec!["react"]);
+            } else {
+                panic!("Expected Update command");
+            }
+        }
+
+        #[test]
+        fn test_args_update_command_with_global_flag() {
+            let args = Args::try_parse_from(&["vite-plus", "update", "-g"]).unwrap();
+            if let Commands::Update { global, .. } = &args.commands {
+                assert!(global);
+            } else {
+                panic!("Expected Update command");
+            }
+
+            let args = Args::try_parse_from(&["vite-plus", "update", "--global"]).unwrap();
+            if let Commands::Update { global, .. } = &args.commands {
+                assert!(global);
+            } else {
+                panic!("Expected Update command");
+            }
+        }
+
+        #[test]
+        fn test_args_update_command_with_recursive_flag() {
+            let args = Args::try_parse_from(&["vite-plus", "update", "-r"]).unwrap();
+            if let Commands::Update { recursive, .. } = &args.commands {
+                assert!(recursive);
+            } else {
+                panic!("Expected Update command");
+            }
+
+            let args = Args::try_parse_from(&["vite-plus", "update", "--recursive"]).unwrap();
+            if let Commands::Update { recursive, .. } = &args.commands {
+                assert!(recursive);
+            } else {
+                panic!("Expected Update command");
+            }
+        }
+
+        #[test]
+        fn test_args_update_command_with_workspace_root_flag() {
+            let args = Args::try_parse_from(&["vite-plus", "update", "-w"]).unwrap();
+            if let Commands::Update { workspace_root, .. } = &args.commands {
+                assert!(workspace_root);
+            } else {
+                panic!("Expected Update command");
+            }
+
+            let args = Args::try_parse_from(&["vite-plus", "update", "--workspace-root"]).unwrap();
+            if let Commands::Update { workspace_root, .. } = &args.commands {
+                assert!(workspace_root);
+            } else {
+                panic!("Expected Update command");
+            }
+        }
+
+        #[test]
+        fn test_args_update_command_with_dev_flag() {
+            let args = Args::try_parse_from(&["vite-plus", "update", "-D"]).unwrap();
+            if let Commands::Update { dev, .. } = &args.commands {
+                assert!(dev);
+            } else {
+                panic!("Expected Update command");
+            }
+
+            let args = Args::try_parse_from(&["vite-plus", "update", "--dev"]).unwrap();
+            if let Commands::Update { dev, .. } = &args.commands {
+                assert!(dev);
+            } else {
+                panic!("Expected Update command");
+            }
+        }
+
+        #[test]
+        fn test_args_update_command_with_prod_flag() {
+            let args = Args::try_parse_from(&["vite-plus", "update", "-P"]).unwrap();
+            if let Commands::Update { prod, .. } = &args.commands {
+                assert!(prod);
+            } else {
+                panic!("Expected Update command");
+            }
+
+            let args = Args::try_parse_from(&["vite-plus", "update", "--prod"]).unwrap();
+            if let Commands::Update { prod, .. } = &args.commands {
+                assert!(prod);
+            } else {
+                panic!("Expected Update command");
+            }
+        }
+
+        #[test]
+        fn test_args_update_command_with_interactive_flag() {
+            let args = Args::try_parse_from(&["vite-plus", "update", "-i"]).unwrap();
+            if let Commands::Update { interactive, .. } = &args.commands {
+                assert!(interactive);
+            } else {
+                panic!("Expected Update command");
+            }
+
+            let args = Args::try_parse_from(&["vite-plus", "update", "--interactive"]).unwrap();
+            if let Commands::Update { interactive, .. } = &args.commands {
+                assert!(interactive);
+            } else {
+                panic!("Expected Update command");
+            }
+        }
+
+        #[test]
+        fn test_args_update_command_with_no_optional_flag() {
+            let args = Args::try_parse_from(&["vite-plus", "update", "--no-optional"]).unwrap();
+            if let Commands::Update { no_optional, .. } = &args.commands {
+                assert!(no_optional);
+            } else {
+                panic!("Expected Update command");
+            }
+        }
+
+        #[test]
+        fn test_args_update_command_with_no_save_flag() {
+            let args = Args::try_parse_from(&["vite-plus", "update", "--no-save"]).unwrap();
+            if let Commands::Update { no_save, .. } = &args.commands {
+                assert!(no_save);
+            } else {
+                panic!("Expected Update command");
+            }
+        }
+
+        #[test]
+        fn test_args_update_command_with_workspace_flag() {
+            let args = Args::try_parse_from(&["vite-plus", "update", "--workspace"]).unwrap();
+            if let Commands::Update { workspace, .. } = &args.commands {
+                assert!(workspace);
+            } else {
+                panic!("Expected Update command");
+            }
+        }
+
+        #[test]
+        fn test_args_update_command_with_filter() {
+            let args =
+                Args::try_parse_from(&["vite-plus", "update", "--filter", "app", "react"]).unwrap();
+            if let Commands::Update { filter, packages, .. } = &args.commands {
+                assert_eq!(filter, &Some(vec!["app".to_string()]));
+                assert_eq!(packages, &vec!["react"]);
+            } else {
+                panic!("Expected Update command");
+            }
+        }
+
+        #[test]
+        fn test_args_update_command_with_multiple_filters() {
+            let args = Args::try_parse_from(&[
+                "vite-plus",
+                "update",
+                "--filter",
+                "app",
+                "--filter",
+                "web",
+                "react",
+            ])
+            .unwrap();
+            if let Commands::Update { filter, packages, .. } = &args.commands {
+                assert_eq!(filter, &Some(vec!["app".to_string(), "web".to_string()]));
+                assert_eq!(packages, &vec!["react"]);
+            } else {
+                panic!("Expected Update command");
+            }
+        }
+
+        #[test]
+        fn test_args_update_command_with_combined_flags() {
+            let args = Args::try_parse_from(&[
+                "vite-plus",
+                "update",
+                "-L",
+                "-r",
+                "-D",
+                "--filter",
+                "app",
+                "typescript",
+                "eslint",
+            ])
+            .unwrap();
+            if let Commands::Update { latest, recursive, dev, filter, packages, .. } =
+                &args.commands
+            {
+                assert!(latest);
+                assert!(recursive);
+                assert!(dev);
+                assert_eq!(filter, &Some(vec!["app".to_string()]));
+                assert_eq!(packages, &vec!["typescript", "eslint"]);
+            } else {
+                panic!("Expected Update command");
+            }
+        }
+
+        #[test]
+        fn test_args_update_command_with_pass_through_args() {
+            let args = Args::try_parse_from(&[
+                "vite-plus",
+                "update",
+                "react",
+                "--",
+                "--registry",
+                "https://custom-registry.com",
+            ])
+            .unwrap();
+            if let Commands::Update { packages, pass_through_args, .. } = &args.commands {
+                assert_eq!(packages, &vec!["react"]);
+                assert_eq!(
+                    pass_through_args,
+                    &Some(vec![
+                        "--registry".to_string(),
+                        "https://custom-registry.com".to_string()
+                    ])
+                );
+            } else {
+                panic!("Expected Update command");
+            }
+        }
+
+        #[test]
+        fn test_args_update_command_complex_scenario() {
+            let args = Args::try_parse_from(&[
+                "vite-plus",
+                "update",
+                "-L",
+                "-r",
+                "-w",
+                "-D",
+                "--filter",
+                "app",
+                "--filter",
+                "web",
+                "--no-optional",
+                "react",
+                "vue",
+                "--",
+                "--registry",
+                "https://registry.npmjs.org",
+            ])
+            .unwrap();
+            if let Commands::Update {
+                latest,
+                recursive,
+                workspace_root,
+                dev,
+                filter,
+                no_optional,
+                packages,
+                pass_through_args,
+                ..
+            } = &args.commands
+            {
+                assert!(latest);
+                assert!(recursive);
+                assert!(workspace_root);
+                assert!(dev);
+                assert_eq!(filter, &Some(vec!["app".to_string(), "web".to_string()]));
+                assert!(no_optional);
+                assert_eq!(packages, &vec!["react", "vue"]);
+                assert_eq!(
+                    pass_through_args,
+                    &Some(vec!["--registry".to_string(), "https://registry.npmjs.org".to_string()])
+                );
+            } else {
+                panic!("Expected Update command");
+            }
+        }
+
+        #[test]
+        fn test_args_update_command_all_packages() {
+            // When no packages are specified, should update all packages
+            let args = Args::try_parse_from(&["vite-plus", "update", "-r"]).unwrap();
+            if let Commands::Update { recursive, packages, .. } = &args.commands {
+                assert!(recursive);
+                assert!(packages.is_empty());
+            } else {
+                panic!("Expected Update command");
+            }
+        }
+
+        #[test]
+        fn test_args_update_command_workspace_combinations() {
+            // Test --workspace-root with --recursive
+            let args = Args::try_parse_from(&["vite-plus", "update", "-w", "-r"]).unwrap();
+            if let Commands::Update { workspace_root, recursive, .. } = &args.commands {
+                assert!(workspace_root);
+                assert!(recursive);
+            } else {
+                panic!("Expected Update command");
+            }
+
+            // Test --workspace flag
+            let args =
+                Args::try_parse_from(&["vite-plus", "update", "--workspace", "react"]).unwrap();
+            if let Commands::Update { workspace, packages, .. } = &args.commands {
+                assert!(workspace);
+                assert_eq!(packages, &vec!["react"]);
+            } else {
+                panic!("Expected Update command");
             }
         }
     }

--- a/packages/cli/binding/src/commands/mod.rs
+++ b/packages/cli/binding/src/commands/mod.rs
@@ -6,4 +6,5 @@ pub(crate) mod lib_cmd;
 pub(crate) mod lint;
 pub(crate) mod remove;
 pub(crate) mod test;
+pub(crate) mod update;
 pub(crate) mod vite;

--- a/packages/cli/binding/src/commands/update.rs
+++ b/packages/cli/binding/src/commands/update.rs
@@ -1,0 +1,76 @@
+use std::process::ExitStatus;
+
+use vite_package_manager::{
+    commands::update::UpdateCommandOptions, package_manager::PackageManager,
+};
+use vite_path::AbsolutePathBuf;
+
+use crate::Error;
+
+/// Update command for updating packages to their latest versions.
+///
+/// This command automatically detects the package manager and translates
+/// the update command to the appropriate package manager-specific syntax.
+pub struct UpdateCommand {
+    cwd: AbsolutePathBuf,
+}
+
+impl UpdateCommand {
+    pub fn new(cwd: AbsolutePathBuf) -> Self {
+        Self { cwd }
+    }
+
+    pub async fn execute(
+        self,
+        packages: &[String],
+        latest: bool,
+        global: bool,
+        recursive: bool,
+        filters: Option<&[String]>,
+        workspace_root: bool,
+        dev: bool,
+        prod: bool,
+        interactive: bool,
+        no_optional: bool,
+        no_save: bool,
+        workspace_only: bool,
+        pass_through_args: Option<&[String]>,
+    ) -> Result<ExitStatus, Error> {
+        // Detect package manager
+        let package_manager = PackageManager::builder(&self.cwd).build().await?;
+
+        let update_command_options = UpdateCommandOptions {
+            packages,
+            latest,
+            global,
+            recursive,
+            filters,
+            workspace_root,
+            dev,
+            prod,
+            interactive,
+            no_optional,
+            no_save,
+            workspace_only,
+            pass_through_args,
+        };
+        package_manager.run_update_command(&update_command_options, &self.cwd).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_update_command_new() {
+        let workspace_root = if cfg!(windows) {
+            AbsolutePathBuf::new("C:\\test".into()).unwrap()
+        } else {
+            AbsolutePathBuf::new("/test".into()).unwrap()
+        };
+
+        let cmd = UpdateCommand::new(workspace_root.clone());
+        assert_eq!(cmd.cwd, workspace_root);
+    }
+}

--- a/packages/cli/snap-tests/exit-non-zero-on-cmd-not-exists/snap.txt
+++ b/packages/cli/snap-tests/exit-non-zero-on-cmd-not-exists/snap.txt
@@ -1,6 +1,6 @@
 [2]> vite command-not-exists # should exit with non-zero code
 error: 'vite' requires a subcommand but one was not provided
-  [subcommands: run, lint, fmt, build, test, lib, dev, doc, cache, install, i, add, remove, rm, un, uninstall, help]
+  [subcommands: run, lint, fmt, build, test, lib, dev, doc, cache, install, i, add, remove, rm, un, uninstall, update, up, help]
 
 Usage: vite [OPTIONS] [TASK] [-- <TASK_ARGS>...] <COMMAND>
 

--- a/packages/global/snap-tests/cli-helper-message/snap.txt
+++ b/packages/global/snap-tests/cli-helper-message/snap.txt
@@ -14,6 +14,7 @@ Commands:
   install  Install command. It will be passed to the package manager's install command currently
   add      Add packages to dependencies
   remove   Remove packages from dependencies
+  update   Update packages to their latest versions
   help     Print this message or the help of the given subcommand(s)
 
 Arguments:

--- a/packages/global/snap-tests/command-update-npm10-with-workspace/package.json
+++ b/packages/global/snap-tests/command-update-npm10-with-workspace/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "command-update-npm10-with-workspace",
+  "version": "1.0.0",
+  "packageManager": "npm@10.9.4",
+  "workspaces": [
+    "packages/*"
+  ],
+  "dependencies": {
+    "testnpm2": "*"
+  }
+}

--- a/packages/global/snap-tests/command-update-npm10-with-workspace/packages/app/package.json
+++ b/packages/global/snap-tests/command-update-npm10-with-workspace/packages/app/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "app",
+  "dependencies": {
+    "testnpm2": "*",
+    "test-vite-plus-install": "*"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "*"
+  }
+}

--- a/packages/global/snap-tests/command-update-npm10-with-workspace/packages/utils/package.json
+++ b/packages/global/snap-tests/command-update-npm10-with-workspace/packages/utils/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@vite-plus-test/utils",
+  "version": "1.0.0",
+  "dependencies": {
+    "testnpm2": "*"
+  }
+}

--- a/packages/global/snap-tests/command-update-npm10-with-workspace/snap.txt
+++ b/packages/global/snap-tests/command-update-npm10-with-workspace/snap.txt
@@ -1,0 +1,117 @@
+> vp update testnpm2 -w -- --no-audit && cat package.json # should update in workspace root
+Running: npm update --include-workspace-root --no-audit testnpm2
+
+added 5 packages in <variable>ms
+{
+  "name": "command-update-npm10-with-workspace",
+  "version": "1.0.0",
+  "packageManager": "npm@<semver>",
+  "workspaces": [
+    "packages/*"
+  ],
+  "dependencies": {
+    "testnpm2": "*"
+  }
+}
+
+> vp update testnpm2 --latest --filter app -- --no-audit && cat packages/app/package.json # should update in specific package
+Warning: npm doesn't support --latest flag. Updating within semver range only.
+Running: npm update --workspace app --no-audit testnpm2
+
+up to date in <variable>ms
+{
+  "name": "app",
+  "dependencies": {
+    "testnpm2": "*",
+    "test-vite-plus-install": "*"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "*"
+  }
+}
+
+> vp up -D --filter app -- --no-audit && cat packages/app/package.json # should update dev dependencies in app
+Running: npm update --workspace app --include=dev --no-audit
+
+up to date in <variable>ms
+{
+  "name": "app",
+  "dependencies": {
+    "testnpm2": "*",
+    "test-vite-plus-install": "*"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "*"
+  }
+}
+
+npm warn workspaces app in filter set, but no workspace folder present
+
+> vp update --filter "*" -- --no-audit && cat packages/app/package.json packages/utils/package.json # should update in all packages
+Running: npm update --workspace * --no-audit
+
+up to date in <variable>ms
+{
+  "name": "app",
+  "dependencies": {
+    "testnpm2": "*",
+    "test-vite-plus-install": "*"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "*"
+  }
+}
+{
+  "name": "@vite-plus-test/utils",
+  "version": "1.0.0",
+  "dependencies": {
+    "testnpm2": "*"
+  }
+}
+
+npm warn workspaces app in filter set, but no workspace folder present
+npm warn workspaces @vite-plus-test/utils in filter set, but no workspace folder present
+
+> vp update -r --no-save -- --no-audit && cat package.json packages/app/package.json # should update recursively without saving
+Running: npm update --include-workspace-root --workspaces --no-save --no-audit
+
+up to date in <variable>ms
+{
+  "name": "command-update-npm10-with-workspace",
+  "version": "1.0.0",
+  "packageManager": "npm@<semver>",
+  "workspaces": [
+    "packages/*"
+  ],
+  "dependencies": {
+    "testnpm2": "*"
+  }
+}
+{
+  "name": "app",
+  "dependencies": {
+    "testnpm2": "*",
+    "test-vite-plus-install": "*"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "*"
+  }
+}
+
+npm warn workspaces app in filter set, but no workspace folder present
+npm warn workspaces @vite-plus-test/utils in filter set, but no workspace folder present
+
+> vp update --workspace --filter app @vite-plus-test/utils -- --no-audit && cat packages/app/package.json # should update workspace dependency
+Running: npm update --workspace app --no-audit @vite-plus-test/utils
+
+up to date in <variable>ms
+{
+  "name": "app",
+  "dependencies": {
+    "testnpm2": "*",
+    "test-vite-plus-install": "*"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "*"
+  }
+}

--- a/packages/global/snap-tests/command-update-npm10-with-workspace/steps.json
+++ b/packages/global/snap-tests/command-update-npm10-with-workspace/steps.json
@@ -1,0 +1,13 @@
+{
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": [
+    "vp update testnpm2 -w -- --no-audit && cat package.json # should update in workspace root",
+    "vp update testnpm2 --latest --filter app -- --no-audit && cat packages/app/package.json # should update in specific package",
+    "vp up -D --filter app -- --no-audit && cat packages/app/package.json # should update dev dependencies in app",
+    "vp update --filter \"*\" -- --no-audit && cat packages/app/package.json packages/utils/package.json # should update in all packages",
+    "vp update -r --no-save -- --no-audit && cat package.json packages/app/package.json # should update recursively without saving",
+    "vp update --workspace --filter app @vite-plus-test/utils -- --no-audit && cat packages/app/package.json # should update workspace dependency"
+  ]
+}

--- a/packages/global/snap-tests/command-update-npm10/package.json
+++ b/packages/global/snap-tests/command-update-npm10/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "command-update-npm10",
+  "version": "1.0.0",
+  "packageManager": "npm@10.9.2",
+  "dependencies": {
+    "testnpm2": "*"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "*"
+  },
+  "optionalDependencies": {
+    "test-vite-plus-package-optional": "*"
+  }
+}

--- a/packages/global/snap-tests/command-update-npm10/snap.txt
+++ b/packages/global/snap-tests/command-update-npm10/snap.txt
@@ -1,0 +1,122 @@
+> vp update testnpm2 -- --no-audit && cat package.json # should update package within semver range
+Running: npm update --no-audit testnpm2
+
+added 3 packages in <variable>ms
+{
+  "name": "command-update-npm10",
+  "version": "1.0.0",
+  "packageManager": "npm@<semver>",
+  "dependencies": {
+    "testnpm2": "*"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "*"
+  },
+  "optionalDependencies": {
+    "test-vite-plus-package-optional": "*"
+  }
+}
+
+> vp up testnpm2 --latest -- --no-audit && cat package.json # should to absolute latest version
+Warning: npm doesn't support --latest flag. Updating within semver range only.
+Running: npm update --no-audit testnpm2
+
+up to date in <variable>ms
+{
+  "name": "command-update-npm10",
+  "version": "1.0.0",
+  "packageManager": "npm@<semver>",
+  "dependencies": {
+    "testnpm2": "*"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "*"
+  },
+  "optionalDependencies": {
+    "test-vite-plus-package-optional": "*"
+  }
+}
+
+> vp update -D -- --no-audit && cat package.json # should update only dev dependencies
+Running: npm update --include=dev --no-audit
+
+up to date in <variable>ms
+{
+  "name": "command-update-npm10",
+  "version": "1.0.0",
+  "packageManager": "npm@<semver>",
+  "dependencies": {
+    "testnpm2": "*"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "*"
+  },
+  "optionalDependencies": {
+    "test-vite-plus-package-optional": "*"
+  }
+}
+
+> vp update -P --no-save -- --no-audit && cat package.json # should update only dependencies and optionalDependencies without saving
+Running: npm update --include=prod --no-save --no-audit
+
+up to date in <variable>ms
+{
+  "name": "command-update-npm10",
+  "version": "1.0.0",
+  "packageManager": "npm@<semver>",
+  "dependencies": {
+    "testnpm2": "*"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "*"
+  },
+  "optionalDependencies": {
+    "test-vite-plus-package-optional": "*"
+  }
+}
+
+> vp rm testnpm2 && vp add testnpm2@1.0.0 -O -- --no-audit && vp update --no-optional --latest -- --no-audit && cat package.json # should skip optional dependencies
+Running: npm uninstall testnpm2
+
+removed 1 package in <variable>ms
+Running: npm install --save-optional --no-audit testnpm2@<semver>
+
+added 1 package in <variable>ms
+Warning: npm doesn't support --latest flag. Updating within semver range only.
+Running: npm update --no-optional --no-audit
+
+changed 1 package in <variable>ms
+{
+  "name": "command-update-npm10",
+  "version": "1.0.0",
+  "packageManager": "npm@<semver>",
+  "devDependencies": {
+    "test-vite-plus-package": "*"
+  },
+  "optionalDependencies": {
+    "test-vite-plus-package-optional": "*",
+    "testnpm2": "^1.0.0"
+  }
+}
+
+npm warn config optional Use `--omit=optional` to exclude optional dependencies, or
+npm warn config `--include=optional` to include them.
+npm warn config
+npm warn config       Default value does install optional deps unless otherwise omitted.
+
+> vp update -- --no-audit && cat package.json # should update all packages but won't change the package.json
+Running: npm update --no-audit
+
+added 2 packages in <variable>ms
+{
+  "name": "command-update-npm10",
+  "version": "1.0.0",
+  "packageManager": "npm@<semver>",
+  "devDependencies": {
+    "test-vite-plus-package": "*"
+  },
+  "optionalDependencies": {
+    "test-vite-plus-package-optional": "*",
+    "testnpm2": "^1.0.0"
+  }
+}

--- a/packages/global/snap-tests/command-update-npm10/steps.json
+++ b/packages/global/snap-tests/command-update-npm10/steps.json
@@ -1,0 +1,13 @@
+{
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": [
+    "vp update testnpm2 -- --no-audit && cat package.json # should update package within semver range",
+    "vp up testnpm2 --latest -- --no-audit && cat package.json # should to absolute latest version",
+    "vp update -D -- --no-audit && cat package.json # should update only dev dependencies",
+    "vp update -P --no-save -- --no-audit && cat package.json # should update only dependencies and optionalDependencies without saving",
+    "vp rm testnpm2 && vp add testnpm2@1.0.0 -O -- --no-audit && vp update --no-optional --latest -- --no-audit && cat package.json # should skip optional dependencies",
+    "vp update -- --no-audit && cat package.json # should update all packages but won't change the package.json"
+  ]
+}

--- a/packages/global/snap-tests/command-update-pnpm10-with-workspace/package.json
+++ b/packages/global/snap-tests/command-update-pnpm10-with-workspace/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "command-update-pnpm10-with-workspace",
+  "version": "1.0.0",
+  "packageManager": "pnpm@10.18.0",
+  "dependencies": {
+    "testnpm2": "*"
+  }
+}

--- a/packages/global/snap-tests/command-update-pnpm10-with-workspace/packages/app/package.json
+++ b/packages/global/snap-tests/command-update-pnpm10-with-workspace/packages/app/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "app",
+  "dependencies": {
+    "testnpm2": "*",
+    "test-vite-plus-install": "*",
+    "@vite-plus-test/utils": "workspace:*"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "*"
+  }
+}

--- a/packages/global/snap-tests/command-update-pnpm10-with-workspace/packages/utils/package.json
+++ b/packages/global/snap-tests/command-update-pnpm10-with-workspace/packages/utils/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@vite-plus-test/utils",
+  "version": "1.0.0",
+  "dependencies": {
+    "testnpm2": "*"
+  }
+}

--- a/packages/global/snap-tests/command-update-pnpm10-with-workspace/pnpm-workspace.yaml
+++ b/packages/global/snap-tests/command-update-pnpm10-with-workspace/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - packages/*

--- a/packages/global/snap-tests/command-update-pnpm10-with-workspace/snap.txt
+++ b/packages/global/snap-tests/command-update-pnpm10-with-workspace/snap.txt
@@ -1,0 +1,116 @@
+> vp update testnpm2 --latest -w && cat package.json # should update in workspace root
+Running: pnpm update --latest --workspace-root testnpm2
+Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
+
+Packages: +<variable>
++<repeat>
+Done in <variable>ms using pnpm v<semver>
+{
+  "name": "command-update-pnpm10-with-workspace",
+  "version": "1.0.0",
+  "packageManager": "pnpm@<semver>",
+  "dependencies": {
+    "testnpm2": "^1.0.1"
+  }
+}
+
+> vp update testnpm2 --latest --filter app && cat packages/app/package.json # should update in specific package
+Running: pnpm --filter app update --latest testnpm2
+.                                        |  WARN  `node_modules` is present. Lockfile only installation will make it out-of-date
+Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
+.                                        |   +2 +<repeat>
+Done in <variable>ms using pnpm v<semver>
+{
+  "name": "app",
+  "dependencies": {
+    "@vite-plus-test/utils": "workspace:*",
+    "test-vite-plus-install": "*",
+    "testnpm2": "^1.0.1"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "*"
+  }
+}
+
+> vp up -D --filter app && cat packages/app/package.json # should update dev dependencies in app
+Running: pnpm --filter app update --dev
+.                                        |  WARN  `node_modules` is present. Lockfile only installation will make it out-of-date
+Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
+Done in <variable>ms using pnpm v<semver>
+{
+  "name": "app",
+  "dependencies": {
+    "@vite-plus-test/utils": "workspace:*",
+    "test-vite-plus-install": "*",
+    "testnpm2": "^1.0.1"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "^1.0.0"
+  }
+}
+
+> vp update --latest --filter "*" && cat packages/app/package.json packages/utils/package.json # should update in all packages
+Running: pnpm --filter * update --latest
+Scope: all <variable> workspace projects
+Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
+Done in <variable>ms using pnpm v<semver>
+{
+  "name": "app",
+  "dependencies": {
+    "@vite-plus-test/utils": "workspace:*",
+    "test-vite-plus-install": "^1.0.0",
+    "testnpm2": "^1.0.1"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "^1.0.0"
+  }
+}
+{
+  "name": "@vite-plus-test/utils",
+  "version": "1.0.0",
+  "dependencies": {
+    "testnpm2": "^1.0.1"
+  }
+}
+
+> vp update -r --no-save && cat package.json packages/app/package.json # should update recursively without saving
+Running: pnpm update --recursive --no-save
+Scope: all <variable> workspace projects
+Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
+Done in <variable>ms using pnpm v<semver>
+{
+  "name": "command-update-pnpm10-with-workspace",
+  "version": "1.0.0",
+  "packageManager": "pnpm@<semver>",
+  "dependencies": {
+    "testnpm2": "^1.0.1"
+  }
+}
+{
+  "name": "app",
+  "dependencies": {
+    "@vite-plus-test/utils": "workspace:*",
+    "test-vite-plus-install": "^1.0.0",
+    "testnpm2": "^1.0.1"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "^1.0.0"
+  }
+}
+
+> vp update --workspace --filter app @vite-plus-test/utils && cat packages/app/package.json # should update workspace dependency
+Running: pnpm --filter app update --workspace @vite-plus-test/utils
+.                                        |  WARN  `node_modules` is present. Lockfile only installation will make it out-of-date
+Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
+Done in <variable>ms using pnpm v<semver>
+{
+  "name": "app",
+  "dependencies": {
+    "@vite-plus-test/utils": "workspace:*",
+    "test-vite-plus-install": "^1.0.0",
+    "testnpm2": "^1.0.1"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "^1.0.0"
+  }
+}

--- a/packages/global/snap-tests/command-update-pnpm10-with-workspace/steps.json
+++ b/packages/global/snap-tests/command-update-pnpm10-with-workspace/steps.json
@@ -1,0 +1,13 @@
+{
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": [
+    "vp update testnpm2 --latest -w && cat package.json # should update in workspace root",
+    "vp update testnpm2 --latest --filter app && cat packages/app/package.json # should update in specific package",
+    "vp up -D --filter app && cat packages/app/package.json # should update dev dependencies in app",
+    "vp update --latest --filter \"*\" && cat packages/app/package.json packages/utils/package.json # should update in all packages",
+    "vp update -r --no-save && cat package.json packages/app/package.json # should update recursively without saving",
+    "vp update --workspace --filter app @vite-plus-test/utils && cat packages/app/package.json # should update workspace dependency"
+  ]
+}

--- a/packages/global/snap-tests/command-update-pnpm10/package.json
+++ b/packages/global/snap-tests/command-update-pnpm10/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "command-update-pnpm10",
+  "version": "1.0.0",
+  "packageManager": "pnpm@10.18.0",
+  "dependencies": {
+    "testnpm2": "*"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "*"
+  },
+  "optionalDependencies": {
+    "test-vite-plus-package-optional": "*"
+  }
+}

--- a/packages/global/snap-tests/command-update-pnpm10/snap.txt
+++ b/packages/global/snap-tests/command-update-pnpm10/snap.txt
@@ -1,0 +1,191 @@
+> vp update --help # should show help
+Update packages to their latest versions
+
+Usage: vp update [OPTIONS] [PACKAGES]... [-- <PASS_THROUGH_ARGS>...]
+
+Arguments:
+  [PACKAGES]...           Packages to update (optional - updates all if omitted)
+  [PASS_THROUGH_ARGS]...  Additional arguments to pass through to the package manager
+
+Options:
+  -L, --latest            Update to latest version (ignore semver range)
+  -g, --global            Update global packages
+  -r, --recursive         Update recursively in all workspace packages
+      --filter <PATTERN>  Filter packages in monorepo (can be used multiple times)
+  -w, --workspace-root    Include workspace root
+  -D, --dev               Update only devDependencies
+  -P, --prod              Update only dependencies (production)
+  -i, --interactive       Interactive mode - show outdated packages and choose which to update
+      --no-optional       Don't update optionalDependencies
+      --no-save           Update lockfile only, don't modify package.json
+      --workspace         Only update if package exists in workspace (pnpm-specific)
+  -h, --help              Print help
+
+> vp update testnpm2 && cat package.json # should update package within semver range
+Running: pnpm update testnpm2
+Packages: +<variable>
++<repeat>
+Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
+
+dependencies:
++ testnpm2 <semver>
+
+optionalDependencies:
++ test-vite-plus-package-optional <semver>
+
+devDependencies:
++ test-vite-plus-package <semver>
+
+Done in <variable>ms using pnpm v<semver>
+{
+  "name": "command-update-pnpm10",
+  "version": "1.0.0",
+  "packageManager": "pnpm@<semver>",
+  "dependencies": {
+    "testnpm2": "^1.0.1"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "*"
+  },
+  "optionalDependencies": {
+    "test-vite-plus-package-optional": "*"
+  }
+}
+
+> vp up testnpm2 --latest && cat package.json # should to absolute latest version
+Running: pnpm update --latest testnpm2
+Already up to date
+Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
+
+Done in <variable>ms using pnpm v<semver>
+{
+  "name": "command-update-pnpm10",
+  "version": "1.0.0",
+  "packageManager": "pnpm@<semver>",
+  "dependencies": {
+    "testnpm2": "^1.0.1"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "*"
+  },
+  "optionalDependencies": {
+    "test-vite-plus-package-optional": "*"
+  }
+}
+
+> vp update -D && cat package.json # should update only dev dependencies
+Running: pnpm update --dev
+Already up to date
+Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
+
+dependencies: skipped
+
+optionalDependencies: skipped
+
+Done in <variable>ms using pnpm v<semver>
+{
+  "name": "command-update-pnpm10",
+  "version": "1.0.0",
+  "packageManager": "pnpm@<semver>",
+  "dependencies": {
+    "testnpm2": "^1.0.1"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "^1.0.0"
+  },
+  "optionalDependencies": {
+    "test-vite-plus-package-optional": "*"
+  }
+}
+
+> vp update -P --no-save && cat package.json # should update only dependencies and optionalDependencies without saving
+Running: pnpm update --prod --no-save
+Already up to date
+Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
+
+devDependencies: skipped
+
+Done in <variable>ms using pnpm v<semver>
+{
+  "name": "command-update-pnpm10",
+  "version": "1.0.0",
+  "packageManager": "pnpm@<semver>",
+  "dependencies": {
+    "testnpm2": "^1.0.1"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "^1.0.0"
+  },
+  "optionalDependencies": {
+    "test-vite-plus-package-optional": "*"
+  }
+}
+
+> vp rm testnpm2 && vp add testnpm2@1.0.0 -O && vp update --no-optional --latest && cat package.json # should skip optional dependencies
+Running: pnpm remove testnpm2
+Packages: -1
+-
+Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
+
+dependencies:
+- testnpm2 <semver>
+
+Done in <variable>ms using pnpm v<semver>
+Running: pnpm add --save-optional testnpm2@<semver>
+Packages: +<variable>
++<repeat>
+Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
+
+optionalDependencies:
++ testnpm2 <semver> (1.0.1 is available)
+
+Done in <variable>ms using pnpm v<semver>
+Running: pnpm update --latest --no-optional
+Packages: -2
+--
+Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
+
+optionalDependencies:
+- test-vite-plus-package-optional <semver>
+- testnpm2 <semver>
+
+Done in <variable>ms using pnpm v<semver>
+{
+  "name": "command-update-pnpm10",
+  "version": "1.0.0",
+  "packageManager": "pnpm@<semver>",
+  "devDependencies": {
+    "test-vite-plus-package": "^1.0.0"
+  },
+  "optionalDependencies": {
+    "test-vite-plus-package-optional": "^1.0.0",
+    "testnpm2": "1.0.1"
+  }
+}
+
+> vp update && vp update --recursive && cat package.json # should update all packages and change the package.json
+Running: pnpm update
+Packages: +<variable>
++<repeat>
+Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
+
+optionalDependencies:
++ test-vite-plus-package-optional <semver>
++ testnpm2 <semver>
+
+Done in <variable>ms using pnpm v<semver>
+Running: pnpm update --recursive
+Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
+Done in <variable>ms using pnpm v<semver>
+{
+  "name": "command-update-pnpm10",
+  "version": "1.0.0",
+  "packageManager": "pnpm@<semver>",
+  "devDependencies": {
+    "test-vite-plus-package": "^1.0.0"
+  },
+  "optionalDependencies": {
+    "test-vite-plus-package-optional": "^1.0.0",
+    "testnpm2": "1.0.1"
+  }
+}

--- a/packages/global/snap-tests/command-update-pnpm10/steps.json
+++ b/packages/global/snap-tests/command-update-pnpm10/steps.json
@@ -1,0 +1,14 @@
+{
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": [
+    "vp update --help # should show help",
+    "vp update testnpm2 && cat package.json # should update package within semver range",
+    "vp up testnpm2 --latest && cat package.json # should to absolute latest version",
+    "vp update -D && cat package.json # should update only dev dependencies",
+    "vp update -P --no-save && cat package.json # should update only dependencies and optionalDependencies without saving",
+    "vp rm testnpm2 && vp add testnpm2@1.0.0 -O && vp update --no-optional --latest && cat package.json # should skip optional dependencies",
+    "vp update && vp update --recursive && cat package.json # should update all packages and change the package.json"
+  ]
+}

--- a/packages/global/snap-tests/command-update-yarn4-with-workspace/package.json
+++ b/packages/global/snap-tests/command-update-yarn4-with-workspace/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "command-update-yarn4-with-workspace",
+  "version": "1.0.0",
+  "packageManager": "yarn@4.10.3",
+  "workspaces": [
+    "packages/*"
+  ],
+  "dependencies": {
+    "testnpm2": "*"
+  }
+}

--- a/packages/global/snap-tests/command-update-yarn4-with-workspace/packages/app/package.json
+++ b/packages/global/snap-tests/command-update-yarn4-with-workspace/packages/app/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "app",
+  "dependencies": {
+    "testnpm2": "*",
+    "test-vite-plus-install": "*",
+    "@vite-plus-test/utils": "workspace:*"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "*"
+  }
+}

--- a/packages/global/snap-tests/command-update-yarn4-with-workspace/packages/utils/package.json
+++ b/packages/global/snap-tests/command-update-yarn4-with-workspace/packages/utils/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@vite-plus-test/utils",
+  "version": "1.0.0",
+  "dependencies": {
+    "testnpm2": "*"
+  }
+}

--- a/packages/global/snap-tests/command-update-yarn4-with-workspace/snap.txt
+++ b/packages/global/snap-tests/command-update-yarn4-with-workspace/snap.txt
@@ -1,0 +1,170 @@
+> vp update testnpm2 && cat package.json packages/utils/package.json # should update all testnpm2 versions
+Running: yarn up testnpm2
+➤ YN0000: · Yarn <semver>
+➤ YN0000: ┌ Resolution step
+➤ YN0085: │ + test-vite-plus-install@npm:1.0.0, test-vite-plus-package@npm:1.0.0, testnpm2@npm:1.0.1
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Fetch step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Link step
+➤ YN0000: └ Completed
+➤ YN0000: · Done in <variable>ms <variable>ms
+{
+  "name": "command-update-yarn4-with-workspace",
+  "version": "1.0.0",
+  "packageManager": "yarn@<semver>",
+  "workspaces": [
+    "packages/*"
+  ],
+  "dependencies": {
+    "testnpm2": "^1.0.1"
+  }
+}
+{
+  "name": "@vite-plus-test/utils",
+  "version": "1.0.0",
+  "dependencies": {
+    "testnpm2": "^1.0.1"
+  }
+}
+
+> vp update testnpm2 --latest --filter app && cat packages/app/package.json # should update in specific package
+Running: yarn workspaces foreach --all --include app up testnpm2
+➤ YN0000: · Yarn <semver>
+➤ YN0000: ┌ Resolution step
+➤ YN0085: │ + testnpm2@npm:1.0.1
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Fetch step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Link step
+➤ YN0000: └ Completed
+➤ YN0000: · Done in <variable>ms <variable>ms
+Done in <variable>ms <variable>ms
+{
+  "name": "app",
+  "dependencies": {
+    "@vite-plus-test/utils": "workspace:*",
+    "test-vite-plus-install": "*",
+    "testnpm2": "^1.0.1"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "*"
+  }
+}
+
+> vp up -D --filter app && cat packages/app/package.json # should update dev dependencies in app
+Running: yarn workspaces foreach --all --include app up
+➤ YN0000: · Yarn <semver>
+➤ YN0000: ┌ Resolution step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Fetch step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Link step
+➤ YN0000: └ Completed
+➤ YN0000: · Done in <variable>ms <variable>ms
+Done in <variable>ms <variable>ms
+{
+  "name": "app",
+  "dependencies": {
+    "@vite-plus-test/utils": "workspace:*",
+    "test-vite-plus-install": "*",
+    "testnpm2": "^1.0.1"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "*"
+  }
+}
+
+> vp update --filter "*" && cat packages/app/package.json packages/utils/package.json # should update in all packages
+Running: yarn workspaces foreach --all --include * up
+➤ YN0000: · Yarn <semver>
+➤ YN0000: ┌ Resolution step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Fetch step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Link step
+➤ YN0000: └ Completed
+➤ YN0000: · Done in <variable>ms <variable>ms
+➤ YN0000: · Yarn <semver>
+➤ YN0000: ┌ Resolution step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Fetch step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Link step
+➤ YN0000: └ Completed
+➤ YN0000: · Done in <variable>ms <variable>ms
+Done in <variable>ms <variable>ms
+{
+  "name": "app",
+  "dependencies": {
+    "@vite-plus-test/utils": "workspace:*",
+    "test-vite-plus-install": "*",
+    "testnpm2": "^1.0.1"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "*"
+  }
+}
+{
+  "name": "@vite-plus-test/utils",
+  "version": "1.0.0",
+  "dependencies": {
+    "testnpm2": "^1.0.1"
+  }
+}
+
+> vp update -r --no-save && cat package.json packages/app/package.json # should update recursively without saving
+Running: yarn up --recursive
+➤ YN0000: · Yarn <semver>
+➤ YN0000: ┌ Resolution step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Fetch step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Link step
+➤ YN0000: └ Completed
+➤ YN0000: · Done in <variable>ms <variable>ms
+{
+  "name": "command-update-yarn4-with-workspace",
+  "version": "1.0.0",
+  "packageManager": "yarn@<semver>",
+  "workspaces": [
+    "packages/*"
+  ],
+  "dependencies": {
+    "testnpm2": "^1.0.1"
+  }
+}
+{
+  "name": "app",
+  "dependencies": {
+    "@vite-plus-test/utils": "workspace:*",
+    "test-vite-plus-install": "*",
+    "testnpm2": "^1.0.1"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "*"
+  }
+}
+
+> vp update --workspace --filter app @vite-plus-test/utils && cat packages/app/package.json # should update workspace dependency
+Running: yarn workspaces foreach --all --include app up @vite-plus-test/utils
+➤ YN0000: · Yarn <semver>
+➤ YN0000: ┌ Resolution step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Fetch step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Link step
+➤ YN0000: └ Completed
+➤ YN0000: · Done in <variable>ms <variable>ms
+Done in <variable>ms <variable>ms
+{
+  "name": "app",
+  "dependencies": {
+    "@vite-plus-test/utils": "workspace:^",
+    "test-vite-plus-install": "*",
+    "testnpm2": "^1.0.1"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "*"
+  }
+}

--- a/packages/global/snap-tests/command-update-yarn4-with-workspace/steps.json
+++ b/packages/global/snap-tests/command-update-yarn4-with-workspace/steps.json
@@ -1,0 +1,13 @@
+{
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": [
+    "vp update testnpm2 && cat package.json packages/utils/package.json # should update all testnpm2 versions",
+    "vp update testnpm2 --latest --filter app && cat packages/app/package.json # should update in specific package",
+    "vp up -D --filter app && cat packages/app/package.json # should update dev dependencies in app",
+    "vp update --filter \"*\" && cat packages/app/package.json packages/utils/package.json # should update in all packages",
+    "vp update -r --no-save && cat package.json packages/app/package.json # should update recursively without saving",
+    "vp update --workspace --filter app @vite-plus-test/utils && cat packages/app/package.json # should update workspace dependency"
+  ]
+}

--- a/packages/global/snap-tests/command-update-yarn4/package.json
+++ b/packages/global/snap-tests/command-update-yarn4/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "command-update-yarn4",
+  "version": "1.0.0",
+  "packageManager": "yarn@4.10.3",
+  "dependencies": {
+    "testnpm2": "*"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "*"
+  },
+  "optionalDependencies": {
+    "test-vite-plus-package-optional": "*"
+  }
+}

--- a/packages/global/snap-tests/command-update-yarn4/snap.txt
+++ b/packages/global/snap-tests/command-update-yarn4/snap.txt
@@ -1,0 +1,116 @@
+> vp update testnpm2 && cat package.json # should update package within semver range
+Running: yarn up testnpm2
+➤ YN0000: · Yarn <semver>
+➤ YN0000: ┌ Resolution step
+➤ YN0085: │ + test-vite-plus-package-optional@npm:1.0.0, test-vite-plus-package@npm:1.0.0, testnpm2@npm:1.0.1
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Fetch step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Link step
+➤ YN0000: └ Completed
+➤ YN0000: · Done in <variable>ms <variable>ms
+{
+  "name": "command-update-yarn4",
+  "version": "1.0.0",
+  "packageManager": "yarn@<semver>",
+  "dependencies": {
+    "testnpm2": "^1.0.1"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "*"
+  },
+  "optionalDependencies": {
+    "test-vite-plus-package-optional": "*"
+  }
+}
+
+> vp rm testnpm2 && vp add testnpm2@1.0.0 -D && vp update testnpm2 --latest && cat package.json # should to absolute latest version
+Running: yarn remove testnpm2
+➤ YN0000: · Yarn <semver>
+➤ YN0000: ┌ Resolution step
+➤ YN0085: │ - testnpm2@npm:1.0.1
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Fetch step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Link step
+➤ YN0000: └ Completed
+➤ YN0000: · Done in <variable>ms <variable>ms
+Running: yarn add --dev testnpm2@<semver>
+➤ YN0000: · Yarn <semver>
+➤ YN0000: ┌ Resolution step
+➤ YN0085: │ + testnpm2@npm:1.0.0
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Fetch step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Link step
+➤ YN0000: └ Completed
+➤ YN0000: · Done in <variable>ms <variable>ms
+Running: yarn up testnpm2
+➤ YN0000: · Yarn <semver>
+➤ YN0000: ┌ Resolution step
+➤ YN0085: │ + testnpm2@npm:1.0.1
+➤ YN0085: │ - testnpm2@npm:1.0.0
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Fetch step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Link step
+➤ YN0000: └ Completed
+➤ YN0000: · Done in <variable>ms <variable>ms
+{
+  "name": "command-update-yarn4",
+  "version": "1.0.0",
+  "packageManager": "yarn@<semver>",
+  "devDependencies": {
+    "test-vite-plus-package": "*",
+    "testnpm2": "^1.0.1"
+  },
+  "optionalDependencies": {
+    "test-vite-plus-package-optional": "*"
+  }
+}
+
+> vp update -D && cat package.json # should update and ignore -D options
+Running: yarn up
+➤ YN0000: · Yarn <semver>
+➤ YN0000: ┌ Resolution step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Fetch step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Link step
+➤ YN0000: └ Completed
+➤ YN0000: · Done in <variable>ms <variable>ms
+{
+  "name": "command-update-yarn4",
+  "version": "1.0.0",
+  "packageManager": "yarn@<semver>",
+  "devDependencies": {
+    "test-vite-plus-package": "*",
+    "testnpm2": "^1.0.1"
+  },
+  "optionalDependencies": {
+    "test-vite-plus-package-optional": "*"
+  }
+}
+
+> vp update --recursive && cat package.json # should update all packages but won't change the package.json
+Running: yarn up --recursive
+➤ YN0000: · Yarn <semver>
+➤ YN0000: ┌ Resolution step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Fetch step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Link step
+➤ YN0000: └ Completed
+➤ YN0000: · Done in <variable>ms <variable>ms
+{
+  "name": "command-update-yarn4",
+  "version": "1.0.0",
+  "packageManager": "yarn@<semver>",
+  "devDependencies": {
+    "test-vite-plus-package": "*",
+    "testnpm2": "^1.0.1"
+  },
+  "optionalDependencies": {
+    "test-vite-plus-package-optional": "*"
+  }
+}

--- a/packages/global/snap-tests/command-update-yarn4/steps.json
+++ b/packages/global/snap-tests/command-update-yarn4/steps.json
@@ -1,0 +1,11 @@
+{
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": [
+    "vp update testnpm2 && cat package.json # should update package within semver range",
+    "vp rm testnpm2 && vp add testnpm2@1.0.0 -D && vp update testnpm2 --latest && cat package.json # should to absolute latest version",
+    "vp update -D && cat package.json # should update and ignore -D options",
+    "vp update --recursive && cat package.json # should update all packages but won't change the package.json"
+  ]
+}

--- a/packages/tools/src/__tests__/__snapshots__/utils.spec.ts.snap
+++ b/packages/tools/src/__tests__/__snapshots__/utils.spec.ts.snap
@@ -5,6 +5,16 @@ exports[`replaceUnstableOutput() > replace date 1`] = `
 <date>"
 `;
 
+exports[`replaceUnstableOutput() > replace ignore npm audited packages log 1`] = `
+"removed 1 package in <variable>ms
+Done in <variable>ms"
+`;
+
+exports[`replaceUnstableOutput() > replace ignore pnpm request warning log 1`] = `
+"Foo bar
+Packages:"
+`;
+
 exports[`replaceUnstableOutput() > replace tsdown output 1`] = `
 "ℹ tsdown v<semver> powered by rolldown v<semver>
 ℹ entry: src/index.ts
@@ -54,6 +64,12 @@ vitest/<semver>
 foo/v<semver>
 foo@<semver>
 bar@v<semver>"
+`;
+
+exports[`replaceUnstableOutput() > replace yarn YN0000: └ Completed with duration to empty string 1`] = `
+"➤ YN0000: └ Completed
+➤ YN0000: └ Completed
+➤ YN0000: └ Completed"
 `;
 
 exports[`replaceUnstableOutput() > replace yarn YN0013 1`] = `

--- a/packages/tools/src/__tests__/utils.spec.ts
+++ b/packages/tools/src/__tests__/utils.spec.ts
@@ -92,6 +92,34 @@ Done in 171ms using pnpm v10.16.1
     `;
     expect(replaceUnstableOutput(output.trim())).toMatchSnapshot();
   });
+
+  test('replace yarn YN0000: └ Completed with duration to empty string', () => {
+    const output = `
+➤ YN0000: └ Completed in 100ms
+➤ YN0000: └ Completed in 100ms 200ms
+➤ YN0000: └ Completed
+    `;
+    expect(replaceUnstableOutput(output.trim())).toMatchSnapshot();
+  });
+
+  test('replace ignore pnpm request warning log', () => {
+    const output = `
+Foo bar
+ WARN  Request took <variable>ms: https://registry.npmjs.org/testnpm2
+Packages:
+    `;
+    expect(replaceUnstableOutput(output.trim())).toMatchSnapshot();
+  });
+
+  test('replace ignore npm audited packages log', () => {
+    const output = `
+removed 1 package, and audited 3 packages in 700ms
+
+found 0 vulnerabilities
+Done in 1000ms
+    `;
+    expect(replaceUnstableOutput(output.trim())).toMatchSnapshot();
+  });
 });
 
 describe('isPassThroughEnv()', () => {

--- a/packages/tools/src/utils.ts
+++ b/packages/tools/src/utils.ts
@@ -26,17 +26,29 @@ export function replaceUnstableOutput(output: string, cwd?: string) {
     // ignore pnpm progress
     .replaceAll(/Progress: resolved \d+, reused \d+, downloaded \d+, added \d+\n/g, '')
     // ignore pnpm warn
-    .replaceAll(/WARN\s+Skip\s+adding .+?\n/g, '')
+    .replaceAll(/ ?WARN\s+Skip\s+adding .+?\n/g, '')
+    .replaceAll(/ ?WARN\s+Request\s+took .+?\n/g, '')
     .replaceAll(/Scope: all \d+ workspace projects/g, 'Scope: all <variable> workspace projects')
     .replaceAll(/\++\n/g, '+<repeat>\n')
     // ignore yarn YN0013, because it's unstable output, only exists on CI environment
     // ➤ YN0013: │ A package was added to the project (+ 0.7 KiB).
     .replaceAll(/➤ YN0013:[^\n]+\n/g, '')
+    // ignore yarn `YN0000: └ Completed <duration>`, it's unstable output
+    // ➤ YN0000: └ Completed in <variable>ms <variable>ms
+    // ➤ YN0000: └ Completed in <variable>ms
+    // =>
+    // ➤ YN0000: └ Completed
+    .replaceAll(/➤ YN0000: └ Completed.* <variable>(s|ms|µs)( <variable>(s|ms|µs))?\n/g, '➤ YN0000: └ Completed\n')
     // ignore npm warn
     // npm warn Unknown env config "recursive". This will stop working in the next major version of npm
     .replaceAll(/npm warn Unknown env config .+?\n/g, '')
     // WARN  Issue while reading "/path/to/.npmrc". Failed to replace env in config: ${NPM_AUTH_TOKEN}
     .replaceAll(/WARN\s+Issue\s+while\s+reading .+?\n/g, '')
+    // ignore npm audited packages log
+    // "removed 1 package, and audited 3 packages in 700ms" => "removed <variable> package in <variable>ms"
+    // "\nfound 0 vulnerabilities\n" => ""
+    .replaceAll(/(removed \d+ package), and audited \d+ packages( in <variable>(?:s|ms|µs))\n/g, '$1$2\n')
+    .replaceAll(/\nfound \d+ vulnerabilities\n/g, '')
     // replace size for tsdown
     .replaceAll(/ \d+(\.\d+)? ([km]B)/g, ' <variable> $2');
 }

--- a/rfcs/update-package-command.md
+++ b/rfcs/update-package-command.md
@@ -1,0 +1,852 @@
+# RFC: Vite+ Update Package Command
+
+## Summary
+
+Add `vite update` (alias: `vite up`) command that automatically adapts to the detected package manager (pnpm/yarn/npm) for updating packages to their latest versions within the specified semver range, with support for updating to absolute latest versions, workspace-aware operations, and interactive mode.
+
+## Motivation
+
+Currently, developers must manually use package manager-specific commands to update dependencies:
+
+```bash
+pnpm update react
+yarn upgrade react
+npm update react
+```
+
+This creates friction in monorepo workflows and requires remembering different syntaxes. A unified interface would:
+
+1. **Simplify workflows**: One command works across all package managers
+2. **Auto-detection**: Automatically uses the correct package manager
+3. **Consistency**: Same syntax regardless of underlying tool
+4. **Integration**: Works seamlessly with existing vite+ features
+
+### Current Pain Points
+
+```bash
+# Developer needs to know which package manager is used
+pnpm update react --latest          # pnpm project
+yarn upgrade react --latest         # yarn project
+npm update react                    # npm project (no --latest flag)
+
+# Different commands for updating all packages
+pnpm update                         # pnpm
+yarn upgrade                        # yarn@1 / yarn upgrade-interactive for yarn@2+
+npm update                          # npm
+```
+
+### Proposed Solution
+
+```bash
+# Works for all package managers
+vite update react             # Update to latest within semver range
+vite up react --latest        # Update to absolute latest version
+vite update                   # Update all packages
+
+# Workspace operations
+vite update --filter app                    # Update in specific package
+vite update react --latest --filter "app*"  # Update to latest in multiple packages
+vite update -r                              # Update recursively in all workspaces
+```
+
+## Proposed Solution
+
+### Command Syntax
+
+#### Update Command
+
+```bash
+vite update [PACKAGES]... [OPTIONS]
+vite up [PACKAGES]... [OPTIONS]        # Alias
+```
+
+**Examples:**
+
+```bash
+# Update to latest version within semver range
+vite update react react-dom
+
+# Update to absolute latest version
+vite update react --latest
+vite up react -L
+
+# Update all dependencies
+vite update
+
+# Update all to latest
+vite update --latest
+
+# Update only dev dependencies
+vite update -D
+
+# Update only production dependencies
+vite update -P
+
+# Workspace operations
+vite update --filter app                    # Update in specific package
+vite update react --latest --filter "app*"  # Update in multiple packages
+vite update -r                              # Update in all workspace packages
+vite update -g typescript                   # Update global package
+
+# Interactive mode (pnpm only)
+vite update --interactive
+vite up -i
+
+# Advanced options
+vite update --no-optional                   # Skip optional dependencies
+vite update --no-save                       # Update lockfile only
+vite update react --latest --no-save        # Test latest version without saving
+```
+
+### Command Mapping
+
+#### Update Command Mapping
+
+- https://pnpm.io/cli/update
+- https://yarnpkg.com/cli/up (yarn@2+)
+- https://classic.yarnpkg.com/en/docs/cli/upgrade (yarn@1)
+- https://docs.npmjs.com/cli/v11/commands/npm-update
+
+| Vite+ Flag             | pnpm                        | yarn@1               | yarn@2+                                     | npm                            | Description                                                |
+| ---------------------- | --------------------------- | -------------------- | ------------------------------------------- | ------------------------------ | ---------------------------------------------------------- |
+| `[packages]`           | `update [packages]`         | `upgrade [packages]` | `up [packages]`                             | `update [packages]`            | Update specific packages (or all if omitted)               |
+| `-L, --latest`         | `--latest` / `-L`           | `--latest`           | N/A (default behavior)                      | N/A                            | Update to latest version (ignore semver range)             |
+| `-g, --global`         | N/A                         | N/A                  | N/A                                         | `--global` / `-g`              | Update global packages                                     |
+| `-r, --recursive`      | `-r, --recursive`           | N/A                  | `--recursive` / `-R`                        | `--workspaces`                 | Update recursively in all workspace packages               |
+| `--filter <pattern>`   | `--filter <pattern> update` | N/A                  | `workspaces foreach --include <pattern> up` | `update --workspace <pattern>` | Target specific workspace package(s)                       |
+| `-w, --workspace-root` | `-w`                        | N/A                  | N/A                                         | `--include-workspace-root`     | Include workspace root                                     |
+| `-D, --dev`            | `--dev` / `-D`              | N/A                  | N/A                                         | `--include=dev`                | Update only devDependencies                                |
+| `-P, --prod`           | `--prod` / `-P`             | N/A                  | N/A                                         | `--include=prod`               | Update only dependencies and optionalDependencies          |
+| `-i, --interactive`    | `--interactive` / `-i`      | N/A                  | `--interactive` / `-i`                      | N/A                            | Show outdated packages and choose which to update          |
+| `--no-optional`        | `--no-optional`             | N/A                  | N/A                                         | `--no-optional`                | Don't update optionalDependencies                          |
+| `--no-save`            | `--no-save`                 | N/A                  | N/A                                         | `--no-save`                    | Update lockfile only, don't modify package.json            |
+| `--workspace`          | `--workspace`               | N/A                  | N/A                                         | N/A                            | Only update if package exists in workspace (pnpm-specific) |
+
+**Note**:
+
+- For pnpm, `--filter` must come before the command (e.g., `pnpm --filter app update react`)
+- Yarn@2+ uses `up` or `upgrade` command, and updates to latest by default
+- Yarn@1 uses `upgrade` command
+- npm doesn't support `--latest` flag, it always updates within semver range
+- `--no-optional` skips updating optional dependencies (pnpm/npm only)
+- `--no-save` updates lockfile without modifying package.json (pnpm/npm only)
+
+**Aliases:**
+
+- `vite up` = `vite update`
+
+### Command Translation Strategy
+
+#### Global Package Updates
+
+For global packages, use npm cli only (same as add/remove):
+
+```bash
+vite update -g typescript
+-> npm update --global typescript
+```
+
+#### Latest Version Updates
+
+Different package managers handle "latest" differently:
+
+**pnpm**: Has explicit `--latest` flag
+
+```bash
+vite update react --latest
+-> pnpm update --latest react
+```
+
+**yarn@1**: Has `--latest` flag
+
+```bash
+vite update react --latest
+-> yarn upgrade --latest react
+```
+
+**yarn@2+**: Updates to latest by default, use `^` or `~` for range updates
+
+```bash
+vite update react --latest
+-> yarn up react                    # Already updates to latest
+```
+
+**npm**: No `--latest` flag, only updates within semver range
+
+```bash
+vite update react --latest
+-> npx npm-check-updates -u react && npm install
+# OR warn user and update within range
+-> npm update react
+```
+
+### Implementation Architecture
+
+#### 1. Command Structure
+
+**File**: `crates/vite_task/src/lib.rs`
+
+Add new command variant:
+
+```rust
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    // ... existing commands
+
+    /// Update packages to their latest versions
+    #[command(alias = "up")]
+    Update {
+        /// Update to latest version (ignore semver range)
+        #[arg(short = 'L', long)]
+        latest: bool,
+
+        /// Update global packages
+        #[arg(short = 'g', long)]
+        global: bool,
+
+        /// Update recursively in all workspace packages
+        #[arg(short = 'r', long)]
+        recursive: bool,
+
+        /// Filter packages in monorepo (can be used multiple times)
+        #[arg(long, value_name = "PATTERN")]
+        filter: Option<Vec<String>>,
+
+        /// Include workspace root
+        #[arg(short = 'w', long)]
+        workspace_root: bool,
+
+        /// Update only devDependencies
+        #[arg(short = 'D', long)]
+        dev: bool,
+
+        /// Update only dependencies (production)
+        #[arg(short = 'P', long)]
+        prod: bool,
+
+        /// Interactive mode - show outdated packages and choose
+        #[arg(short = 'i', long)]
+        interactive: bool,
+
+        /// Don't update optionalDependencies
+        #[arg(long)]
+        no_optional: bool,
+
+        /// Update lockfile only, don't modify package.json
+        #[arg(long)]
+        no_save: bool,
+
+        /// Packages to update (optional - updates all if omitted)
+        packages: Vec<String>,
+
+        /// Additional arguments to pass through to the package manager
+        #[arg(last = true, allow_hyphen_values = true)]
+        pass_through_args: Option<Vec<String>>,
+    },
+}
+```
+
+#### 2. Package Manager Adapter
+
+**File**: `crates/vite_package_manager/src/update.rs` (new file)
+
+```rust
+#[derive(Debug, Default)]
+pub struct UpdateCommandOptions<'a> {
+    pub packages: &'a [String],
+    pub latest: bool,
+    pub global: bool,
+    pub recursive: bool,
+    pub filters: Option<&'a [String]>,
+    pub workspace_root: bool,
+    pub dev: bool,
+    pub prod: bool,
+    pub interactive: bool,
+    pub no_optional: bool,
+    pub no_save: bool,
+    pub pass_through_args: Option<&'a [String]>,
+}
+
+impl PackageManager {
+    pub fn resolve_update_command(&self, options: &UpdateCommandOptions) -> ResolveCommandResult {
+        let bin_name: String;
+        let mut args: Vec<String> = Vec::new();
+
+        // Global packages use npm only
+        if options.global {
+            bin_name = "npm".into();
+            args.push("update".into());
+            args.push("--global".into());
+            args.extend_from_slice(options.packages);
+            return ResolveCommandResult { bin_path: bin_name, args, envs };
+        }
+
+        match self.client {
+            PackageManagerType::Pnpm => {
+                bin_name = "pnpm".into();
+                // pnpm: --filter must come before command
+                if let Some(filters) = options.filters {
+                    for filter in filters {
+                        args.push("--filter".into());
+                        args.push(filter.clone());
+                    }
+                }
+                args.push("update".into());
+
+                if options.latest {
+                    args.push("--latest".into());
+                }
+                if options.workspace_root {
+                    args.push("--workspace-root".into());
+                }
+                if options.recursive {
+                    args.push("--recursive".into());
+                }
+                if options.dev {
+                    args.push("--dev".into());
+                }
+                if options.prod {
+                    args.push("--prod".into());
+                }
+                if options.interactive {
+                    args.push("--interactive".into());
+                }
+                if options.no_optional {
+                    args.push("--no-optional".into());
+                }
+                if options.no_save {
+                    args.push("--no-save".into());
+                }
+            }
+            PackageManagerType::Yarn => {
+                bin_name = "yarn".into();
+
+                // Determine yarn version
+                let is_yarn_v1 = self.version.starts_with("1.");
+
+                if is_yarn_v1 {
+                    // yarn@1: yarn upgrade [--latest]
+                    if let Some(filters) = options.filters {
+                        // yarn@1 doesn't support workspace filtering well
+                        // Use basic workspace command
+                        args.push("workspace".into());
+                        args.push(filters[0].clone());
+                    }
+                    args.push("upgrade".into());
+                    if options.latest {
+                        args.push("--latest".into());
+                    }
+                } else {
+                    // yarn@2+: yarn up (already updates to latest by default)
+                    if let Some(filters) = options.filters {
+                        args.push("workspaces".into());
+                        args.push("foreach".into());
+                        args.push("--all".into());
+                        for filter in filters {
+                            args.push("--include".into());
+                            args.push(filter.clone());
+                        }
+                    }
+                    args.push("up".into());
+                    if options.recursive {
+                        args.push("--recursive".into());
+                    }
+                    if options.interactive {
+                        args.push("--interactive".into());
+                    }
+                }
+            }
+            PackageManagerType::Npm => {
+                bin_name = "npm".into();
+                args.push("update".into());
+
+                if let Some(filters) = options.filters {
+                    for filter in filters {
+                        args.push("--workspace".into());
+                        args.push(filter.clone());
+                    }
+                }
+                if options.workspace_root {
+                    args.push("--include-workspace-root".into());
+                }
+                if options.recursive {
+                    args.push("--workspaces".into());
+                }
+                if options.no_optional {
+                    args.push("--no-optional".into());
+                }
+                if options.no_save {
+                    args.push("--no-save".into());
+                }
+
+                // npm doesn't have --latest flag
+                // Warn user or handle differently
+                if options.latest {
+                    eprintln!("Warning: npm doesn't support --latest flag. Use 'npm outdated' to check for updates.");
+                }
+            }
+        }
+
+        args.extend_from_slice(options.packages);
+        if let Some(pass_through_args) = options.pass_through_args {
+            args.extend_from_slice(pass_through_args);
+        }
+
+        ResolveCommandResult { bin_path: bin_name, args, envs }
+    }
+}
+```
+
+#### 3. Update Command Implementation
+
+**File**: `crates/vite_task/src/update.rs` (new file)
+
+```rust
+pub struct UpdateCommand {
+    workspace_root: AbsolutePathBuf,
+}
+
+impl UpdateCommand {
+    pub fn new(workspace_root: AbsolutePathBuf) -> Self {
+        Self { workspace_root }
+    }
+
+    pub async fn execute(
+        self,
+        packages: &[String],
+        latest: bool,
+        global: bool,
+        recursive: bool,
+        filters: Option<&[String]>,
+        workspace_root: bool,
+        dev: bool,
+        prod: bool,
+        interactive: bool,
+        no_optional: bool,
+        no_save: bool,
+        pass_through_args: Option<&[String]>,
+    ) -> Result<ExecutionSummary, Error> {
+        // Detect package manager
+        let package_manager = PackageManager::builder(&self.workspace_root).build().await?;
+        let workspace = Workspace::partial_load(self.workspace_root)?;
+
+        let update_command_options = UpdateCommandOptions {
+            packages,
+            latest,
+            global,
+            recursive,
+            filters,
+            workspace_root,
+            dev,
+            prod,
+            interactive,
+            no_optional,
+            no_save,
+            pass_through_args,
+        };
+        let resolve_command = package_manager.resolve_update_command(&update_command_options);
+
+        println!("Running: {} {}", resolve_command.bin_path, resolve_command.args.join(" "));
+
+        let resolved_task = ResolvedTask::resolve_from_builtin_with_command_result(
+            &workspace,
+            "update",
+            resolve_command.args.iter(),
+            ResolveCommandResult { bin_path: resolve_command.bin_path, envs: resolve_command.envs },
+            false,
+            None,
+        )?;
+
+        let mut task_graph: StableGraph<ResolvedTask, ()> = Default::default();
+        task_graph.add_node(resolved_task);
+        let summary = ExecutionPlan::plan(task_graph, false)?.execute(&workspace).await?;
+        workspace.unload().await?;
+
+        Ok(summary)
+    }
+}
+```
+
+## Design Decisions
+
+### 1. No Caching
+
+**Decision**: Do not cache update operations.
+
+**Rationale**:
+
+- Update commands modify package.json and lockfiles
+- Side effects make caching inappropriate
+- Each execution should run fresh
+- Similar to how add/remove/install work
+
+### 2. Default Behavior: Update All vs Specific
+
+**Decision**: When no packages are specified, update all dependencies.
+
+**Rationale**:
+
+- Matches behavior of all three package managers
+- Common use case: `vite update` to update everything
+- Specific updates: `vite update react`
+
+### 3. Latest Flag Handling for npm
+
+**Decision**: Warn users that npm doesn't support --latest, but still run the command.
+
+**Rationale**:
+
+- npm only updates within semver range
+- Alternative tools like `npm-check-updates` exist but require separate installation
+- Better to warn and proceed than to fail
+
+**Alternative**: Could integrate with `npx npm-check-updates`:
+
+```bash
+vite update react --latest
+# For npm: npx npm-check-updates -u react && npm install
+```
+
+### 4. Interactive Mode
+
+**Decision**: Support interactive mode for pnpm and yarn@2+.
+
+**Rationale**:
+
+- pnpm has `--interactive` flag
+- yarn@2+ has `--interactive` flag
+- Provides better UX for reviewing updates
+- npm doesn't support this natively
+
+### 5. Workspace Filtering
+
+**Decision**: Use same filtering approach as add/remove commands.
+
+**Rationale**:
+
+- Consistency across commands
+- Leverage existing filter patterns
+- Works well with pnpm's filter syntax
+
+## Error Handling
+
+### No Package Manager Detected
+
+```bash
+$ vite update react
+Error: No package manager detected
+Please run one of:
+  - vite install (to set up package manager)
+  - Add packageManager field to package.json
+```
+
+### Interactive Mode Not Supported
+
+```bash
+$ vite update --interactive
+Warning: npm doesn't support interactive mode
+Running standard update instead...
+```
+
+## User Experience
+
+### Success Output
+
+```bash
+$ vite update react --latest
+Detected package manager: pnpm@10.15.0
+Running: pnpm update --latest react
+
+Packages: +0 -0 ~1
+~1
+Progress: resolved 150, reused 145, downloaded 1, added 0, done
+
+dependencies:
+~ react 18.2.0 → 18.3.1
+
+Done in 1.2s
+```
+
+### Interactive Mode Output
+
+```bash
+$ vite up -i
+Detected package manager: pnpm@10.15.0
+Running: pnpm update --interactive
+
+? Choose which packages to update: (Press <space> to select, <a> to select all)
+❯◯ react 18.2.0 → 18.3.1
+ ◯ react-dom 18.2.0 → 18.3.1
+ ◯ typescript 5.0.0 → 5.5.0
+ ◯ vite 5.0.0 → 6.0.0
+```
+
+## Alternative Designs Considered
+
+### Alternative 1: Separate Command for Latest Updates
+
+```bash
+vite update react        # Update within range
+vite upgrade react       # Update to latest
+```
+
+**Rejected because**:
+
+- More commands to remember
+- `--latest` flag is clearer
+- Matches pnpm's API design
+
+### Alternative 2: Always Update to Latest
+
+```bash
+vite update react        # Always updates to latest
+vite update react --range # Updates within semver range
+```
+
+**Rejected because**:
+
+- Breaks semver expectations
+- Different from package manager defaults
+- Could cause unexpected breaking changes
+
+## Implementation Plan
+
+### Phase 1: Core Functionality
+
+1. Add `Update` command variant to `Commands` enum
+2. Create `update.rs` module in both crates
+3. Implement package manager command resolution
+4. Add basic error handling
+
+### Phase 2: Advanced Features
+
+1. Add interactive mode support
+2. Implement workspace filtering
+3. Add dev/prod dependency filtering
+4. Handle yarn version detection
+
+### Phase 3: Testing
+
+1. Unit tests for command resolution
+2. Integration tests with mock package managers
+3. Test interactive mode (where supported)
+4. Test workspace operations
+
+### Phase 4: Documentation
+
+1. Update CLI documentation
+2. Add examples to README
+3. Document package manager compatibility
+
+## Testing Strategy
+
+### Test Package Manager Versions
+
+- pnpm@9.x [WIP]
+- pnpm@10.x
+- yarn@1.x [WIP]
+- yarn@4.x
+- npm@10.x
+- npm@11.x [WIP]
+
+### Unit Tests
+
+```rust
+#[test]
+fn test_pnpm_update_basic() {
+    let pm = PackageManager::mock(PackageManagerType::Pnpm);
+    let args = pm.resolve_update_command(&UpdateCommandOptions {
+        packages: &["react".to_string()],
+        latest: false,
+        ..Default::default()
+    });
+    assert_eq!(args, vec!["update", "react"]);
+}
+
+#[test]
+fn test_pnpm_update_latest() {
+    let pm = PackageManager::mock(PackageManagerType::Pnpm);
+    let args = pm.resolve_update_command(&UpdateCommandOptions {
+        packages: &["react".to_string()],
+        latest: true,
+        ..Default::default()
+    });
+    assert_eq!(args, vec!["update", "--latest", "react"]);
+}
+
+#[test]
+fn test_npm_update_latest_warning() {
+    // Should warn but still execute
+    let pm = PackageManager::mock(PackageManagerType::Npm);
+    let args = pm.resolve_update_command(&UpdateCommandOptions {
+        packages: &["react".to_string()],
+        latest: true,
+        ..Default::default()
+    });
+    assert_eq!(args, vec!["update", "react"]);
+}
+```
+
+## CLI Help Output
+
+```bash
+$ vite update --help
+Update packages to their latest versions
+
+Usage: vite update [PACKAGES]... [OPTIONS]
+
+Aliases: up
+
+Arguments:
+  [PACKAGES]...  Packages to update (updates all if omitted)
+
+Options:
+  -L, --latest           Update to latest version (ignore semver range)
+  -g, --global           Update global packages
+  -r, --recursive        Update recursively in all workspace packages
+  --filter <PATTERN>     Filter packages in monorepo (can be used multiple times)
+  -w, --workspace-root   Include workspace root
+  -D, --dev              Update only devDependencies
+  -P, --prod             Update only dependencies
+  -i, --interactive      Show outdated packages and choose which to update
+  --no-optional          Don't update optionalDependencies
+  --no-save              Update lockfile only, don't modify package.json
+  -h, --help             Print help
+
+Examples:
+  vite update                          # Update all packages within semver range
+  vite update react react-dom          # Update specific packages
+  vite update --latest                 # Update all to latest versions
+  vite up react -L                     # Update react to latest
+  vite update -i                       # Interactive mode
+  vite update --filter app             # Update in specific workspace
+  vite update -r                       # Update in all workspaces
+  vite update -D                       # Update only dev dependencies
+  vite update --no-optional            # Skip optional dependencies
+  vite update --no-save                # Update lockfile only
+```
+
+## Real-World Usage Examples
+
+### Monorepo Package Updates
+
+```bash
+# Update React in all frontend packages to latest
+vite update react react-dom --latest --filter "@myorg/app-*"
+
+# Update all dev dependencies in all packages
+vite update -D -r
+
+# Interactive update in specific package
+vite update -i --filter web
+
+# Update all to latest in workspace root
+vite update --latest -w
+
+# Update TypeScript across entire monorepo
+vite update typescript --latest -r
+```
+
+### Development Workflow
+
+```bash
+# Check for updates interactively
+vite up -i
+
+# Update all dependencies within semver range
+vite update
+
+# Update security patches
+vite update
+
+# Update to latest versions (major updates)
+vite update --latest
+
+# Update specific package to latest
+vite up react -L
+
+# Update global packages
+vite update -g typescript
+
+# Test updates without saving to package.json
+vite update --no-save
+
+# Update without optional dependencies
+vite update --no-optional
+```
+
+## Package Manager Compatibility
+
+| Feature          | pnpm               | yarn@1           | yarn@2+          | npm              | Notes                      |
+| ---------------- | ------------------ | ---------------- | ---------------- | ---------------- | -------------------------- |
+| Update command   | `update`           | `upgrade`        | `up`             | `update`         | Different command names    |
+| Latest flag      | `--latest` / `-L`  | `--latest`       | N/A (default)    | ❌ Not supported | npm only updates in range  |
+| Interactive      | `--interactive`    | ❌ Not supported | `--interactive`  | ❌ Not supported | Limited support            |
+| Workspace filter | `--filter`         | ⚠️ Limited        | ⚠️ Limited        | `--workspace`    | pnpm most flexible         |
+| Recursive        | `--recursive`      | ❌ Not supported | `--recursive`    | `--workspaces`   | Different flags            |
+| Dev/Prod filter  | `--dev` / `--prod` | ❌ Not supported | ❌ Not supported | ❌ Not supported | pnpm only                  |
+| Global           | `-g`               | `global upgrade` | ❌ Not supported | `-g`             | Use npm for global         |
+| No optional      | `--no-optional`    | ❌ Not supported | ❌ Not supported | `--no-optional`  | Skip optional dependencies |
+| No save          | `--no-save`        | ❌ Not supported | ❌ Not supported | `--no-save`      | Lockfile only updates      |
+
+## Future Enhancements
+
+### 1. Outdated Command
+
+Show outdated packages before updating:
+
+```bash
+vite outdated
+vite outdated --filter app
+```
+
+### 2. Smart Update Suggestions
+
+```bash
+$ vite update
+Analyzing dependencies...
+⚠️  Major updates available:
+  react 17.0.0 → 18.3.1 (breaking changes)
+
+✓ Minor updates:
+  lodash 4.17.20 → 4.17.21
+
+Run 'vite update --latest' to update to latest versions
+Run 'vite update -i' for interactive mode
+```
+
+### 3. Changelog Display
+
+```bash
+$ vite update react --latest
+Updating react 18.2.0 → 18.3.1
+
+📝 Changelog:
+  - New useOptimistic hook
+  - Performance improvements
+  - Bug fixes
+
+Continue? (Y/n)
+```
+
+## Success Metrics
+
+1. **Adoption**: % of users using `vite update` vs direct package manager
+2. **Update Frequency**: Track how often dependencies are kept up-to-date
+3. **User Feedback**: Survey/issues about command ergonomics
+4. **Error Rate**: Track command failures vs package manager direct usage
+
+## Conclusion
+
+This RFC proposes adding `vite update` command to provide a unified interface for updating packages across pnpm/yarn/npm. The design:
+
+- ✅ Automatically adapts to detected package manager
+- ✅ Supports updating specific packages or all packages
+- ✅ Provides `--latest` flag to update beyond semver range
+- ✅ Full workspace support with filtering
+- ✅ Interactive mode for better UX (where supported)
+- ✅ Graceful degradation for package manager-specific features
+- ✅ No caching overhead
+- ✅ Simple implementation leveraging existing infrastructure
+
+The implementation follows the same patterns as add/remove commands while providing the update-specific features developers need.


### PR DESCRIPTION
### TL;DR

Add `vite update` command to update packages across different package managers.

### What changed?

- Added a new `update.rs` module to handle package updates across pnpm, yarn, and npm
- Implemented `UpdateCommandOptions` to configure update behavior with various flags
- Added command resolution logic for each package manager with appropriate flags
- Created comprehensive test suite for all package managers and their versions
- Added snap tests for real-world usage scenarios
- Included documentation in RFC format

### How to test?

Test the new update command with different package managers:

```bash
# Basic update
vite update react

# Update to latest version
vite update react --latest

# Update all packages
vite update

# Update in specific workspace
vite update --filter app

# Update recursively in all workspaces
vite update -r

# Update only dev dependencies
vite update -D

# Interactive mode
vite update -i
```

### Why make this change?

This change provides a unified interface for updating packages across different package managers. It simplifies workflows by automatically detecting and using the correct package manager syntax, providing consistent commands regardless of the underlying tool. The implementation handles the differences between pnpm, yarn (v1 and v2+), and npm, making it easier for developers to maintain dependencies without remembering package manager-specific commands.