### PR TITLE
refactor: move run_command to vite_command crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4181,7 +4181,6 @@ dependencies = [
  "hex",
  "httpmock",
  "indoc",
- "nix 0.30.1",
  "pathdiff",
  "reqwest",
  "semver 1.0.27",
@@ -4194,12 +4193,12 @@ dependencies = [
  "test-log",
  "tokio",
  "tracing",
+ "vite_command",
  "vite_error",
  "vite_glob",
  "vite_path",
  "vite_str",
  "vite_workspace",
- "which",
 ]
 
 [[package]]

--- a/crates/vite_install/Cargo.toml
+++ b/crates/vite_install/Cargo.toml
@@ -25,19 +25,18 @@ tar = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
+vite_command = { workspace = true }
 vite_error = { workspace = true }
 vite_glob = { workspace = true }
 vite_path = { workspace = true }
 vite_str = { workspace = true }
 vite_workspace = { workspace = true }
-which = { workspace = true, features = ["tracing"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 reqwest = { workspace = true, features = ["stream", "native-tls-vendored", "json"] }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 reqwest = { workspace = true, features = ["stream", "rustls-tls", "json"] }
-nix = { workspace = true }
 
 [dev-dependencies]
 httpmock = { workspace = true }

--- a/crates/vite_install/src/commands/add.rs
+++ b/crates/vite_install/src/commands/add.rs
@@ -1,10 +1,11 @@
 use std::{collections::HashMap, process::ExitStatus};
 
+use vite_command::run_command;
 use vite_error::Error;
 use vite_path::AbsolutePath;
 
 use crate::package_manager::{
-    PackageManager, PackageManagerType, ResolveCommandResult, format_path_env, run_command,
+    PackageManager, PackageManagerType, ResolveCommandResult, format_path_env,
 };
 
 /// The type of dependency to save.

--- a/crates/vite_install/src/commands/dedupe.rs
+++ b/crates/vite_install/src/commands/dedupe.rs
@@ -1,10 +1,11 @@
 use std::{collections::HashMap, process::ExitStatus};
 
+use vite_command::run_command;
 use vite_error::Error;
 use vite_path::AbsolutePath;
 
 use crate::package_manager::{
-    PackageManager, PackageManagerType, ResolveCommandResult, format_path_env, run_command,
+    PackageManager, PackageManagerType, ResolveCommandResult, format_path_env,
 };
 
 /// Options for the dedupe command.

--- a/crates/vite_install/src/commands/link.rs
+++ b/crates/vite_install/src/commands/link.rs
@@ -1,10 +1,11 @@
 use std::{collections::HashMap, process::ExitStatus};
 
+use vite_command::run_command;
 use vite_error::Error;
 use vite_path::AbsolutePath;
 
 use crate::package_manager::{
-    PackageManager, PackageManagerType, ResolveCommandResult, format_path_env, run_command,
+    PackageManager, PackageManagerType, ResolveCommandResult, format_path_env,
 };
 
 /// Options for the link command.

--- a/crates/vite_install/src/commands/outdated.rs
+++ b/crates/vite_install/src/commands/outdated.rs
@@ -1,10 +1,11 @@
 use std::{collections::HashMap, process::ExitStatus, str::FromStr};
 
+use vite_command::run_command;
 use vite_error::Error;
 use vite_path::AbsolutePath;
 
 use crate::package_manager::{
-    PackageManager, PackageManagerType, ResolveCommandResult, format_path_env, run_command,
+    PackageManager, PackageManagerType, ResolveCommandResult, format_path_env,
 };
 
 /// Output format for the outdated command.

--- a/crates/vite_install/src/commands/remove.rs
+++ b/crates/vite_install/src/commands/remove.rs
@@ -1,10 +1,11 @@
 use std::{collections::HashMap, process::ExitStatus};
 
+use vite_command::run_command;
 use vite_error::Error;
 use vite_path::AbsolutePath;
 
 use crate::package_manager::{
-    PackageManager, PackageManagerType, ResolveCommandResult, format_path_env, run_command,
+    PackageManager, PackageManagerType, ResolveCommandResult, format_path_env,
 };
 
 /// Options for the remove command.

--- a/crates/vite_install/src/commands/unlink.rs
+++ b/crates/vite_install/src/commands/unlink.rs
@@ -1,10 +1,11 @@
 use std::{collections::HashMap, process::ExitStatus};
 
+use vite_command::run_command;
 use vite_error::Error;
 use vite_path::AbsolutePath;
 
 use crate::package_manager::{
-    PackageManager, PackageManagerType, ResolveCommandResult, format_path_env, run_command,
+    PackageManager, PackageManagerType, ResolveCommandResult, format_path_env,
 };
 
 /// Options for the unlink command.

--- a/crates/vite_install/src/commands/update.rs
+++ b/crates/vite_install/src/commands/update.rs
@@ -1,10 +1,11 @@
 use std::{collections::HashMap, process::ExitStatus};
 
+use vite_command::run_command;
 use vite_error::Error;
 use vite_path::AbsolutePath;
 
 use crate::package_manager::{
-    PackageManager, PackageManagerType, ResolveCommandResult, format_path_env, run_command,
+    PackageManager, PackageManagerType, ResolveCommandResult, format_path_env,
 };
 
 /// Options for the update command.

--- a/crates/vite_install/src/commands/why.rs
+++ b/crates/vite_install/src/commands/why.rs
@@ -1,10 +1,11 @@
 use std::{collections::HashMap, process::ExitStatus};
 
+use vite_command::run_command;
 use vite_error::Error;
 use vite_path::AbsolutePath;
 
 use crate::package_manager::{
-    PackageManager, PackageManagerType, ResolveCommandResult, format_path_env, run_command,
+    PackageManager, PackageManagerType, ResolveCommandResult, format_path_env,
 };
 
 /// Options for the why command.

--- a/crates/vite_install/src/package_manager.rs
+++ b/crates/vite_install/src/package_manager.rs
@@ -4,12 +4,11 @@ use std::{
     fs::{self, File},
     io::BufReader,
     path::Path,
-    process::{ExitStatus, Stdio},
 };
 
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
-use tokio::{fs::remove_dir_all, process::Command};
+use tokio::fs::remove_dir_all;
 use vite_error::Error;
 use vite_path::{AbsolutePath, AbsolutePathBuf};
 use vite_str::Str;
@@ -502,89 +501,6 @@ pub(crate) fn format_path_env(bin_prefix: impl AsRef<Path>) -> String {
     let mut paths = env::split_paths(&env::var_os("PATH").unwrap_or_default()).collect::<Vec<_>>();
     paths.insert(0, bin_prefix.as_ref().to_path_buf());
     env::join_paths(paths).unwrap().to_string_lossy().to_string()
-}
-
-#[cfg(unix)]
-fn fix_stdio_streams() {
-    // libuv may mark stdin/stdout/stderr as close-on-exec, which interferes with Rust's subprocess spawning.
-    // As a workaround, we clear the FD_CLOEXEC flag on these file descriptors to prevent them from being closed when spawning child processes.
-    //
-    // For details see https://github.com/libuv/libuv/issues/2062
-    // Fixed by reference from https://github.com/electron/electron/pull/15555
-
-    use std::os::fd::BorrowedFd;
-
-    use nix::{
-        fcntl::{FcntlArg, FdFlag, fcntl},
-        libc::{STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO},
-    };
-
-    // Safe function to clear FD_CLOEXEC flag
-    fn clear_cloexec(fd: BorrowedFd<'_>) {
-        // Borrow RawFd as BorrowedFd to satisfy AsFd constraint
-        if let Ok(flags) = fcntl(fd, FcntlArg::F_GETFD) {
-            let mut fd_flags = FdFlag::from_bits_retain(flags);
-            if fd_flags.contains(FdFlag::FD_CLOEXEC) {
-                fd_flags.remove(FdFlag::FD_CLOEXEC);
-                // Ignore errors: some fd may be closed
-                let _ = fcntl(fd, FcntlArg::F_SETFD(fd_flags));
-            }
-        }
-    }
-
-    // Clear FD_CLOEXEC on stdin, stdout, stderr
-    clear_cloexec(unsafe { BorrowedFd::borrow_raw(STDIN_FILENO) });
-    clear_cloexec(unsafe { BorrowedFd::borrow_raw(STDOUT_FILENO) });
-    clear_cloexec(unsafe { BorrowedFd::borrow_raw(STDERR_FILENO) });
-}
-
-// TODO: should move to vite-command crate later
-/// Run a command with the given bin name, arguments, environment variables, and current working directory.
-///
-/// # Arguments
-///
-/// * `bin_name`: The name of the binary to run.
-/// * `args`: The arguments to pass to the binary.
-/// * `envs`: The custom environment variables to set for the command, will be merged with the system environment variables.
-/// * `cwd`: The current working directory for the command.
-///
-/// # Returns
-///
-/// Returns the exit status of the command.
-pub(crate) async fn run_command(
-    bin_name: &str,
-    args: &[String],
-    envs: &HashMap<String, String>,
-    cwd: impl AsRef<AbsolutePath>,
-) -> Result<ExitStatus, Error> {
-    println!("Running: {} {}", bin_name, args.join(" "));
-
-    // Resolve the command path using which crate
-    // If PATH is provided in envs, use which_in to search in custom paths
-    // Otherwise, use which to search in system PATH
-    let paths = envs.get("PATH");
-    let bin_path = which::which_in(bin_name, paths, cwd.as_ref())
-        .map_err(|_| Error::CannotFindBinaryPath(bin_name.into()))?;
-
-    let mut cmd = Command::new(bin_path);
-    cmd.args(args)
-        .envs(envs)
-        .current_dir(cwd.as_ref())
-        .stdin(Stdio::inherit())
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit());
-
-    // fix stdio streams on unix
-    #[cfg(unix)]
-    unsafe {
-        cmd.pre_exec(|| {
-            fix_stdio_streams();
-            Ok(())
-        });
-    }
-
-    let status = cmd.status().await?;
-    Ok(status)
 }
 
 #[cfg(test)]
@@ -1870,35 +1786,6 @@ mod tests {
             // Regular files should be ignored
             assert!(matcher.is_match("README.md"), "Should ignore docs");
             assert!(matcher.is_match("src/app.ts"), "Should ignore source files");
-        }
-    }
-
-    mod run_command_tests {
-        use super::*;
-
-        #[tokio::test]
-        async fn test_run_command_and_find_binary_path() {
-            let temp_dir = create_temp_dir();
-            let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
-            let envs = HashMap::from([("PATH".to_string(), format_path_env(&temp_dir_path))]);
-            let result =
-                run_command("npm", &["--version".to_string()], &envs, &temp_dir_path).await;
-            assert!(result.is_ok(), "Should run command successfully, but got error: {:?}", result);
-        }
-
-        #[tokio::test]
-        async fn test_run_command_and_not_find_binary_path() {
-            let temp_dir = create_temp_dir();
-            let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
-            let envs = HashMap::from([("PATH".to_string(), format_path_env(&temp_dir_path))]);
-            let result =
-                run_command("npm-not-exists", &["--version".to_string()], &envs, &temp_dir_path)
-                    .await;
-            assert!(result.is_err(), "Should not find binary path, but got: {:?}", result);
-            assert_eq!(
-                result.unwrap_err().to_string(),
-                "Cannot find binary path for command 'npm-not-exists'"
-            );
         }
     }
 }

--- a/packages/global/snap-tests/command-add-npm10-with-workspace/snap.txt
+++ b/packages/global/snap-tests/command-add-npm10-with-workspace/snap.txt
@@ -1,5 +1,4 @@
 > vp add testnpm2 -D -w -- --no-audit && cat package.json packages/app/package.json packages/utils/package.json # should add package to workspace root
-Running: npm install --include-workspace-root --save-dev --no-audit testnpm2
 
 added 3 packages in <variable>ms
 {
@@ -23,7 +22,6 @@ added 3 packages in <variable>ms
 }
 
 > vp add @vite-plus-test/utils --workspace -- --no-audit && cat package.json packages/app/package.json packages/utils/package.json # should add @vite-plus-test/utils to workspace root
-Running: npm install --no-audit @vite-plus-test/utils
 
 up to date in <variable>ms
 {
@@ -50,7 +48,6 @@ up to date in <variable>ms
 }
 
 > vp add testnpm2 test-vite-plus-install@1.0.0 --filter app -- --no-audit && cat package.json packages/app/package.json packages/utils/package.json # should add packages to packages/app
-Running: npm install --workspace app --no-audit testnpm2 test-vite-plus-install@<semver>
 
 added 1 package in <variable>ms
 {
@@ -81,7 +78,6 @@ added 1 package in <variable>ms
 }
 
 > vp add @vite-plus-test/utils --workspace --filter app -- --no-audit && cat package.json packages/app/package.json packages/utils/package.json # should add @vite-plus-test/utils to packages/app
