### PR TITLE
feat(cli): make packages argument required for add/remove commands

### DIFF
--- a/crates/vite_error/src/lib.rs
+++ b/crates/vite_error/src/lib.rs
@@ -93,9 +93,6 @@ pub enum Error {
     #[error("Unrecognized any package manager, please specify the package manager")]
     UnrecognizedPackageManager,
 
-    #[error("No packages specified. Usage: vite add <packages>...")]
-    NoPackagesSpecified,
-
     #[error(
         "Package manager {name}@{version} in {package_json_path:?} is invalid, expected format: 'package-manager-name@major.minor.patch'"
     )]

--- a/packages/cli/binding/src/cli.rs
+++ b/packages/cli/binding/src/cli.rs
@@ -180,6 +180,7 @@ pub enum Commands {
         global: bool,
 
         /// Packages to add
+        #[arg(required = true)]
         packages: Vec<String>,
 
         /// Additional arguments to pass through to the package manager
@@ -218,6 +219,7 @@ pub enum Commands {
         global: bool,
 
         /// Packages to remove
+        #[arg(required = true)]
         packages: Vec<String>,
 
         /// Additional arguments to pass through to the package manager
@@ -2007,17 +2009,6 @@ mod tests {
         fn test_args_remove_command_invalid_filter() {
             let args = Args::try_parse_from(&["vite-plus", "remove", "react", "--filter"]);
             assert!(args.is_err());
-        }
-
-        #[test]
-        fn test_args_remove_command_no_packages() {
-            // Remove command should accept empty packages list (package manager will handle this)
-            let args = Args::try_parse_from(&["vite-plus", "remove"]).unwrap();
-            if let Commands::Remove { packages, .. } = &args.commands {
-                assert!(packages.is_empty());
-            } else {
-                panic!("Expected Remove command");
-            }
         }
 
         #[test]

--- a/packages/cli/binding/src/commands/add.rs
+++ b/packages/cli/binding/src/commands/add.rs
@@ -34,10 +34,6 @@ impl AddCommand {
         allow_build: Option<&str>,
         pass_through_args: Option<&[String]>,
     ) -> Result<ExitStatus, Error> {
-        if packages.is_empty() {
-            return Err(Error::NoPackagesSpecified);
-        }
-
         let add_command_options = AddCommandOptions {
             packages,
             save_dependency_type,
@@ -72,21 +68,5 @@ mod tests {
 
         let cmd = AddCommand::new(workspace_root.clone());
         assert_eq!(cmd.cwd, workspace_root);
-    }
-
-    #[tokio::test]
-    async fn test_add_command_no_packages() {
-        let workspace_root = if cfg!(windows) {
-            AbsolutePathBuf::new("C:\\test".into()).unwrap()
-        } else {
-            AbsolutePathBuf::new("/test".into()).unwrap()
-        };
-
-        let cmd = AddCommand::new(workspace_root);
-        let result =
-            cmd.execute(&vec![], None, false, None, None, false, false, false, None, None).await;
-
-        assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), Error::NoPackagesSpecified));
     }
 }

--- a/packages/cli/binding/src/commands/remove.rs
+++ b/packages/cli/binding/src/commands/remove.rs
@@ -30,10 +30,6 @@ impl RemoveCommand {
         global: bool,
         pass_through_args: Option<&[String]>,
     ) -> Result<ExitStatus, Error> {
-        if packages.is_empty() {
-            return Err(Error::NoPackagesSpecified);
-        }
-
         // Detect package manager
         let package_manager = PackageManager::builder(&self.cwd).build().await?;
 
@@ -66,21 +62,5 @@ mod tests {
 
         let cmd = RemoveCommand::new(workspace_root.clone());
         assert_eq!(cmd.cwd, workspace_root);
-    }
-
-    #[tokio::test]
-    async fn test_remove_command_no_packages() {
-        let workspace_root = if cfg!(windows) {
-            AbsolutePathBuf::new("C:\\test".into()).unwrap()
-        } else {
-            AbsolutePathBuf::new("/test".into()).unwrap()
-        };
-
-        let cmd = RemoveCommand::new(workspace_root);
-        let result =
-            cmd.execute(&vec![], false, false, false, None, false, false, false, None).await;
-
-        assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), Error::NoPackagesSpecified));
     }
 }

--- a/packages/global/snap-tests/command-add-npm10/snap.txt
+++ b/packages/global/snap-tests/command-add-npm10/snap.txt
@@ -1,10 +1,10 @@
 > vp add --help # should show help
 Add packages to dependencies
 
