### PR TITLE
chore: bump rust & vite-task version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1355,7 +1355,7 @@ dependencies = [
 [[package]]
 name = "fspy"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=41f102edf54b9cda98dffa161acd8bb5b5514759#41f102edf54b9cda98dffa161acd8bb5b5514759"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1390,7 +1390,7 @@ dependencies = [
 [[package]]
 name = "fspy_detours_sys"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=41f102edf54b9cda98dffa161acd8bb5b5514759#41f102edf54b9cda98dffa161acd8bb5b5514759"
 dependencies = [
  "cc",
  "winapi",
@@ -1399,7 +1399,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_unix"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=41f102edf54b9cda98dffa161acd8bb5b5514759#41f102edf54b9cda98dffa161acd8bb5b5514759"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1414,7 +1414,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_windows"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=41f102edf54b9cda98dffa161acd8bb5b5514759#41f102edf54b9cda98dffa161acd8bb5b5514759"
 dependencies = [
  "bincode",
  "constcat",
@@ -1430,7 +1430,7 @@ dependencies = [
 [[package]]
 name = "fspy_seccomp_unotify"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=41f102edf54b9cda98dffa161acd8bb5b5514759#41f102edf54b9cda98dffa161acd8bb5b5514759"
 dependencies = [
  "bincode",
  "futures-util",
@@ -1447,7 +1447,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=41f102edf54b9cda98dffa161acd8bb5b5514759#41f102edf54b9cda98dffa161acd8bb5b5514759"
 dependencies = [
  "allocator-api2",
  "bincode",
@@ -1465,7 +1465,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared_unix"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=41f102edf54b9cda98dffa161acd8bb5b5514759#41f102edf54b9cda98dffa161acd8bb5b5514759"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1483,7 +1483,7 @@ dependencies = [
 [[package]]
 name = "fspy_test_utils"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=41f102edf54b9cda98dffa161acd8bb5b5514759#41f102edf54b9cda98dffa161acd8bb5b5514759"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -4384,7 +4384,7 @@ dependencies = [
 [[package]]
 name = "vite_glob"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=41f102edf54b9cda98dffa161acd8bb5b5514759#41f102edf54b9cda98dffa161acd8bb5b5514759"
 dependencies = [
  "thiserror 2.0.17",
  "wax",
@@ -4393,7 +4393,7 @@ dependencies = [
 [[package]]
 name = "vite_graph_ser"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=41f102edf54b9cda98dffa161acd8bb5b5514759#41f102edf54b9cda98dffa161acd8bb5b5514759"
 dependencies = [
  "petgraph 0.8.3",
  "serde",
@@ -4447,7 +4447,7 @@ dependencies = [
 [[package]]
 name = "vite_path"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=41f102edf54b9cda98dffa161acd8bb5b5514759#41f102edf54b9cda98dffa161acd8bb5b5514759"
 dependencies = [
  "bincode",
  "diff-struct",
@@ -4460,7 +4460,7 @@ dependencies = [
 [[package]]
 name = "vite_shell"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=41f102edf54b9cda98dffa161acd8bb5b5514759#41f102edf54b9cda98dffa161acd8bb5b5514759"
 dependencies = [
  "bincode",
  "brush-parser",
@@ -4473,7 +4473,7 @@ dependencies = [
 [[package]]
 name = "vite_str"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=41f102edf54b9cda98dffa161acd8bb5b5514759#41f102edf54b9cda98dffa161acd8bb5b5514759"
 dependencies = [
  "bincode",
  "compact_str",
@@ -4484,7 +4484,7 @@ dependencies = [
 [[package]]
 name = "vite_task"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=41f102edf54b9cda98dffa161acd8bb5b5514759#41f102edf54b9cda98dffa161acd8bb5b5514759"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4518,7 +4518,7 @@ dependencies = [
 [[package]]
 name = "vite_task_graph"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=41f102edf54b9cda98dffa161acd8bb5b5514759#41f102edf54b9cda98dffa161acd8bb5b5514759"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4539,7 +4539,7 @@ dependencies = [
 [[package]]
 name = "vite_task_plan"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=41f102edf54b9cda98dffa161acd8bb5b5514759#41f102edf54b9cda98dffa161acd8bb5b5514759"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4564,7 +4564,7 @@ dependencies = [
 [[package]]
 name = "vite_workspace"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=c57008d77e940ea235822c02351020de34fa97a6#c57008d77e940ea235822c02351020de34fa97a6"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=41f102edf54b9cda98dffa161acd8bb5b5514759#41f102edf54b9cda98dffa161acd8bb5b5514759"
 dependencies = [
  "petgraph 0.8.3",
  "rustc-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ criterion = { version = "0.7", features = ["html_reports"] }
 crossterm = { version = "0.29.0", features = ["event-stream"] }
 directories = "6.0.0"
 flate2 = "1.0.35"
-fspy = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "c57008d77e940ea235822c02351020de34fa97a6" }
+fspy = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "41f102edf54b9cda98dffa161acd8bb5b5514759" }
 futures-util = "0.3.31"
 hex = "0.4.3"
 httpmock = "0.7"
@@ -94,13 +94,13 @@ tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "serde"] }
 vite_command = { path = "crates/vite_command" }
 vite_error = { path = "crates/vite_error" }
-vite_glob = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "c57008d77e940ea235822c02351020de34fa97a6" }
+vite_glob = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "41f102edf54b9cda98dffa161acd8bb5b5514759" }
 vite_install = { path = "crates/vite_install" }
 vite_migration = { path = "crates/vite_migration" }
-vite_path = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "c57008d77e940ea235822c02351020de34fa97a6" }
-vite_str = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "c57008d77e940ea235822c02351020de34fa97a6" }
-vite_task = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "c57008d77e940ea235822c02351020de34fa97a6" }
-vite_workspace = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "c57008d77e940ea235822c02351020de34fa97a6" }
+vite_path = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "41f102edf54b9cda98dffa161acd8bb5b5514759" }
+vite_str = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "41f102edf54b9cda98dffa161acd8bb5b5514759" }
+vite_task = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "41f102edf54b9cda98dffa161acd8bb5b5514759" }
+vite_workspace = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "41f102edf54b9cda98dffa161acd8bb5b5514759" }
 wax = "0.6.0"
 which = "8.0.0"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,4 @@
 [toolchain]
-# Needed nightly features:
-# - cargo `Z-bindeps` to build and embed preload shared libraries as dependencies of fspy
-# - `windows_process_extensions_main_thread_handle` to get the main thread handle for Detours injection
-channel = "nightly-2025-10-31"
+# nightly features required by vite-task
+channel = "nightly-2025-12-11"
 profile = "default"


### PR DESCRIPTION
### TL;DR

Updated the Rust toolchain to a newer nightly version.

### What changed?

- Updated the Rust toolchain from `nightly-2025-10-31` to `nightly-2025-12-11`
- Updated the comment to indicate the nightly features are required by `vite-task` instead of listing specific features needed for `fspy`
- Removed comments about specific nightly features that were previously required

### How to test?

- Run `cargo build` to verify the project compiles with the new toolchain
- Verify that all `vite-task` functionality works as expected

### Why make this change?

The project now depends on `vite-task` which requires a newer nightly version of Rust. The previous nightly features for `fspy` (Z-bindeps and Windows process extensions) are no longer needed or have been replaced by the requirements of `vite-task`.