### PR TITLE
fix: update build-types filter from rolldown-vite to vite

### DIFF
--- a/.github/actions/build-upstream/action.yml
+++ b/.github/actions/build-upstream/action.yml
@@ -20,7 +20,7 @@ runs:
           pnpm --filter rolldown build-binding:release --target ${{ inputs.target }} --use-napi-cross
         fi
         pnpm --filter rolldown build-node
-        pnpm --filter rolldown-vite build-types
+        pnpm --filter vite build-types
         pnpm --filter=@voidzero-dev/vite-plus-core build
         pnpm --filter=@voidzero-dev/vite-plus-test build
         CC=clang pnpm --filter=@voidzero-dev/vite-plus build --target ${{ inputs.target }} --use-napi-cross
@@ -36,7 +36,7 @@ runs:
           pnpm --filter rolldown build-binding:release --target ${{ inputs.target }} --use-napi-cross
         fi
         pnpm --filter rolldown build-node
-        pnpm --filter rolldown-vite build-types
+        pnpm --filter vite build-types
         pnpm --filter=@voidzero-dev/vite-plus-core build
         pnpm --filter=@voidzero-dev/vite-plus-test build
         TARGET_CFLAGS="-D_BSD_SOURCE" pnpm --filter=@voidzero-dev/vite-plus build --target ${{ inputs.target }} --use-napi-cross
@@ -52,7 +52,7 @@ runs:
           pnpm --filter rolldown build-binding:release --target ${{ inputs.target }}
         fi
         pnpm --filter rolldown build-node
-        pnpm --filter rolldown-vite build-types
+        pnpm --filter vite build-types
         pnpm --filter=@voidzero-dev/vite-plus-core build
         pnpm --filter=@voidzero-dev/vite-plus-test build
         pnpm --filter=@voidzero-dev/vite-plus build --target ${{ inputs.target }}


### PR DESCRIPTION
### TL;DR

Updated build scripts to use the correct package filter for building types and added a postbuild script to verify output files.

### What changed?

- Changed the package filter in GitHub action from `rolldown-vite` to `vite` for the `build-types` command in three different build configurations
- Added a `postbuild` script to the core package that runs after build completion to list files in the `dist/vite/node` directory

### How to test?

1. Run the build process using the GitHub action to verify that types are correctly built using the `vite` filter
2. Check the build logs to confirm that the `postbuild` script executes and displays the contents of the `dist/vite/node` directory

### Why make this change?

The package filter was incorrectly referencing `rolldown-vite` instead of `vite`, which could cause type generation to fail or target the wrong package. The added postbuild script helps with debugging by providing visibility into the build output files, making it easier to verify that the correct files are being generated.