### PR TITLE
chore: make impl_handler macro self-contained

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1540,7 +1540,6 @@ dependencies = [
  "phf",
  "rand 0.9.2",
  "slab",
- "syscalls",
  "tar",
  "tempfile",
  "thread_local",

--- a/crates/fspy/Cargo.toml
+++ b/crates/fspy/Cargo.toml
@@ -26,7 +26,6 @@ arrayvec = { workspace = true }
 blink-alloc = { workspace = true }
 fspy_seccomp_unotify = { workspace = true, features = ["supervisor"] }
 nix = { workspace = true, features = ["uio"] }
-syscalls = { workspace = true, features = ["std"] }
 thread_local = { workspace = true }
 tokio = { workspace = true, features = ["bytes"] }
 tokio-seqpacket = { workspace = true }

--- a/crates/fspy_seccomp_unotify/src/supervisor/handler/mod.rs
+++ b/crates/fspy_seccomp_unotify/src/supervisor/handler/mod.rs
@@ -9,6 +9,9 @@ pub trait SeccompNotifyHandler {
     fn handle_notify(&mut self, notify: &seccomp_notif) -> io::Result<()>;
 }
 
+#[doc(hidden)] // Re-export for use in the macro
+pub use syscalls::Sysno;
+
 #[macro_export]
 macro_rules! impl_handler {
     ($type:ty: $(
@@ -17,17 +20,17 @@ macro_rules! impl_handler {
     )* ) => {
 
     impl $crate::supervisor::handler::SeccompNotifyHandler for $type {
-        fn syscalls() -> &'static [::syscalls::Sysno] {
+        fn syscalls() -> &'static [$crate::supervisor::handler::Sysno] {
             &[ $(
                 $(#[$attr])?
-                ::syscalls::Sysno::$syscall
+                $crate::supervisor::handler::Sysno::$syscall
             ),* ]
         }
         fn handle_notify(&mut self, notify: &::libc::seccomp_notif) -> ::std::io::Result<()> {
             $crate::supervisor::handler::arg::Caller::with_pid(notify.pid as _, |caller| {
                 $(
                     $(#[$attr])?
-                    if notify.data.nr == ::syscalls::Sysno::$syscall as _ {
+                    if notify.data.nr == $crate::supervisor::handler::Sysno::$syscall as _ {
                         return self.$syscall(caller, $crate::supervisor::handler::arg::FromNotify::from_notify(notify)?)
                     }
                 )*


### PR DESCRIPTION
Removed the direct dependency on `syscalls` crate from `fspy` and re-exported `Sysno` from the `fspy_seccomp_unotify` crate.

### Why make this change?

This change improves the crate's dependency structure by removing a direct dependency on `syscalls` from the `fspy` crate. Instead, `fspy` now uses the `Sysno` type that's re-exported from `fspy_seccomp_unotify`, which already depends on `syscalls`. This reduces dependency coupling and makes the API more self-contained.