### PR TITLE
fix(cli): use correct directory for vite-lib config in monorepos

### DIFF
--- a/packages/cli/binding/src/cli.rs
+++ b/packages/cli/binding/src/cli.rs
@@ -410,11 +410,11 @@ pub async fn main<
             summary
         }
         Commands::Lib { args } => {
-            let workspace = Workspace::partial_load(cwd)?;
+            let workspace = Workspace::partial_load(cwd.clone())?;
             let lib_fn =
                 options.map(|o| o.lib).expect("lib command requires CliOptions to be provided");
             let lib_config_path = workspace.cache_path().join("vite-lib.config.js");
-            if write_vite_lib_config(&workspace.root_dir(), &lib_config_path).await? {
+            if write_vite_lib_config(&cwd, &lib_config_path).await? {
                 args.extend_from_slice(&[
                     "--config".to_string(),
                     lib_config_path.as_path().to_string_lossy().into_owned(),

--- a/packages/cli/snap-tests/command-lib-monorepo/package.json
+++ b/packages/cli/snap-tests/command-lib-monorepo/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "command-lib-monorepo",
+  "version": "1.0.0",
+  "type": "module",
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/packages/cli/snap-tests/command-lib-monorepo/packages/hello/package.json
+++ b/packages/cli/snap-tests/command-lib-monorepo/packages/hello/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "hello",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "vite lib"
+  }
+}

--- a/packages/cli/snap-tests/command-lib-monorepo/packages/hello/src/hello.ts
+++ b/packages/cli/snap-tests/command-lib-monorepo/packages/hello/src/hello.ts
@@ -1,0 +1,3 @@
+export function hello() {
+  console.log('Hello tsdown!');
+}

--- a/packages/cli/snap-tests/command-lib-monorepo/packages/hello/src/index.ts
+++ b/packages/cli/snap-tests/command-lib-monorepo/packages/hello/src/index.ts
@@ -1,0 +1,3 @@
+import { hello } from './hello.ts';
+
+hello();

--- a/packages/cli/snap-tests/command-lib-monorepo/packages/hello/tsdown.config.ts
+++ b/packages/cli/snap-tests/command-lib-monorepo/packages/hello/tsdown.config.ts
@@ -1,0 +1,4 @@
+export default {
+  entry: 'src/index.ts',
+  format: ['esm', 'cjs'],
+};

--- a/packages/cli/snap-tests/command-lib-monorepo/snap.txt
+++ b/packages/cli/snap-tests/command-lib-monorepo/snap.txt
@@ -1,0 +1,57 @@
+> vite run hello#build # should build the library
+~/packages/hello$ vite lib
+ℹ tsdown v<semver> powered by rolldown v<semver>
+ℹ Using tsdown config: <cwd>/packages/hello/tsdown.config.ts
+ℹ entry: src/index.ts
+ℹ Build start
+ℹ [ESM] dist/index.mjs  <variable> kB │ gzip: <variable> kB
+ℹ [ESM] 1 files, total: <variable> kB
+ℹ [CJS] dist/index.cjs  <variable> kB │ gzip: <variable> kB
+ℹ [CJS] 1 files, total: <variable> kB
+✔ Build complete in <variable>ms
+
+
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    Vite+ Task Runner • Execution Summary
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Statistics:   1 tasks • 0 cache hits • 1 cache misses 
+Performance:  0% cache hit rate
+
+Task Details:
+────────────────────────────────────────────────
+  [1] lib: ~/packages/hello$ vite lib ✓
+      → Cache miss: no previous cache entry found
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+> ls packages/hello/dist # should have the library
+index.cjs
+index.mjs
+
+> vite run hello#build # should hit cache
+~/packages/hello$ vite lib (✓ cache hit, replaying)
+ℹ tsdown v<semver> powered by rolldown v<semver>
+ℹ Using tsdown config: <cwd>/packages/hello/tsdown.config.ts
+ℹ entry: src/index.ts
+ℹ Build start
+ℹ [ESM] dist/index.mjs  <variable> kB │ gzip: <variable> kB
+ℹ [ESM] 1 files, total: <variable> kB
+ℹ [CJS] dist/index.cjs  <variable> kB │ gzip: <variable> kB
+ℹ [CJS] 1 files, total: <variable> kB
+✔ Build complete in <variable>ms
+
+
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    Vite+ Task Runner • Execution Summary
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Statistics:   1 tasks • 1 cache hits • 0 cache misses 
+Performance:  100% cache hit rate, <variable>ms saved in total
+
+Task Details:
+────────────────────────────────────────────────
+  [1] lib: ~/packages/hello$ vite lib ✓
+      → Cache hit - output replayed - <variable>ms saved
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/packages/cli/snap-tests/command-lib-monorepo/steps.json
+++ b/packages/cli/snap-tests/command-lib-monorepo/steps.json
@@ -1,0 +1,11 @@
+{
+  "ignoredPlatforms": ["win32"],
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": [
+    "vite run hello#build # should build the library",
+    "ls packages/hello/dist # should have the library",
+    "vite run hello#build # should hit cache"
+  ]
+}


### PR DESCRIPTION
### TL;DR

Fix the `vite lib` command to work correctly in monorepo packages by using the correct directory path.

### What changed?

- Fixed the `lib` command in the CLI to use the correct directory path when generating the Vite lib config
- Instead of using the workspace root directory, now using the current working directory
- Added a new snapshot test for the `lib` command in a monorepo setup to verify the fix

### How to test?

1. Navigate to a package within a monorepo
2. Run `vite lib` or `vite run <package>#build` where the package uses `vite lib` in its build script
3. Verify that the library builds correctly and outputs files to the package's dist directory
4. Run the command again to verify caching works properly

### Why make this change?

When running the `vite lib` command in a package within a monorepo, the command was incorrectly using the workspace root directory instead of the package directory to generate the Vite configuration. This caused the build to fail or produce incorrect output. This fix ensures that the command works correctly in monorepo setups by using the current working directory of the package.