### PR TITLE
chore: support Windows and MacOS in binding version update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,7 @@ jobs:
       - uses: oxc-project/setup-node@fdbf0dfd334c4e6d56ceeb77d91c76339c2a0885 # v1.0.4
 
       - name: Set binding version
-        run: |
-          sed -i 's/version = "0.0.0"/version = "0.0.0-${{ github.sha }}"/' packages/cli/binding/Cargo.toml
+        run: pnpm exec replace-file-content packages/cli/binding/Cargo.toml 'version = "0.0.0"' 'version = "0.0.0-${{ github.sha }}"'
 
       - name: Build
         if: ${{ matrix.settings.target == 'x86_64-unknown-linux-gnu' }}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@oxc-node/core": "catalog:",
     "@types/node": "catalog:",
     "@voidzero-dev/vite-plus": "workspace:*",
+    "@voidzero-dev/vite-plus-tools": "workspace:*",
     "husky": "catalog:",
     "lint-staged": "catalog:",
     "oxfmt": "catalog:",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -4,9 +4,13 @@
   "type": "module",
   "bin": {
     "json-edit": "./src/json-edit.ts",
-    "snap-test": "./src/snap-test.ts"
+    "snap-test": "./src/snap-test.ts",
+    "replace-file-content": "./src/replace-file-content.ts"
   },
   "devDependencies": {
     "minimatch": "catalog:"
+  },
+  "scripts": {
+    "snap-test": "snap-test"
   }
 }

--- a/packages/tools/snap-tests/replace-file-content/foo/example.toml
+++ b/packages/tools/snap-tests/replace-file-content/foo/example.toml
@@ -1,0 +1,14 @@
+[package]
+name = "foo"
+version = "0.0.0"
+edition = "2024"
+
+[[bin]]
+name = "vite"
+path = "src/main.rs"
+
+[dependencies]
+clap = { workspace = true, features = ["derive"] }
+crossterm = { workspace = true }
+napi = { workspace = true }
+napi-derive = { workspace = true }

--- a/packages/tools/snap-tests/replace-file-content/snap.txt
+++ b/packages/tools/snap-tests/replace-file-content/snap.txt
@@ -1,0 +1,31 @@
+> cat foo/example.toml # should show original toml file
+[package]
+name = "foo"
+version = "0.0.0"
+edition = "2024"
+
+[[bin]]
+name = "vite"
+path = "src/main.rs"
+
+[dependencies]
+clap = { workspace = true, features = ["derive"] }
+crossterm = { workspace = true }
+napi = { workspace = true }
+napi-derive = { workspace = true }
+
+> replace-file-content foo/example.toml 'version = "0.0.0"' 'version = "1.0.0"' && cat foo/example.toml # should edit toml file
+[package]
+name = "foo"
+version = "1.0.0"
+edition = "2024"
+
+[[bin]]
+name = "vite"
+path = "src/main.rs"
+
+[dependencies]
+clap = { workspace = true, features = ["derive"] }
+crossterm = { workspace = true }
+napi = { workspace = true }
+napi-derive = { workspace = true }

--- a/packages/tools/snap-tests/replace-file-content/steps.json
+++ b/packages/tools/snap-tests/replace-file-content/steps.json
@@ -1,0 +1,8 @@
+{
+  "env": {
+  },
+  "commands": [
+    "cat foo/example.toml # should show original toml file",
+    "replace-file-content foo/example.toml 'version = \"0.0.0\"' 'version = \"1.0.0\"' && cat foo/example.toml # should edit toml file"
+  ]
+}

--- a/packages/tools/src/replace-file-content.ts
+++ b/packages/tools/src/replace-file-content.ts
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+const filename = process.argv[2];
+const searchValue = process.argv[3];
+const newValue = process.argv[4];
+
+if (!filename || !searchValue || !newValue) {
+  console.error('Usage: replace-file-content <filename> <searchValue> <newValue>');
+  console.error('Example: replace-file-content example.toml \'version = "0.0.0"\' \'version = "0.0.1"\'');
+  process.exit(1);
+}
+
+const filepath = path.resolve(filename);
+const content = readFileSync(filepath, 'utf-8');
+const newContent = content.replace(searchValue, newValue);
+writeFileSync(filepath, newContent, 'utf-8');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       '@voidzero-dev/vite-plus':
         specifier: workspace:*
         version: link:packages/cli
+      '@voidzero-dev/vite-plus-tools':
+        specifier: workspace:*
+        version: link:packages/tools
       husky:
         specifier: 'catalog:'
         version: 9.1.7


### PR DESCRIPTION
Add `replace-file-content` utility to fix cross-platform compatibility in release workflow

## What changed?

- Created a new cross-platform Node.js utility script `replace-file-content` that replaces text in files
- Updated the release workflow to use this utility instead of `sed` for modifying the binding version
- Added tests for the new utility to ensure it works correctly
- Added the tools package as a workspace dependency in the root package.json

## Why?

The previous approach using `sed` in the release workflow is not cross-platform compatible, which can cause issues when running on different operating systems. The new utility provides a consistent way to replace file content across all platforms.

## How to test?

The PR includes snapshot tests for the new utility that verify it correctly replaces content in files. You can also manually test by running:

```
pnpm exec replace-file-content <filename> <search-text> <replacement-text>
```

For example:
```
pnpm exec replace-file-content example.toml 'version = "0.0.0"' 'version = "1.0.0"'
```