### PR TITLE
feat(deps): upgrade upstream dependencies

### DIFF
--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -264,7 +264,7 @@
     "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
     "happy-dom": "*",
     "jsdom": "*",
-    "@vitest/ui": "4.0.16"
+    "@vitest/ui": "4.0.17"
   },
   "peerDependenciesMeta": {
     "@edge-runtime/vm": {
@@ -303,17 +303,17 @@
   "devDependencies": {
     "@oxc-node/cli": "catalog:",
     "@oxc-node/core": "catalog:",
-    "@vitest/browser": "4.0.16",
-    "@vitest/browser-playwright": "4.0.16",
-    "@vitest/browser-preview": "4.0.16",
-    "@vitest/browser-webdriverio": "4.0.16",
-    "@vitest/expect": "4.0.16",
-    "@vitest/mocker": "4.0.16",
-    "@vitest/pretty-format": "4.0.16",
-    "@vitest/runner": "4.0.16",
-    "@vitest/snapshot": "4.0.16",
-    "@vitest/spy": "4.0.16",
-    "@vitest/utils": "4.0.16",
+    "@vitest/browser": "4.0.17",
+    "@vitest/browser-playwright": "4.0.17",
+    "@vitest/browser-preview": "4.0.17",
+    "@vitest/browser-webdriverio": "4.0.17",
+    "@vitest/expect": "4.0.17",
+    "@vitest/mocker": "4.0.17",
+    "@vitest/pretty-format": "4.0.17",
+    "@vitest/runner": "4.0.17",
+    "@vitest/snapshot": "4.0.17",
+    "@vitest/spy": "4.0.17",
+    "@vitest/utils": "4.0.17",
     "chai": "^6.2.1",
     "estree-walker": "^3.0.3",
     "expect-type": "^1.2.2",
@@ -324,7 +324,7 @@
     "rolldown": "workspace:*",
     "rolldown-plugin-dts": "catalog:",
     "tinyrainbow": "^3.0.3",
-    "vitest-dev": "^4.0.16",
+    "vitest-dev": "^4.0.17",
     "why-is-node-running": "^2.3.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,8 +220,8 @@ catalogs:
       specifier: ^1.0.1
       version: 1.0.2
     tsdown:
-      specifier: ^0.19.0-beta.5
-      version: 0.19.0-beta.5
+      specifier: ^0.20.0-beta.2
+      version: 0.20.0-beta.2
     typescript:
       specifier: ^5.9.3
       version: 5.9.3
@@ -246,7 +246,7 @@ overrides:
   rolldown: workspace:rolldown@*
   vite: workspace:@voidzero-dev/vite-plus-core@*
   vitest: workspace:@voidzero-dev/vite-plus-test@*
-  vitest-dev: npm:vitest@^4.0.16
+  vitest-dev: npm:vitest@^4.0.17
 
 packageExtensionsChecksum: sha256-BLDZCgUIohvBXMHo3XFOlGLzGXRyK3sDU0nMBRk9APY=
 
@@ -358,7 +358,7 @@ importers:
         version: 0.20.0(oxc-resolver@11.14.0)(rolldown@rolldown+packages+rolldown)(typescript@5.9.3)
       tsdown:
         specifier: 'catalog:'
-        version: 0.19.0-beta.5(@arethetypeswrong/core@0.18.2)(@vitejs/devtools@0.0.0-alpha.24(@pnpm/logger@1001.0.1)(vite@packages+core)(vue@3.5.25(typescript@5.9.3)))(oxc-resolver@11.14.0)(publint@0.3.16)(typescript@5.9.3)(unplugin-lightningcss@0.4.3)(unplugin-unused@0.5.6)
+        version: 0.20.0-beta.2(@arethetypeswrong/core@0.18.2)(@vitejs/devtools@0.0.0-alpha.24(@pnpm/logger@1001.0.1)(vite@packages+core)(vue@3.5.25(typescript@5.9.3)))(oxc-resolver@11.14.0)(publint@0.3.16)(typescript@5.9.3)(unplugin-lightningcss@0.4.3)(unplugin-unused@0.5.6)
       vite:
         specifier: workspace:@voidzero-dev/vite-plus-core@*
         version: link:../core
@@ -491,7 +491,7 @@ importers:
         version: 1.2.2
       tsdown:
         specifier: 'catalog:'
-        version: 0.19.0-beta.5(@arethetypeswrong/core@0.18.2)(@vitejs/devtools@0.0.0-alpha.24(@pnpm/logger@1001.0.1)(vite@packages+core)(vue@3.5.25(typescript@5.9.3)))(oxc-resolver@11.14.0)(publint@0.3.16)(typescript@5.9.3)(unplugin-lightningcss@0.4.3)(unplugin-unused@0.5.6)
+        version: 0.20.0-beta.2(@arethetypeswrong/core@0.18.2)(@vitejs/devtools@0.0.0-alpha.24(@pnpm/logger@1001.0.1)(vite@packages+core)(vue@3.5.25(typescript@5.9.3)))(oxc-resolver@11.14.0)(publint@0.3.16)(typescript@5.9.3)(unplugin-lightningcss@0.4.3)(unplugin-unused@0.5.6)
       vite:
         specifier: workspace:@voidzero-dev/vite-plus-core@*
         version: 'link:'
@@ -576,8 +576,8 @@ importers:
         specifier: ^20.0.0 || ^22.0.0 || >=24.0.0
         version: 22.19.3
       '@vitest/ui':
-        specifier: 4.0.16
-        version: 4.0.16(vitest@4.0.16)
+        specifier: 4.0.17
+        version: 4.0.17(vitest@4.0.17)
       '@voidzero-dev/vite-plus-core':
         specifier: workspace:*
         version: link:../core
@@ -625,38 +625,38 @@ importers:
         specifier: 'catalog:'
         version: 0.0.35
       '@vitest/browser':
-        specifier: 4.0.16
-        version: 4.0.16(vite@packages+core)(vitest@4.0.16)
+        specifier: 4.0.17
+        version: 4.0.17(vite@packages+core)(vitest@4.0.17)
       '@vitest/browser-playwright':
-        specifier: 4.0.16
-        version: 4.0.16(playwright@1.57.0)(vite@packages+core)(vitest@4.0.16)
+        specifier: 4.0.17
+        version: 4.0.17(playwright@1.57.0)(vite@packages+core)(vitest@4.0.17)
       '@vitest/browser-preview':
-        specifier: 4.0.16
-        version: 4.0.16(vite@packages+core)(vitest@4.0.16)
+        specifier: 4.0.17
+        version: 4.0.17(vite@packages+core)(vitest@4.0.17)
       '@vitest/browser-webdriverio':
-        specifier: 4.0.16
-        version: 4.0.16(vite@packages+core)(vitest@4.0.16)(webdriverio@9.20.1)
+        specifier: 4.0.17
+        version: 4.0.17(vite@packages+core)(vitest@4.0.17)(webdriverio@9.20.1)
       '@vitest/expect':
-        specifier: 4.0.16
-        version: 4.0.16
+        specifier: 4.0.17
+        version: 4.0.17
       '@vitest/mocker':
-        specifier: 4.0.16
-        version: 4.0.16(vite@packages+core)
+        specifier: 4.0.17
+        version: 4.0.17(vite@packages+core)
       '@vitest/pretty-format':
-        specifier: 4.0.16
-        version: 4.0.16
+        specifier: 4.0.17
+        version: 4.0.17
       '@vitest/runner':
-        specifier: 4.0.16
-        version: 4.0.16
+        specifier: 4.0.17
+        version: 4.0.17
       '@vitest/snapshot':
-        specifier: 4.0.16
-        version: 4.0.16
+        specifier: 4.0.17
+        version: 4.0.17
       '@vitest/spy':
-        specifier: 4.0.16
-        version: 4.0.16
+        specifier: 4.0.17
+        version: 4.0.17
       '@vitest/utils':
-        specifier: 4.0.16
-        version: 4.0.16
+        specifier: 4.0.17
+        version: 4.0.17
       chai:
         specifier: ^6.2.1
         version: 6.2.1
@@ -688,8 +688,8 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       vitest-dev:
-        specifier: npm:vitest@^4.0.16
-        version: vitest@4.0.16(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@22.19.3)(@vitest/browser-playwright@4.0.16(playwright@1.57.0)(vite@packages+core)(vitest@4.0.16))(@vitest/browser-preview@4.0.16(vite@packages+core)(vitest@4.0.16))(@vitest/browser-webdriverio@4.0.16(vite@packages+core)(vitest@4.0.16)(webdriverio@9.20.1))(@vitest/ui@4.0.16(vitest@4.0.16))(happy-dom@20.0.10)(jsdom@27.2.0)
+        specifier: npm:vitest@^4.0.17
+        version: vitest@4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@22.19.3)(@vitest/browser-playwright@4.0.17(playwright@1.57.0)(vite@packages+core)(vitest@4.0.17))(@vitest/browser-preview@4.0.17(vite@packages+core)(vitest@4.0.17))(@vitest/browser-webdriverio@4.0.17(vite@packages+core)(vitest@4.0.17)(webdriverio@9.20.1))(@vitest/ui@4.0.17(vitest@4.0.17))(happy-dom@20.0.10)(jsdom@27.2.0)
       why-is-node-running:
         specifier: ^2.3.0
         version: 2.3.0
@@ -4635,33 +4635,33 @@ packages:
   '@vitejs/release-scripts@1.6.0':
     resolution: {integrity: sha512-XV+w22Fvn+wqDtEkz8nQIJzvmRVSh90c2xvOO7cX9fkX8+39ZJpYRiXDIRJG1JRnF8khm1rHjulid+l+khc7TQ==}
 
-  '@vitest/browser-playwright@4.0.16':
-    resolution: {integrity: sha512-I2Fy/ANdphi1yI46d15o0M1M4M0UJrUiVKkH5oKeRZZCdPg0fw/cfTKZzv9Ge9eobtJYp4BGblMzXdXH0vcl5g==}
+  '@vitest/browser-playwright@4.0.17':
+    resolution: {integrity: sha512-CE9nlzslHX6Qz//MVrjpulTC9IgtXTbJ+q7Rx1HD+IeSOWv4NHIRNHPA6dB4x01d9paEqt+TvoqZfmgq40DxEQ==}
     peerDependencies:
       playwright: '*'
       vitest: workspace:@voidzero-dev/vite-plus-test@*
 
-  '@vitest/browser-preview@4.0.16':
-    resolution: {integrity: sha512-dfxJs4D5qSst4zY25txsklu0ZGPSQUhCq4VUuO2aOYtOO5+2EH7Dil37BTf1PG6DDdM8kF8NjAvnvZfsE2uzAQ==}
+  '@vitest/browser-preview@4.0.17':
+    resolution: {integrity: sha512-HDvWHVraG5qcZpDBTZ2kOZhSth3AuB3s5tQ6cb9fbBt6IFstXPj2mwuJszg1+53V0CzSG/o5SYsBB3AzlMfUFQ==}
     peerDependencies:
       vitest: workspace:@voidzero-dev/vite-plus-test@*
 
-  '@vitest/browser-webdriverio@4.0.16':
-    resolution: {integrity: sha512-DE0dCXQMtqMJJ0NruA0LTawHa4kPnNGfWYQh1r20QeD5oIDNbggpL4/jy58Wn8OcruaEGEHTKEWdaNOhdHefsg==}
+  '@vitest/browser-webdriverio@4.0.17':
+    resolution: {integrity: sha512-0u1C2yW5J9wt7vrkZ5+VTj6+Ckz4LKV3SBWjk55clK5Earqh24c1tv+VdRW1ZSxlzJ6gjeAm/YoFM7MMq6tFHw==}
     peerDependencies:
       vitest: workspace:@voidzero-dev/vite-plus-test@*
       webdriverio: '*'
 
-  '@vitest/browser@4.0.16':
-    resolution: {integrity: sha512-t4toy8X/YTnjYEPoY0pbDBg3EvDPg1elCDrfc+VupPHwoN/5/FNQ8Z+xBYIaEnOE2vVEyKwqYBzZ9h9rJtZVcg==}
+  '@vitest/browser@4.0.17':
+    resolution: {integrity: sha512-cgf2JZk2fv5or3efmOrRJe1V9Md89BPgz4ntzbf84yAb+z2hW6niaGFinl9aFzPZ1q3TGfWZQWZ9gXTFThs2Qw==}
     peerDependencies:
       vitest: workspace:@voidzero-dev/vite-plus-test@*
 
-  '@vitest/expect@4.0.16':
-    resolution: {integrity: sha512-eshqULT2It7McaJkQGLkPjPjNph+uevROGuIMJdG3V+0BSR2w9u6J9Lwu+E8cK5TETlfou8GRijhafIMhXsimA==}
+  '@vitest/expect@4.0.17':
+    resolution: {integrity: sha512-mEoqP3RqhKlbmUmntNDDCJeTDavDR+fVYkSOw8qRwJFaW/0/5zA9zFeTrHqNtcmwh6j26yMmwx2PqUDPzt5ZAQ==}
 
-  '@vitest/mocker@4.0.16':
-    resolution: {integrity: sha512-yb6k4AZxJTB+q9ycAvsoxGn+j/po0UaPgajllBgt1PzoMAAmJGYFdDk0uCcRcxb3BrME34I6u8gHZTQlkqSZpg==}
+  '@vitest/mocker@4.0.17':
+    resolution: {integrity: sha512-+ZtQhLA3lDh1tI2wxe3yMsGzbp7uuJSWBM1iTIKCbppWTSBN09PUC+L+fyNlQApQoR+Ps8twt2pbSSXg2fQVEQ==}
     peerDependencies:
       msw: ^2.4.9
       vite: workspace:@voidzero-dev/vite-plus-core@*
@@ -4671,25 +4671,25 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.0.16':
-    resolution: {integrity: sha512-eNCYNsSty9xJKi/UdVD8Ou16alu7AYiS2fCPRs0b1OdhJiV89buAXQLpTbe+X8V9L6qrs9CqyvU7OaAopJYPsA==}
+  '@vitest/pretty-format@4.0.17':
+    resolution: {integrity: sha512-Ah3VAYmjcEdHg6+MwFE17qyLqBHZ+ni2ScKCiW2XrlSBV4H3Z7vYfPfz7CWQ33gyu76oc0Ai36+kgLU3rfF4nw==}
 
-  '@vitest/runner@4.0.16':
-    resolution: {integrity: sha512-VWEDm5Wv9xEo80ctjORcTQRJ539EGPB3Pb9ApvVRAY1U/WkHXmmYISqU5E79uCwcW7xYUV38gwZD+RV755fu3Q==}
+  '@vitest/runner@4.0.17':
+    resolution: {integrity: sha512-JmuQyf8aMWoo/LmNFppdpkfRVHJcsgzkbCA+/Bk7VfNH7RE6Ut2qxegeyx2j3ojtJtKIbIGy3h+KxGfYfk28YQ==}
 
-  '@vitest/snapshot@4.0.16':
-    resolution: {integrity: sha512-sf6NcrYhYBsSYefxnry+DR8n3UV4xWZwWxYbCJUt2YdvtqzSPR7VfGrY0zsv090DAbjFZsi7ZaMi1KnSRyK1XA==}
+  '@vitest/snapshot@4.0.17':
+    resolution: {integrity: sha512-npPelD7oyL+YQM2gbIYvlavlMVWUfNNGZPcu0aEUQXt7FXTuqhmgiYupPnAanhKvyP6Srs2pIbWo30K0RbDtRQ==}
 
-  '@vitest/spy@4.0.16':
-    resolution: {integrity: sha512-4jIOWjKP0ZUaEmJm00E0cOBLU+5WE0BpeNr3XN6TEF05ltro6NJqHWxXD0kA8/Zc8Nh23AT8WQxwNG+WeROupw==}
+  '@vitest/spy@4.0.17':
+    resolution: {integrity: sha512-I1bQo8QaP6tZlTomQNWKJE6ym4SHf3oLS7ceNjozxxgzavRAgZDc06T7kD8gb9bXKEgcLNt00Z+kZO6KaJ62Ew==}
 
-  '@vitest/ui@4.0.16':
-    resolution: {integrity: sha512-rkoPH+RqWopVxDnCBE/ysIdfQ2A7j1eDmW8tCxxrR9nnFBa9jKf86VgsSAzxBd1x+ny0GC4JgiD3SNfRHv3pOg==}
+  '@vitest/ui@4.0.17':
+    resolution: {integrity: sha512-hRDjg6dlDz7JlZAvjbiCdAJ3SDG+NH8tjZe21vjxfvT2ssYAn72SRXMge3dKKABm3bIJ3C+3wdunIdur8PHEAw==}
     peerDependencies:
       vitest: workspace:@voidzero-dev/vite-plus-test@*
 
-  '@vitest/utils@4.0.16':
-    resolution: {integrity: sha512-h8z9yYhV3e1LEfaQ3zdypIrnAg/9hguReGZoS7Gl0aBG5xgA410zBqECqmaF/+RkTggRsfnzc1XaAHA6bmUufA==}
+  '@vitest/utils@4.0.17':
+    resolution: {integrity: sha512-RG6iy+IzQpa9SB8HAFHJ9Y+pTzI+h8553MrciN9eC6TFBErqrQaTas4vG+MVj8S4uKk8uTT2p0vgZPnTdxd96w==}
 
   '@vue/compiler-core@3.5.25':
     resolution: {integrity: sha512-vay5/oQJdsNHmliWoZfHPoVZZRmnSWhug0BYT34njkYTPqClh3DNWLkZNJBVSjsNMrg0CCrBfoKkjZQPM/QVUw==}
@@ -7321,6 +7321,25 @@ packages:
       vue-tsc:
         optional: true
 
+  rolldown-plugin-dts@0.21.0:
+    resolution: {integrity: sha512-t/KiDGti8cXD69phhBGWG4mjIlN1BX5auS8iNPrRvkCII6FKccjR+E0lmP5fCwuEvH3lJPaF5iu/CMGUn6nuoQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@ts-macro/tsc': ^0.3.6
+      '@typescript/native-preview': '>=7.0.0-dev.20250601.1'
+      rolldown: workspace:rolldown@*
+      typescript: ^5.0.0
+      vue-tsc: ~3.2.0
+    peerDependenciesMeta:
+      '@ts-macro/tsc':
+        optional: true
+      '@typescript/native-preview':
+        optional: true
+      typescript:
+        optional: true
+      vue-tsc:
+        optional: true
+
   rollup-plugin-license@3.6.0:
     resolution: {integrity: sha512-1ieLxTCaigI5xokIfszVDRoy6c/Wmlot1fDEnea7Q/WXSR8AqOjYljHDLObAx7nFxHC2mbxT3QnTSPhaic2IYw==}
     engines: {node: '>=14.0.0'}
@@ -7917,8 +7936,8 @@ packages:
       unplugin-unused:
         optional: true
 
-  tsdown@0.19.0-beta.5:
-    resolution: {integrity: sha512-2/Mn1jqkJS65tD1oXqld7cShhx/Gg8etv4Oy1eEm0Cl+hEbYmXVQtsV9OL75X4ObbYu42U0vO7g6KyuAaEwklg==}
+  tsdown@0.20.0-beta.2:
+    resolution: {integrity: sha512-HoZt4jKulm3pPqh1lke/+D+48Rnv5l7cLkPp5ZxbpDUxh+viESsItQzRXVo0lbQMO7TXoZF4hC6gIpEZoZs0aQ==}
     engines: {node: '>=20.19.0'}
     hasBin: true
     peerDependencies:
@@ -8232,18 +8251,18 @@ packages:
       postcss:
         optional: true
 
-  vitest@4.0.16:
-    resolution: {integrity: sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==}
+  vitest@4.0.17:
+    resolution: {integrity: sha512-FQMeF0DJdWY0iOnbv466n/0BudNdKj1l5jYgl5JVTwjSsZSlqyXFt/9+1sEyhR6CLowbZpV7O1sCHrzBhucKKg==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.0.16
-      '@vitest/browser-preview': 4.0.16
-      '@vitest/browser-webdriverio': 4.0.16
-      '@vitest/ui': 4.0.16
+      '@vitest/browser-playwright': 4.0.17
+      '@vitest/browser-preview': 4.0.17
+      '@vitest/browser-webdriverio': 4.0.17
+      '@vitest/ui': 4.0.17
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -11333,35 +11352,35 @@ snapshots:
     transitivePeerDependencies:
       - conventional-commits-filter
 
-  '@vitest/browser-playwright@4.0.16(playwright@1.57.0)(vite@packages+core)(vitest@4.0.16)':
+  '@vitest/browser-playwright@4.0.17(playwright@1.57.0)(vite@packages+core)(vitest@4.0.17)':
     dependencies:
-      '@vitest/browser': 4.0.16(vite@packages+core)(vitest@4.0.16)
-      '@vitest/mocker': 4.0.16(vite@packages+core)
+      '@vitest/browser': 4.0.17(vite@packages+core)(vitest@4.0.17)
+      '@vitest/mocker': 4.0.17(vite@packages+core)
       playwright: 1.57.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.16(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@22.19.3)(@vitest/browser-playwright@4.0.16(playwright@1.57.0)(vite@packages+core)(vitest@4.0.16))(@vitest/browser-preview@4.0.16(vite@packages+core)(vitest@4.0.16))(@vitest/browser-webdriverio@4.0.16(vite@packages+core)(vitest@4.0.16)(webdriverio@9.20.1))(@vitest/ui@4.0.16(vitest@4.0.16))(happy-dom@20.0.10)(jsdom@27.2.0)
+      vitest: 4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@22.19.3)(@vitest/browser-playwright@4.0.17(playwright@1.57.0)(vite@packages+core)(vitest@4.0.17))(@vitest/browser-preview@4.0.17(vite@packages+core)(vitest@4.0.17))(@vitest/browser-webdriverio@4.0.17(vite@packages+core)(vitest@4.0.17)(webdriverio@9.20.1))(@vitest/ui@4.0.17(vitest@4.0.17))(happy-dom@20.0.10)(jsdom@27.2.0)
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser-preview@4.0.16(vite@packages+core)(vitest@4.0.16)':
+  '@vitest/browser-preview@4.0.17(vite@packages+core)(vitest@4.0.17)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/browser': 4.0.16(vite@packages+core)(vitest@4.0.16)
-      vitest: 4.0.16(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@22.19.3)(@vitest/browser-playwright@4.0.16(playwright@1.57.0)(vite@packages+core)(vitest@4.0.16))(@vitest/browser-preview@4.0.16(vite@packages+core)(vitest@4.0.16))(@vitest/browser-webdriverio@4.0.16(vite@packages+core)(vitest@4.0.16)(webdriverio@9.20.1))(@vitest/ui@4.0.16(vitest@4.0.16))(happy-dom@20.0.10)(jsdom@27.2.0)
+      '@vitest/browser': 4.0.17(vite@packages+core)(vitest@4.0.17)
+      vitest: 4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@22.19.3)(@vitest/browser-playwright@4.0.17(playwright@1.57.0)(vite@packages+core)(vitest@4.0.17))(@vitest/browser-preview@4.0.17(vite@packages+core)(vitest@4.0.17))(@vitest/browser-webdriverio@4.0.17(vite@packages+core)(vitest@4.0.17)(webdriverio@9.20.1))(@vitest/ui@4.0.17(vitest@4.0.17))(happy-dom@20.0.10)(jsdom@27.2.0)
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser-webdriverio@4.0.16(vite@packages+core)(vitest@4.0.16)(webdriverio@9.20.1)':
+  '@vitest/browser-webdriverio@4.0.17(vite@packages+core)(vitest@4.0.17)(webdriverio@9.20.1)':
     dependencies:
-      '@vitest/browser': 4.0.16(vite@packages+core)(vitest@4.0.16)
-      vitest: 4.0.16(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@22.19.3)(@vitest/browser-playwright@4.0.16(playwright@1.57.0)(vite@packages+core)(vitest@4.0.16))(@vitest/browser-preview@4.0.16(vite@packages+core)(vitest@4.0.16))(@vitest/browser-webdriverio@4.0.16(vite@packages+core)(vitest@4.0.16)(webdriverio@9.20.1))(@vitest/ui@4.0.16(vitest@4.0.16))(happy-dom@20.0.10)(jsdom@27.2.0)
+      '@vitest/browser': 4.0.17(vite@packages+core)(vitest@4.0.17)
+      vitest: 4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@22.19.3)(@vitest/browser-playwright@4.0.17(playwright@1.57.0)(vite@packages+core)(vitest@4.0.17))(@vitest/browser-preview@4.0.17(vite@packages+core)(vitest@4.0.17))(@vitest/browser-webdriverio@4.0.17(vite@packages+core)(vitest@4.0.17)(webdriverio@9.20.1))(@vitest/ui@4.0.17(vitest@4.0.17))(happy-dom@20.0.10)(jsdom@27.2.0)
       webdriverio: 9.20.1
     transitivePeerDependencies:
       - bufferutil
@@ -11369,16 +11388,16 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.0.16(vite@packages+core)(vitest@4.0.16)':
+  '@vitest/browser@4.0.17(vite@packages+core)(vitest@4.0.17)':
     dependencies:
-      '@vitest/mocker': 4.0.16(vite@packages+core)
-      '@vitest/utils': 4.0.16
+      '@vitest/mocker': 4.0.17(vite@packages+core)
+      '@vitest/utils': 4.0.17
       magic-string: 0.30.21
       pixelmatch: 7.1.0
       pngjs: 7.0.0
       sirv: 3.0.2(patch_hash=c07c56eb72faea34341d465cde2314e89db472106ed378181e3447893af6bf95)
       tinyrainbow: 3.0.3
-      vitest: 4.0.16(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@22.19.3)(@vitest/browser-playwright@4.0.16(playwright@1.57.0)(vite@packages+core)(vitest@4.0.16))(@vitest/browser-preview@4.0.16(vite@packages+core)(vitest@4.0.16))(@vitest/browser-webdriverio@4.0.16(vite@packages+core)(vitest@4.0.16)(webdriverio@9.20.1))(@vitest/ui@4.0.16(vitest@4.0.16))(happy-dom@20.0.10)(jsdom@27.2.0)
+      vitest: 4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@22.19.3)(@vitest/browser-playwright@4.0.17(playwright@1.57.0)(vite@packages+core)(vitest@4.0.17))(@vitest/browser-preview@4.0.17(vite@packages+core)(vitest@4.0.17))(@vitest/browser-webdriverio@4.0.17(vite@packages+core)(vitest@4.0.17)(webdriverio@9.20.1))(@vitest/ui@4.0.17(vitest@4.0.17))(happy-dom@20.0.10)(jsdom@27.2.0)
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
@@ -11386,54 +11405,54 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/expect@4.0.16':
+  '@vitest/expect@4.0.17':
     dependencies:
       '@standard-schema/spec': 1.0.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.0.16
-      '@vitest/utils': 4.0.16
+      '@vitest/spy': 4.0.17
+      '@vitest/utils': 4.0.17
       chai: 6.2.1
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.16(vite@packages+core)':
+  '@vitest/mocker@4.0.17(vite@packages+core)':
     dependencies:
-      '@vitest/spy': 4.0.16
+      '@vitest/spy': 4.0.17
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: link:packages/core
 
-  '@vitest/pretty-format@4.0.16':
+  '@vitest/pretty-format@4.0.17':
     dependencies:
       tinyrainbow: 3.0.3
 
-  '@vitest/runner@4.0.16':
+  '@vitest/runner@4.0.17':
     dependencies:
-      '@vitest/utils': 4.0.16
+      '@vitest/utils': 4.0.17
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.0.16':
+  '@vitest/snapshot@4.0.17':
     dependencies:
-      '@vitest/pretty-format': 4.0.16
+      '@vitest/pretty-format': 4.0.17
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.0.16': {}
+  '@vitest/spy@4.0.17': {}
 
-  '@vitest/ui@4.0.16(vitest@4.0.16)':
+  '@vitest/ui@4.0.17(vitest@4.0.17)':
     dependencies:
-      '@vitest/utils': 4.0.16
+      '@vitest/utils': 4.0.17
       fflate: 0.8.2
       flatted: 3.3.3
       pathe: 2.0.3
       sirv: 3.0.2(patch_hash=c07c56eb72faea34341d465cde2314e89db472106ed378181e3447893af6bf95)
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.16(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@22.19.3)(@vitest/browser-playwright@4.0.16(playwright@1.57.0)(vite@packages+core)(vitest@4.0.16))(@vitest/browser-preview@4.0.16(vite@packages+core)(vitest@4.0.16))(@vitest/browser-webdriverio@4.0.16(vite@packages+core)(vitest@4.0.16)(webdriverio@9.20.1))(@vitest/ui@4.0.16(vitest@4.0.16))(happy-dom@20.0.10)(jsdom@27.2.0)
+      vitest: 4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@22.19.3)(@vitest/browser-playwright@4.0.17(playwright@1.57.0)(vite@packages+core)(vitest@4.0.17))(@vitest/browser-preview@4.0.17(vite@packages+core)(vitest@4.0.17))(@vitest/browser-webdriverio@4.0.17(vite@packages+core)(vitest@4.0.17)(webdriverio@9.20.1))(@vitest/ui@4.0.17(vitest@4.0.17))(happy-dom@20.0.10)(jsdom@27.2.0)
 