-Usage: vp add [OPTIONS] [PACKAGES]... [-- <PASS_THROUGH_ARGS>...]
+Usage: vp add [OPTIONS] <PACKAGES>... [-- <PASS_THROUGH_ARGS>...]
 
 Arguments:
-  [PACKAGES]...           Packages to add
+  <PACKAGES>...           Packages to add
   [PASS_THROUGH_ARGS]...  Additional arguments to pass through to the package manager
 
 Options:

--- a/packages/global/snap-tests/command-add-npm11/snap.txt
+++ b/packages/global/snap-tests/command-add-npm11/snap.txt
@@ -1,10 +1,10 @@
 > vp add --help # should show help
 Add packages to dependencies
 
-Usage: vp add [OPTIONS] [PACKAGES]... [-- <PASS_THROUGH_ARGS>...]
+Usage: vp add [OPTIONS] <PACKAGES>... [-- <PASS_THROUGH_ARGS>...]
 
 Arguments:
-  [PACKAGES]...           Packages to add
+  <PACKAGES>...           Packages to add
   [PASS_THROUGH_ARGS]...  Additional arguments to pass through to the package manager
 
 Options:

--- a/packages/global/snap-tests/command-add-pnpm10/snap.txt
+++ b/packages/global/snap-tests/command-add-pnpm10/snap.txt
@@ -1,10 +1,10 @@
 > vp add --help # should show help
 Add packages to dependencies
 
-Usage: vp add [OPTIONS] [PACKAGES]... [-- <PASS_THROUGH_ARGS>...]
+Usage: vp add [OPTIONS] <PACKAGES>... [-- <PASS_THROUGH_ARGS>...]
 
 Arguments:
-  [PACKAGES]...           Packages to add
+  <PACKAGES>...           Packages to add
   [PASS_THROUGH_ARGS]...  Additional arguments to pass through to the package manager
 
 Options:
@@ -35,6 +35,14 @@ Options:
   -h, --help
           Print help
 
+[2]> vp add # should error because no packages specified
+error: the following required arguments were not provided:
+  <PACKAGES>...
+
+Usage: vp add <PACKAGES>... [-- <PASS_THROUGH_ARGS>...]
+
+For more information, try '--help'.
+
 > vp add testnpm2 urllib -D -- --loglevel=verbose --verbose && cat package.json # should add package as dev dependencies
 Running: pnpm add --save-dev --loglevel=verbose --verbose testnpm2 urllib
 Packages: +<variable>
@@ -56,8 +64,107 @@ Done in <variable>ms using pnpm v<semver>
   }
 }
 
-> #vp add testnpm2 test-vite-plus-install --allow-build=test-vite-plus-install && cat package.json # should add packages to dependencies
-> #vp install test-vite-plus-package@1.0.0 --save-peer && cat package.json # should install package alias for add
-> #vp add test-vite-plus-package-optional -O && cat package.json # should add package as optional dependencies
-> #vp add test-vite-plus-package-optional -- --loglevel=warn && cat package.json # support pass through arguments
-> #vp add -g testnpm2 -- --dry-run && cat package.json # support add global package with dry-run
+> vp add testnpm2 test-vite-plus-install --allow-build=test-vite-plus-install && cat package.json # should add packages to dependencies
+Running: pnpm add --allow-build=test-vite-plus-install testnpm2 test-vite-plus-install
+Packages: +<variable>
++<repeat>
+Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
+
+dependencies:
++ test-vite-plus-install <semver>
+
+Done in <variable>ms using pnpm v<semver>
+{
+  "name": "command-add-pnpm10",
+  "version": "1.0.0",
+  "packageManager": "pnpm@<semver>",
+  "devDependencies": {
+    "testnpm2": "^1.0.1",
+    "urllib": "^4.8.2"
+  },
+  "dependencies": {
+    "test-vite-plus-install": "^1.0.0"
+  }
+}
+
+> vp install test-vite-plus-package@1.0.0 --save-peer && cat package.json # should install package alias for add
+Running: pnpm add --save-peer test-vite-plus-package@<semver>
+Packages: +<variable>
++<repeat>
+Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
+
+peerDependencies:
++ test-vite-plus-package <semver>
+
+devDependencies:
++ test-vite-plus-package <semver> already in devDependencies, was not moved to dependencies.
+
+Done in <variable>ms using pnpm v<semver>
+{
+  "name": "command-add-pnpm10",
+  "version": "1.0.0",
+  "packageManager": "pnpm@<semver>",
+  "devDependencies": {
+    "test-vite-plus-package": "1.0.0",
+    "testnpm2": "^1.0.1",
+    "urllib": "^4.8.2"
+  },
+  "dependencies": {
+    "test-vite-plus-install": "^1.0.0"
+  },
+  "peerDependencies": {
+    "test-vite-plus-package": "1.0.0"
+  }
+}
+
+> vp add test-vite-plus-package-optional -O && cat package.json # should add package as optional dependencies
+Running: pnpm add --save-optional test-vite-plus-package-optional
+Packages: +<variable>
++<repeat>
+Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
+
+optionalDependencies:
++ test-vite-plus-package-optional <semver>
+
+Done in <variable>ms using pnpm v<semver>
+{
+  "name": "command-add-pnpm10",
+  "version": "1.0.0",
+  "packageManager": "pnpm@<semver>",
+  "devDependencies": {
+    "test-vite-plus-package": "1.0.0",
+    "testnpm2": "^1.0.1",
+    "urllib": "^4.8.2"
+  },
+  "dependencies": {
+    "test-vite-plus-install": "^1.0.0"
+  },
+  "peerDependencies": {
+    "test-vite-plus-package": "1.0.0"
+  },
+  "optionalDependencies": {
+    "test-vite-plus-package-optional": "^1.0.0"
+  }
+}
+
+> vp add test-vite-plus-package-optional -- --loglevel=warn && cat package.json # support pass through arguments
+Running: pnpm add --loglevel=warn test-vite-plus-package-optional
+{
+  "name": "command-add-pnpm10",
+  "version": "1.0.0",
+  "packageManager": "pnpm@<semver>",
+  "devDependencies": {
+    "test-vite-plus-package": "1.0.0",
+    "testnpm2": "^1.0.1",
+    "urllib": "^4.8.2"
+  },
+  "dependencies": {
+    "test-vite-plus-install": "^1.0.0"
+  },
+  "peerDependencies": {
+    "test-vite-plus-package": "1.0.0"
+  },
+  "optionalDependencies": {
+    "test-vite-plus-package-optional": "^1.0.0"
+  }
+}

