### PR TITLE
feat(cli): expose vite lib config

### DIFF
--- a/packages/cli/binding/src/cli.rs
+++ b/packages/cli/binding/src/cli.rs
@@ -413,6 +413,13 @@ pub async fn main<
             let workspace = Workspace::partial_load(cwd)?;
             let lib_fn =
                 options.map(|o| o.lib).expect("lib command requires CliOptions to be provided");
+            let lib_config_path = workspace.cache_path().join("vite-lib.config.js");
+            if write_vite_lib_config(&workspace.root_dir(), &lib_config_path).await? {
+                args.extend_from_slice(&[
+                    "--config".to_string(),
+                    lib_config_path.as_path().to_string_lossy().into_owned(),
+                ]);
+            }
             let summary = lib(lib_fn, &workspace, args).await?;
             workspace.unload().await?;
             summary
@@ -552,6 +559,42 @@ async fn read_vite_config_from_workspace_root<
         return Ok(Some(vite_config));
     }
     Ok(None)
+}
+
+async fn write_vite_lib_config(
+    workspace_root: &AbsolutePathBuf,
+    lib_config_path: &AbsolutePathBuf,
+) -> Result<bool, Error> {
+    let relative_vite_config_path =
+        lib_config_path.strip_prefix(workspace_root).map_err(|e| Error::InvalidRelativePath {
+            path: e.stripped_path.into(),
+            reason: e.invalid_path_data_error.into(),
+        })?;
+    if let Some(relative_vite_config_path) = relative_vite_config_path {
+        let relative_prefix = relative_vite_config_path
+            .as_path()
+            .components()
+            .skip(1)
+            .map(|_| "..".to_string())
+            .collect::<Vec<_>>()
+            .join("/");
+        write(
+            &lib_config_path,
+            format!(
+                r#"let config
+try {{
+  const viteConfig = await import('{relative_prefix}/vite.config.ts')
+  config = viteConfig.default.lib
+}} catch {{
+}}
+export default config
+"#
+            ),
+        )
+        .await?;
+        return Ok(true);
+    }
+    Ok(false)
 }
 
 #[cfg(test)]

--- a/packages/cli/snap-tests/command-lib/snap.txt
+++ b/packages/cli/snap-tests/command-lib/snap.txt
@@ -53,6 +53,7 @@ Options:
 
 > vite lib src/index.ts # should build the library
 ℹ tsdown v<semver> powered by rolldown v<semver>
+ℹ Using tsdown config: <cwd>/node_modules/.vite/task-cache/vite-lib.config.js
 ℹ entry: src/index.ts
 ℹ Build start
 ℹ dist/index.mjs  <variable> kB │ gzip: <variable> kB
@@ -66,6 +67,7 @@ index.mjs
 > vite lib src/index.ts # should hit cache
 ✓ cache hit, replaying
 ℹ tsdown v<semver> powered by rolldown v<semver>
+ℹ Using tsdown config: <cwd>/node_modules/.vite/task-cache/vite-lib.config.js
 ℹ entry: src/index.ts
 ℹ Build start
 ℹ dist/index.mjs  <variable> kB │ gzip: <variable> kB

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -15,27 +15,8 @@ import { fmt } from './resolve-fmt.js';
 import { lib } from './resolve-lib.js';
 import { lint } from './resolve-lint.js';
 import { test } from './resolve-test.js';
+import { resolveUniversalViteConfig } from './resolve-vite-config.js';
 import { vite } from './resolve-vite.js';
-
-async function resolveUniversalViteConfig(err: null | Error, viteConfigCwd: string) {
-  if (err) {
-    throw err;
-  }
-  try {
-    const { resolveConfig } = await import('./index.js');
-    const config = await resolveConfig({ root: viteConfigCwd }, 'build');
-
-    return Promise.resolve(
-      JSON.stringify({
-        lint: config.lint,
-        fmt: config.fmt,
-      }),
-    );
-  } catch (err) {
-    console.error('[vite+] resolve universal vite config error:', err);
-    throw err;
-  }
-}
 
 // Initialize the CLI with tool resolvers
 // These functions will be called from Rust when needed

--- a/packages/cli/src/resolve-vite-config.ts
+++ b/packages/cli/src/resolve-vite-config.ts
@@ -1,0 +1,19 @@
+export async function resolveUniversalViteConfig(err: null | Error, viteConfigCwd: string) {
+  if (err) {
+    throw err;
+  }
+  try {
+    const { resolveConfig } = await import('./index.js');
+    const config = await resolveConfig({ root: viteConfigCwd }, 'build');
+
+    return Promise.resolve(
+      JSON.stringify({
+        lint: config.lint,
+        fmt: config.fmt,
+      }),
+    );
+  } catch (err) {
+    console.error('[vite+] resolve universal vite config error:', err);
+    throw err;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Expose Vite lib config to `tsdown` during `vite lib`**
> 
> - `Lib` command writes `node_modules/.vite/task-cache/vite-lib.config.js` via `write_vite_lib_config`, which imports `vite.config.ts` and exports `default.lib`; the file is then passed to tsdown via `--config`.
> - Updated snapshots to reflect "Using tsdown config" output path.
> - Extracted `resolveUniversalViteConfig` from `bin.ts` into `src/resolve-vite-config.ts` and import it in `bin.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 579e326f79bf2f29f0ca9be745a6c3d6fa18dfe2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->