-  '@vitest/utils@4.0.16':
+  '@vitest/utils@4.0.17':
     dependencies:
-      '@vitest/pretty-format': 4.0.16
+      '@vitest/pretty-format': 4.0.17
       tinyrainbow: 3.0.3
 
   '@vue/compiler-core@3.5.25':
@@ -14215,6 +14234,22 @@ snapshots:
     transitivePeerDependencies:
       - oxc-resolver
 
+  rolldown-plugin-dts@0.21.0(oxc-resolver@11.14.0)(rolldown@rolldown+packages+rolldown)(typescript@5.9.3):
+    dependencies:
+      '@babel/generator': 7.28.5
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
+      ast-kit: 2.2.0
+      birpc: 4.0.0
+      dts-resolver: 2.1.3(oxc-resolver@11.14.0)
+      get-tsconfig: 4.13.0
+      obug: 2.1.1
+      rolldown: link:rolldown/packages/rolldown
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - oxc-resolver
+
   rollup-plugin-license@3.6.0(picomatch@4.0.3)(rollup@4.53.3):
     dependencies:
       commenting: 1.1.0
@@ -14802,7 +14837,7 @@ snapshots:
       - synckit
       - vue-tsc
 
-  tsdown@0.19.0-beta.5(@arethetypeswrong/core@0.18.2)(@vitejs/devtools@0.0.0-alpha.24(@pnpm/logger@1001.0.1)(vite@packages+core)(vue@3.5.25(typescript@5.9.3)))(oxc-resolver@11.14.0)(publint@0.3.16)(typescript@5.9.3)(unplugin-lightningcss@0.4.3)(unplugin-unused@0.5.6):
+  tsdown@0.20.0-beta.2(@arethetypeswrong/core@0.18.2)(@vitejs/devtools@0.0.0-alpha.24(@pnpm/logger@1001.0.1)(vite@packages+core)(vue@3.5.25(typescript@5.9.3)))(oxc-resolver@11.14.0)(publint@0.3.16)(typescript@5.9.3)(unplugin-lightningcss@0.4.3)(unplugin-unused@0.5.6):
     dependencies:
       ansis: 4.2.0
       cac: 6.7.14
