### PR TITLE
chore: bump vite-task and re-enable Windows tests 

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -205,11 +205,6 @@ jobs:
           - os: windows-latest
             project:
               name: frm-stack
-          # tanstack-start-helloworld fails due to vite-task relative path bug on Windows
-          # TODO: Re-enable after vite-task Windows path handling is fixed
-          - os: windows-latest
-            project:
-              name: tanstack-start-helloworld
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1355,7 +1355,7 @@ dependencies = [
 [[package]]
 name = "fspy"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=803c069e9bf2865de1a4155834a32f8a6b36e6ec#803c069e9bf2865de1a4155834a32f8a6b36e6ec"
+source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1390,7 +1390,7 @@ dependencies = [
 [[package]]
 name = "fspy_detours_sys"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=803c069e9bf2865de1a4155834a32f8a6b36e6ec#803c069e9bf2865de1a4155834a32f8a6b36e6ec"
+source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "cc",
  "winapi",
@@ -1399,7 +1399,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=803c069e9bf2865de1a4155834a32f8a6b36e6ec#803c069e9bf2865de1a4155834a32f8a6b36e6ec"
+source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1414,7 +1414,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_windows"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=803c069e9bf2865de1a4155834a32f8a6b36e6ec#803c069e9bf2865de1a4155834a32f8a6b36e6ec"
+source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "bincode",
  "constcat",
@@ -1430,7 +1430,7 @@ dependencies = [
 [[package]]
 name = "fspy_seccomp_unotify"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=803c069e9bf2865de1a4155834a32f8a6b36e6ec#803c069e9bf2865de1a4155834a32f8a6b36e6ec"
+source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "bincode",
  "futures-util",
@@ -1447,7 +1447,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=803c069e9bf2865de1a4155834a32f8a6b36e6ec#803c069e9bf2865de1a4155834a32f8a6b36e6ec"
+source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "allocator-api2",
  "bincode",
@@ -1465,7 +1465,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=803c069e9bf2865de1a4155834a32f8a6b36e6ec#803c069e9bf2865de1a4155834a32f8a6b36e6ec"
+source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1483,7 +1483,7 @@ dependencies = [
 [[package]]
 name = "fspy_test_utils"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=803c069e9bf2865de1a4155834a32f8a6b36e6ec#803c069e9bf2865de1a4155834a32f8a6b36e6ec"
+source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -4384,7 +4384,7 @@ dependencies = [
 [[package]]
 name = "vite_glob"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=803c069e9bf2865de1a4155834a32f8a6b36e6ec#803c069e9bf2865de1a4155834a32f8a6b36e6ec"
+source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "thiserror 2.0.17",
  "wax",
@@ -4393,7 +4393,7 @@ dependencies = [
 [[package]]
 name = "vite_graph_ser"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=803c069e9bf2865de1a4155834a32f8a6b36e6ec#803c069e9bf2865de1a4155834a32f8a6b36e6ec"
+source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "petgraph 0.8.3",
  "serde",
@@ -4447,7 +4447,7 @@ dependencies = [
 [[package]]
 name = "vite_path"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=803c069e9bf2865de1a4155834a32f8a6b36e6ec#803c069e9bf2865de1a4155834a32f8a6b36e6ec"
+source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "bincode",
  "diff-struct",
@@ -4460,7 +4460,7 @@ dependencies = [
 [[package]]
 name = "vite_shell"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=803c069e9bf2865de1a4155834a32f8a6b36e6ec#803c069e9bf2865de1a4155834a32f8a6b36e6ec"
+source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "bincode",
  "brush-parser",
@@ -4473,7 +4473,7 @@ dependencies = [
 [[package]]
 name = "vite_str"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=803c069e9bf2865de1a4155834a32f8a6b36e6ec#803c069e9bf2865de1a4155834a32f8a6b36e6ec"
+source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "bincode",
  "compact_str",
@@ -4484,7 +4484,7 @@ dependencies = [
 [[package]]
 name = "vite_task"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=803c069e9bf2865de1a4155834a32f8a6b36e6ec#803c069e9bf2865de1a4155834a32f8a6b36e6ec"
+source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4518,7 +4518,7 @@ dependencies = [
 [[package]]
 name = "vite_task_graph"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=803c069e9bf2865de1a4155834a32f8a6b36e6ec#803c069e9bf2865de1a4155834a32f8a6b36e6ec"
+source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4539,7 +4539,7 @@ dependencies = [
 [[package]]
 name = "vite_task_plan"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=803c069e9bf2865de1a4155834a32f8a6b36e6ec#803c069e9bf2865de1a4155834a32f8a6b36e6ec"
+source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4564,7 +4564,7 @@ dependencies = [
 [[package]]
 name = "vite_workspace"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=803c069e9bf2865de1a4155834a32f8a6b36e6ec#803c069e9bf2865de1a4155834a32f8a6b36e6ec"
+source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "petgraph 0.8.3",
  "rustc-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ criterion = { version = "0.7", features = ["html_reports"] }
 crossterm = { version = "0.29.0", features = ["event-stream"] }
 directories = "6.0.0"
 flate2 = "1.0.35"
-fspy = { git = "https://github.com/voidzero-dev/vite-task", rev = "803c069e9bf2865de1a4155834a32f8a6b36e6ec" }
+fspy = { git = "https://github.com/voidzero-dev/vite-task", rev = "c57008d77e940ea235822c02351020de34fa97a6" }
 futures-util = "0.3.31"
 hex = "0.4.3"
 httpmock = "0.7"
@@ -74,13 +74,13 @@ tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "serde"] }
 vite_command = { path = "crates/vite_command" }
 vite_error = { path = "crates/vite_error" }
-vite_glob = { git = "https://github.com/voidzero-dev/vite-task", rev = "803c069e9bf2865de1a4155834a32f8a6b36e6ec" }
+vite_glob = { git = "https://github.com/voidzero-dev/vite-task", rev = "c57008d77e940ea235822c02351020de34fa97a6" }
 vite_install = { path = "crates/vite_install" }
 vite_migration = { path = "crates/vite_migration" }
-vite_path = { git = "https://github.com/voidzero-dev/vite-task", rev = "803c069e9bf2865de1a4155834a32f8a6b36e6ec" }
-vite_str = { git = "https://github.com/voidzero-dev/vite-task", rev = "803c069e9bf2865de1a4155834a32f8a6b36e6ec" }
-vite_task = { git = "https://github.com/voidzero-dev/vite-task", rev = "803c069e9bf2865de1a4155834a32f8a6b36e6ec" }
-vite_workspace = { git = "https://github.com/voidzero-dev/vite-task", rev = "803c069e9bf2865de1a4155834a32f8a6b36e6ec" }
+vite_path = { git = "https://github.com/voidzero-dev/vite-task", rev = "c57008d77e940ea235822c02351020de34fa97a6" }
+vite_str = { git = "https://github.com/voidzero-dev/vite-task", rev = "c57008d77e940ea235822c02351020de34fa97a6" }
+vite_task = { git = "https://github.com/voidzero-dev/vite-task", rev = "c57008d77e940ea235822c02351020de34fa97a6" }
+vite_workspace = { git = "https://github.com/voidzero-dev/vite-task", rev = "c57008d77e940ea235822c02351020de34fa97a6" }
 wax = "0.6.0"
 which = "8.0.0"
 


### PR DESCRIPTION
### TL;DR

Updated vite-task dependency to fix Windows path handling issues and re-enabled tanstack-start-helloworld tests on Windows.

### What changed?

- Updated the vite-task dependency from revision `803c069e9bf2865de1a4155834a32f8a6b36e6ec` to `c57008d77e940ea235822c02351020de34fa97a6`
- Removed the exclusion for the tanstack-start-helloworld project in the Windows e2e tests

### Why make this change?

The tanstack-start-helloworld project was previously failing on Windows due to a bug in vite-task's relative path handling. The updated version of vite-task includes a fix for this issue, allowing us to re-enable these tests on Windows platforms.