--- a/packages/global/snap-tests/command-add-pnpm10/steps.json
+++ b/packages/global/snap-tests/command-add-pnpm10/steps.json
@@ -4,11 +4,11 @@
   },
   "commands": [
     "vp add --help # should show help",
+    "vp add # should error because no packages specified",
     "vp add testnpm2 urllib -D -- --loglevel=verbose --verbose && cat package.json # should add package as dev dependencies",
-    "#vp add testnpm2 test-vite-plus-install --allow-build=test-vite-plus-install && cat package.json # should add packages to dependencies",
-    "#vp install test-vite-plus-package@1.0.0 --save-peer && cat package.json # should install package alias for add",
-    "#vp add test-vite-plus-package-optional -O && cat package.json # should add package as optional dependencies",
-    "#vp add test-vite-plus-package-optional -- --loglevel=warn && cat package.json # support pass through arguments",
-    "#vp add -g testnpm2 -- --dry-run && cat package.json # support add global package with dry-run"
+    "vp add testnpm2 test-vite-plus-install --allow-build=test-vite-plus-install && cat package.json # should add packages to dependencies",
+    "vp install test-vite-plus-package@1.0.0 --save-peer && cat package.json # should install package alias for add",
+    "vp add test-vite-plus-package-optional -O && cat package.json # should add package as optional dependencies",
+    "vp add test-vite-plus-package-optional -- --loglevel=warn && cat package.json # support pass through arguments"
   ]
 }

--- a/packages/global/snap-tests/command-add-pnpm9/snap.txt
+++ b/packages/global/snap-tests/command-add-pnpm9/snap.txt
@@ -1,10 +1,10 @@
 > vp add --help # should show help
 Add packages to dependencies
 
-Usage: vp add [OPTIONS] [PACKAGES]... [-- <PASS_THROUGH_ARGS>...]
+Usage: vp add [OPTIONS] <PACKAGES>... [-- <PASS_THROUGH_ARGS>...]
 
 Arguments:
-  [PACKAGES]...           Packages to add
+  <PACKAGES>...           Packages to add
   [PASS_THROUGH_ARGS]...  Additional arguments to pass through to the package manager
 
 Options:

--- a/packages/global/snap-tests/command-add-yarn4/snap.txt
+++ b/packages/global/snap-tests/command-add-yarn4/snap.txt
@@ -1,10 +1,10 @@
 > vp add --help # should show help
 Add packages to dependencies
 
-Usage: vp add [OPTIONS] [PACKAGES]... [-- <PASS_THROUGH_ARGS>...]
+Usage: vp add [OPTIONS] <PACKAGES>... [-- <PASS_THROUGH_ARGS>...]
 
 Arguments:
