### PR TITLE
test: ignore unstable snap-test output

### DIFF
--- a/packages/tools/src/__tests__/__snapshots__/utils.spec.ts.snap
+++ b/packages/tools/src/__tests__/__snapshots__/utils.spec.ts.snap
@@ -20,6 +20,12 @@ added 3 packages in <variable>ms
 Done in <variable>ms"
 `;
 
+exports[`replaceUnstableOutput() > replace ignore npm notice access token expired or revoked warning log 1`] = `
+"line 1
+line 2
+line 3"
+`;
+
 exports[`replaceUnstableOutput() > replace ignore npm registry domain 1`] = `
 "https://registry.<domain>/testnpm2
 https://registry.<domain>/debug

--- a/packages/tools/src/__tests__/utils.spec.ts
+++ b/packages/tools/src/__tests__/utils.spec.ts
@@ -170,6 +170,18 @@ npm notice integrity: sha512-qugLL42iCblSD[...]Gfk6HJodp2ZOQ==
     `;
     expect(replaceUnstableOutput(output.trim())).toMatchSnapshot();
   });
+
+  test('replace ignore npm notice access token expired or revoked warning log', () => {
+    const output = `
+line 1
+npm notice Access token expired or revoked. Please try logging in again.
+npm notice Access token expired or revoked. Please try logging in again.
+line 2
+npm notice Access token expired or revoked. Please try logging in again.
+line 3
+    `;
+    expect(replaceUnstableOutput(output.trim())).toMatchSnapshot();
+  });
 });
 
 describe('isPassThroughEnv()', () => {

--- a/packages/tools/src/utils.ts
+++ b/packages/tools/src/utils.ts
@@ -95,6 +95,8 @@ export function replaceUnstableOutput(output: string, cwd?: string) {
       .replaceAll(`Checking formatting...\n`, 'Checking formatting...')
       // remove warning <name>@<semver>: No license field
       .replaceAll(/warning .+?: No license field\n/g, '')
+      // remove "npm notice Access token expired or revoked..."
+      .replaceAll(/npm notice Access token expired or revoked.+?\n/g, '')
   );
 }
 


### PR DESCRIPTION
### TL;DR

Added support for ignoring "npm notice Access token expired or revoked" warnings in test output.

### What changed?

- Added a new regex pattern in `replaceUnstableOutput()` function to filter out "npm notice Access token expired or revoked" warning messages
- Added a corresponding test case to verify the new functionality
- Updated test snapshots to include the new test case

### How to test?

1. Run the test suite to verify that the new test case passes
2. Verify that when running commands that might produce the "npm notice Access token expired or revoked" warning, these messages are properly filtered out from the output

### Why make this change?

These npm access token warnings are non-deterministic and can cause test failures when they appear in output that's being compared against snapshots. By filtering them out, we improve test stability and prevent false negatives in test runs.