### PR TITLE
chore: move dependencies out of snap test case

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,6 +46,7 @@
     "@napi-rs/cli": "catalog:",
     "@oxc-node/core": "catalog:",
     "@vitest/browser": "catalog:",
+    "@vitest/browser-playwright": "catalog:",
     "@voidzero-dev/vite-plus-tools": "workspace:",
     "playwright": "catalog:",
     "rolldown": "catalog:"

--- a/packages/cli/snap-tests/vitest-browser-mode/package.json
+++ b/packages/cli/snap-tests/vitest-browser-mode/package.json
@@ -1,8 +1,5 @@
 {
   "name": "vitest-browser-mode",
   "version": "1.0.0",
-  "packageManager": "pnpm@10.19.0",
-  "dependencies": {
-    "@vitest/browser-playwright": "^4.0.1"
-  }
+  "packageManager": "pnpm@10.19.0"
 }

--- a/packages/cli/snap-tests/vitest-browser-mode/snap.txt
+++ b/packages/cli/snap-tests/vitest-browser-mode/snap.txt
@@ -1,22 +1,3 @@
-> vite install
-Packages: +<variable>
-+<repeat>
-Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
-
-dependencies:
-+ @vitest/browser-playwright <semver>
-
-╭ Warning ─────────────────────────────────────────────────────────────────────╮
-│                                                                              │
-│   Ignored build scripts: esbuild.                                            │
-│   Run "pnpm approve-builds" to pick which dependencies should be allowed     │
-│   to run scripts.                                                            │
-│                                                                              │
-╰──────────────────────────────────────────────────────────────────────────────╯
-
-Done in <variable>ms using pnpm v<semver>
-
-
 > vite test
 
  RUN  v<semver> <cwd>

--- a/packages/cli/snap-tests/vitest-browser-mode/steps.json
+++ b/packages/cli/snap-tests/vitest-browser-mode/steps.json
@@ -3,7 +3,6 @@
     "VITE_DISABLE_AUTO_INSTALL": "1"
   },
   "commands": [
-    "vite install",
     "vite test",
     "echo //comment >> src/foo.js",
     "vite test",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,11 @@ catalogs:
       specifier: ^24.9.1
       version: 24.9.1
     '@vitest/browser':
-      specifier: ^4.0.3
-      version: 4.0.3
+      specifier: ^4.0.4
+      version: 4.0.4
+    '@vitest/browser-playwright':
+      specifier: ^4.0.4
+      version: 4.0.4
     create-tsdown:
       specifier: 0.0.3
       version: 0.0.3
@@ -79,8 +82,8 @@ catalogs:
       specifier: 2.0.0-alpha.12
       version: 2.0.0-alpha.12
     vitest:
-      specifier: ^4.0.3
-      version: 4.0.3
+      specifier: ^4.0.4
+      version: 4.0.4
     vue:
       specifier: ^3.5.21
       version: 3.5.21
@@ -122,7 +125,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.3(@types/node@24.9.1)(esbuild@0.25.8)(jiti@2.6.1)(yaml@2.8.1)
+        version: 4.0.4(@types/node@24.9.1)(@vitest/browser-playwright@4.0.4)(esbuild@0.25.8)(jiti@2.6.1)(yaml@2.8.1)
 
   docs:
     devDependencies:
@@ -158,7 +161,7 @@ importers:
         version: 2.0.0-alpha.12(@types/node@24.9.1)(esbuild@0.25.8)(jiti@2.6.1)(oxc-minify@0.82.3)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.1)
       vitest:
         specifier: 'catalog:'
-        version: 4.0.3(@types/node@24.9.1)(esbuild@0.25.8)(jiti@2.6.1)(yaml@2.8.1)
+        version: 4.0.4(@types/node@24.9.1)(@vitest/browser-playwright@4.0.4)(esbuild@0.25.8)(jiti@2.6.1)(yaml@2.8.1)
     devDependencies:
       '@napi-rs/cli':
         specifier: 'catalog:'
@@ -168,7 +171,10 @@ importers:
         version: 0.0.32
       '@vitest/browser':
         specifier: 'catalog:'
