### PR TITLE
feat(cli): expose tsdown types and entry

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -66,6 +66,10 @@
       "types": "./binding/index.d.ts"
     },
     "./package.json": "./package.json",
+    "./lib": {
+      "import": "./dist/lib.js",
+      "types": "./dist/lib.d.ts"
+    },
     "./test": {
       "import": {
         "types": "./dist/test/index.d.ts",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,3 +1,4 @@
+import type { defineConfig as defineLibConfig } from '@voidzero-dev/vite-plus-core/lib';
 import { defineConfig } from '@voidzero-dev/vite-plus-test/config';
 
 import type { OxfmtConfig } from './oxfmt-config';
@@ -11,6 +12,8 @@ declare module '@voidzero-dev/vite-plus-core' {
     lint?: OxlintConfig;
 
     fmt?: OxfmtConfig;
+
+    lib?: Parameters<typeof defineLibConfig>[0];
   }
 }
 

--- a/packages/cli/src/lib.ts
+++ b/packages/cli/src/lib.ts
@@ -1,0 +1,2 @@
+export { defineConfig, build, buildSingle, globalLogger } from '@voidzero-dev/vite-plus-core/lib';
+export type * from '@voidzero-dev/vite-plus-core/lib';

--- a/packages/core/build-support/rewrite-imports.ts
+++ b/packages/core/build-support/rewrite-imports.ts
@@ -4,18 +4,21 @@ import pkgJson from '../package.json' with { type: 'json' };
 
 export const RewriteImportsPlugin: Plugin = {
   name: 'rewrite-imports-for-vite-plus',
-  resolveId(id: string) {
-    if (id.startsWith('vite/')) {
-      return { id: id.replace(/^vite\//, `${pkgJson.name}/`), external: true };
-    }
-    if (id === 'rolldown') {
-      return { id: `${pkgJson.name}/rolldown`, external: true };
-    }
-    if (id.startsWith('rolldown/')) {
-      return {
-        id: id.replace(/^rolldown\//, `${pkgJson.name}/rolldown/`),
-        external: true,
-      };
-    }
+  resolveId: {
+    order: 'pre',
+    handler(id: string) {
+      if (id.startsWith('vite/')) {
+        return { id: id.replace(/^vite\//, `${pkgJson.name}/`), external: true };
+      }
+      if (id === 'rolldown') {
+        return { id: `${pkgJson.name}/rolldown`, external: true };
+      }
+      if (id.startsWith('rolldown/')) {
+        return {
+          id: id.replace(/^rolldown\//, `${pkgJson.name}/rolldown/`),
+          external: true,
+        };
+      }
+    },
   },
 };

--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -3,6 +3,7 @@ import { join, parse, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { build, type BuildOptions } from 'rolldown';
+import { dts } from 'rolldown-plugin-dts';
 import { glob } from 'tinyglobby';
 
 import { RewriteImportsPlugin } from './build-support/rewrite-imports';
@@ -46,7 +47,8 @@ async function buildVite() {
               external === 'tinyglobby' ||
               external === 'fdir' ||
               external === 'rolldown')) ||
-          (external instanceof RegExp && external.test('rolldown/'))
+          external === 'yaml' ||
+          (external instanceof RegExp && (external.test('rolldown/') || external.test('vite/')))
         );
       });
     }
@@ -71,6 +73,8 @@ async function buildVite() {
 
     if (Array.isArray(config.plugins)) {
       config.plugins = [
+        // Add RewriteImportsPlugin to handle vite/rolldown import rewrites
+        RewriteImportsPlugin,
         {
           name: 'rewrite-static-paths',
           transform(_, id, meta) {
@@ -112,8 +116,6 @@ async function buildVite() {
             }
           },
         },
-        // Add RewriteImportsPlugin to handle vite/rolldown import rewrites
-        RewriteImportsPlugin,
         ...config.plugins.filter((plugin) => {
           return !(
             typeof plugin === 'object' &&
@@ -243,7 +245,10 @@ async function bundleTsdown() {
 
   // Re-build tsdown cli
   await build({
-    input: join(tsdownSourceDir, 'dist/run.mjs'),
+    input: {
+      run: join(tsdownSourceDir, 'dist/run.mjs'),
+      index: join(tsdownSourceDir, 'dist/index.mjs'),
+    },
     output: {
       format: 'esm',
       cleanDir: true,
@@ -252,6 +257,23 @@ async function bundleTsdown() {
     platform: 'node',
     external: (id: string) => tsdownExternal.some((e) => id.startsWith(e)),
     plugins: [RewriteImportsPlugin],
+  });
+
+  await build({
+    input: {
+      'index-types': join(tsdownSourceDir, 'dist/index.d.mts'),
+    },
+    output: {
+      format: 'esm',
+      dir: join(projectDir, 'dist/tsdown'),
+    },
+    plugins: [
+      RewriteImportsPlugin,
+      dts({
+        oxc: true,
+        dtsInput: true,
+      }),
+    ],
   });
 }
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,6 +48,10 @@
       "default": "./dist/pluginutils/index.js",
       "types": "./dist/pluginutils/index.d.ts"
     },
+    "./lib": {
+      "default": "./dist/tsdown/index.mjs",
+      "types": "./dist/tsdown/index-types.d.ts"
+    },
     "./types/*": {
       "types": "./dist/vite/types/*"
     },
@@ -160,9 +164,12 @@
     "@oxc-node/cli": "catalog:",
     "@oxc-node/core": "catalog:",
     "es-module-lexer": "^1.7.0",
+    "hookable": "^6.0.1",
     "magic-string": "^0.30.21",
+    "pkg-types": "^2.3.0",
     "picocolors": "^1.1.1",
     "rolldown": "workspace:*",
+    "rolldown-plugin-dts": "catalog:",
     "vite": "workspace:*",
     "rollup": "^4.18.0",
     "rollup-plugin-license": "^3.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -438,15 +438,24 @@ importers:
       es-module-lexer:
         specifier: ^1.7.0
         version: 1.7.0
+      hookable:
+        specifier: ^6.0.1
+        version: 6.0.1
       magic-string:
         specifier: ^0.30.21
         version: 0.30.21
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
+      pkg-types:
+        specifier: ^2.3.0
+        version: 2.3.0
       rolldown:
         specifier: workspace:rolldown@*
         version: link:../../rolldown/packages/rolldown
+      rolldown-plugin-dts:
+        specifier: 'catalog:'
+        version: 0.18.3(oxc-resolver@11.14.0)(rolldown@rolldown+packages+rolldown)(typescript@5.9.3)
       rollup:
         specifier: ^4.18.0
         version: 4.53.3
@@ -5044,6 +5053,9 @@ packages:
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
+  confbox@0.2.2:
+    resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
+
   connect@3.7.0:
     resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
     engines: {node: '>= 0.10.0'}
@@ -5560,6 +5572,9 @@ packages:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
 
+  exsolve@1.0.8:
+    resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
+
   extract-zip@2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
     engines: {node: '>= 10.17.0'}
@@ -5826,6 +5841,9 @@ packages:
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
+
+  hookable@6.0.1:
+    resolution: {integrity: sha512-uKGyY8BuzN/a5gvzvA+3FVWo0+wUjgtfSdnmjtrOVwQCZPHpHDH2WRO3VZSOeluYrHoDCiXFffZXs8Dj1ULWtw==}
 
   host-validation-middleware@0.1.2:
     resolution: {integrity: sha512-pg/prhP/e/TqIc3tGj8Nkza4o8j4GE212FNJJN+vhebYnHIPfLZbTmRp8yiT9vEtPeIWCz6sD41EpaO9ys5Tfg==}
@@ -6758,6 +6776,9 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  pkg-types@2.3.0:
+    resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
   playwright-chromium@1.57.0:
     resolution: {integrity: sha512-GCVVTbmIDrZuBxWYoQ70rehRXMb3Q7ccENe63a+rGTWwypeVAgh/DD5o5QQ898oer5pdIv3vGINUlEkHtOZQEw==}
@@ -11711,6 +11732,8 @@ snapshots:
 
   confbox@0.1.8: {}
 
+  confbox@0.2.2: {}
+
   connect@3.7.0:
     dependencies:
       debug: 2.6.9
@@ -12282,6 +12305,8 @@ snapshots:
 
   expect-type@1.2.2: {}
 
+  exsolve@1.0.8: {}
+
   extract-zip@2.0.1:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
@@ -12577,6 +12602,8 @@ snapshots:
   he@1.2.0: {}
 
   hookable@5.5.3: {}
+
+  hookable@6.0.1: {}
 
   host-validation-middleware@0.1.2: {}
 
@@ -13530,6 +13557,12 @@ snapshots:
     dependencies:
       confbox: 0.1.8
       mlly: 1.8.0
+      pathe: 2.0.3
+
+  pkg-types@2.3.0:
+    dependencies:
+      confbox: 0.2.2
+      exsolve: 1.0.8
       pathe: 2.0.3
 
   playwright-chromium@1.57.0:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Expose `lib` API and tsdown types via new exports; update build to bundle tsdown entries with generated d.ts and refine import rewriting/external handling.
> 
> - **CLI**:
>   - Add `exports.{ "./lib": { import: "./dist/lib.js", types: "./dist/lib.d.ts" } }` in `packages/cli/package.json`.
>   - Extend `UserConfig` to accept `lib` options and add `src/lib.ts` re-exporting core `lib` APIs.
> - **Core**:
>   - `RewriteImportsPlugin`: switch to `resolveId` with `{ order: 'pre', handler }`.
>   - Build system (`build.ts`):
>     - Adjust externals filtering (include `yaml` and `vite/` patterns) and place `RewriteImportsPlugin` before transforms.
>     - Bundle tsdown with multiple inputs (`run`, `index`) and generate type declarations via `rolldown-plugin-dts` for `index-types`.
>   - `package.json`: add `exports["./lib"]` pointing to `dist/tsdown/index.mjs` with `types`.
> - **Dependencies**:
>   - Add `rolldown-plugin-dts`, `hookable`, and `pkg-types`; lockfile updates accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20c2492a38818e08c5b916f489353f170736bf90. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->