### PR TITLE
fix(cli): export additional vitest values from cli package

### DIFF
--- a/packages/cli/src/__tests__/index.spec.ts
+++ b/packages/cli/src/__tests__/index.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@voidzero-dev/vite-plus-test';
+
+import {
+  configDefaults,
+  coverageConfigDefaults,
+  defaultExclude,
+  defaultInclude,
+  defaultBrowserPort,
+  defineConfig,
+  defineProject,
+} from '../index';
+
+test('should keep vitest exports stable', () => {
+  expect(defineConfig).toBeTypeOf('function');
+  expect(defineProject).toBeTypeOf('function');
+  expect(configDefaults).toBeDefined();
+  expect(coverageConfigDefaults).toBeDefined();
+  expect(defaultExclude).toBeDefined();
+  expect(defaultInclude).toBeDefined();
+  expect(defaultBrowserPort).toBeDefined();
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,3 +17,12 @@ declare module '@voidzero-dev/vite-plus-core' {
 export * from '@voidzero-dev/vite-plus-core';
 
 export { defineConfig };
+// TODO: how to keep sync with vitest exports?
+export {
+  configDefaults,
+  coverageConfigDefaults,
+  defaultExclude,
+  defaultInclude,
+  defaultBrowserPort,
+  defineProject,
+} from '@voidzero-dev/vite-plus-test/config';


### PR DESCRIPTION
### TL;DR

Added missing Vitest exports to the CLI package to ensure API stability.

### What changed?

- Added exports for `configDefaults`, `coverageConfigDefaults`, `defaultExclude`, `defaultInclude`, `defaultBrowserPort`, and `defineProject` from `@voidzero-dev/vite-plus-test/config` in the CLI package
- Added a test file to verify that these exports are properly defined and accessible
- Added a TODO comment to track the need to keep exports in sync with Vitest

### How to test?

Run the newly added test to verify that all exports are properly defined:
```bash
pnpm test packages/cli/src/__tests__/index.spec.ts
```

### Why make this change?

This change ensures API stability by exposing all necessary Vitest exports through the CLI package. Users who import these values from the CLI package will now have access to the complete set of configuration utilities, making the API more consistent and comprehensive.