### PR TITLE
chore: improve local install instructions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' }}
 
       - name: Configure Git for access to vite-task
-        run: git config --global url."https://x-access-token:${{ secrets.VITE_TASK_TOKEN }}@github.com/".insteadOf "https://github.com/"
+        run: git config --global url."https://x-access-token:${{ secrets.VITE_TASK_TOKEN }}@github.com/".insteadOf "ssh://git@github.com/"
 
       - run: cargo check --all-targets --all-features
         env:
@@ -77,7 +77,7 @@ jobs:
       - uses: ./.github/actions/clone
 
       - name: Configure Git for access to vite-task
-        run: git config --global url."https://x-access-token:${{ secrets.VITE_TASK_TOKEN }}@github.com/".insteadOf "https://github.com/"
+        run: git config --global url."https://x-access-token:${{ secrets.VITE_TASK_TOKEN }}@github.com/".insteadOf "ssh://git@github.com/"
 
       - uses: oxc-project/setup-rust@d286d43bc1f606abbd98096666ff8be68c8d5f57 # v1.0.0
         with:
@@ -111,7 +111,7 @@ jobs:
       - uses: ./.github/actions/clone
 
       - name: Configure Git for access to vite-task
-        run: git config --global url."https://x-access-token:${{ secrets.VITE_TASK_TOKEN }}@github.com/".insteadOf "https://github.com/"
+        run: git config --global url."https://x-access-token:${{ secrets.VITE_TASK_TOKEN }}@github.com/".insteadOf "ssh://git@github.com/"
 
       - uses: oxc-project/setup-rust@d286d43bc1f606abbd98096666ff8be68c8d5f57 # v1.0.0
         with:
@@ -160,7 +160,7 @@ jobs:
       - uses: ./.github/actions/clone
 
       - name: Configure Git for access to vite-task
-        run: git config --global url."https://x-access-token:${{ secrets.VITE_TASK_TOKEN }}@github.com/".insteadOf "https://github.com/"
+        run: git config --global url."https://x-access-token:${{ secrets.VITE_TASK_TOKEN }}@github.com/".insteadOf "ssh://git@github.com/"
 
       - run: |
           brew install rustup
@@ -218,7 +218,7 @@ jobs:
       - uses: ./.github/actions/clone
 
       - name: Configure Git for access to vite-task
-        run: git config --global url."https://x-access-token:${{ secrets.VITE_TASK_TOKEN }}@github.com/".insteadOf "https://github.com/"
+        run: git config --global url."https://x-access-token:${{ secrets.VITE_TASK_TOKEN }}@github.com/".insteadOf "ssh://git@github.com/"
 
       - uses: oxc-project/setup-rust@d286d43bc1f606abbd98096666ff8be68c8d5f57 # v1.0.0
         with:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: ./.github/actions/clone
 
       - name: Configure Git for access to vite-task
-        run: git config --global url."https://x-access-token:${{ secrets.VITE_TASK_TOKEN }}@github.com/".insteadOf "https://github.com/"
+        run: git config --global url."https://x-access-token:${{ secrets.VITE_TASK_TOKEN }}@github.com/".insteadOf "ssh://git@github.com/"
 
       - uses: oxc-project/setup-rust@d286d43bc1f606abbd98096666ff8be68c8d5f57 # v1.0.0
         with:
@@ -83,7 +83,7 @@ jobs:
 
       - name: Pack packages into tgz
         run: |
-          pnpm run bootstrap-cli:ci
+          pnpm bootstrap-cli:ci
           mkdir -p tmp/tgz
           cd packages/core && pnpm pack --pack-destination ../../tmp/tgz && cd ../..
           cd packages/test && pnpm pack --pack-destination ../../tmp/tgz && cd ../..

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
           pnpm exec tool replace-file-content packages/global/binding/Cargo.toml 'version = "0.0.0"' 'version = "0.0.0-${{ github.sha }}"'
 
       - name: Configure Git for access to vite-task
-        run: git config --global url."https://x-access-token:${{ secrets.VITE_TASK_TOKEN }}@github.com/".insteadOf "https://github.com/"
+        run: git config --global url."https://x-access-token:${{ secrets.VITE_TASK_TOKEN }}@github.com/".insteadOf "ssh://git@github.com/"
 
       - name: Build
         uses: ./.github/actions/build-upstream
@@ -138,7 +138,7 @@ jobs:
       - uses: oxc-project/setup-node@fdbf0dfd334c4e6d56ceeb77d91c76339c2a0885 # v1.0.4
 
       - name: Configure Git for access to vite-task
