### PR TITLE
fix: update client types path in core package.json

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,7 @@
   "exports": {
     ".": "./dist/vite/node/index.js",
     "./client": {
-      "types": "./client.d.ts"
+      "types": "./dist/vite/client.d.ts"
     },
     "./dist/client/*": "./dist/vite/client/*",
     "./internal": "./dist/vite/node/internal.js",


### PR DESCRIPTION
```bash
> tsc && vite build

error TS2688: Cannot find type definition file for 'vite/client'.
  The file is in the program because:
    Entry point of type library 'vite/client' specified in compilerOptions

  tsconfig.json:7:15
    7     "types": ["vite/client"],
                    ~~~~~~~~~~~~~
    File is entry point of type library specified here.


Found 1 error.
```