-  [PACKAGES]...           Packages to add
+  <PACKAGES>...           Packages to add
   [PASS_THROUGH_ARGS]...  Additional arguments to pass through to the package manager
 
 Options:

--- a/packages/global/snap-tests/command-remove-pnpm10/snap.txt
+++ b/packages/global/snap-tests/command-remove-pnpm10/snap.txt
@@ -1,10 +1,10 @@
 > vp remove --help # should show help
 Remove packages from dependencies
 
-Usage: vp remove [OPTIONS] [PACKAGES]... [-- <PASS_THROUGH_ARGS>...]
+Usage: vp remove [OPTIONS] <PACKAGES>... [-- <PASS_THROUGH_ARGS>...]
 
 Arguments:
-  [PACKAGES]...           Packages to remove
+  <PACKAGES>...           Packages to remove
   [PASS_THROUGH_ARGS]...  Additional arguments to pass through to the package manager
 
 Options:
@@ -16,6 +16,14 @@ Options:
   -r, --recursive         Remove recursively from all workspace packages, including workspace root
   -g, --global            Remove global packages
   -h, --help              Print help
+
+[2]> vp remove # should error because no packages specified
+error: the following required arguments were not provided:
+  <PACKAGES>...
+
+Usage: vp remove <PACKAGES>... [-- <PASS_THROUGH_ARGS>...]
+
+For more information, try '--help'.
 
 [1]> vp remove testnpm2 -D && cat package.json # should error when remove not exists package from dev dependencies
 Running: pnpm remove --save-dev testnpm2
@@ -109,6 +117,6 @@ error: unexpected argument '--stream' found
 
   tip: to pass '--stream' as a value, use '-- --stream'
 
-Usage: vp remove [OPTIONS] [PACKAGES]... [-- <PASS_THROUGH_ARGS>...]
+Usage: vp remove [OPTIONS] <PACKAGES>... [-- <PASS_THROUGH_ARGS>...]
 
 For more information, try '--help'.

--- a/packages/global/snap-tests/command-remove-pnpm10/steps.json
+++ b/packages/global/snap-tests/command-remove-pnpm10/steps.json
@@ -4,6 +4,7 @@
   },
   "commands": [
     "vp remove --help # should show help",
+    "vp remove # should error because no packages specified",
     "vp remove testnpm2 -D && cat package.json # should error when remove not exists package from dev dependencies",
     "vp add testnpm2 && vp add -D test-vite-plus-install && vp add -O test-vite-plus-package-optional && cat package.json # should add packages to dependencies",
     "vp remove testnpm2 test-vite-plus-install && cat package.json # should remove packages from dependencies",

--- a/rfcs/add-remove-package-commands.md
+++ b/rfcs/add-remove-package-commands.md
@@ -444,10 +444,6 @@ impl AddCommand {
         workspace_only: bool,
         extra_args: Vec<String>,
     ) -> Result<ExecutionSummary, Error> {
-        if packages.is_empty() {
-            return Err(Error::NoPackagesSpecified);
-        }
-
         let package_manager = PackageManager::builder(&self.workspace_root).build().await?;
         let workspace = Workspace::partial_load(self.workspace_root)?;
 
@@ -504,10 +500,6 @@ impl RemoveCommand {
         workspace_root: bool,
         extra_args: Vec<String>,
     ) -> Result<ExecutionSummary, Error> {
-        if packages.is_empty() {
-            return Err(Error::NoPackagesSpecified);
-        }
-
         let package_manager = PackageManager::builder(&self.workspace_root).build().await?;
         let workspace = Workspace::partial_load(self.workspace_root)?;
 


### PR DESCRIPTION
### TL;DR

Make package arguments required for `add` and `remove` commands in the CLI.

### What changed?

- Added the `required = true` attribute to the `packages` argument in both `add` and `remove` commands
- Removed the `NoPackagesSpecified` error from the error enum as it's no longer needed
- Removed validation code that checked for empty packages in the `add` and `remove` command implementations
- Removed tests that were checking the empty packages case
- Updated snap tests to reflect the new required argument behavior
- Updated command help text in snap tests to show packages as required (`<PACKAGES>...` instead of `[PACKAGES]...`)
- Added a new test case to verify the error when no packages are specified

### How to test?

1. Run `vp add` without any packages and verify it shows an error about missing required arguments
2. Run `vp remove` without any packages and verify it shows an error about missing required arguments
3. Run the snap tests to verify the updated behavior

### Why make this change?

This change improves the CLI interface by making it clearer that package names are required for both `add` and `remove` commands. By using Clap's built-in argument validation instead of custom error handling, we get more consistent error messages and better help text. This also simplifies the code by removing unnecessary validation logic and error types.