@@ -14813,7 +14848,7 @@ snapshots:
       obug: 2.1.1
       picomatch: 4.0.3
       rolldown: link:rolldown/packages/rolldown
-      rolldown-plugin-dts: 0.20.0(oxc-resolver@11.14.0)(rolldown@rolldown+packages+rolldown)(typescript@5.9.3)
+      rolldown-plugin-dts: 0.21.0(oxc-resolver@11.14.0)(rolldown@rolldown+packages+rolldown)(typescript@5.9.3)
       semver: 7.7.3
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
@@ -15090,15 +15125,15 @@ snapshots:
       - typescript
       - universal-cookie
 
-  vitest@4.0.16(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@22.19.3)(@vitest/browser-playwright@4.0.16(playwright@1.57.0)(vite@packages+core)(vitest@4.0.16))(@vitest/browser-preview@4.0.16(vite@packages+core)(vitest@4.0.16))(@vitest/browser-webdriverio@4.0.16(vite@packages+core)(vitest@4.0.16)(webdriverio@9.20.1))(@vitest/ui@4.0.16(vitest@4.0.16))(happy-dom@20.0.10)(jsdom@27.2.0):
+  vitest@4.0.17(@edge-runtime/vm@5.0.0)(@opentelemetry/api@1.9.0)(@types/node@22.19.3)(@vitest/browser-playwright@4.0.17(playwright@1.57.0)(vite@packages+core)(vitest@4.0.17))(@vitest/browser-preview@4.0.17(vite@packages+core)(vitest@4.0.17))(@vitest/browser-webdriverio@4.0.17(vite@packages+core)(vitest@4.0.17)(webdriverio@9.20.1))(@vitest/ui@4.0.17(vitest@4.0.17))(happy-dom@20.0.10)(jsdom@27.2.0):
     dependencies:
