### PR TITLE
chore(fspy): remove ignoring Chromium processes

### DIFF
--- a/crates/fspy_shared_unix/src/spawn/linux/mod.rs
+++ b/crates/fspy_shared_unix/src/spawn/linux/mod.rs
@@ -24,36 +24,19 @@ pub fn handle_exec(
     command: &mut Exec,
     encoded_payload: &EncodedPayload,
 ) -> nix::Result<Option<PreExec>> {
-    // Check if the program is Chrome or Chromium
-    let program_path = Path::new(OsStr::from_bytes(&command.program));
-    let skip_injection = if let Some(file_name) = program_path.file_name() {
-        let file_name_bytes = file_name.as_bytes();
-        // Check for Chrome or Chromium in the filename (case-insensitive)
-        file_name_bytes.windows(6).any(|w| w == b"Chrome" || w == b"chrome")
-            || file_name_bytes.windows(8).any(|w| w == b"Chromium" || w == b"chromium")
-    } else {
-        false
-    };
-
-    if skip_injection {
-        command.envs.retain(|(name, _)| name != LD_PRELOAD && name != PAYLOAD_ENV_NAME);
+    let executable_fd = open_executable(Path::new(OsStr::from_bytes(&command.program)))?;
+    let executable_mmap = unsafe { Mmap::map(&executable_fd) }
+        .map_err(|io_error| nix::Error::try_from(io_error).unwrap_or(nix::Error::UnknownErrno))?;
+    if elf::is_dynamically_linked_to_libc(executable_mmap)? {
+        ensure_env(
+            &mut command.envs,
+            LD_PRELOAD,
+            encoded_payload.payload.preload_path.as_os_str().as_bytes(),
+        )?;
+        ensure_env(&mut command.envs, PAYLOAD_ENV_NAME, &encoded_payload.encoded_string)?;
         Ok(None)
     } else {
-        let executable_fd = open_executable(Path::new(OsStr::from_bytes(&command.program)))?;
-        let executable_mmap = unsafe { Mmap::map(&executable_fd) }.map_err(|io_error| {
-            nix::Error::try_from(io_error).unwrap_or(nix::Error::UnknownErrno)
-        })?;
-        if elf::is_dynamically_linked_to_libc(executable_mmap)? {
-            ensure_env(
-                &mut command.envs,
-                LD_PRELOAD,
-                encoded_payload.payload.preload_path.as_os_str().as_bytes(),
-            )?;
-            ensure_env(&mut command.envs, PAYLOAD_ENV_NAME, &encoded_payload.encoded_string)?;
-            Ok(None)
-        } else {
-            command.envs.retain(|(name, _)| name != LD_PRELOAD && name != PAYLOAD_ENV_NAME);
-            Ok(Some(PreExec(encoded_payload.payload.seccomp_payload.clone())))
-        }
+        command.envs.retain(|(name, _)| name != LD_PRELOAD && name != PAYLOAD_ENV_NAME);
+        Ok(Some(PreExec(encoded_payload.payload.seccomp_payload.clone())))
     }
 }

--- a/crates/fspy_shared_unix/src/spawn/macos.rs
+++ b/crates/fspy_shared_unix/src/spawn/macos.rs
@@ -5,7 +5,6 @@ use std::{
     path::{Path, absolute},
 };
 
-use bstr::ByteSlice;
 use phf::{Set, phf_set};
 
 use crate::{
@@ -42,14 +41,7 @@ pub fn handle_exec(
     let injectable = if let (Some(parent), Some(file_name)) =
         (program_path.parent(), program_path.file_name())
     {
-        // Exclude Chrome and Chromium-based browsers
-        if file_name.as_bytes().windows(6).any(|w| w == b"Chrome" || w == b"chrome")
-            || file_name.as_bytes().windows(8).any(|w| w == b"Chromium" || w == b"chromium")
-            || command.program.contains_str("Google Chrome")
-            || command.program.contains_str("Chromium")
-        {
-            false
-        } else if matches!(parent.as_os_str().as_bytes(), b"/bin" | b"/usr/bin") {
+        if matches!(parent.as_os_str().as_bytes(), b"/bin" | b"/usr/bin") {
             let fixtures = &encoded_payload.payload.fixtures;
             if matches!(file_name.as_bytes(), b"sh" | b"bash") {
                 command.program = fixtures.bash_path.as_os_str().as_bytes().into();


### PR DESCRIPTION
Chromium processes can now be successfully tracked after #234, and we have it monitored since #235.