### PR TITLE
chore(cli): set binding version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,10 @@ jobs:
 
       - uses: oxc-project/setup-node@fdbf0dfd334c4e6d56ceeb77d91c76339c2a0885 # v1.0.4
 
+      - name: Set binding version
+        run: |
+          sed -i 's/version = "0.0.0"/version = "0.0.0-${{ github.sha }}"/' packages/cli/binding/Cargo.toml
+
       - name: Build
         if: ${{ matrix.settings.target == 'x86_64-unknown-linux-gnu' }}
         run: pnpm --filter=@voidzero-dev/vite-plus build --target ${{ matrix.settings.target }} --use-napi-cross
@@ -108,7 +112,7 @@ jobs:
           pattern: bindings-*
           merge-multiple: true
 
-      - name: Set version
+      - name: Set npm packages version
         run: |
           sed -i 's/"version": "0.0.0"/"version": "0.0.0-${{ github.sha }}"/' packages/global/package.json
           sed -i 's/"version": "0.0.0"/"version": "0.0.0-${{ github.sha }}"/' packages/cli/package.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4794,7 +4794,7 @@ dependencies = [
 
 [[package]]
 name = "vite-plus-cli"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "clap",
  "crossterm 0.29.0",

--- a/packages/cli/binding/Cargo.toml
+++ b/packages/cli/binding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vite-plus-cli"
-version = "0.0.1"
+version = "0.0.0"
 edition = "2024"
 
 [[bin]]


### PR DESCRIPTION
### TL;DR

Fix version handling in the release workflow to ensure consistent versioning across Rust and npm packages.

### What changed?

- Added a new step in the release workflow to set the binding version using the commit SHA
- Renamed the existing version step to "Set npm packages version" for clarity
- Updated the version in `packages/cli/binding/Cargo.toml` from "0.0.1" to "0.0.0" to match the npm versioning pattern
- Corresponding update in `Cargo.lock` to reflect the version change

### How to test?

1. Trigger the release workflow
2. Verify that both the Rust binding and npm packages have the same version format (`0.0.0-{commit-sha}`)
3. Check that the artifacts are properly versioned in the release

### Why make this change?

This change ensures version consistency between the Rust bindings and npm packages during the release process. By using the same version pattern across all components, we avoid potential compatibility issues and make it easier to track which versions belong together.