### PR TITLE
fix(test): missing .d.cts files

### DIFF
--- a/packages/test/build.ts
+++ b/packages/test/build.ts
@@ -401,7 +401,8 @@ async function bundleVitest() {
       file.endsWith('.js') ||
       file.endsWith('.mjs') ||
       file.endsWith('.cjs') ||
-      file.endsWith('.d.ts')
+      file.endsWith('.d.ts') ||
+      file.endsWith('.d.cts')
     ) {
       let content = await readFile(file, 'utf-8');
       content = content


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures type definition files are correctly processed during the build.
> 
> - Extends vite-to-core import rewrite to also cover `*.d.cts` files alongside `*.js`, `*.mjs`, `*.cjs`, and `*.d.ts` in `packages/test/build.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 927d5a920b4536c159a9e03a621000ae6ff0bc32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->