### PR TITLE
feat(tools): add json-sort CLI tool for sorting JSON arrays

### DIFF
--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -1,4 +1,5 @@
 # tools for internal development use
 
 - json-edit: A CLI tool to edit JSON files such as package.json in e2e tests
+- json-sort: A CLI tool to sort JSON keys in a file
 - snap-test: run snapshot tests for CLI

--- a/packages/tools/snap-tests/json-sort/array.json
+++ b/packages/tools/snap-tests/json-sort/array.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "test",
+    "age": 18
+  },
+  {
+    "name": "abc",
+    "age": 20
+  },
+  {
+    "name": "def",
+    "age": 15
+  },
+  {
+    "name": "ghi",
+    "age": 18
+  }
+]

--- a/packages/tools/snap-tests/json-sort/snap.txt
+++ b/packages/tools/snap-tests/json-sort/snap.txt
@@ -1,0 +1,59 @@
+> cat array.json # should show original array.json file
+[
+  {
+    "name": "test",
+    "age": 18
+  },
+  {
+    "name": "abc",
+    "age": 20
+  },
+  {
+    "name": "def",
+    "age": 15
+  },
+  {
+    "name": "ghi",
+    "age": 18
+  }
+]
+
+> tool json-sort array.json '_.name' && cat array.json # should sort array.json file by name
+[
+  {
+    "name": "abc",
+    "age": 20
+  },
+  {
+    "name": "def",
+    "age": 15
+  },
+  {
+    "name": "ghi",
+    "age": 18
+  },
+  {
+    "name": "test",
+    "age": 18
+  }
+]
+
+> tool json-sort array.json '_.age' && cat array.json # should sort array.json file by age
+[
+  {
+    "name": "def",
+    "age": 15
+  },
+  {
+    "name": "ghi",
+    "age": 18
+  },
+  {
+    "name": "test",
+    "age": 18
+  },
+  {
+    "name": "abc",
+    "age": 20
+  }
+]

--- a/packages/tools/snap-tests/json-sort/steps.json
+++ b/packages/tools/snap-tests/json-sort/steps.json
@@ -1,0 +1,9 @@
+{
+  "env": {
+  },
+  "commands": [
+    "cat array.json # should show original array.json file",
+    "tool json-sort array.json '_.name' && cat array.json # should sort array.json file by name",
+    "tool json-sort array.json '_.age' && cat array.json # should sort array.json file by age"
+  ]
+}

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -13,8 +13,12 @@ switch (subcommand) {
     const { syncRemote } = await import('./sync-remote-deps');
     syncRemote();
     break;
+  case 'json-sort':
+    const { jsonSort } = await import('./json-sort');
+    jsonSort();
+    break;
   default:
     console.error(`Unknown subcommand: ${subcommand}`);
-    console.error('Available subcommands: snap-test, replace-file-content, sync-remote');
+    console.error('Available subcommands: snap-test, replace-file-content, sync-remote, json-sort');
     process.exit(1);
 }

--- a/packages/tools/src/json-sort.ts
+++ b/packages/tools/src/json-sort.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { parseArgs } from 'node:util';
+
+export function jsonSort() {
+  const { positionals } = parseArgs({
+    allowPositionals: true,
+    args: process.argv.slice(3),
+  });
+
+  const filename = positionals[0];
+  const script = positionals[1];
+
+  if (!filename || !script) {
+    console.error('Usage: tool json-sort <filename> <script>');
+    console.error("Example: tool json-sort array.json '_.name'");
+    process.exit(1);
+  }
+
+  const data = JSON.parse(readFileSync(filename, 'utf-8'));
+  assert(Array.isArray(data), 'json data must be an array');
+  // sort json by script
+  const func = new Function('_', `return ${script};`);
+  const sortedJson = data.sort((a: any, b: any) => {
+    const aValue = func(a);
+    const bValue = func(b);
+    if (aValue < bValue) {
+      return -1;
+    }
+    if (aValue > bValue) {
+      return 1;
+    }
+    return 0;
+  });
+
+  writeFileSync(filename, JSON.stringify(sortedJson, null, 2) + '\n', 'utf-8');
+}


### PR DESCRIPTION
### TL;DR

Added a new `json-sort` CLI tool to sort JSON arrays by specified properties.

### What changed?

- Created a new `json-sort` CLI tool that sorts JSON arrays based on a specified property
- Added the tool to the main CLI interface in `index.ts`
- Updated the README to include the new tool
- Added snapshot tests to verify the functionality:
  - Sorting an array of objects by the `name` property
  - Sorting an array of objects by the `age` property

### How to test?

Run the tool with a JSON file containing an array and specify the property to sort by:

```bash
tool json-sort array.json '_.name'
```

Or check the snapshot tests:

```bash
tool snap-test json-sort
```

### Why make this change?

This tool provides a convenient way to sort JSON arrays by specific properties, which is useful for organizing data in configuration files, test fixtures, or any JSON array that needs to be sorted in a specific order. It complements the existing `json-edit` tool by providing another way to manipulate JSON files.