### PR TITLE
fix(cli): fix tsgolint path resolution for yarn install

### DIFF
--- a/packages/cli/src/resolve-lint.ts
+++ b/packages/cli/src/resolve-lint.ts
@@ -11,6 +11,7 @@
  * provides ESLint-compatible linting with significantly better performance.
  */
 
+import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { relative } from 'node:path/win32';
 import { fileURLToPath } from 'node:url';
@@ -33,22 +34,28 @@ export async function lint(): Promise<{
 }> {
   // Resolve the oxlint binary directly (it's a native executable)
   const binPath = resolve('oxlint/bin/oxlint');
-  const oxlintTsgolintPath = join(
-    dirname(fileURLToPath(import.meta.url)),
-    '..',
-    'node_modules',
-    '.bin',
-    `tsgolint${process.platform === 'win32' ? '.cmd' : ''}`,
-  );
+  let oxlintTsgolintPath = resolve('oxlint-tsgolint/bin/tsgolint');
+  if (process.platform === 'win32') {
+    // If on Windows, resolve the tsgolint binary from the local node_modules
+    oxlintTsgolintPath = join(
+      dirname(fileURLToPath(import.meta.url)),
+      '..',
+      'node_modules',
+      '.bin',
+      'tsgolint.cmd',
+    );
+    if (!existsSync(oxlintTsgolintPath)) {
+      // Fallback to the cwd node_modules
+      oxlintTsgolintPath = join(process.cwd(), 'node_modules', '.bin', 'tsgolint.cmd');
+    }
+    oxlintTsgolintPath = `.\\${relative(process.cwd(), oxlintTsgolintPath)}`;
+  }
   const result = {
     binPath,
     // TODO: provide envs inference API
     envs: {
       ...DEFAULT_ENVS,
-      OXLINT_TSGOLINT_PATH:
-        process.platform !== 'win32'
-          ? oxlintTsgolintPath
-          : `.\\${relative(process.cwd(), oxlintTsgolintPath)}`,
+      OXLINT_TSGOLINT_PATH: oxlintTsgolintPath,
     },
   };
   return result;


### PR DESCRIPTION
### What changed?

- Added `existsSync` import from `node:fs` to check if files exist
- Modified the tsgolint binary resolution logic to:
  - First try to resolve from `oxlint-tsgolint/bin/tsgolint` for non-Windows platforms
  - For Windows, attempt to find the binary in the local `node_modules/.bin` directory
  - Add a fallback to the current working directory's `node_modules/.bin` if not found
- Simplified the environment variable assignment by moving the platform-specific logic to the path resolution

```bash
yarn lint

Failed to find tsgolint executable: OXLINT_TSGOLINT_PATH points to 
'~/rollipop/node_modules/@voidzero-dev/vite-plus/node_modules/.bin/tsgolint' 
which does not exist
```