-      '@vitest/expect': 4.0.16
-      '@vitest/mocker': 4.0.16(vite@packages+core)
-      '@vitest/pretty-format': 4.0.16
-      '@vitest/runner': 4.0.16
-      '@vitest/snapshot': 4.0.16
-      '@vitest/spy': 4.0.16
-      '@vitest/utils': 4.0.16
+      '@vitest/expect': 4.0.17
+      '@vitest/mocker': 4.0.17(vite@packages+core)
+      '@vitest/pretty-format': 4.0.17
+      '@vitest/runner': 4.0.17
+      '@vitest/snapshot': 4.0.17
+      '@vitest/spy': 4.0.17
+      '@vitest/utils': 4.0.17
       es-module-lexer: 1.7.0
       expect-type: 1.2.2
       magic-string: 0.30.21
@@ -15116,10 +15151,10 @@ snapshots:
       '@edge-runtime/vm': 5.0.0
       '@opentelemetry/api': 1.9.0
       '@types/node': 22.19.3
-      '@vitest/browser-playwright': 4.0.16(playwright@1.57.0)(vite@packages+core)(vitest@4.0.16)
-      '@vitest/browser-preview': 4.0.16(vite@packages+core)(vitest@4.0.16)
-      '@vitest/browser-webdriverio': 4.0.16(vite@packages+core)(vitest@4.0.16)(webdriverio@9.20.1)
-      '@vitest/ui': 4.0.16(vitest@4.0.16)
+      '@vitest/browser-playwright': 4.0.17(playwright@1.57.0)(vite@packages+core)(vitest@4.0.17)
+      '@vitest/browser-preview': 4.0.17(vite@packages+core)(vitest@4.0.17)
+      '@vitest/browser-webdriverio': 4.0.17(vite@packages+core)(vitest@4.0.17)(webdriverio@9.20.1)
+      '@vitest/ui': 4.0.17(vitest@4.0.17)
       happy-dom: 20.0.10
       jsdom: 27.2.0
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -99,7 +99,7 @@ catalog:
   terser: ^5.44.1
   tinybench: ^6.0.0
   tinyexec: ^1.0.1
