### PR TITLE
ci: auto run e2e tests on PRs with `test: e2e` label

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -15,8 +15,6 @@ on:
       - '**/*.md'
   pull_request:
     types: [opened, synchronize, labeled]
-    paths:
-      - 'ecosystem-ci/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.sha }}
@@ -29,10 +27,9 @@ defaults:
 jobs:
   download-previous-rolldown-binaries:
     runs-on: ubuntu-latest
-    # Run if: not a PR, OR not a labeled event (paths filter handled it), OR has 'test: e2e' label
+    # Run if: not a PR, OR PR has 'test: e2e' label
     if: >-
       github.event_name != 'pull_request' ||
-      github.event.action != 'labeled' ||
       contains(github.event.pull_request.labels.*.name, 'test: e2e')
     permissions:
       contents: read


### PR DESCRIPTION
Add support for triggering e2e tests when a PR is labeled with
`test: e2e`. This allows manually requesting e2e tests on any PR
without requiring changes to ecosystem-ci files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>