### PR TITLE
feat(global): print versions includes global and local CLI

### DIFF
--- a/packages/global/snap-tests/cli-helper-message/snap.txt
+++ b/packages/global/snap-tests/cli-helper-message/snap.txt
@@ -31,7 +31,9 @@ Options:
   -V, --version  Print version
 
 > vp -V # show version
-vite-plus-global-cli <semver>
+Vite+ Version:
+- Local: Not found
+- Global: v<semver>
 
 > vp install -h # show install help message
 Install all dependencies, or add packages if package names are provided

--- a/packages/global/src/index.ts
+++ b/packages/global/src/index.ts
@@ -11,6 +11,8 @@ if (command === 'gen' || command === 'g' || command === 'generate' || command ==
   import('./migration/bin.js');
 } else if (LOCAL_CLI_COMMANDS.includes(command)) {
   import('./local/bin.js');
+} else if (command === '--version' || command === '-V') {
+  import('./version.js');
 } else {
   // Delegate to rust commands
   import('./global/bin.js');

--- a/packages/global/src/version.ts
+++ b/packages/global/src/version.ts
@@ -1,0 +1,39 @@
+import { createRequire } from 'node:module';
+
+import { detectPackageMetadata, VITE_PLUS_NAME } from './utils/index.js';
+
+const require = createRequire(import.meta.url);
+
+interface GlobalPackageJson {
+  version: string;
+}
+
+/**
+ * Get the global CLI version from package.json
+ */
+export function getGlobalVersion(): string {
+  const pkg: GlobalPackageJson = require('../package.json');
+  return pkg.version;
+}
+
+/**
+ * Get the local CLI version if installed in the given directory
+ */
+export function getLocalVersion(cwd: string): string | null {
+  const metadata = detectPackageMetadata(cwd, VITE_PLUS_NAME);
+  return metadata?.version ?? null;
+}
+
+/**
+ * Print version information for both local and global CLI
+ */
+export function printVersion(cwd: string): void {
+  const globalVersion = getGlobalVersion();
+  const localVersion = getLocalVersion(cwd);
+
+  console.log('Vite+ Version:');
+  console.log(`- Local: ${localVersion ? `v${localVersion}` : 'Not found'}`);
+  console.log(`- Global: v${globalVersion}`);
+}
+
+printVersion(process.cwd());


### PR DESCRIPTION
Local CLI found:

```bash
vite -V
Vite+ Version:
- Local: v0.0.0-cbf4c7d2a31eb554e9814394cec2c5968a87a187
- Global: v0.0.0
```

Local CLI not found:

```bash
vite -V
Vite+ Version:
- Local: Not found
- Global: v0.0.0
```