-        run: git config --global url."https://x-access-token:${{ secrets.VITE_TASK_TOKEN }}@github.com/".insteadOf "https://github.com/"
+        run: git config --global url."https://x-access-token:${{ secrets.VITE_TASK_TOKEN }}@github.com/".insteadOf "ssh://git@github.com/"
 
       - name: Download cli dist
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/upgrade-deps.yml
+++ b/.github/workflows/upgrade-deps.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: ./.github/actions/clone
 
       - name: Configure Git for access to vite-task
-        run: git config --global url."https://x-access-token:${{ secrets.VITE_TASK_TOKEN }}@github.com/".insteadOf "https://github.com/"
+        run: git config --global url."https://x-access-token:${{ secrets.VITE_TASK_TOKEN }}@github.com/".insteadOf "ssh://git@github.com/"
 
       - uses: oxc-project/setup-rust@d286d43bc1f606abbd98096666ff8be68c8d5f57 # v1.0.0
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing Guide
+
+## Initial Setup
+
+You'll need the following tools installed on your system:
+
+```
+brew install pnpm node just cmake
+```
+
+Install Rust & Cargo using rustup:
+
+```
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+cargo install cargo-binstall
+```
+
+Initial setup to install dependencies for Vite+:
+
+```
+just init
+```
+
+## Build Vite+ and upstream dependencies
+
+To create a release build of Vite+ and all upstream dependencies, run:
+
+```
+just build
+```
+
+## Pull upstream dependencies
+
+When you want to pull the latest upstream dependencies such as Rolldown and Vite, run:
+
+```
+node packages/tools/src/index.ts sync-remote
+pnpm install
+```
+
+## Install internal global cli
+
+Add the following lines to your `~/.npmrc` file:
+
+```
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+@voidzero-dev:registry=https://npm.pkg.github.com/
+```
+
+Create a classic personal access token, following this guide: https://docs.github.com/en/packages/learn-github-packages/about-permissions-for-github-packages#about-scopes-and-permissions-for-package-registries
+
+Use this token to install the global cli:
+
+```
+GITHUB_TOKEN=<your-token> npm install -g @voidzero-dev/global
+```
+
+Use 1Password cli:
+
+```
+GITHUB_TOKEN=$(op read "op://YOUR_GITHUB_TOKEN_PATH") npm install -g @voidzero-dev/global
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1355,7 +1355,7 @@ dependencies = [
 [[package]]
 name = "fspy"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1390,7 +1390,7 @@ dependencies = [
 [[package]]
 name = "fspy_detours_sys"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "cc",
  "winapi",
@@ -1399,7 +1399,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1414,7 +1414,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_windows"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "bincode",
  "constcat",
@@ -1430,7 +1430,7 @@ dependencies = [
 [[package]]
 name = "fspy_seccomp_unotify"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "bincode",
  "futures-util",
@@ -1447,7 +1447,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "allocator-api2",
  "bincode",
@@ -1465,7 +1465,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1483,7 +1483,7 @@ dependencies = [
 [[package]]
 name = "fspy_test_utils"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -4384,7 +4384,7 @@ dependencies = [
 [[package]]
 name = "vite_glob"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "thiserror 2.0.17",
  "wax",
@@ -4393,7 +4393,7 @@ dependencies = [
 [[package]]
 name = "vite_graph_ser"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "petgraph 0.8.3",
  "serde",
@@ -4447,7 +4447,7 @@ dependencies = [
 [[package]]
 name = "vite_path"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "bincode",
  "diff-struct",
@@ -4460,7 +4460,7 @@ dependencies = [
 [[package]]
 name = "vite_shell"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "bincode",
  "brush-parser",
@@ -4473,7 +4473,7 @@ dependencies = [
 [[package]]
 name = "vite_str"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "bincode",
  "compact_str",
@@ -4484,7 +4484,7 @@ dependencies = [
 [[package]]
 name = "vite_task"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4518,7 +4518,7 @@ dependencies = [
 [[package]]
 name = "vite_task_graph"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4539,7 +4539,7 @@ dependencies = [
 [[package]]
 name = "vite_task_plan"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4564,7 +4564,7 @@ dependencies = [
 [[package]]
 name = "vite_workspace"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
 dependencies = [
  "petgraph 0.8.3",
  "rustc-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,11 @@
 [workspace]
 resolver = "3"
-members = ["bench", "crates/*", "packages/cli/binding", "packages/global/binding"]
+members = [
+  "bench",
+  "crates/*",
+  "packages/cli/binding",
+  "packages/global/binding",
+]
 
 [workspace.package]
 authors = ["Vite+ Authors"]
@@ -12,7 +17,10 @@ rust-version = "1.89.0"
 absolute_paths_not_starting_with_crate = "warn"
 non_ascii_idents = "warn"
 unit-bindings = "warn"
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)', 'cfg(coverage_nightly)'] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(coverage)',
+  'cfg(coverage_nightly)',
+] }
 tail_expr_drop_order = "warn"
 unsafe_op_in_unsafe_fn = "warn"
 unused_unsafe = "warn"
@@ -36,25 +44,37 @@ anyhow = "1.0.98"
 async-trait = "0.1.89"
 ast-grep-config = "0.40.1"
 ast-grep-core = "0.40.1"
-ast-grep-language = { version = "0.40.1", default-features = false, features = ["tree-sitter-bash", "tree-sitter-typescript"] }
+ast-grep-language = { version = "0.40.1", default-features = false, features = [
+  "tree-sitter-bash",
+  "tree-sitter-typescript",
+] }
 backon = "1.3.0"
 bincode = "2.0.1"
-bstr = { version = "1.12.0", default-features = false, features = ["alloc", "std"] }
+bstr = { version = "1.12.0", default-features = false, features = [
+  "alloc",
+  "std",
+] }
 clap = "4.5.40"
 criterion = { version = "0.7", features = ["html_reports"] }
 crossterm = { version = "0.29.0", features = ["event-stream"] }
 directories = "6.0.0"
 flate2 = "1.0.35"
-fspy = { git = "https://github.com/voidzero-dev/vite-task", rev = "c57008d77e940ea235822c02351020de34fa97a6" }
+fspy = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "c57008d77e940ea235822c02351020de34fa97a6" }
 futures-util = "0.3.31"
 hex = "0.4.3"
 httpmock = "0.7"
 ignore = "0.4"
 indoc = "2.0.5"
 monostate = "1.0.2"
-napi = { version = "3.0.0", default-features = false, features = ["async", "error_anyhow"] }
+napi = { version = "3.0.0", default-features = false, features = [
+  "async",
+  "error_anyhow",
+] }
 napi-build = "2"
-napi-derive = { version = "3.0.0", default-features = false, features = ["type-def", "strict"] }
+napi-derive = { version = "3.0.0", default-features = false, features = [
+  "type-def",
+  "strict",
+] }
 nix = { version = "0.30.1", features = ["dir"] }
 pathdiff = "0.2.3"
 reqwest = { version = "0.12", default-features = false }
@@ -74,13 +94,13 @@ tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "serde"] }
 vite_command = { path = "crates/vite_command" }
 vite_error = { path = "crates/vite_error" }
-vite_glob = { git = "https://github.com/voidzero-dev/vite-task", rev = "c57008d77e940ea235822c02351020de34fa97a6" }
+vite_glob = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "c57008d77e940ea235822c02351020de34fa97a6" }
 vite_install = { path = "crates/vite_install" }
 vite_migration = { path = "crates/vite_migration" }
-vite_path = { git = "https://github.com/voidzero-dev/vite-task", rev = "c57008d77e940ea235822c02351020de34fa97a6" }
-vite_str = { git = "https://github.com/voidzero-dev/vite-task", rev = "c57008d77e940ea235822c02351020de34fa97a6" }
-vite_task = { git = "https://github.com/voidzero-dev/vite-task", rev = "c57008d77e940ea235822c02351020de34fa97a6" }
-vite_workspace = { git = "https://github.com/voidzero-dev/vite-task", rev = "c57008d77e940ea235822c02351020de34fa97a6" }
+vite_path = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "c57008d77e940ea235822c02351020de34fa97a6" }
+vite_str = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "c57008d77e940ea235822c02351020de34fa97a6" }
+vite_task = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "c57008d77e940ea235822c02351020de34fa97a6" }
+vite_workspace = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "c57008d77e940ea235822c02351020de34fa97a6" }
 wax = "0.6.0"
 which = "8.0.0"
 
@@ -94,7 +114,7 @@ which = "8.0.0"
 # To use: Ensure vite-task is cloned at ../vite-task relative to vite-plus.
 # Comment out this section before committing.
 # =============================================================================
-# [patch."https://github.com/voidzero-dev/vite-task"]
+# [patch."ssh://git@github.com/voidzero-dev/vite-task.git"]
 # fspy = { path = "../vite-task/crates/fspy" }
 # vite_glob = { path = "../vite-task/crates/vite_glob" }
 # vite_path = { path = "../vite-task/crates/vite_path" }
@@ -114,5 +134,5 @@ opt-level = 3
 lto = "fat"
 codegen-units = 1
 strip = "symbols" # set to `false` for debug information
-debug = false # set to `true` for debug information
-panic = "abort" # Let it crash and force ourselves to write safe Rust.
+debug = false     # set to `true` for debug information
+panic = "abort"   # Let it crash and force ourselves to write safe Rust.

--- a/README.md
+++ b/README.md
@@ -1,37 +1,3 @@
 # Vite+
 
-## Pull upstream dependencies
-
-```
-pnpm tool sync-remote
-pnpm install
-```
-
-## Build Vite+ and upstream dependencies
-
-```
-just build
-```
-
-## Install internal global cli
-
-Add the following lines to your `~/.npmrc` file:
-
-```
-//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
-@voidzero-dev:registry=https://npm.pkg.github.com/
-```
-
-Create a classic personal access token, following this guide: https://docs.github.com/en/packages/learn-github-packages/about-permissions-for-github-packages#about-scopes-and-permissions-for-package-registries
-
-Use this token to install the global cli:
-
-```
-GITHUB_TOKEN=<your-token> npm install -g @voidzero-dev/global
-```
-
-Use 1Password cli:
-
-```
-GITHUB_TOKEN=$(op read "op://YOUR_GITHUB_TOKEN_PATH") npm install -g @voidzero-dev/global
-```
+The Unified Toolchain for the Web

--- a/justfile
+++ b/justfile
@@ -10,8 +10,9 @@ alias r := ready
 
 init:
   cargo binstall watchexec-cli cargo-insta typos-cli cargo-shear dprint taplo-cli -y
-  pnpm tool sync-remote
-  pnpm run bootstrap-cli
+  node packages/tools/src/index.ts sync-remote
+  pnpm install
+  pnpm bootstrap-cli
 
 build:
   pnpm --filter @rolldown/pluginutils build

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "vite-plus-monorepo",
   "license": "BUSL-1.1",
   "private": true,
-  "packageManager": "pnpm@10.24.0",
+  "packageManager": "pnpm@10.28.0",
   "engines": {
-    "node": "^20.19.0 || >=22.12.0"
+    "node": ">=22.18.0"
   },
   "type": "module",
   "scripts": {

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -2,23 +2,23 @@ const subcommand = process.argv[2];
 
 switch (subcommand) {
   case 'snap-test':
-    const { snapTest } = await import('./snap-test');
+    const { snapTest } = await import('./snap-test.ts');
     await snapTest();
     break;
   case 'replace-file-content':
-    const { replaceFileContent } = await import('./replace-file-content');
+    const { replaceFileContent } = await import('./replace-file-content.ts');
     replaceFileContent();
     break;
   case 'sync-remote':
-    const { syncRemote } = await import('./sync-remote-deps');
+    const { syncRemote } = await import('./sync-remote-deps.ts');
     await syncRemote();
     break;
   case 'json-sort':
-    const { jsonSort } = await import('./json-sort');
+    const { jsonSort } = await import('./json-sort.ts');
     jsonSort();
     break;
   case 'merge-peer-deps':
-    const { mergePeerDeps } = await import('./merge-peer-deps');
+    const { mergePeerDeps } = await import('./merge-peer-deps.ts');
     mergePeerDeps();
     break;
   default:

--- a/packages/tools/tsconfig.json
+++ b/packages/tools/tsconfig.json
@@ -1,14 +1,14 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "composite": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "composite": true,
+    "noEmit": true,
     "outDir": "./dist",
-    "noEmit": false,
-    "allowImportingTsExtensions": false,
-    "rootDir": "./src",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "rootDir": "./src"
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist", "./snap-tests/**", "./*.json"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "declaration": true,
     "erasableSyntaxOnly": true,
     "esModuleInterop": true,


### PR DESCRIPTION
I found it hard to figure out how to install Vite+ for local development. There are circular dependencies in the repo: It expects that Vite and Rolldown are present prior to installing dependencies, but the `tools` script used for syncing requires dependencies to be installed. I fixed it so the script can be invoked directly.

I changed Cargo to pull `vite-task` via ssh instead of requiring https auth for GitHub.

I pulled everything together into a `CONTRIBUTING.md` guide so we can fill the `README.md` with user-relevant content later.