### PR TITLE
chore(tools): run snap-test in parallel on local machines

### DIFF
--- a/packages/tools/src/snap-test.ts
+++ b/packages/tools/src/snap-test.ts
@@ -53,8 +53,9 @@ for (const caseName of fs.readdirSync(casesDir)) {
   }
 }
 
-await Promise.all(tasks);
-
+if (tasks.length > 0) {
+  await Promise.all(tasks);
+}
 interface Steps {
   ignoredPlatforms?: string[];
   env: Record<string, string>;


### PR DESCRIPTION
CI env still fails, see https://app.graphite.dev/github/pr/voidzero-dev/vite-plus/251/chore(cli)-restore-to-run-snap-test-parallel  
  
run 10 times work:  
`￼seq 10 | xargs -n 1 sh -c 'pnpm bootstrap-cli && pnpm test && git status'`