### PR TITLE
chore: remove creation of `.npmrc` through `vite migrate`.

### DIFF
--- a/packages/global/snap-tests/gen-create-tsdown-with-scope-name/snap.txt
+++ b/packages/global/snap-tests/gen-create-tsdown-with-scope-name/snap.txt
@@ -1,7 +1,3 @@
 > vite gen vite:library --no-interactive --directory @my-scope/my-library # create vite library with scope name
 > ls my-library/package.json # check package.json
 my-library/package.json
-
-> cat my-library/.npmrc # check .npmrc
-@voidzero-dev:registry=https://npm.pkg.github.com/
-//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}

--- a/packages/global/snap-tests/gen-create-tsdown-with-scope-name/steps.json
+++ b/packages/global/snap-tests/gen-create-tsdown-with-scope-name/steps.json
@@ -1,5 +1,4 @@
 {
-  
   "env": {
     "VITE_DISABLE_AUTO_INSTALL": "1"
   },
@@ -8,7 +7,6 @@
       "command": "vite gen vite:library --no-interactive --directory @my-scope/my-library # create vite library with scope name",
       "ignoreOutput": true
     },
-    "ls my-library/package.json # check package.json",
-    "cat my-library/.npmrc # check .npmrc"
+    "ls my-library/package.json # check package.json"
   ]
 }

--- a/packages/global/snap-tests/gen-create-tsdown/snap.txt
+++ b/packages/global/snap-tests/gen-create-tsdown/snap.txt
@@ -2,9 +2,6 @@
 > ls vite-plus-library/package.json # check package.json
 vite-plus-library/package.json
 
-> cat vite-plus-library/.npmrc # check .npmrc
-@voidzero-dev:registry=https://npm.pkg.github.com/
-//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
 > vite gen vite:library --directory my-vue -- --template vue # create vite library with custom template
 > ls my-vue/package.json # check package.json
 my-vue/package.json

--- a/packages/global/snap-tests/gen-create-tsdown/steps.json
+++ b/packages/global/snap-tests/gen-create-tsdown/steps.json
@@ -1,5 +1,4 @@
 {
-  
   "env": {
     "VITE_DISABLE_AUTO_INSTALL": "1"
   },
@@ -9,7 +8,6 @@
       "ignoreOutput": true
     },
     "ls vite-plus-library/package.json # check package.json",
-    "cat vite-plus-library/.npmrc # check .npmrc",
     {
       "command": "vite gen vite:library --directory my-vue -- --template vue # create vite library with custom template",
       "ignoreOutput": true

--- a/packages/global/snap-tests/gen-create-vite-with-scope-name/snap.txt
+++ b/packages/global/snap-tests/gen-create-vite-with-scope-name/snap.txt
@@ -1,7 +1,3 @@
 > vite gen vite:application --no-interactive --directory @my-scope/my-vite-app -- --template vanilla-ts # create vite app with vanilla-ts template with scope name
 > ls my-vite-app/package.json # check package.json
 my-vite-app/package.json
-
-> cat my-vite-app/.npmrc # check .npmrc
-@voidzero-dev:registry=https://npm.pkg.github.com/
-//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}

--- a/packages/global/snap-tests/gen-create-vite-with-scope-name/steps.json
+++ b/packages/global/snap-tests/gen-create-vite-with-scope-name/steps.json
@@ -1,5 +1,4 @@
 {
-  
   "env": {
     "VITE_DISABLE_AUTO_INSTALL": "1"
   },
@@ -8,7 +7,6 @@
       "command": "vite gen vite:application --no-interactive --directory @my-scope/my-vite-app -- --template vanilla-ts # create vite app with vanilla-ts template with scope name",
       "ignoreOutput": true
     },
-    "ls my-vite-app/package.json # check package.json",
-    "cat my-vite-app/.npmrc # check .npmrc"
+    "ls my-vite-app/package.json # check package.json"
   ]
 }

--- a/packages/global/snap-tests/gen-create-vite/snap.txt
+++ b/packages/global/snap-tests/gen-create-vite/snap.txt
@@ -2,9 +2,6 @@
 > ls vite-plus-application/package.json # check package.json
 vite-plus-application/package.json
 
-> cat vite-plus-application/.npmrc # check .npmrc
-@voidzero-dev:registry=https://npm.pkg.github.com/
-//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
 > vite gen vite:application --no-interactive --directory my-react-ts -- --template react-ts # create vite app with react-ts template
 > ls my-react-ts/package.json # check package.json
 my-react-ts/package.json

--- a/packages/global/snap-tests/gen-create-vite/steps.json
+++ b/packages/global/snap-tests/gen-create-vite/steps.json
@@ -1,5 +1,4 @@
 {
-  
   "env": {
     "VITE_DISABLE_AUTO_INSTALL": "1"
   },
@@ -9,7 +8,6 @@
       "ignoreOutput": true
     },
     "ls vite-plus-application/package.json # check package.json",