-Running: npm install --workspace app --no-audit @vite-plus-test/utils
 
 up to date in <variable>ms
 {
@@ -113,7 +109,6 @@ up to date in <variable>ms
 }
 
 > vp add testnpm2 test-vite-plus-install@1.0.0 --filter "*" -- --no-audit && cat package.json packages/app/package.json packages/utils/package.json # should add testnpm2 test-vite-plus-install to all packages except workspace root
-Running: npm install --workspace * --no-audit testnpm2 test-vite-plus-install@<semver>
 
 up to date in <variable>ms
 {
@@ -149,7 +144,6 @@ up to date in <variable>ms
 }
 
 > vp add -E testnpm2 test-vite-plus-install@1.0.0 --filter "*" --workspace-root -- --no-audit && cat package.json packages/app/package.json packages/utils/package.json # should add testnpm2 test-vite-plus-install to all packages include workspace root
-Running: npm install --workspace * --include-workspace-root --save-exact --no-audit testnpm2 test-vite-plus-install@<semver>
 
 up to date in <variable>ms
 {
@@ -186,7 +180,6 @@ up to date in <variable>ms
 }
 
 > vp install test-vite-plus-package@1.0.0 --filter "*" --workspace-root -- --no-audit && cat package.json packages/app/package.json packages/utils/package.json # should install packages alias for add command
