### PR TITLE
feat(deps): upgrade upstream dependencies

### DIFF
--- a/packages/tools/.upstream-versions.json
+++ b/packages/tools/.upstream-versions.json
@@ -7,6 +7,6 @@
   "rolldown-vite": {
     "repo": "https://github.com/vitejs/vite.git",
     "branch": "main",
-    "hash": "10b24952cf0121410c45537931b609de60ae0471"
+    "hash": "e6bc1a8b3229d8a499481aa0ae500315d7a61aaf"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -954,8 +954,8 @@ importers:
   rolldown-vite/packages/vite:
     dependencies:
       '@oxc-project/runtime':
-        specifier: 0.106.0
-        version: 0.106.0
+        specifier: 0.107.0
+        version: 0.107.0
       '@types/node':
         specifier: ^20.19.0 || >=22.12.0
         version: 22.19.3
@@ -1006,8 +1006,8 @@ importers:
         specifier: ^0.3.31
         version: 0.3.31
       '@oxc-project/types':
-        specifier: 0.106.0
-        version: 0.106.0
+        specifier: 0.107.0
+        version: 0.107.0
       '@polka/compression':
         specifier: ^1.0.0-next.25
         version: 1.0.0-next.25
@@ -3499,16 +3499,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxc-project/runtime@0.106.0':
-    resolution: {integrity: sha512-5SW18pzHX3JRVSw07MoTLEB9yZ9/VTr0C/kdMA1202647roYTGs1HP53UHsY5GOQzkExClCqV3eBURl5mHcD2A==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-
   '@oxc-project/runtime@0.107.0':
     resolution: {integrity: sha512-Pkuh11dhnrlJky91CSu1T2v6LX59LMJqNEE0P5tot40DYOeEb1mlrINVYWcUi/bY0JkozCSWukmDxiaqB6wHGg==}
     engines: {node: ^20.19.0 || >=22.12.0}
-
-  '@oxc-project/types@0.106.0':
-    resolution: {integrity: sha512-QdsH3rZq480VnOHSHgPYOhjL8O8LBdcnSjM408BpPCCUc0JYYZPG9Gafl9i3OcGk/7137o+gweb4cCv3WAUykg==}
 
   '@oxc-project/types@0.107.0':
     resolution: {integrity: sha512-QFDRbYfV2LVx8tyqtyiah3jQPUj1mK2+RYwxyFWyGoys6XJnwTdlzO6rdNNHOPorHAu5Uo34oWRKcvNpbJarmQ==}
@@ -10377,11 +10370,7 @@ snapshots:
   '@oxc-parser/binding-win32-x64-msvc@0.107.0':
     optional: true
 
-  '@oxc-project/runtime@0.106.0': {}
-
   '@oxc-project/runtime@0.107.0': {}
-
-  '@oxc-project/types@0.106.0': {}
 
   '@oxc-project/types@0.107.0': {}
 


### PR DESCRIPTION
Automated daily upgrade of upstream dependencies:
- rolldown (latest tag)
- rolldown-vite (latest tag)
- vitest (latest npm version)
- tsdown (latest npm version)

Build status: success

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Automated dependency refresh.
> 
> - Updates `packages/tools/.upstream-versions.json` to new `rolldown-vite` commit `e6bc1a8...`
> - `pnpm-lock.yaml`: bumps `@oxc-project/runtime` and `@oxc-project/types` to `0.107.0` in `rolldown-vite/packages/vite` and removes `0.106.0` entries
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96608ff8465b89f38e70bd2a7bef9c39429649e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->