-        version: 4.0.3(rolldown-vite@7.1.19(@types/node@24.9.1)(esbuild@0.25.8)(jiti@2.6.1)(yaml@2.8.1))(vitest@4.0.3(@types/node@24.9.1)(esbuild@0.25.8)(jiti@2.6.1)(yaml@2.8.1))
+        version: 4.0.4(rolldown-vite@7.1.19(@types/node@24.9.1)(esbuild@0.25.8)(jiti@2.6.1)(yaml@2.8.1))(vitest@4.0.4)
+      '@vitest/browser-playwright':
+        specifier: 'catalog:'
+        version: 4.0.4(playwright@1.56.1)(rolldown-vite@7.1.19(@types/node@24.9.1)(esbuild@0.25.8)(jiti@2.6.1)(yaml@2.8.1))(vitest@4.0.4)
       '@voidzero-dev/vite-plus-tools':
         specifier: 'workspace:'
         version: link:../tools
@@ -204,7 +210,7 @@ importers:
         version: 7.1.19(@types/node@24.9.1)(esbuild@0.25.8)(jiti@2.6.1)(yaml@2.8.1)
       vitest:
         specifier: 'catalog:'
-        version: 4.0.3(@types/node@24.9.1)(esbuild@0.25.8)(jiti@2.6.1)(yaml@2.8.1)
+        version: 4.0.4(@types/node@24.9.1)(@vitest/browser-playwright@4.0.4)(esbuild@0.25.8)(jiti@2.6.1)(yaml@2.8.1)
     devDependencies:
       '@clack/prompts':
         specifier: 'catalog:'
@@ -1486,16 +1492,22 @@ packages:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0
       vue: ^3.2.25
 
-  '@vitest/browser@4.0.3':
-    resolution: {integrity: sha512-XmGOU2m0x86yFIrAFiIQ5yV7dpk8hW1HCohUR7QOGfywGS8z2WshdEZc5A+G67mS69L8Ub3NEttjWtXVhw/Sew==}
+  '@vitest/browser-playwright@4.0.4':
+    resolution: {integrity: sha512-jGKnGZ5ZKXuwQ1Ldwll/rZxk3webz4gz3kvoTYX2NH2ASPiwFGck8D09Sf2wVjCuDqebPXXd69zUIt1o4yQ5tA==}
     peerDependencies:
-      vitest: 4.0.3
+      playwright: '*'
+      vitest: 4.0.4
 
-  '@vitest/expect@4.0.3':
-    resolution: {integrity: sha512-v3eSDx/bF25pzar6aEJrrdTXJduEBU3uSGXHslIdGIpJVP8tQQHV6x1ZfzbFQ/bLIomLSbR/2ZCfnaEGkWkiVQ==}
+  '@vitest/browser@4.0.4':
+    resolution: {integrity: sha512-1ZXztcBtRd3maKliHzWbQohsyRjam0ws6OPRWNWfGxFUOHTlNBtDnJAm8z1x7IzVkZ6JcOAumHJAbxNJh4tkDw==}
+    peerDependencies:
+      vitest: 4.0.4
 