-    "cat vite-plus-application/.npmrc # check .npmrc",
     {
       "command": "vite gen vite:application --no-interactive --directory my-react-ts -- --template react-ts # create vite app with react-ts template",
       "ignoreOutput": true

--- a/packages/global/snap-tests/gen-vite-monorepo/snap.txt
+++ b/packages/global/snap-tests/gen-vite-monorepo/snap.txt
@@ -52,9 +52,6 @@ peerDependencyRules:
     vite: '*'
     vitest: '*'
 
-> cat vite-plus-monorepo/.npmrc # check .npmrc
-@voidzero-dev:registry=https://npm.pkg.github.com/
-//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
 > test -d vite-plus-monorepo/.git && echo 'Git initialized' || echo 'No git' # check git init
 Git initialized
 

--- a/packages/global/snap-tests/gen-vite-monorepo/steps.json
+++ b/packages/global/snap-tests/gen-vite-monorepo/steps.json
@@ -1,5 +1,4 @@
 {
-  
   "commands": [
     {
       "command": "vite gen vite:monorepo --no-interactive # create monorepo with default values",
@@ -8,7 +7,6 @@
     "ls vite-plus-monorepo | LC_ALL=C sort # check files created",
     "cat vite-plus-monorepo/package.json # check package.json",
     "cat vite-plus-monorepo/pnpm-workspace.yaml # check workspace config",
-    "cat vite-plus-monorepo/.npmrc # check .npmrc",
     "test -d vite-plus-monorepo/.git && echo 'Git initialized' || echo 'No git' # check git init",
     "ls vite-plus-monorepo/apps # check apps directory created",
     "ls vite-plus-monorepo/apps/website/package.json # check website package.json",

--- a/packages/global/snap-tests/migration-monorepo-yarn4/snap.txt
+++ b/packages/global/snap-tests/migration-monorepo-yarn4/snap.txt
@@ -73,9 +73,6 @@ npmScopes:
     npmRegistryServer: https://npm.pkg.github.com
     npmAuthToken: ${GITHUB_TOKEN}
 
-> cat .npmrc # check .npmrc
-@voidzero-dev:registry=https://npm.pkg.github.com/
-//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
 > cat packages/app/package.json # check app package.json
 {
   "name": "app",

--- a/packages/global/snap-tests/migration-monorepo-yarn4/steps.json
+++ b/packages/global/snap-tests/migration-monorepo-yarn4/steps.json
@@ -8,7 +8,6 @@
     "cat .oxlintrc.json && exit 1 || true # check .oxlintrc.json is removed",
     "cat package.json # check package.json",
     "cat .yarnrc.yml # check .yarnrc.yml",
-    "cat .npmrc # check .npmrc",
     "cat packages/app/package.json # check app package.json",
     "cat packages/utils/package.json # check utils package.json"
   ]

--- a/packages/global/src/migration/migrator.ts
+++ b/packages/global/src/migration/migrator.ts
@@ -135,8 +135,6 @@ export function rewriteStandaloneProject(projectPath: string, workspaceInfo: Wor
     return pkg;
   });
 
-  // set .npmrc to use vite-plus
-  rewriteNpmrc(projectPath);
   rewriteLintStagedConfigFile(projectPath);
   mergeViteConfigFiles(projectPath);
   mergeTsdownConfigFile(projectPath);
@@ -167,8 +165,6 @@ export function rewriteMonorepo(workspaceInfo: WorkspaceInfo): void {
     );
   }
 
-  // set .npmrc to use vite-plus
-  rewriteNpmrc(workspaceInfo.rootDir);
   rewriteLintStagedConfigFile(workspaceInfo.rootDir);
   mergeViteConfigFiles(workspaceInfo.rootDir);
   mergeTsdownConfigFile(workspaceInfo.rootDir);
@@ -541,40 +537,6 @@ function rewriteLintStagedConfigFile(projectPath: string): void {
     prompts.log.warn(
       `Please migrate the lint-staged config manually, see https://viteplus.dev/migration/#lint-staged for more details`,
     );
-  }
-}
-
-// TODO: should remove this function after vite-plus is released to npm
-/**
- * Rewrite .npmrc to add custom registry and auth token
- * ```
- * @voidzero-dev:registry=https://npm.pkg.github.com/
- * //npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
- * ```
- * @param projectPath - The path to the project
- */
-function rewriteNpmrc(projectPath: string): void {
-  const npmrcPath = path.join(projectPath, '.npmrc');
-  if (!fs.existsSync(npmrcPath)) {
-    fs.writeFileSync(npmrcPath, '');
-  }
-
-  let changed = false;
-  let content = fs.readFileSync(npmrcPath, 'utf-8');
-  const customRegistry = `@voidzero-dev:registry=https://npm.pkg.github.com/`;
-  if (!content.includes(customRegistry)) {
-    content = content ? `${content.trimEnd()}\n${customRegistry}` : customRegistry;
-    changed = true;
-  }
-  // don't set if it already exists
-  let customAuthToken = '//npm.pkg.github.com/:_authToken=';
-  if (!content.includes(customAuthToken)) {
-    customAuthToken += '${GITHUB_TOKEN}';
-    content = content ? `${content.trimEnd()}\n${customAuthToken}` : customAuthToken;
-    changed = true;
-  }
-  if (changed) {
-    fs.writeFileSync(npmrcPath, content);
   }
 }
 


### PR DESCRIPTION
There is no need to create this file inside of projects once the package is published. This PR removes the feature.