-  tsdown: ^0.19.0-beta.5
+  tsdown: ^0.20.0-beta.2
   tsx: ^4.20.6
   typescript: ^5.9.3
   unified: ^11.0.5
@@ -150,7 +150,7 @@ overrides:
   rolldown: 'workspace:rolldown@*'
   vite: 'workspace:@voidzero-dev/vite-plus-core@*'
   vitest: 'workspace:@voidzero-dev/vite-plus-test@*'
-  vitest-dev: 'npm:vitest@^4.0.16'
+  vitest-dev: 'npm:vitest@^4.0.17'
 packageExtensions:
   sass-embedded:
     peerDependencies:


### PR DESCRIPTION
Automated daily upgrade of upstream dependencies:
- rolldown (latest tag)
- rolldown-vite (latest tag)
- vitest (latest npm version)
- tsdown (latest npm version)

Build status: success

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrades upstream testing/build tooling across the workspace.
> 
> - Bumps `vitest` and related `@vitest/*` packages to `4.0.17` (including `@vitest/ui` peer dep and `vitest-dev` override)
> - Upgrades `tsdown` to `0.20.0-beta.2` and aligns transitive `rolldown-plugin-dts` to `0.21.0`
> - Updates `pnpm-workspace.yaml` overrides and refreshes `pnpm-lock.yaml` to reflect new versions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1dd6bab82b6f597e0d061f5a7523e0df3fb4049b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->