### PR TITLE
chore(cli): export package.json

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -63,6 +63,7 @@
     "./binding": {
       "import": "./binding/index.js",
       "types": "./binding/index.d.ts"
-    }
+    },
+    "./package.json": "./package.json"
   }
 }


### PR DESCRIPTION
Allow the global CLI to easily determine the current version of the vite-plus CLI.