-Running: npm install --workspace * --include-workspace-root --no-audit test-vite-plus-package@<semver>
 
 added 1 package in <variable>ms
 {

--- a/packages/global/snap-tests/command-add-npm10/snap.txt
+++ b/packages/global/snap-tests/command-add-npm10/snap.txt
@@ -36,7 +36,6 @@ Options:
           Print help
 
 > vp add testnpm2 -D -- --no-audit && cat package.json # should add package as dev dependencies
-Running: npm install --save-dev --no-audit testnpm2
 
 added 1 package in <variable>ms
 {
@@ -49,7 +48,6 @@ added 1 package in <variable>ms
 }
 
 > vp add testnpm2 test-vite-plus-install --allow-build=test-vite-plus-install -- --no-audit && cat package.json # should add packages to dependencies
-Running: npm install --no-audit testnpm2 test-vite-plus-install
 
 added 1 package in <variable>ms
 {
@@ -65,7 +63,6 @@ added 1 package in <variable>ms
 }
 
 > vp install test-vite-plus-package@1.0.0 --save-peer -- --no-audit && cat package.json # should install package alias for add
-Running: npm install --save-peer --no-audit test-vite-plus-package@<semver>
 
 added 1 package in <variable>ms
 {
@@ -84,7 +81,6 @@ added 1 package in <variable>ms
 }
 
 > vp add test-vite-plus-package-optional -O -- --no-audit && cat package.json # should add package as optional dependencies
-Running: npm install --save-optional --no-audit test-vite-plus-package-optional
 
 added 1 package in <variable>ms
 {
@@ -106,7 +102,6 @@ added 1 package in <variable>ms
 }
 
 > vp add test-vite-plus-package-optional -- --loglevel=warn --no-audit && cat package.json # support pass through arguments
-Running: npm install --loglevel=warn --no-audit test-vite-plus-package-optional
 
 up to date in <variable>ms
 {

--- a/packages/global/snap-tests/command-add-npm11-with-workspace/snap.txt
+++ b/packages/global/snap-tests/command-add-npm11-with-workspace/snap.txt
@@ -1,5 +1,4 @@
 > vp add testnpm2 -D -w -- --no-audit && cat package.json packages/app/package.json packages/utils/package.json # should add package to workspace root
-Running: npm install --include-workspace-root --save-dev --no-audit testnpm2
 
 added 3 packages in <variable>ms
 {
@@ -23,7 +22,6 @@ added 3 packages in <variable>ms
 }
 
 > vp add @vite-plus-test/utils --workspace -- --no-audit && cat package.json packages/app/package.json packages/utils/package.json # should add @vite-plus-test/utils to workspace root
-Running: npm install --no-audit @vite-plus-test/utils
 
 up to date in <variable>ms
 {
@@ -50,7 +48,6 @@ up to date in <variable>ms
 }
 
 > vp add testnpm2 test-vite-plus-install@1.0.0 --filter app -- --no-audit && cat package.json packages/app/package.json packages/utils/package.json # should add packages to packages/app
-Running: npm install --workspace app --no-audit testnpm2 test-vite-plus-install@<semver>
 
 added 1 package in <variable>ms
 {
@@ -81,7 +78,6 @@ added 1 package in <variable>ms
 }
 
 > vp add @vite-plus-test/utils --workspace --filter app -- --no-audit && cat package.json packages/app/package.json packages/utils/package.json # should add @vite-plus-test/utils to packages/app
-Running: npm install --workspace app --no-audit @vite-plus-test/utils
 
 up to date in <variable>ms
 {
@@ -113,7 +109,6 @@ up to date in <variable>ms
 }
 
 > vp add testnpm2 test-vite-plus-install@1.0.0 --filter "*" -- --no-audit && cat package.json packages/app/package.json packages/utils/package.json # should add testnpm2 test-vite-plus-install to all packages except workspace root
-Running: npm install --workspace * --no-audit testnpm2 test-vite-plus-install@<semver>
 
 up to date in <variable>ms
 {
@@ -149,7 +144,6 @@ up to date in <variable>ms
 }
 
 > vp add -E testnpm2 test-vite-plus-install@1.0.0 --filter "*" --workspace-root -- --no-audit && cat package.json packages/app/package.json packages/utils/package.json # should add testnpm2 test-vite-plus-install to all packages include workspace root
-Running: npm install --workspace * --include-workspace-root --save-exact --no-audit testnpm2 test-vite-plus-install@<semver>
 
 up to date in <variable>ms
 {
@@ -186,7 +180,6 @@ up to date in <variable>ms
 }
 
 > vp install test-vite-plus-package@1.0.0 --filter "*" --workspace-root -- --no-audit && cat package.json packages/app/package.json packages/utils/package.json # should install packages alias for add command
-Running: npm install --workspace * --include-workspace-root --no-audit test-vite-plus-package@<semver>
 
 added 1 package in <variable>ms
 {

--- a/packages/global/snap-tests/command-add-npm11/snap.txt
+++ b/packages/global/snap-tests/command-add-npm11/snap.txt
@@ -36,7 +36,6 @@ Options:
           Print help
 
 > vp add testnpm2 -D -- --no-audit && cat package.json # should add package as dev dependencies
-Running: npm install --save-dev --no-audit testnpm2
 
 added 1 package in <variable>ms
 {
@@ -49,7 +48,6 @@ added 1 package in <variable>ms
 }
 
 > vp add testnpm2 test-vite-plus-install --allow-build=test-vite-plus-install -- --no-audit && cat package.json # should add packages to dependencies
-Running: npm install --no-audit testnpm2 test-vite-plus-install
 
 added 1 package in <variable>ms
 {
@@ -65,7 +63,6 @@ added 1 package in <variable>ms
 }
 
 > vp install test-vite-plus-package@1.0.0 --save-peer -- --no-audit && cat package.json # should install package alias for add
-Running: npm install --save-peer --no-audit test-vite-plus-package@<semver>
 
 added 1 package in <variable>ms
 {
@@ -84,7 +81,6 @@ added 1 package in <variable>ms
 }
 
 > vp add test-vite-plus-package-optional -O -- --no-audit && cat package.json # should add package as optional dependencies
-Running: npm install --save-optional --no-audit test-vite-plus-package-optional
 
 added 1 package in <variable>ms
 {
@@ -106,7 +102,6 @@ added 1 package in <variable>ms
 }
 
 > vp add test-vite-plus-package-optional -- --loglevel=warn --no-audit && cat package.json # support pass through arguments
-Running: npm install --loglevel=warn --no-audit test-vite-plus-package-optional
 
 up to date in <variable>ms
 {

--- a/packages/global/snap-tests/command-add-pnpm10-with-workspace/snap.txt
+++ b/packages/global/snap-tests/command-add-pnpm10-with-workspace/snap.txt
@@ -1,5 +1,4 @@
 > vp add testnpm2 -D -w && cat package.json # should add package to workspace root
-Running: pnpm add --workspace-root --save-dev testnpm2
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
 devDependencies:
@@ -18,7 +17,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp add @vite-plus-test/utils --workspace && cat package.json # should add @vite-plus-test/utils to workspace root
-Running: pnpm add --workspace @vite-plus-test/utils
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
 dependencies:
@@ -39,7 +37,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp add testnpm2 test-vite-plus-install@1.0.0 --filter app && cat package.json packages/app/package.json packages/utils/package.json # should add packages to packages/app
-Running: pnpm --filter app add testnpm2 test-vite-plus-install@<semver>
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 .                                        |   +1 +<repeat>
 Done in <variable>ms using pnpm v<semver>
@@ -68,7 +65,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp add @vite-plus-test/utils --workspace --filter app && cat package.json packages/app/package.json packages/utils/package.json # should add @vite-plus-test/utils to packages/app
-Running: pnpm --filter app add --workspace @vite-plus-test/utils
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 Done in <variable>ms using pnpm v<semver>
 {
@@ -97,7 +93,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp add -E testnpm2 test-vite-plus-install --filter "*" && cat package.json packages/app/package.json packages/utils/package.json # should add testnpm2 test-vite-plus-install to all packages except workspace root
-Running: pnpm --filter * add --save-exact testnpm2 test-vite-plus-install
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 Done in <variable>ms using pnpm v<semver>
 {
@@ -130,7 +125,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp install test-vite-plus-package@1.0.0 --filter "*" --workspace-root --save-catalog && cat package.json packages/app/package.json packages/utils/package.json pnpm-workspace.yaml # should install packages alias for add command
-Running: pnpm --filter * add --workspace-root --save-catalog test-vite-plus-package@<semver>
 .                                        |   +1 +<repeat>
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 Done in <variable>ms using pnpm v<semver>
@@ -172,7 +166,6 @@ catalog:
   test-vite-plus-package: <semver>
 
 > vp add --filter app test-vite-plus-package-optional --save-catalog-name v1 && cat packages/app/package.json pnpm-workspace.yaml # should add with save-catalog-name
-Running: pnpm --filter app add --save-catalog-name=v1 test-vite-plus-package-optional
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 .                                        |   +1 +<repeat>
 Done in <variable>ms using pnpm v<semver>
@@ -197,7 +190,6 @@ catalogs:
     test-vite-plus-package-optional: ^1.0.0
 
 > vp add --filter=./packages/utils test-vite-plus-package-optional -O --save-catalog-name v2 && cat packages/utils/package.json pnpm-workspace.yaml # should add other with save-catalog-name
-Running: pnpm --filter ./packages/utils add --save-optional --save-catalog-name=v2 test-vite-plus-package-optional
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 Done in <variable>ms using pnpm v<semver>
 {

--- a/packages/global/snap-tests/command-add-pnpm10/snap.txt
+++ b/packages/global/snap-tests/command-add-pnpm10/snap.txt
@@ -44,7 +44,6 @@ Usage: vp add <PACKAGES>... [-- <PASS_THROUGH_ARGS>...]
 For more information, try '--help'.
 
 > vp add testnpm2 urllib -D -- --loglevel=verbose --verbose && cat package.json # should add package as dev dependencies
-Running: pnpm add --save-dev --loglevel=verbose --verbose testnpm2 urllib
 Packages: +<variable>
 +<repeat>
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
@@ -65,7 +64,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp add testnpm2 test-vite-plus-install --allow-build=test-vite-plus-install && cat package.json # should add packages to dependencies
-Running: pnpm add --allow-build=test-vite-plus-install testnpm2 test-vite-plus-install
 Packages: +<variable>
 +<repeat>
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
@@ -88,7 +86,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp install test-vite-plus-package@1.0.0 --save-peer && cat package.json # should install package alias for add
-Running: pnpm add --save-peer test-vite-plus-package@<semver>
 Packages: +<variable>
 +<repeat>
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
@@ -118,7 +115,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp add test-vite-plus-package-optional -O && cat package.json # should add package as optional dependencies
-Running: pnpm add --save-optional test-vite-plus-package-optional
 Packages: +<variable>
 +<repeat>
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
@@ -148,7 +144,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp add test-vite-plus-package-optional -- --loglevel=warn && cat package.json # support pass through arguments
-Running: pnpm add --loglevel=warn test-vite-plus-package-optional
 {
   "name": "command-add-pnpm10",
   "version": "1.0.0",

--- a/packages/global/snap-tests/command-add-pnpm9-with-workspace/snap.txt
+++ b/packages/global/snap-tests/command-add-pnpm9-with-workspace/snap.txt
@@ -1,5 +1,4 @@
 > vp add testnpm2 -D -w && cat package.json # should add package to workspace root
-Running: pnpm add --workspace-root --save-dev testnpm2
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
 devDependencies:
@@ -18,11 +17,9 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 [1]> vp add @vite-plus-test/utils --workspace && cat package.json # should add @vite-plus-test/utils to workspace root
-Running: pnpm add --workspace @vite-plus-test/utils
  ERR_PNPM_ADDING_TO_ROOT  Running this command will add the dependency to the workspace root, which might not be what you want - if you really meant it, make it explicit by running this command again with the -w flag (or --workspace-root). If you don't want to see this warning anymore, you may set the ignore-workspace-root-check setting to true.
 
 > vp add testnpm2 test-vite-plus-install@1.0.0 --filter app && cat package.json packages/app/package.json packages/utils/package.json # should add packages to packages/app
-Running: pnpm --filter app add testnpm2 test-vite-plus-install@<semver>
 .                                        |  WARN  `node_modules` is present. Lockfile only installation will make it out-of-date
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 .                                        |   +1 +<repeat>
@@ -49,7 +46,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp add @vite-plus-test/utils --workspace --filter app && cat package.json packages/app/package.json packages/utils/package.json # should add @vite-plus-test/utils to packages/app
-Running: pnpm --filter app add --workspace @vite-plus-test/utils
 .                                        |  WARN  `node_modules` is present. Lockfile only installation will make it out-of-date
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 Done in <variable>ms using pnpm v<semver>
@@ -76,7 +72,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp add -E testnpm2 test-vite-plus-install --filter "*" && cat package.json packages/app/package.json packages/utils/package.json # should add testnpm2 test-vite-plus-install to all packages except workspace root
-Running: pnpm --filter * add --save-exact testnpm2 test-vite-plus-install
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 Done in <variable>ms using pnpm v<semver>
 {
@@ -106,7 +101,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp install test-vite-plus-package@1.0.0 --filter "*" --workspace-root && cat package.json packages/app/package.json packages/utils/package.json pnpm-workspace.yaml # should install packages alias for add command
-Running: pnpm --filter * add --workspace-root test-vite-plus-package@<semver>
 .                                        |   +1 +<repeat>
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 Done in <variable>ms using pnpm v<semver>
@@ -144,13 +138,11 @@ packages:
   - packages/*
 
 [1]> vp add --filter app test-vite-plus-package-optional --save-catalog-name v1 # should error because save-catalog-name is not supported at pnpm@9
-Running: pnpm --filter app add --save-catalog-name=v1 test-vite-plus-package-optional
  ERROR  Unknown option: 'save-catalog-name'
 Did you mean 'save-optional'? Use "--config.unknown=value" to force an unknown option.
 For help, run: pnpm help add
 
 [1]> vp add --filter=./packages/utils test-vite-plus-package-optional -O --save-catalog v2 # should error because save-catalog is not supported at pnpm@9
-Running: pnpm --filter ./packages/utils add --save-optional --save-catalog test-vite-plus-package-optional v2
  ERROR  Unknown option: 'save-catalog'
 Did you mean 'save-exact', or 'save-prod'? Use "--config.unknown=value" to force an unknown option.
 For help, run: pnpm help add

--- a/packages/global/snap-tests/command-add-pnpm9/snap.txt
+++ b/packages/global/snap-tests/command-add-pnpm9/snap.txt
@@ -36,7 +36,6 @@ Options:
           Print help
 
 > vp add testnpm2 -D && cat package.json # should add package as dev dependencies
-Running: pnpm add --save-dev testnpm2
 Packages: +<variable>
 +<repeat>
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
@@ -55,7 +54,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp add testnpm2 test-vite-plus-install && cat package.json # should add packages to dependencies
-Running: pnpm add testnpm2 test-vite-plus-install
 Packages: +<variable>
 +<repeat>
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
@@ -77,12 +75,10 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 [1]> vp add testnpm2 test-vite-plus-install --allow-build=test-vite-plus-install # should error because allow-build is not supported at pnpm@9
-Running: pnpm add --allow-build=test-vite-plus-install testnpm2 test-vite-plus-install
  ERROR  Unknown option: 'allow-build'
 For help, run: pnpm help add
 
 > vp install test-vite-plus-package@1.0.0 --save-peer && cat package.json # should install package alias for add
-Running: pnpm add --save-peer test-vite-plus-package@<semver>
 Packages: +<variable>
 +<repeat>
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
@@ -111,7 +107,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp add test-vite-plus-package-optional -O && cat package.json # should add package as optional dependencies
-Running: pnpm add --save-optional test-vite-plus-package-optional
 Packages: +<variable>
 +<repeat>
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
@@ -140,7 +135,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp add test-vite-plus-package-optional -- --loglevel=warn && cat package.json # support pass through arguments
-Running: pnpm add --loglevel=warn test-vite-plus-package-optional
 {
   "name": "command-add-pnpm9",
   "version": "1.0.0",

--- a/packages/global/snap-tests/command-add-yarn4-with-workspace/snap.txt
+++ b/packages/global/snap-tests/command-add-yarn4-with-workspace/snap.txt
@@ -1,5 +1,4 @@
 > vp add testnpm2 -D -w && cat package.json packages/app/package.json packages/utils/package.json # should add package to workspace root
-Running: yarn add --dev testnpm2
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0085: │ + testnpm2@npm:1.0.1
@@ -30,7 +29,6 @@ Running: yarn add --dev testnpm2
 }
 
 > vp add @vite-plus-test/utils --workspace -w && cat package.json packages/app/package.json packages/utils/package.json # should add @vite-plus-test/utils to workspace root
-Running: yarn add @vite-plus-test/utils
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0000: └ Completed
@@ -63,7 +61,6 @@ Running: yarn add @vite-plus-test/utils
 }
 
 > vp add testnpm2 test-vite-plus-install@1.0.0 --filter app && cat package.json packages/app/package.json packages/utils/package.json # should add packages to packages/app
-Running: yarn workspaces foreach --all --include app add testnpm2 test-vite-plus-install@<semver>
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0085: │ + test-vite-plus-install@npm:1.0.0
@@ -102,7 +99,6 @@ Done in <variable>ms <variable>ms
 }
 
 > vp add @vite-plus-test/utils --workspace --filter app && cat package.json packages/app/package.json packages/utils/package.json # should add @vite-plus-test/utils to packages/app
-Running: yarn workspaces foreach --all --include app add @vite-plus-test/utils
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0000: └ Completed
@@ -141,7 +137,6 @@ Done in <variable>ms <variable>ms
 }
 
 > vp add testnpm2 test-vite-plus-install@1.0.0 --filter "*" --filter @vite-plus-test/utils && cat package.json packages/app/package.json packages/admin/package.json packages/utils/package.json # should add testnpm2 test-vite-plus-install to all packages and workspace root
-Running: yarn workspaces foreach --all --include * --include @vite-plus-test/utils add testnpm2 test-vite-plus-install@<semver>
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0000: └ Completed
@@ -216,7 +211,6 @@ Done in <variable>ms <variable>ms
 }
 
 > vp install -O test-vite-plus-package-optional --filter "*" && cat package.json packages/app/package.json packages/admin/package.json packages/utils/package.json # should install packages alias for add command
-Running: yarn workspaces foreach --all --include * add --optional test-vite-plus-package-optional
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0085: │ + test-vite-plus-package-optional@npm:1.0.0

--- a/packages/global/snap-tests/command-add-yarn4/snap.txt
+++ b/packages/global/snap-tests/command-add-yarn4/snap.txt
@@ -36,7 +36,6 @@ Options:
           Print help
 
 > vp add testnpm2 -D && cat package.json # should add package as dev dependencies
-Running: yarn add --dev testnpm2
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0085: │ + testnpm2@npm:1.0.1
@@ -56,7 +55,6 @@ Running: yarn add --dev testnpm2
 }
 
 > vp add testnpm2 test-vite-plus-install --allow-build=test-vite-plus-install && cat package.json # should add packages to dependencies
-Running: yarn add testnpm2 test-vite-plus-install
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0085: │ + test-vite-plus-install@npm:1.0.0
@@ -79,7 +77,6 @@ Running: yarn add testnpm2 test-vite-plus-install
 }
 
 > vp install test-vite-plus-package@1.0.0 --save-peer && cat package.json # should install package alias for add
-Running: yarn add --peer test-vite-plus-package@<semver>
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0000: └ Completed
@@ -104,7 +101,6 @@ Running: yarn add --peer test-vite-plus-package@<semver>
 }
 
 > vp add test-vite-plus-package-optional -O && cat package.json # should add package as optional dependencies
-Running: yarn add --optional test-vite-plus-package-optional
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0085: │ + test-vite-plus-package-optional@npm:1.0.0
@@ -133,7 +129,6 @@ Running: yarn add --optional test-vite-plus-package-optional
 }
 
 > vp add test-vite-plus-package-optional -- --tilde && cat package.json # support pass through arguments
-Running: yarn add --tilde test-vite-plus-package-optional
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0000: └ Completed

--- a/packages/global/snap-tests/command-dedupe-npm10/snap.txt
+++ b/packages/global/snap-tests/command-dedupe-npm10/snap.txt
@@ -1,5 +1,4 @@
 > vp dedupe && cat package.json # should dedupe dependencies
-Running: npm dedupe
 
 added 3 packages in <variable>ms
 {
@@ -18,7 +17,6 @@ added 3 packages in <variable>ms
 }
 
 > vp dedupe --check && cat package.json # should check if deduplication would make changes
-Running: npm dedupe --dry-run
 
 up to date in <variable>ms
 {
@@ -37,7 +35,6 @@ up to date in <variable>ms
 }
 
 > vp ddp -- --loglevel=warn && cat package.json # support pass through arguments
-Running: npm dedupe --loglevel=warn
 
 up to date in <variable>ms
 {

--- a/packages/global/snap-tests/command-dedupe-pnpm10/snap.txt
+++ b/packages/global/snap-tests/command-dedupe-pnpm10/snap.txt
@@ -11,7 +11,6 @@ Options:
   -h, --help   Print help
 
 > vp dedupe && cat package.json # should dedupe dependencies
-Running: pnpm dedupe
 Already up to date
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
@@ -40,7 +39,6 @@ devDependencies:
 }
 
 > vp dedupe --check && cat package.json # should check if deduplication would make changes
-Running: pnpm dedupe --check
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
 {
@@ -59,7 +57,6 @@ Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <
 }
 
 > vp ddp -- --loglevel=warn && cat package.json # support pass through arguments
-Running: pnpm dedupe --loglevel=warn
 {
   "name": "command-dedupe-pnpm10",
   "version": "1.0.0",
@@ -88,7 +85,6 @@ Running: pnpm dedupe --loglevel=warn
     "test-vite-plus-package-optional": "1.0.0"
   }
 }
-Running: pnpm dedupe --check
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
  ERR_PNPM_DEDUPE_CHECK_ISSUES  Dedupe --check found changes to the lockfile
@@ -105,7 +101,6 @@ Run pnpm dedupe to apply the changes above.
 
 
 > vp dedupe && cat package.json && vp dedupe --check # should dedupe fix the change by removing the dependencies
-Running: pnpm dedupe
 Packages: -1
 -
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
@@ -125,6 +120,5 @@ dependencies:
     "test-vite-plus-package-optional": "1.0.0"
   }
 }
-Running: pnpm dedupe --check
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 

--- a/packages/global/snap-tests/command-dedupe-yarn4/snap.txt
+++ b/packages/global/snap-tests/command-dedupe-yarn4/snap.txt
@@ -1,5 +1,4 @@
 > vp dedupe && cat package.json # should dedupe dependencies
-Running: yarn dedupe
 ➤ YN0000: ┌ Deduplication step
 ➤ YN0000: │ No packages can be deduped using the highest strategy
 ➤ YN0000: └ Completed
@@ -28,7 +27,6 @@ Running: yarn dedupe
 }
 
 > vp dedupe --check && cat package.json # should check if deduplication would make changes
-Running: yarn dedupe --check
 ➤ YN0000: ┌ Deduplication step
 ➤ YN0000: │ No packages can be deduped using the highest strategy
 ➤ YN0000: └ Completed
@@ -48,7 +46,6 @@ Running: yarn dedupe --check
 }
 
 > vp ddp -- --json && cat package.json # support pass through arguments
-Running: yarn dedupe --json
 {
   "name": "command-dedupe-yarn4",
   "version": "1.0.0",

--- a/packages/global/snap-tests/command-link-npm10/snap.txt
+++ b/packages/global/snap-tests/command-link-npm10/snap.txt
@@ -1,6 +1,5 @@
 > mkdir -p ../test-lib-npm && echo '{"name": "test-lib-npm", "version": "1.0.0"}' > ../test-lib-npm/package.json # create test library
 > vp link ../test-lib-npm && cat package.json # should link local directory
-Running: npm link ../test-lib-npm
 
 added 1 package in <variable>ms
 {
@@ -10,7 +9,6 @@ added 1 package in <variable>ms
 }
 
 > vp ln ../test-lib-npm && cat package.json # should work with ln alias
-Running: npm link ../test-lib-npm
 
 up to date in <variable>ms
 {
@@ -20,7 +18,6 @@ up to date in <variable>ms
 }
 
 > vp unlink test-lib-npm && cat package.json # cleanup temp states
-Running: npm unlink test-lib-npm
 
 removed 1 package in <variable>ms
 {

--- a/packages/global/snap-tests/command-link-pnpm10/snap.txt
+++ b/packages/global/snap-tests/command-link-pnpm10/snap.txt
@@ -23,7 +23,6 @@ Done in <variable>ms using pnpm v<semver>
 
 > mkdir -p ../test-lib-pnpm && echo '{"name": "testnpm2", "version": "1.0.0"}' > ../test-lib-pnpm/package.json # create test library
 > vp link ../test-lib-pnpm && cat package.json pnpm-lock.yaml # should link local directory
-Running: pnpm link ../test-lib-pnpm
 Packages: -1
 -
 
@@ -57,7 +56,6 @@ importers:
         version: link:../test-lib-pnpm
 
 > vp ln ../test-lib-pnpm && cat package.json pnpm-lock.yaml # should work with ln alias
-Running: pnpm link ../test-lib-pnpm
 Lockfile is up to date, resolution step is skipped
 
 {
@@ -86,9 +84,7 @@ importers:
         version: link:../test-lib-pnpm
 
 > vp unlink ../test-lib-pnpm && vp unlink testnpm2 && cat package.json pnpm-lock.yaml # should unlink the package
-Running: pnpm unlink ../test-lib-pnpm
 Nothing to unlink
-Running: pnpm unlink testnpm2
 Nothing to unlink
 {
   "name": "command-link-pnpm10",

--- a/packages/global/snap-tests/command-link-yarn4/snap.txt
+++ b/packages/global/snap-tests/command-link-yarn4/snap.txt
@@ -1,6 +1,5 @@
 > mkdir -p ../test-lib-yarn && echo '{"name": "test-lib-yarn", "version": "1.0.0"}' > ../test-lib-yarn/package.json # create test library
 > vp link ../test-lib-yarn && cat package.json # should link local directory
-Running: yarn link ../test-lib-yarn
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0000: └ Completed
@@ -19,7 +18,6 @@ Running: yarn link ../test-lib-yarn
 }
 
 > vp ln ../test-lib-yarn && cat package.json # should work with ln alias
-Running: yarn link ../test-lib-yarn
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0000: └ Completed
@@ -38,7 +36,6 @@ Running: yarn link ../test-lib-yarn
 }
 
 > vp unlink test-lib-yarn && cat package.json # cleanup temp states
-Running: yarn unlink test-lib-yarn
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0000: └ Completed

--- a/packages/global/snap-tests/command-outdated-npm10-with-workspace/snap.txt
+++ b/packages/global/snap-tests/command-outdated-npm10-with-workspace/snap.txt
@@ -4,15 +4,11 @@ added 6 packages in <variable>ms
 
 
 [1]> vp outdated testnpm2 -w # should outdated in workspace root
-Running: npm outdated --include-workspace-root testnpm2
 Package   Current  Wanted  Latest  Location               Depended by
 testnpm2    <semver>   <semver>   <semver>  node_modules/testnpm2  command-outdated-npm10-with-workspace
 
 > vp outdated testnpm2 --filter app # should outdated in specific package
-Running: npm outdated --workspace app testnpm2
-
 [1]> vp outdated --filter "*" --format json # should outdated in all packages
-Running: npm outdated --json --workspace *
 {
   "test-vite-plus-other-optional": {
     "current": "1.0.0",
@@ -24,7 +20,6 @@ Running: npm outdated --json --workspace *
 }
 
 [1]> vp outdated -r # should outdated recursively
-Running: npm outdated --all
 Package                        Current  Wanted  Latest  Location                                    Depended by
 test-vite-plus-other-optional    <semver>   <semver>   <semver>  node_modules/test-vite-plus-other-optional  app@
 testnpm2                         <semver>   <semver>   <semver>  node_modules/testnpm2                       command-outdated-npm10-with-workspace

--- a/packages/global/snap-tests/command-outdated-npm10/snap.txt
+++ b/packages/global/snap-tests/command-outdated-npm10/snap.txt
@@ -4,15 +4,11 @@ added 4 packages in <variable>ms
 
 
 [1]> vp outdated testnpm2 # should outdated package
-Running: npm outdated testnpm2
 Package   Current  Wanted  Latest  Location               Depended by
 testnpm2    <semver>   <semver>   <semver>  node_modules/testnpm2  command-outdated-npm10
 
 > vp outdated test-vite* # should outdated with glob pattern not working on npm
-Running: npm outdated test-vite*
-
 [1]> vp outdated --format json # should support json output
-Running: npm outdated --json
 {
   "test-vite-plus-other-optional": {
     "current": "1.0.0",
@@ -38,25 +34,21 @@ Running: npm outdated --json
 }
 
 [1]> vp outdated --format list # should support list output
-Running: npm outdated --parseable
 <cwd>/node_modules/test-vite-plus-other-optional:test-vite-plus-other-optional@<semver>:test-vite-plus-other-optional@<semver>:test-vite-plus-other-optional@<semver>:command-outdated-npm10
 <cwd>/node_modules/test-vite-plus-top-package:test-vite-plus-top-package@<semver>:test-vite-plus-top-package@<semver>:test-vite-plus-top-package@<semver>:command-outdated-npm10
 <cwd>/node_modules/testnpm2:testnpm2@<semver>:testnpm2@<semver>:testnpm2@<semver>:command-outdated-npm10
 
 [1]> vp outdated --format table # should support table output
-Running: npm outdated
 Package                        Current  Wanted  Latest  Location                                    Depended by
 test-vite-plus-other-optional    <semver>   <semver>   <semver>  node_modules/test-vite-plus-other-optional  command-outdated-npm10
 test-vite-plus-top-package       <semver>   <semver>   <semver>  node_modules/test-vite-plus-top-package     command-outdated-npm10
 testnpm2                         <semver>   <semver>   <semver>  node_modules/testnpm2                       command-outdated-npm10
 
 [1]> vp outdated testnpm2 --long # should support --long
-Running: npm outdated --long testnpm2
 Package   Current  Wanted  Latest  Location               Depended by             Package Type  Homepage
 testnpm2    <semver>   <semver>   <semver>  node_modules/testnpm2  command-outdated-npm10  dependencies
 
 [1]> vp outdated -r # should support recursive output
-Running: npm outdated --all
 Package                        Current  Wanted  Latest  Location                                    Depended by
 test-vite-plus-other-optional    <semver>   <semver>   <semver>  node_modules/test-vite-plus-other-optional  command-outdated-npm10
 test-vite-plus-top-package       <semver>   <semver>   <semver>  node_modules/test-vite-plus-top-package     command-outdated-npm10
@@ -64,7 +56,6 @@ testnpm2                         <semver>   <semver>   <semver>  node_modules/te
 
 [1]> vp outdated -P # should support prod output
 Warning: --prod/--dev not supported by npm
-Running: npm outdated
 Package                        Current  Wanted  Latest  Location                                    Depended by
 test-vite-plus-other-optional    <semver>   <semver>   <semver>  node_modules/test-vite-plus-other-optional  command-outdated-npm10
 test-vite-plus-top-package       <semver>   <semver>   <semver>  node_modules/test-vite-plus-top-package     command-outdated-npm10
@@ -72,7 +63,6 @@ testnpm2                         <semver>   <semver>   <semver>  node_modules/te
 
 [1]> vp outdated -D # should support dev output
 Warning: --prod/--dev not supported by npm
-Running: npm outdated
 Package                        Current  Wanted  Latest  Location                                    Depended by
 test-vite-plus-other-optional    <semver>   <semver>   <semver>  node_modules/test-vite-plus-other-optional  command-outdated-npm10
 test-vite-plus-top-package       <semver>   <semver>   <semver>  node_modules/test-vite-plus-top-package     command-outdated-npm10
@@ -80,7 +70,6 @@ testnpm2                         <semver>   <semver>   <semver>  node_modules/te
 
 [1]> vp outdated --no-optional # should support no-optional output
 Warning: --no-optional not supported by npm
-Running: npm outdated
 Package                        Current  Wanted  Latest  Location                                    Depended by
 test-vite-plus-other-optional    <semver>   <semver>   <semver>  node_modules/test-vite-plus-other-optional  command-outdated-npm10
 test-vite-plus-top-package       <semver>   <semver>   <semver>  node_modules/test-vite-plus-top-package     command-outdated-npm10
@@ -88,7 +77,6 @@ testnpm2                         <semver>   <semver>   <semver>  node_modules/te
 
 [1]> vp outdated --compatible # should compatible output nothing
 Warning: --compatible not supported by npm
-Running: npm outdated
 Package                        Current  Wanted  Latest  Location                                    Depended by
 test-vite-plus-other-optional    <semver>   <semver>   <semver>  node_modules/test-vite-plus-other-optional  command-outdated-npm10
 test-vite-plus-top-package       <semver>   <semver>   <semver>  node_modules/test-vite-plus-top-package     command-outdated-npm10
@@ -96,7 +84,6 @@ testnpm2                         <semver>   <semver>   <semver>  node_modules/te
 
 [1]> json-edit package.json '_.optionalDependencies["test-vite-plus-other-optional"] = "^1.0.0"' && vp outdated --compatible # should support compatible output with optional dependencies
 Warning: --compatible not supported by npm
-Running: npm outdated
 Package                        Current  Wanted  Latest  Location                                    Depended by
 test-vite-plus-other-optional    <semver>   <semver>   <semver>  node_modules/test-vite-plus-other-optional  command-outdated-npm10
 test-vite-plus-top-package       <semver>   <semver>   <semver>  node_modules/test-vite-plus-top-package     command-outdated-npm10
@@ -104,7 +91,6 @@ testnpm2                         <semver>   <semver>   <semver>  node_modules/te
 
 [1]> vp outdated --sort-by name # should support sort-by output
 Warning: --sort-by not supported by npm
-Running: npm outdated
 Package                        Current  Wanted  Latest  Location                                    Depended by
 test-vite-plus-other-optional    <semver>   <semver>   <semver>  node_modules/test-vite-plus-other-optional  command-outdated-npm10
 test-vite-plus-top-package       <semver>   <semver>   <semver>  node_modules/test-vite-plus-top-package     command-outdated-npm10

--- a/packages/global/snap-tests/command-outdated-pnpm10-with-workspace/snap.txt
+++ b/packages/global/snap-tests/command-outdated-pnpm10-with-workspace/snap.txt
@@ -11,7 +11,6 @@ Done in <variable>ms using pnpm v<semver>
 
 
 [1]> vp outdated testnpm2 -w # should outdated in workspace root
-Running: pnpm outdated --workspace-root testnpm2
 ┌──────────┬─────────┬────────┐
 │ Package  │ Current │ Latest │
 ├──────────┼─────────┼────────┤
@@ -19,7 +18,6 @@ Running: pnpm outdated --workspace-root testnpm2
 └──────────┴─────────┴────────┘
 
 [1]> vp outdated testnpm2 --filter app # should outdated in specific package
-Running: pnpm --filter app outdated testnpm2
 ┌──────────┬─────────┬────────┬────────────┐
 │ Package  │ Current │ Latest │ Dependents │
 ├──────────┼─────────┼────────┼────────────┤
@@ -27,10 +25,7 @@ Running: pnpm --filter app outdated testnpm2
 └──────────┴─────────┴────────┴────────────┘
 
 > vp outdated -D --filter app # should outdated dev dependencies in app
-Running: pnpm --filter app outdated --dev
-
 [1]> vp outdated --filter "*" --format json # should outdated in all packages
-Running: pnpm --filter * outdated --format json
 {
   "testnpm2": {
     "current": "1.0.0",
@@ -69,7 +64,6 @@ Running: pnpm --filter * outdated --format json
 }
 
 [1]> vp outdated -r # should outdated recursively
-Running: pnpm outdated --recursive
 ┌──────────────────────────────────────────┬─────────┬────────┬────────────────────────────────┐
 │ Package                                  │ Current │ Latest │ Dependents                     │
 ├──────────────────────────────────────────┼─────────┼────────┼────────────────────────────────┤

--- a/packages/global/snap-tests/command-outdated-pnpm10/snap.txt
+++ b/packages/global/snap-tests/command-outdated-pnpm10/snap.txt
@@ -39,7 +39,6 @@ Done in <variable>ms using pnpm v<semver>
 
 
 [1]> vp outdated testnpm2 # should outdated package
-Running: pnpm outdated testnpm2
 ┌──────────┬─────────┬────────┐
 │ Package  │ Current │ Latest │
 ├──────────┼─────────┼────────┤
@@ -47,7 +46,6 @@ Running: pnpm outdated testnpm2
 └──────────┴─────────┴────────┘
 
 [1]> vp outdated test-vite* # should outdated with one glob pattern
-Running: pnpm outdated test-vite*
 ┌──────────────────────────────────────────┬─────────┬────────┐
 │ Package                                  │ Current │ Latest │
 ├──────────────────────────────────────────┼─────────┼────────┤
@@ -57,7 +55,6 @@ Running: pnpm outdated test-vite*
 └──────────────────────────────────────────┴─────────┴────────┘
 
 [1]> vp outdated test-vite* '*npm*' # should outdated with multiple glob patterns
-Running: pnpm outdated test-vite* *npm*
 ┌──────────────────────────────────────────┬─────────┬────────┐
 │ Package                                  │ Current │ Latest │
 ├──────────────────────────────────────────┼─────────┼────────┤
@@ -69,7 +66,6 @@ Running: pnpm outdated test-vite* *npm*
 └──────────────────────────────────────────┴─────────┴────────┘
 
 [1]> vp outdated --format json # should support json output
-Running: pnpm outdated --format json
 {
   "testnpm2": {
     "current": "1.0.0",
@@ -95,7 +91,6 @@ Running: pnpm outdated --format json
 }
 
 [1]> vp outdated --format list # should support list output
-Running: pnpm outdated --format list
 testnpm2
 <semver> => <semver>
 
@@ -106,7 +101,6 @@ test-vite-plus-top-package (dev)
 <semver> => <semver>
 
 [1]> vp outdated --format table # should support table output
-Running: pnpm outdated --format table
 ┌──────────────────────────────────────────┬─────────┬────────┐
 │ Package                                  │ Current │ Latest │
 ├──────────────────────────────────────────┼─────────┼────────┤
@@ -118,12 +112,10 @@ Running: pnpm outdated --format table
 └──────────────────────────────────────────┴─────────┴────────┘
 
 [1]> vp outdated testnpm2 --long --format list # should support --long
-Running: pnpm outdated --format list --long testnpm2
 testnpm2
 <semver> => <semver>
 
 [1]> vp outdated -r # should support recursive output
-Running: pnpm outdated --recursive
 ┌──────────────────────────────────────────┬─────────┬────────┬─────────────────────────┐
 │ Package                                  │ Current │ Latest │ Dependents              │
 ├──────────────────────────────────────────┼─────────┼────────┼─────────────────────────┤
@@ -135,7 +127,6 @@ Running: pnpm outdated --recursive
 └──────────────────────────────────────────┴─────────┴────────┴─────────────────────────┘
 
 [1]> vp outdated -P # should support prod output
-Running: pnpm outdated --prod
 ┌──────────────────────────────────────────┬─────────┬────────┐
 │ Package                                  │ Current │ Latest │
 ├──────────────────────────────────────────┼─────────┼────────┤
@@ -145,7 +136,6 @@ Running: pnpm outdated --prod
 └──────────────────────────────────────────┴─────────┴────────┘
 
 [1]> vp outdated -D # should support dev output
-Running: pnpm outdated --dev
 ┌──────────────────────────────────┬─────────┬────────┐
 │ Package                          │ Current │ Latest │
 ├──────────────────────────────────┼─────────┼────────┤
@@ -153,7 +143,6 @@ Running: pnpm outdated --dev
 └──────────────────────────────────┴─────────┴────────┘
 
 [1]> vp outdated --no-optional # should support no-optional output
-Running: pnpm outdated --no-optional
 ┌──────────────────────────────────┬─────────┬────────┐
 │ Package                          │ Current │ Latest │
 ├──────────────────────────────────┼─────────┼────────┤
@@ -163,10 +152,7 @@ Running: pnpm outdated --no-optional
 └──────────────────────────────────┴─────────┴────────┘
 
 > vp outdated --compatible # should compatible output nothing
-Running: pnpm outdated --compatible
-
 [1]> json-edit package.json '_.optionalDependencies["test-vite-plus-other-optional"] = "^1.0.0"' && vp outdated --compatible # should support compatible output with optional dependencies
-Running: pnpm outdated --compatible
 ┌──────────────────────────────────────────┬─────────┬────────┐
 │ Package                                  │ Current │ Latest │
 ├──────────────────────────────────────────┼─────────┼────────┤
@@ -174,7 +160,6 @@ Running: pnpm outdated --compatible
 └──────────────────────────────────────────┴─────────┴────────┘
 
 [1]> vp outdated --sort-by name # should support sort-by output
-Running: pnpm outdated --sort-by name
 ┌──────────────────────────────────────────┬─────────┬────────┐
 │ Package                                  │ Current │ Latest │
 ├──────────────────────────────────────────┼─────────┼────────┤
@@ -186,5 +171,4 @@ Running: pnpm outdated --sort-by name
 └──────────────────────────────────────────┴─────────┴────────┘
 
 > vp outdated testnpm2 -g --format json # should support global output
-Running: npm outdated --json testnpm2 -g
 {}

--- a/packages/global/snap-tests/command-outdated-yarn4/snap.txt
+++ b/packages/global/snap-tests/command-outdated-yarn4/snap.txt
@@ -1,6 +1,5 @@
 > vp outdated -- -h # should show yarn upgrade-interactive help
 Note: yarn@2+ uses 'yarn upgrade-interactive' for checking outdated packages
-Running: yarn upgrade-interactive -h
 Open the upgrade interface
 
 Usage

--- a/packages/global/snap-tests/command-remove-npm10-with-workspace/snap.txt
+++ b/packages/global/snap-tests/command-remove-npm10-with-workspace/snap.txt
@@ -1,11 +1,8 @@
 > vp add testnpm2 -D -w --filter=* -- --no-audit && vp add test-vite-plus-install -w --filter=* -- --no-audit && vp add test-vite-plus-package-optional -O --filter=* -- --no-audit && cat package.json packages/app/package.json packages/utils/package.json # prepare packages
-Running: npm install --workspace * --include-workspace-root --save-dev --no-audit testnpm2
 
 added 3 packages in <variable>ms
-Running: npm install --workspace * --include-workspace-root --no-audit test-vite-plus-install
 
 added 1 package in <variable>ms
-Running: npm install --workspace * --save-optional --no-audit test-vite-plus-package-optional
 
 added 1 package in <variable>ms
 {
@@ -50,7 +47,6 @@ added 1 package in <variable>ms
 }
 
 > vp remove testnpm2 -r -- --no-audit && cat package.json packages/app/package.json packages/utils/package.json # should remove package from all workspaces and root
-Running: npm uninstall --include-workspace-root --workspaces --no-audit testnpm2
 
 removed 1 package in <variable>ms
 {
@@ -86,7 +82,6 @@ removed 1 package in <variable>ms
 }
 
 > vp remove -O test-vite-plus-package-optional -r -- --no-audit && cat package.json packages/app/package.json packages/utils/package.json # should remove optional package from all workspaces
-Running: npm uninstall --include-workspace-root --workspaces --no-audit test-vite-plus-package-optional
 
 removed 1 package in <variable>ms
 {
@@ -116,7 +111,6 @@ removed 1 package in <variable>ms
 }
 
 > vp remove test-vite-plus-install --filter=app -- --no-audit && cat package.json packages/app/package.json packages/utils/package.json # should remove package by filter=app
-Running: npm uninstall --workspace app --no-audit test-vite-plus-install
 
 up to date in <variable>ms
 {
@@ -143,7 +137,6 @@ up to date in <variable>ms
 }
 
 > vp remove test-vite-plus-install --filter=* -- --no-audit && cat package.json packages/app/package.json packages/utils/package.json # should remove package by filter=*
-Running: npm uninstall --workspace * --no-audit test-vite-plus-install
 
 up to date in <variable>ms
 {

--- a/packages/global/snap-tests/command-remove-npm10/snap.txt
+++ b/packages/global/snap-tests/command-remove-npm10/snap.txt
@@ -1,5 +1,4 @@
 > vp remove testnpm2 -D -- --no-audit && cat package.json # should pass when remove not exists package
-Running: npm uninstall --no-audit testnpm2
 
 up to date in <variable>ms
 {
@@ -9,13 +8,10 @@ up to date in <variable>ms
 }
 
 > vp add testnpm2 -- --no-audit && vp add -D test-vite-plus-install -- --no-audit && vp add -O test-vite-plus-package-optional -- --no-audit && cat package.json # should add packages to dependencies
-Running: npm install --no-audit testnpm2
 
 added 1 package in <variable>ms
-Running: npm install --save-dev --no-audit test-vite-plus-install
 
 added 1 package in <variable>ms
-Running: npm install --save-optional --no-audit test-vite-plus-package-optional
 
 added 1 package in <variable>ms
 {
@@ -34,7 +30,6 @@ added 1 package in <variable>ms
 }
 
 > vp remove testnpm2 test-vite-plus-install -- --no-audit && cat package.json # should remove packages from dependencies
-Running: npm uninstall --no-audit testnpm2 test-vite-plus-install
 
 removed 2 packages in <variable>ms
 {
@@ -47,7 +42,6 @@ removed 2 packages in <variable>ms
 }
 
 > vp remove -D test-vite-plus-package-optional -- --loglevel=warn --no-audit && cat package.json # support ignore -O flag and remove package from optional dependencies
-Running: npm uninstall --loglevel=warn --no-audit test-vite-plus-package-optional
 
 removed 1 package in <variable>ms
 {
@@ -57,7 +51,6 @@ removed 1 package in <variable>ms
 }
 
 > vp remove -g testnpm2 -- --dry-run --no-audit && cat package.json # support remove global package with dry-run
-Running: npm uninstall --global --dry-run --no-audit testnpm2
 
 up to date in <variable>ms
 {

--- a/packages/global/snap-tests/command-remove-pnpm10-with-workspace/snap.txt
+++ b/packages/global/snap-tests/command-remove-pnpm10-with-workspace/snap.txt
@@ -1,13 +1,10 @@
 > vp add testnpm2 -D -w --filter=* && vp add test-vite-plus-install -w --filter=* && vp add test-vite-plus-package-optional -O --filter=* && cat package.json packages/app/package.json packages/utils/package.json # prepare packages
-Running: pnpm --filter * add --workspace-root --save-dev testnpm2
 .                                        |   +1 +<repeat>
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 Done in <variable>ms using pnpm v<semver>
-Running: pnpm --filter * add --workspace-root test-vite-plus-install
 .                                        |   +1 +<repeat>
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 Done in <variable>ms using pnpm v<semver>
-Running: pnpm --filter * add --save-optional test-vite-plus-package-optional
 .                                        |   +1 +<repeat>
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 Done in <variable>ms using pnpm v<semver>
@@ -50,7 +47,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp remove testnpm2 -r && cat package.json packages/app/package.json packages/utils/package.json # should remove package from all workspaces and root
-Running: pnpm remove --recursive testnpm2
 Scope: all <variable> workspace projects
 .                                        |   -1 -
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
@@ -85,7 +81,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp remove -O test-vite-plus-package-optional -r && cat package.json packages/app/package.json packages/utils/package.json # should remove optional package from all workspaces
-Running: pnpm remove --recursive --save-optional test-vite-plus-package-optional
 Scope: all <variable> workspace projects
 .                                        |   -1 -
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
@@ -114,7 +109,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp remove test-vite-plus-install --filter=app && cat package.json packages/app/package.json packages/utils/package.json # should remove package by filter=app
-Running: pnpm --filter app remove test-vite-plus-install
 .                                        |  WARN  `node_modules` is present. Lockfile only installation will make it out-of-date
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 Done in <variable>ms using pnpm v<semver>
@@ -139,7 +133,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp remove test-vite-plus-install --filter=* && cat package.json packages/app/package.json packages/utils/package.json # should remove package by filter=*
-Running: pnpm --filter * remove test-vite-plus-install
 Scope: all <variable> workspace projects
 .                                        |   -1 -
 Done in <variable>ms using pnpm v<semver>

--- a/packages/global/snap-tests/command-remove-pnpm10/snap.txt
+++ b/packages/global/snap-tests/command-remove-pnpm10/snap.txt
@@ -26,11 +26,9 @@ Usage: vp remove <PACKAGES>... [-- <PASS_THROUGH_ARGS>...]
 For more information, try '--help'.
 
 [1]> vp remove testnpm2 -D && cat package.json # should error when remove not exists package from dev dependencies
-Running: pnpm remove --save-dev testnpm2
  ERR_PNPM_CANNOT_REMOVE_MISSING_DEPS  Cannot remove 'testnpm2': project has no 'devDependencies'
 
 > vp add testnpm2 && vp add -D test-vite-plus-install && vp add -O test-vite-plus-package-optional && cat package.json # should add packages to dependencies
-Running: pnpm add testnpm2
 Packages: +<variable>
 +<repeat>
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
@@ -39,7 +37,6 @@ dependencies:
 + testnpm2 <semver>
 
 Done in <variable>ms using pnpm v<semver>
-Running: pnpm add --save-dev test-vite-plus-install
 Packages: +<variable>
 +<repeat>
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
@@ -48,7 +45,6 @@ devDependencies:
 + test-vite-plus-install <semver>
 
 Done in <variable>ms using pnpm v<semver>
-Running: pnpm add --save-optional test-vite-plus-package-optional
 Packages: +<variable>
 +<repeat>
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
@@ -73,7 +69,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp remove testnpm2 test-vite-plus-install && cat package.json # should remove packages from dependencies
-Running: pnpm remove testnpm2 test-vite-plus-install
 Packages: -2
 --
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
@@ -95,7 +90,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp remove -O test-vite-plus-package-optional -- --loglevel=warn && cat package.json # support remove package from optional dependencies and pass through arguments
-Running: pnpm remove --save-optional --loglevel=warn test-vite-plus-package-optional
 {
   "name": "command-remove-pnpm10",
   "version": "1.0.0",
@@ -103,7 +97,6 @@ Running: pnpm remove --save-optional --loglevel=warn test-vite-plus-package-opti
 }
 
 > vp remove -g testnpm2 -- --dry-run && cat package.json # support remove global package with dry-run
-Running: npm uninstall --global --dry-run testnpm2
 
 up to date in <variable>ms
 {

--- a/packages/global/snap-tests/command-remove-yarn4-with-workspace/snap.txt
+++ b/packages/global/snap-tests/command-remove-yarn4-with-workspace/snap.txt
@@ -1,5 +1,4 @@
 > vp add testnpm2 -D && vp add testnpm2 -D --filter=* --filter=@vite-plus-test/utils && vp add test-vite-plus-install --filter=* --filter=@vite-plus-test/utils && vp add test-vite-plus-package-optional -O --filter=* --filter=@vite-plus-test/utils && cat package.json packages/app/package.json packages/admin/package.json packages/utils/package.json # prepare packages
-Running: yarn add --dev testnpm2
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0085: │ + testnpm2@npm:1.0.1
@@ -9,7 +8,6 @@ Running: yarn add --dev testnpm2
 ➤ YN0000: ┌ Link step
 ➤ YN0000: └ Completed
 ➤ YN0000: · Done in <variable>ms <variable>ms
-Running: yarn workspaces foreach --all --include * --include @vite-plus-test/utils add --dev testnpm2
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0000: └ Completed
@@ -43,7 +41,6 @@ Running: yarn workspaces foreach --all --include * --include @vite-plus-test/uti
 ➤ YN0000: └ Completed
 ➤ YN0000: · Done in <variable>ms <variable>ms
 Done in <variable>ms <variable>ms
-Running: yarn workspaces foreach --all --include * --include @vite-plus-test/utils add test-vite-plus-install
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0085: │ + test-vite-plus-install@npm:1.0.0
@@ -78,7 +75,6 @@ Running: yarn workspaces foreach --all --include * --include @vite-plus-test/uti
 ➤ YN0000: └ Completed
 ➤ YN0000: · Done in <variable>ms <variable>ms
 Done in <variable>ms <variable>ms
-Running: yarn workspaces foreach --all --include * --include @vite-plus-test/utils add --optional test-vite-plus-package-optional
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0085: │ + test-vite-plus-package-optional@npm:1.0.0
@@ -169,7 +165,6 @@ Done in <variable>ms <variable>ms
 }
 
 > vp remove testnpm2 -r && cat package.json packages/app/package.json packages/admin/package.json packages/utils/package.json # should remove package from all workspaces and root
-Running: yarn remove --all testnpm2
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0085: │ - testnpm2@npm:1.0.1
@@ -223,7 +218,6 @@ Running: yarn remove --all testnpm2
 }
 
 > vp remove -O test-vite-plus-package-optional -r && cat package.json packages/app/package.json packages/admin/package.json packages/utils/package.json # should remove optional package from all workspaces
-Running: yarn remove --all test-vite-plus-package-optional
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0085: │ - test-vite-plus-package-optional@npm:1.0.0
@@ -265,7 +259,6 @@ Running: yarn remove --all test-vite-plus-package-optional
 }
 
 > vp remove test-vite-plus-install --filter=app && cat package.json packages/app/package.json packages/admin/package.json packages/utils/package.json # should remove package by filter=app
-Running: yarn workspaces foreach --all --include app remove test-vite-plus-install
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0000: └ Completed
@@ -304,7 +297,6 @@ Done in <variable>ms <variable>ms
 }
 
 > vp add test-vite-plus-install --filter=app && vp remove test-vite-plus-install --filter=* && cat package.json packages/app/package.json packages/admin/package.json packages/utils/package.json # should remove package by filter=*
-Running: yarn workspaces foreach --all --include app add test-vite-plus-install
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0000: └ Completed
@@ -314,7 +306,6 @@ Running: yarn workspaces foreach --all --include app add test-vite-plus-install
 ➤ YN0000: └ Completed
 ➤ YN0000: · Done in <variable>ms <variable>ms
 Done in <variable>ms <variable>ms
-Running: yarn workspaces foreach --all --include * remove test-vite-plus-install
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0000: └ Completed

--- a/packages/global/snap-tests/command-remove-yarn4/snap.txt
+++ b/packages/global/snap-tests/command-remove-yarn4/snap.txt
@@ -1,11 +1,9 @@
 [1]> vp remove testnpm2 -D && cat package.json # should error when remove not exists package
-Running: yarn remove testnpm2
 Usage Error: Pattern testnpm2 doesn't match any packages referenced by this workspace
 
 $ yarn remove [-A,--all] [--mode #0] ...
 
 > vp add testnpm2 && vp add -D test-vite-plus-install && vp add -O test-vite-plus-package-optional && cat package.json # should add packages to dependencies
-Running: yarn add testnpm2
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0085: │ + testnpm2@npm:1.0.1
@@ -15,7 +13,6 @@ Running: yarn add testnpm2
 ➤ YN0000: ┌ Link step
 ➤ YN0000: └ Completed
 ➤ YN0000: · Done in <variable>ms <variable>ms
-Running: yarn add --dev test-vite-plus-install
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0085: │ + test-vite-plus-install@npm:1.0.0
@@ -25,7 +22,6 @@ Running: yarn add --dev test-vite-plus-install
 ➤ YN0000: ┌ Link step
 ➤ YN0000: └ Completed
 ➤ YN0000: · Done in <variable>ms <variable>ms
-Running: yarn add --optional test-vite-plus-package-optional
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0085: │ + test-vite-plus-package-optional@npm:1.0.0
@@ -51,7 +47,6 @@ Running: yarn add --optional test-vite-plus-package-optional
 }
 
 > vp remove testnpm2 test-vite-plus-install && cat package.json # should remove packages from dependencies
-Running: yarn remove testnpm2 test-vite-plus-install
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0085: │ - test-vite-plus-install@npm:1.0.0, testnpm2@npm:1.0.1
@@ -71,7 +66,6 @@ Running: yarn remove testnpm2 test-vite-plus-install
 }
 
 > vp remove -D test-vite-plus-package-optional && cat package.json # support ignore -O flag and remove package from optional dependencies
-Running: yarn remove test-vite-plus-package-optional
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0085: │ - test-vite-plus-package-optional@npm:1.0.0
@@ -88,7 +82,6 @@ Running: yarn remove test-vite-plus-package-optional
 }
 
 > vp remove -g testnpm2 -- --dry-run && cat package.json # support remove global package with dry-run
-Running: npm uninstall --global --dry-run testnpm2
 
 up to date in <variable>ms
 {

--- a/packages/global/snap-tests/command-unlink-npm10/snap.txt
+++ b/packages/global/snap-tests/command-unlink-npm10/snap.txt
@@ -1,6 +1,5 @@
 > mkdir -p ../unlink-test-lib-npm && echo '{"name": "unlink-test-lib-npm", "version": "1.0.0"}' > ../unlink-test-lib-npm/package.json # create test library
 > vp link ../unlink-test-lib-npm && cat package.json # link the library first
-Running: npm link ../unlink-test-lib-npm
 
 added 1 package in <variable>ms
 {
@@ -10,7 +9,6 @@ added 1 package in <variable>ms
 }
 
 > vp unlink unlink-test-lib-npm && cat package.json # should unlink the package
-Running: npm unlink unlink-test-lib-npm
 
 removed 1 package in <variable>ms
 {

--- a/packages/global/snap-tests/command-unlink-pnpm10/snap.txt
+++ b/packages/global/snap-tests/command-unlink-pnpm10/snap.txt
@@ -13,7 +13,6 @@ Options:
 
 > mkdir -p ../unlink-test-lib && echo '{"name": "unlink-test-lib", "version": "1.0.0"}' > ../unlink-test-lib/package.json # create test library
 > vp link ../unlink-test-lib && cat package.json # link the library first
-Running: pnpm link ../unlink-test-lib
 
 dependencies:
 + unlink-test-lib <semver> <- ../unlink-test-lib
@@ -28,7 +27,6 @@ dependencies:
 }
 
 > vp unlink unlink-test-lib && cat package.json # should unlink the package
-Running: pnpm unlink unlink-test-lib
 Nothing to unlink
 {
   "name": "command-unlink-pnpm10",
@@ -40,12 +38,10 @@ Nothing to unlink
 }
 
 > vp link ../unlink-test-lib # link again
-Running: pnpm link ../unlink-test-lib
 Lockfile is up to date, resolution step is skipped
 
 
 > vp unlink && cat package.json # should unlink all packages
-Running: pnpm unlink
 Nothing to unlink
 {
   "name": "command-unlink-pnpm10",

--- a/packages/global/snap-tests/command-unlink-yarn4/snap.txt
+++ b/packages/global/snap-tests/command-unlink-yarn4/snap.txt
@@ -1,6 +1,5 @@
 > mkdir -p ../unlink-test-lib-yarn && echo '{"name": "unlink-test-lib-yarn", "version": "1.0.0"}' > ../unlink-test-lib-yarn/package.json # create test library
 > vp link ../unlink-test-lib-yarn && cat package.json # link the library first
-Running: yarn link ../unlink-test-lib-yarn
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0000: └ Completed
@@ -19,7 +18,6 @@ Running: yarn link ../unlink-test-lib-yarn
 }
 
 > vp unlink unlink-test-lib-yarn && cat package.json # should unlink the package
-Running: yarn unlink unlink-test-lib-yarn
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0000: └ Completed
@@ -35,7 +33,6 @@ Running: yarn unlink unlink-test-lib-yarn
 }
 
 > vp link ../unlink-test-lib-yarn && cat package.json # link again
-Running: yarn link ../unlink-test-lib-yarn
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0000: └ Completed
@@ -54,7 +51,6 @@ Running: yarn link ../unlink-test-lib-yarn
 }
 
 > vp unlink --recursive && cat package.json # should unlink all with --all flag
-Running: yarn unlink --all
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0000: └ Completed
@@ -70,7 +66,6 @@ Running: yarn unlink --all
 }
 
 > vp unlink -r && cat package.json # should work with -r short form
-Running: yarn unlink --all
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0000: └ Completed

--- a/packages/global/snap-tests/command-update-npm10-with-workspace/snap.txt
+++ b/packages/global/snap-tests/command-update-npm10-with-workspace/snap.txt
@@ -1,5 +1,4 @@
 > vp update testnpm2 -w -- --no-audit && cat package.json # should update in workspace root
-Running: npm update --include-workspace-root --no-audit testnpm2
 
 added 5 packages in <variable>ms
 {
@@ -16,7 +15,6 @@ added 5 packages in <variable>ms
 
 > vp update testnpm2 --latest --filter app -- --no-audit && cat packages/app/package.json # should update in specific package
 Warning: npm doesn't support --latest flag. Updating within semver range only.
-Running: npm update --workspace app --no-audit testnpm2
 
 up to date in <variable>ms
 {
@@ -31,7 +29,6 @@ up to date in <variable>ms
 }
 
 > vp up -D --filter app -- --no-audit && cat packages/app/package.json # should update dev dependencies in app
-Running: npm update --workspace app --include=dev --no-audit
 npm warn workspaces app in filter set, but no workspace folder present
 
 up to date in <variable>ms
@@ -47,7 +44,6 @@ up to date in <variable>ms
 }
 
 > vp update --filter "*" -- --no-audit && cat packages/app/package.json packages/utils/package.json # should update in all packages
-Running: npm update --workspace * --no-audit
 npm warn workspaces app in filter set, but no workspace folder present
 npm warn workspaces @vite-plus-test/utils in filter set, but no workspace folder present
 
@@ -71,7 +67,6 @@ up to date in <variable>ms
 }
 
 > vp update -r --no-save -- --no-audit && cat package.json packages/app/package.json # should update recursively without saving
-Running: npm update --include-workspace-root --workspaces --no-save --no-audit
 npm warn workspaces app in filter set, but no workspace folder present
 npm warn workspaces @vite-plus-test/utils in filter set, but no workspace folder present
 
@@ -99,7 +94,6 @@ up to date in <variable>ms
 }
 
 > vp update --workspace --filter app @vite-plus-test/utils -- --no-audit && cat packages/app/package.json # should update workspace dependency
-Running: npm update --workspace app --no-audit @vite-plus-test/utils
 
 up to date in <variable>ms
 {

--- a/packages/global/snap-tests/command-update-npm10/snap.txt
+++ b/packages/global/snap-tests/command-update-npm10/snap.txt
@@ -1,5 +1,4 @@
 > vp update testnpm2 -- --no-audit && cat package.json # should update package within semver range
-Running: npm update --no-audit testnpm2
 
 added 3 packages in <variable>ms
 {
@@ -19,7 +18,6 @@ added 3 packages in <variable>ms
 
 > vp up testnpm2 --latest -- --no-audit && cat package.json # should to absolute latest version
 Warning: npm doesn't support --latest flag. Updating within semver range only.
-Running: npm update --no-audit testnpm2
 
 up to date in <variable>ms
 {
@@ -38,7 +36,6 @@ up to date in <variable>ms
 }
 
 > vp update -D -- --no-audit && cat package.json # should update only dev dependencies
-Running: npm update --include=dev --no-audit
 
 up to date in <variable>ms
 {
@@ -57,7 +54,6 @@ up to date in <variable>ms
 }
 
 > vp update -P --no-save -- --no-audit && cat package.json # should update only dependencies and optionalDependencies without saving
-Running: npm update --include=prod --no-save --no-audit
 
 up to date in <variable>ms
 {
@@ -76,14 +72,11 @@ up to date in <variable>ms
 }
 
 > vp rm testnpm2 && vp add testnpm2@1.0.0 -O -- --no-audit && vp update --no-optional --latest -- --no-audit && cat package.json # should skip optional dependencies
-Running: npm uninstall testnpm2
 
 removed 1 package in <variable>ms
-Running: npm install --save-optional --no-audit testnpm2@<semver>
 
 added 1 package in <variable>ms
 Warning: npm doesn't support --latest flag. Updating within semver range only.
-Running: npm update --no-optional --no-audit
 npm warn config optional Use `--omit=optional` to exclude optional dependencies, or
 npm warn config `--include=optional` to include them.
 npm warn config
@@ -104,7 +97,6 @@ changed 1 package in <variable>ms
 }
 
 > vp update -- --no-audit && cat package.json # should update all packages but won't change the package.json
-Running: npm update --no-audit
 
 added 2 packages in <variable>ms
 {

--- a/packages/global/snap-tests/command-update-pnpm10-with-workspace/snap.txt
+++ b/packages/global/snap-tests/command-update-pnpm10-with-workspace/snap.txt
@@ -1,5 +1,4 @@
 > vp update testnpm2 --latest -w && cat package.json # should update in workspace root
-Running: pnpm update --latest --workspace-root testnpm2
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
 Packages: +<variable>
@@ -15,7 +14,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp update testnpm2 --latest --filter app && cat packages/app/package.json # should update in specific package
-Running: pnpm --filter app update --latest testnpm2
 .                                        |  WARN  `node_modules` is present. Lockfile only installation will make it out-of-date
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 .                                        |   +2 +<repeat>
@@ -33,7 +31,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp up -D --filter app && cat packages/app/package.json # should update dev dependencies in app
-Running: pnpm --filter app update --dev
 .                                        |  WARN  `node_modules` is present. Lockfile only installation will make it out-of-date
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 Done in <variable>ms using pnpm v<semver>
@@ -50,7 +47,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp update --latest --filter "*" && cat packages/app/package.json packages/utils/package.json # should update in all packages
-Running: pnpm --filter * update --latest
 Scope: all <variable> workspace projects
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 Done in <variable>ms using pnpm v<semver>
@@ -74,7 +70,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp update -r --no-save && cat package.json packages/app/package.json # should update recursively without saving
-Running: pnpm update --recursive --no-save
 Scope: all <variable> workspace projects
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 Done in <variable>ms using pnpm v<semver>
@@ -99,7 +94,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp update --workspace --filter app @vite-plus-test/utils && cat packages/app/package.json # should update workspace dependency
-Running: pnpm --filter app update --workspace @vite-plus-test/utils
 .                                        |  WARN  `node_modules` is present. Lockfile only installation will make it out-of-date
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 Done in <variable>ms using pnpm v<semver>

--- a/packages/global/snap-tests/command-update-pnpm10/snap.txt
+++ b/packages/global/snap-tests/command-update-pnpm10/snap.txt
@@ -22,7 +22,6 @@ Options:
   -h, --help              Print help
 
 > vp update testnpm2 && cat package.json # should update package within semver range
-Running: pnpm update testnpm2
 Packages: +<variable>
 +<repeat>
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
@@ -53,7 +52,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp up testnpm2 --latest && cat package.json # should to absolute latest version
-Running: pnpm update --latest testnpm2
 Already up to date
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
@@ -74,7 +72,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp update -D && cat package.json # should update only dev dependencies
-Running: pnpm update --dev
 Already up to date
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
@@ -99,7 +96,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp update -P --no-save && cat package.json # should update only dependencies and optionalDependencies without saving
-Running: pnpm update --prod --no-save
 Already up to date
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
@@ -122,7 +118,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp rm testnpm2 && vp add testnpm2@1.0.0 -O && vp update --no-optional --latest && cat package.json # should skip optional dependencies
-Running: pnpm remove testnpm2
 Packages: -1
 -
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
@@ -131,7 +126,6 @@ dependencies:
 - testnpm2 <semver>
 
 Done in <variable>ms using pnpm v<semver>
-Running: pnpm add --save-optional testnpm2@<semver>
 Packages: +<variable>
 +<repeat>
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
@@ -140,7 +134,6 @@ optionalDependencies:
 + testnpm2 <semver> (1.0.1 is available)
 
 Done in <variable>ms using pnpm v<semver>
-Running: pnpm update --latest --no-optional
 Packages: -2
 --
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
@@ -164,7 +157,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp update && vp update --recursive && cat package.json # should update all packages and change the package.json
-Running: pnpm update
 Packages: +<variable>
 +<repeat>
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
@@ -174,7 +166,6 @@ optionalDependencies:
 + testnpm2 <semver>
 
 Done in <variable>ms using pnpm v<semver>
-Running: pnpm update --recursive
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 Done in <variable>ms using pnpm v<semver>
 {

--- a/packages/global/snap-tests/command-update-yarn4-with-workspace/snap.txt
+++ b/packages/global/snap-tests/command-update-yarn4-with-workspace/snap.txt
@@ -1,5 +1,4 @@
 > vp update testnpm2 && cat package.json packages/utils/package.json # should update all testnpm2 versions
-Running: yarn up testnpm2
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0085: │ + test-vite-plus-install@npm:1.0.0, test-vite-plus-package@npm:1.0.0, testnpm2@npm:1.0.1
@@ -29,7 +28,6 @@ Running: yarn up testnpm2
 }
 
 > vp update testnpm2 --latest --filter app && cat packages/app/package.json # should update in specific package
-Running: yarn workspaces foreach --all --include app up testnpm2
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0085: │ + testnpm2@npm:1.0.1
@@ -53,7 +51,6 @@ Done in <variable>ms <variable>ms
 }
 
 > vp up -D --filter app && cat packages/app/package.json # should update dev dependencies in app
-Running: yarn workspaces foreach --all --include app up
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0000: └ Completed
@@ -76,7 +73,6 @@ Done in <variable>ms <variable>ms
 }
 
 > vp update --filter "*" && cat packages/app/package.json packages/utils/package.json # should update in all packages
-Running: yarn workspaces foreach --all --include * up
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0000: └ Completed
@@ -114,7 +110,6 @@ Done in <variable>ms <variable>ms
 }
 
 > vp update -r --no-save && cat package.json packages/app/package.json # should update recursively without saving
-Running: yarn up --recursive
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0000: └ Completed
@@ -147,7 +142,6 @@ Running: yarn up --recursive
 }
 
 > vp update --workspace --filter app @vite-plus-test/utils && cat packages/app/package.json # should update workspace dependency
-Running: yarn workspaces foreach --all --include app up @vite-plus-test/utils
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0000: └ Completed

--- a/packages/global/snap-tests/command-update-yarn4/snap.txt
+++ b/packages/global/snap-tests/command-update-yarn4/snap.txt
@@ -1,5 +1,4 @@
 > vp update testnpm2 && cat package.json # should update package within semver range
-Running: yarn up testnpm2
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0085: │ + test-vite-plus-package-optional@npm:1.0.0, test-vite-plus-package@npm:1.0.0, testnpm2@npm:1.0.1
@@ -25,7 +24,6 @@ Running: yarn up testnpm2
 }
 
 > vp rm testnpm2 && vp add testnpm2@1.0.0 -D && vp update testnpm2 --latest && cat package.json # should to absolute latest version
-Running: yarn remove testnpm2
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0085: │ - testnpm2@npm:1.0.1
@@ -35,7 +33,6 @@ Running: yarn remove testnpm2
 ➤ YN0000: ┌ Link step
 ➤ YN0000: └ Completed
 ➤ YN0000: · Done in <variable>ms <variable>ms
-Running: yarn add --dev testnpm2@<semver>
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0085: │ + testnpm2@npm:1.0.0
@@ -45,7 +42,6 @@ Running: yarn add --dev testnpm2@<semver>
 ➤ YN0000: ┌ Link step
 ➤ YN0000: └ Completed
 ➤ YN0000: · Done in <variable>ms <variable>ms
-Running: yarn up testnpm2
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0085: │ + testnpm2@npm:1.0.1
@@ -70,7 +66,6 @@ Running: yarn up testnpm2
 }
 
 > vp update -D && cat package.json # should update and ignore -D options
-Running: yarn up
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0000: └ Completed
@@ -93,7 +88,6 @@ Running: yarn up
 }
 
 > vp update --recursive && cat package.json # should update all packages but won't change the package.json
-Running: yarn up --recursive
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0000: └ Completed

--- a/packages/global/snap-tests/command-why-npm10-with-workspace/snap.txt
+++ b/packages/global/snap-tests/command-why-npm10-with-workspace/snap.txt
@@ -4,7 +4,6 @@ added 6 packages in <variable>ms
 
 
 > vp why testnpm2 --filter app # should check why in specific workspace using --workspace
-Running: npm explain --workspace app testnpm2
 testnpm2@<semver>
 node_modules/testnpm2
   testnpm2@"1.0.0" from @vite-plus-test/utils@undefined
@@ -25,7 +24,6 @@ node_modules/testnpm2
   testnpm2@"1.0.0" from the root project
 
 > vp why test-vite-plus-package --filter app # should check why dev dependencies in app workspace
-Running: npm explain --workspace app test-vite-plus-package
 test-vite-plus-package@<semver> dev
 node_modules/test-vite-plus-package
   dev test-vite-plus-package@"1.0.0" from app@undefined
@@ -35,7 +33,6 @@ node_modules/test-vite-plus-package
       workspace packages/app from the root project
 
 > vp why testnpm2 --filter app --json # should support json output with workspace filter
-Running: npm explain --workspace app --json testnpm2
 [
   {
     "name": "testnpm2",

--- a/packages/global/snap-tests/command-why-npm10/snap.txt
+++ b/packages/global/snap-tests/command-why-npm10/snap.txt
@@ -4,25 +4,21 @@ added 3 packages in <variable>ms
 
 
 > vp why testnpm2 # should show why package is installed (uses npm explain)
-Running: npm explain testnpm2
 testnpm2@<semver>
 node_modules/testnpm2
   testnpm2@"1.0.1" from the root project
 
 > vp explain testnpm2 # should work with explain alias
-Running: npm explain testnpm2
 testnpm2@<semver>
 node_modules/testnpm2
   testnpm2@"1.0.1" from the root project
 
 > vp why test-vite-plus-package # should show why dev package is installed
-Running: npm explain test-vite-plus-package
 test-vite-plus-package@<semver> dev
 node_modules/test-vite-plus-package
   dev test-vite-plus-package@"1.0.0" from the root project
 
 > vp why testnpm2 --json # should support json output
-Running: npm explain --json testnpm2
 [
   {
     "name": "testnpm2",
@@ -49,7 +45,6 @@ Running: npm explain --json testnpm2
 ]
 
 > vp why testnpm2 test-vite-plus-package # should support multiple packages
-Running: npm explain testnpm2 test-vite-plus-package
 testnpm2@<semver>
 node_modules/testnpm2
   testnpm2@"1.0.1" from the root project
@@ -60,34 +55,29 @@ node_modules/test-vite-plus-package
 
 > vp why testnpm2 --long # should warn that --long not supported by npm
 Warning: --long not supported by npm
-Running: npm explain testnpm2
 testnpm2@<semver>
 node_modules/testnpm2
   testnpm2@"1.0.1" from the root project
 
 > vp why testnpm2 --parseable # should warn that --parseable not supported by npm
 Warning: --parseable not supported by npm
-Running: npm explain testnpm2
 testnpm2@<semver>
 node_modules/testnpm2
   testnpm2@"1.0.1" from the root project
 
 > vp why testnpm2 -P # should warn that --prod not supported by npm
 Warning: --prod/--dev not supported by npm
-Running: npm explain testnpm2
 testnpm2@<semver>
 node_modules/testnpm2
   testnpm2@"1.0.1" from the root project
 
 > vp why testnpm2 --find-by customFinder # should warn that --find-by not supported by npm
 Warning: --find-by not supported by npm
-Running: npm explain testnpm2
 testnpm2@<semver>
 node_modules/testnpm2
   testnpm2@"1.0.1" from the root project
 
 > vp why testnpm2 -- --omit=dev # should support pass through arguments
-Running: npm explain testnpm2 --omit=dev
 testnpm2@<semver>
 node_modules/testnpm2
   testnpm2@"1.0.1" from the root project

--- a/packages/global/snap-tests/command-why-pnpm10-with-workspace/snap.txt
+++ b/packages/global/snap-tests/command-why-pnpm10-with-workspace/snap.txt
@@ -11,7 +11,6 @@ Done in <variable>ms using pnpm v<semver>
 
 
 > vp why testnpm2 -w # should check why in workspace root
-Running: pnpm why --workspace-root testnpm2
 Legend: production dependency, optional only, dev only
 
 command-why-pnpm10-with-workspace@<semver> <cwd>
@@ -20,7 +19,6 @@ dependencies:
 testnpm2 <semver>
 
 > vp why testnpm2 --filter app # should check why in specific package
-Running: pnpm --filter app why testnpm2
 Legend: production dependency, optional only, dev only
 
 app <cwd>/packages/app
@@ -31,7 +29,6 @@ dependencies:
 testnpm2 <semver>
 
 > vp why test-vite-plus-package -D --filter app # should check why dev dependencies in app
-Running: pnpm --filter app why --dev test-vite-plus-package
 Legend: production dependency, optional only, dev only
 
 app <cwd>/packages/app
@@ -40,7 +37,6 @@ devDependencies:
 test-vite-plus-package <semver>
 
 > vp why testnpm2 --filter "*" # should check why in all packages
-Running: pnpm --filter * why testnpm2
 Legend: production dependency, optional only, dev only
 
 command-why-pnpm10-with-workspace@<semver> <cwd>
@@ -61,7 +57,6 @@ dependencies:
 testnpm2 <semver>
 
 > vp why testnpm2 -r # should check why recursively
-Running: pnpm why --recursive testnpm2
 Legend: production dependency, optional only, dev only
 
 command-why-pnpm10-with-workspace@<semver> <cwd>
@@ -82,7 +77,6 @@ dependencies:
 testnpm2 <semver>
 
 > vp why testnpm2 --filter app --json # should support json output with filter
-Running: pnpm --filter app why --json testnpm2
 [
   {
     "name": "app",
@@ -113,7 +107,6 @@ Running: pnpm --filter app why --json testnpm2
 ]
 
 > vp why test-vite-plus-install --filter app --depth 1 # should support depth limiting with filter
-Running: pnpm --filter app why --depth 1 test-vite-plus-install
 Legend: production dependency, optional only, dev only
 
 app <cwd>/packages/app

--- a/packages/global/snap-tests/command-why-pnpm10/snap.txt
+++ b/packages/global/snap-tests/command-why-pnpm10/snap.txt
@@ -41,7 +41,6 @@ Done in <variable>ms using pnpm v<semver>
 
 
 > vp why testnpm2 # should show why package is installed
-Running: pnpm why testnpm2
 Legend: production dependency, optional only, dev only
 
 command-why-pnpm10@<semver> <cwd>
@@ -50,7 +49,6 @@ dependencies:
 testnpm2 <semver>
 
 > vp explain testnpm2 # should work with explain alias
-Running: pnpm why testnpm2
 Legend: production dependency, optional only, dev only
 
 command-why-pnpm10@<semver> <cwd>
@@ -59,7 +57,6 @@ dependencies:
 testnpm2 <semver>
 
 > vp why test-vite-plus-package # should show why dev package is installed
-Running: pnpm why test-vite-plus-package
 Legend: production dependency, optional only, dev only
 
 command-why-pnpm10@<semver> <cwd>
@@ -68,7 +65,6 @@ devDependencies:
 test-vite-plus-package <semver>
 
 > vp why testnpm2 test-vite-plus-package # should support multiple packages
-Running: pnpm why testnpm2 test-vite-plus-package
 Legend: production dependency, optional only, dev only
 
 command-why-pnpm10@<semver> <cwd>
@@ -80,7 +76,6 @@ devDependencies:
 test-vite-plus-package <semver>
 
 > vp why testnpm2 --json # should support json output
-Running: pnpm why --json testnpm2
 [
   {
     "name": "command-why-pnpm10",
@@ -99,7 +94,6 @@ Running: pnpm why --json testnpm2
 ]
 
 > vp why testnpm2 --long # should support long output
-Running: pnpm why --long testnpm2
 Legend: production dependency, optional only, dev only
 
 command-why-pnpm10@<semver> <cwd>
@@ -109,12 +103,10 @@ testnpm2 <semver>
   <cwd>/node_modules/.pnpm/testnpm2@<semver>/node_modules/testnpm2
 
 > vp why testnpm2 --parseable # should support parseable output
-Running: pnpm why --parseable testnpm2
 <cwd>
 <cwd>/node_modules/.pnpm/testnpm2@<semver>/node_modules/testnpm2
 
 > vp why testnpm2 -P # should support prod dependencies only
-Running: pnpm why --prod testnpm2
 Legend: production dependency, optional only, dev only
 
 command-why-pnpm10@<semver> <cwd>
@@ -123,7 +115,6 @@ dependencies:
 testnpm2 <semver>
 
 > vp why test-vite-plus-package -D # should support dev dependencies only
-Running: pnpm why --dev test-vite-plus-package
 Legend: production dependency, optional only, dev only
 
 command-why-pnpm10@<semver> <cwd>
@@ -132,7 +123,6 @@ devDependencies:
 test-vite-plus-package <semver>
 
 > vp why testnpm2 --depth 1 # should support depth limiting
-Running: pnpm why --depth 1 testnpm2
 Legend: production dependency, optional only, dev only
 
 command-why-pnpm10@<semver> <cwd>
@@ -141,14 +131,10 @@ dependencies:
 testnpm2 <semver>
 
 > vp why test-vite-plus-package-optional --no-optional # should exclude optional dependencies
-Running: pnpm why --no-optional test-vite-plus-package-optional
-
 [1]> vp why testnpm2 --find-by customFinder # should support find-by option (pnpm-specific)
-Running: pnpm why --find-by customFinder testnpm2
  ERR_PNPM_FINDER_NOT_FOUND  No finder with name customFinder is found
 
 > vp why testnpm2 -- --reporter=silent # should support pass through arguments
-Running: pnpm why testnpm2 --reporter=silent
 Legend: production dependency, optional only, dev only
 
 command-why-pnpm10@<semver> <cwd>

--- a/packages/global/snap-tests/command-why-yarn4/snap.txt
+++ b/packages/global/snap-tests/command-why-yarn4/snap.txt
@@ -12,62 +12,51 @@
 
 
 > vp why testnpm2 # should show why package is installed
-Running: yarn why testnpm2 --peers
 └─ command-why-yarn4@workspace:.
    └─ testnpm2@npm:1.0.1 (via npm:1.0.1)
 
 > vp explain testnpm2 # should work with explain alias
-Running: yarn why testnpm2 --peers
 └─ command-why-yarn4@workspace:.
    └─ testnpm2@npm:1.0.1 (via npm:1.0.1)
 
 > vp why test-vite-plus-package # should show why dev package is installed
-Running: yarn why test-vite-plus-package --peers
 └─ command-why-yarn4@workspace:.
    └─ test-vite-plus-package@npm:1.0.0 (via npm:1.0.0)
 
 > vp why testnpm2 -r # should support recursive in yarn@2+
-Running: yarn why testnpm2 --recursive --peers
 └─ command-why-yarn4@workspace:.
    └─ testnpm2@npm:1.0.1 (via npm:1.0.1)
 
 > vp why testnpm2 test-vite-plus-package # should warn about multiple packages and use first
 Warning: yarn only supports checking one package at a time, using first package
-Running: yarn why testnpm2 --peers
 └─ command-why-yarn4@workspace:.
    └─ testnpm2@npm:1.0.1 (via npm:1.0.1)
 
 > vp why testnpm2 --json # should warn that --json not supported by yarn
 Warning: --json not supported by yarn
-Running: yarn why testnpm2 --peers
 └─ command-why-yarn4@workspace:.
    └─ testnpm2@npm:1.0.1 (via npm:1.0.1)
 
 > vp why testnpm2 --long # should warn that --long not supported by yarn
 Warning: --long not supported by yarn
-Running: yarn why testnpm2 --peers
 └─ command-why-yarn4@workspace:.
    └─ testnpm2@npm:1.0.1 (via npm:1.0.1)
 
 > vp why testnpm2 --parseable # should warn that --parseable not supported by yarn
 Warning: --parseable not supported by yarn
-Running: yarn why testnpm2 --peers
 └─ command-why-yarn4@workspace:.
    └─ testnpm2@npm:1.0.1 (via npm:1.0.1)
 
 > vp why testnpm2 -P # should warn that --prod not supported by yarn
 Warning: --prod/--dev not supported by yarn
-Running: yarn why testnpm2 --peers
 └─ command-why-yarn4@workspace:.
    └─ testnpm2@npm:1.0.1 (via npm:1.0.1)
 
 > vp why testnpm2 --find-by customFinder # should warn that --find-by not supported by yarn
 Warning: --find-by not supported by yarn
-Running: yarn why testnpm2 --peers
 └─ command-why-yarn4@workspace:.
    └─ testnpm2@npm:1.0.1 (via npm:1.0.1)
 
 > vp why testnpm2 --exclude-peers # should exclude peers by removing --peers flag
-Running: yarn why testnpm2
 └─ command-why-yarn4@workspace:.
    └─ testnpm2@npm:1.0.1 (via npm:1.0.1)


### PR DESCRIPTION
### TL;DR

Moved `run_command` function from `vite_install` to a dedicated `vite_command` crate.

### What changed?

- Removed the `run_command` function from `vite_install/src/package_manager.rs`
- Added a dependency on the `vite_command` crate in `vite_install`
- Updated all command modules to import `run_command` from `vite_command` instead
- Removed the `nix` dependency as it's no longer needed in `vite_install`
- Removed the associated tests for `run_command` from `vite_install`

### How to test?

- Run the test suite to ensure all package manager commands still work correctly
- Verify that commands like `add`, `remove`, `update`, etc. still function properly
- Check that the command execution behavior remains consistent across platforms

### Why make this change?

This refactoring improves code organization by moving the command execution functionality to a dedicated crate. This makes the code more modular and allows the command execution logic to be reused across different parts of the project without duplicating code. The `run_command` function is a general utility that deserves its own crate rather than being embedded in the package manager implementation.