### PR TITLE
fix(tools): missing lib exports in sync-remote-deps

### DIFF
--- a/packages/tools/src/sync-remote-deps.ts
+++ b/packages/tools/src/sync-remote-deps.ts
@@ -706,6 +706,12 @@ export async function syncRemote() {
     pluginutilsPackage,
   );
 
+  // additional tsdown exports
+  mergedExports['./lib'] = {
+    default: './dist/tsdown/index.js',
+    types: './dist/tsdown/index-types.d.ts',
+  };
+
   // Update CLI package.json with merged exports
   corePackage.exports = mergedExports;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures the merged `package.json` includes tsdown outputs.
> 
> - In `sync-remote-deps.ts`, adds `mergedExports['./lib']` mapping to `./dist/tsdown/index.js` with `types` at `./dist/tsdown/index-types.d.ts` before writing back to `packages/core/package.json` exports
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06b01d0592684f14afde50dc5f3ba7be79876470. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->