-  '@vitest/mocker@4.0.3':
-    resolution: {integrity: sha512-evZcRspIPbbiJEe748zI2BRu94ThCBE+RkjCpVF8yoVYuTV7hMe+4wLF/7K86r8GwJHSmAPnPbZhpXWWrg1qbA==}
+  '@vitest/expect@4.0.4':
+    resolution: {integrity: sha512-0ioMscWJtfpyH7+P82sGpAi3Si30OVV73jD+tEqXm5+rIx9LgnfdaOn45uaFkKOncABi/PHL00Yn0oW/wK4cXw==}
+
+  '@vitest/mocker@4.0.4':
+    resolution: {integrity: sha512-UTtKgpjWj+pvn3lUM55nSg34098obGhSHH+KlJcXesky8b5wCUgg7s60epxrS6yAG8slZ9W8T9jGWg4PisMf5Q==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0-0
@@ -1505,20 +1517,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.0.3':
-    resolution: {integrity: sha512-N7gly/DRXzxa9w9sbDXwD9QNFYP2hw90LLLGDobPNwiWgyW95GMxsCt29/COIKKh3P7XJICR38PSDePenMBtsw==}
+  '@vitest/pretty-format@4.0.4':
+    resolution: {integrity: sha512-lHI2rbyrLVSd1TiHGJYyEtbOBo2SDndIsN3qY4o4xe2pBxoJLD6IICghNCvD7P+BFin6jeyHXiUICXqgl6vEaQ==}
 
-  '@vitest/runner@4.0.3':
-    resolution: {integrity: sha512-1/aK6fPM0lYXWyGKwop2Gbvz1plyTps/HDbIIJXYtJtspHjpXIeB3If07eWpVH4HW7Rmd3Rl+IS/+zEAXrRtXA==}
+  '@vitest/runner@4.0.4':
+    resolution: {integrity: sha512-99EDqiCkncCmvIZj3qJXBZbyoQ35ghOwVWNnQ5nj0Hnsv4Qm40HmrMJrceewjLVvsxV/JSU4qyx2CGcfMBmXJw==}
 
-  '@vitest/snapshot@4.0.3':
-    resolution: {integrity: sha512-amnYmvZ5MTjNCP1HZmdeczAPLRD6iOm9+2nMRUGxbe/6sQ0Ymur0NnR9LIrWS8JA3wKE71X25D6ya/3LN9YytA==}
+  '@vitest/snapshot@4.0.4':
+    resolution: {integrity: sha512-XICqf5Gi4648FGoBIeRgnHWSNDp+7R5tpclGosFaUUFzY6SfcpsfHNMnC7oDu/iOLBxYfxVzaQpylEvpgii3zw==}
 
-  '@vitest/spy@4.0.3':
-    resolution: {integrity: sha512-82vVL8Cqz7rbXaNUl35V2G7xeNMAjBdNOVaHbrzznT9BmiCiPOzhf0FhU3eP41nP1bLDm/5wWKZqkG4nyU95DQ==}
+  '@vitest/spy@4.0.4':
+    resolution: {integrity: sha512-G9L13AFyYECo40QG7E07EdYnZZYCKMTSp83p9W8Vwed0IyCG1GnpDLxObkx8uOGPXfDpdeVf24P1Yka8/q1s9g==}
 
-  '@vitest/utils@4.0.3':
-    resolution: {integrity: sha512-qV6KJkq8W3piW6MDIbGOmn1xhvcW4DuA07alqaQ+vdx7YA49J85pnwnxigZVQFQw3tWnQNRKWwhz5wbP6iv/GQ==}
+  '@vitest/utils@4.0.4':
+    resolution: {integrity: sha512-4bJLmSvZLyVbNsYFRpPYdJViG9jZyRvMZ35IF4ymXbRZoS+ycYghmwTGiscTXduUg2lgKK7POWIyXJNute1hjw==}
 
   '@vue/compiler-core@3.5.21':
     resolution: {integrity: sha512-8i+LZ0vf6ZgII5Z9XmUvrCyEzocvWT+TeR2VBUVlzIH6Tyv57E20mPZ1bCS+tbejgUgmjrEh7q/0F0bibskAmw==}
@@ -2522,18 +2534,18 @@ packages:
       postcss:
         optional: true
 
-  vitest@4.0.3:
-    resolution: {integrity: sha512-IUSop8jgaT7w0g1yOM/35qVtKjr/8Va4PrjzH1OUb0YH4c3OXB2lCZDkMAB6glA8T5w8S164oJGsbcmAecr4sA==}
+  vitest@4.0.4:
+    resolution: {integrity: sha512-hV31h0/bGbtmDQc0KqaxsTO1v4ZQeF8ojDFuy4sZhFadwAqqvJA0LDw68QUocctI5EDpFMql/jVWKuPYHIf2Ew==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/debug': ^4.1.12
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.0.3
-      '@vitest/browser-preview': 4.0.3
-      '@vitest/browser-webdriverio': 4.0.3
-      '@vitest/ui': 4.0.3
+      '@vitest/browser-playwright': 4.0.4
+      '@vitest/browser-preview': 4.0.4
+      '@vitest/browser-webdriverio': 4.0.4
+      '@vitest/ui': 4.0.4
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -3538,16 +3550,29 @@ snapshots:
       vite: rolldown-vite@7.1.19(@types/node@24.9.1)(esbuild@0.25.8)(jiti@2.6.1)(yaml@2.8.1)
       vue: 3.5.21(typescript@5.9.3)
 
-  '@vitest/browser@4.0.3(rolldown-vite@7.1.19(@types/node@24.9.1)(esbuild@0.25.8)(jiti@2.6.1)(yaml@2.8.1))(vitest@4.0.3(@types/node@24.9.1)(esbuild@0.25.8)(jiti@2.6.1)(yaml@2.8.1))':
+  '@vitest/browser-playwright@4.0.4(playwright@1.56.1)(rolldown-vite@7.1.19(@types/node@24.9.1)(esbuild@0.25.8)(jiti@2.6.1)(yaml@2.8.1))(vitest@4.0.4)':
     dependencies:
-      '@vitest/mocker': 4.0.3(rolldown-vite@7.1.19(@types/node@24.9.1)(esbuild@0.25.8)(jiti@2.6.1)(yaml@2.8.1))
-      '@vitest/utils': 4.0.3
+      '@vitest/browser': 4.0.4(rolldown-vite@7.1.19(@types/node@24.9.1)(esbuild@0.25.8)(jiti@2.6.1)(yaml@2.8.1))(vitest@4.0.4)
+      '@vitest/mocker': 4.0.4(rolldown-vite@7.1.19(@types/node@24.9.1)(esbuild@0.25.8)(jiti@2.6.1)(yaml@2.8.1))
+      playwright: 1.56.1
+      tinyrainbow: 3.0.3
+      vitest: 4.0.4(@types/node@24.9.1)(@vitest/browser-playwright@4.0.4)(esbuild@0.25.8)(jiti@2.6.1)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser@4.0.4(rolldown-vite@7.1.19(@types/node@24.9.1)(esbuild@0.25.8)(jiti@2.6.1)(yaml@2.8.1))(vitest@4.0.4)':
+    dependencies:
+      '@vitest/mocker': 4.0.4(rolldown-vite@7.1.19(@types/node@24.9.1)(esbuild@0.25.8)(jiti@2.6.1)(yaml@2.8.1))
+      '@vitest/utils': 4.0.4
       magic-string: 0.30.21
       pixelmatch: 7.1.0
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.0.3
-      vitest: 4.0.3(@types/node@24.9.1)(esbuild@0.25.8)(jiti@2.6.1)(yaml@2.8.1)
+      vitest: 4.0.4(@types/node@24.9.1)(@vitest/browser-playwright@4.0.4)(esbuild@0.25.8)(jiti@2.6.1)(yaml@2.8.1)
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
@@ -3555,43 +3580,43 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/expect@4.0.3':
+  '@vitest/expect@4.0.4':
     dependencies:
       '@standard-schema/spec': 1.0.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.0.3
-      '@vitest/utils': 4.0.3
+      '@vitest/spy': 4.0.4
+      '@vitest/utils': 4.0.4
       chai: 6.2.0
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.3(rolldown-vite@7.1.19(@types/node@24.9.1)(esbuild@0.25.8)(jiti@2.6.1)(yaml@2.8.1))':
+  '@vitest/mocker@4.0.4(rolldown-vite@7.1.19(@types/node@24.9.1)(esbuild@0.25.8)(jiti@2.6.1)(yaml@2.8.1))':
     dependencies:
-      '@vitest/spy': 4.0.3
+      '@vitest/spy': 4.0.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: rolldown-vite@7.1.19(@types/node@24.9.1)(esbuild@0.25.8)(jiti@2.6.1)(yaml@2.8.1)
 
-  '@vitest/pretty-format@4.0.3':
+  '@vitest/pretty-format@4.0.4':
     dependencies:
       tinyrainbow: 3.0.3
 
-  '@vitest/runner@4.0.3':
+  '@vitest/runner@4.0.4':
     dependencies:
-      '@vitest/utils': 4.0.3
+      '@vitest/utils': 4.0.4
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.0.3':
+  '@vitest/snapshot@4.0.4':
     dependencies:
-      '@vitest/pretty-format': 4.0.3
+      '@vitest/pretty-format': 4.0.4
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.0.3': {}
+  '@vitest/spy@4.0.4': {}
 
-  '@vitest/utils@4.0.3':
+  '@vitest/utils@4.0.4':
     dependencies:
-      '@vitest/pretty-format': 4.0.3
+      '@vitest/pretty-format': 4.0.4
       tinyrainbow: 3.0.3
 
   '@vue/compiler-core@3.5.21':
@@ -4573,15 +4598,15 @@ snapshots:
       - universal-cookie
       - yaml
 
-  vitest@4.0.3(@types/node@24.9.1)(esbuild@0.25.8)(jiti@2.6.1)(yaml@2.8.1):
+  vitest@4.0.4(@types/node@24.9.1)(@vitest/browser-playwright@4.0.4)(esbuild@0.25.8)(jiti@2.6.1)(yaml@2.8.1):
     dependencies:
-      '@vitest/expect': 4.0.3
-      '@vitest/mocker': 4.0.3(rolldown-vite@7.1.19(@types/node@24.9.1)(esbuild@0.25.8)(jiti@2.6.1)(yaml@2.8.1))
-      '@vitest/pretty-format': 4.0.3
-      '@vitest/runner': 4.0.3
-      '@vitest/snapshot': 4.0.3
-      '@vitest/spy': 4.0.3
-      '@vitest/utils': 4.0.3
+      '@vitest/expect': 4.0.4
+      '@vitest/mocker': 4.0.4(rolldown-vite@7.1.19(@types/node@24.9.1)(esbuild@0.25.8)(jiti@2.6.1)(yaml@2.8.1))
+      '@vitest/pretty-format': 4.0.4
+      '@vitest/runner': 4.0.4
+      '@vitest/snapshot': 4.0.4
+      '@vitest/spy': 4.0.4
+      '@vitest/utils': 4.0.4
       debug: 4.4.3
       es-module-lexer: 1.7.0
       expect-type: 1.2.2
@@ -4597,6 +4622,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.9.1
+      '@vitest/browser-playwright': 4.0.4(playwright@1.56.1)(rolldown-vite@7.1.19(@types/node@24.9.1)(esbuild@0.25.8)(jiti@2.6.1)(yaml@2.8.1))(vitest@4.0.4)
     transitivePeerDependencies:
       - esbuild
       - jiti

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,8 @@ catalog:
   '@types/node': ^24.9.1
   '@types/react': ^19.1.8
   '@types/react-dom': ^19.1.6
-  '@vitest/browser': ^4.0.3
+  '@vitest/browser': ^4.0.4
+  '@vitest/browser-playwright': ^4.0.4
   create-tsdown: 0.0.3
   create-vite: ^8.0.0
   cross-spawn: ^7.0.5
@@ -34,7 +35,7 @@ catalog:
   typescript: ^5.9.3
   vite: npm:rolldown-vite@^7.1.19
   vitepress: 2.0.0-alpha.12
-  vitest: ^4.0.3
+  vitest: ^4.0.4
   vue: ^3.5.21
 
 catalogMode: prefer


### PR DESCRIPTION
### TL;DR

Added `@vitest/browser-playwright` as a catalog dependency

### What changed?

- Added `@vitest/browser-playwright` to the CLI package dependencies
- Removed the `@vitest/browser-playwright` dependency from the vitest-browser-mode snap test package.json
- Modified the vitest-browser-mode snap test to no longer run `vite install` before tests
- Updated the snap test output to reflect these changes

### How to test?

1. Run the vitest-browser-mode snap test to verify it works without the explicit installation step
2. Verify that browser tests using Playwright work correctly with the updated dependencies

### Why make this change?

This change streamlines the testing process by making `@vitest/browser-playwright` available as a catalog dependency rather than requiring it to be installed separately in each test. This eliminates the need for an explicit installation step in the vitest-browser-mode snap test, making the testing workflow more efficient and consistent.