### PR TITLE
test(e2e): auto run e2e tests on deps/upstream-update branch PRs

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -10,7 +10,6 @@ on:
   push:
     branches:
       - main
-      - deps/upstream-update
     paths-ignore:
       - '**/*.md'
   pull_request:
@@ -27,10 +26,11 @@ defaults:
 jobs:
   download-previous-rolldown-binaries:
     runs-on: ubuntu-latest
-    # Run if: not a PR, OR PR has 'test: e2e' label
+    # Run if: not a PR, OR PR has 'test: e2e' label, OR PR is from deps/upstream-update branch
     if: >-
       github.event_name != 'pull_request' ||
-      contains(github.event.pull_request.labels.*.name, 'test: e2e')
+      contains(github.event.pull_request.labels.*.name, 'test: e2e') ||
+      github.head_ref == 'deps/upstream-update'
     permissions:
       contents: read
       packages: read


### PR DESCRIPTION
- Add condition to run E2E tests by default for PRs from deps/upstream-update branch
- Remove deps/upstream-update from push.branches to avoid duplicate workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>