### PR TITLE
feat(help): Improve help command output.

### DIFF
--- a/packages/cli/binding/src/cli.rs
+++ b/packages/cli/binding/src/cli.rs
@@ -55,13 +55,13 @@ pub enum CustomTaskSubcommand {
         #[clap(allow_hyphen_values = true, trailing_var_arg = true)]
         args: Vec<String>,
     },
-    /// Build application
+    /// Build for production
     #[command(disable_help_flag = true)]
     Build {
         #[clap(allow_hyphen_values = true, trailing_var_arg = true)]
         args: Vec<String>,
     },
-    /// Run test
+    /// Run tests
     #[command(disable_help_flag = true)]
     Test {
         #[clap(allow_hyphen_values = true, trailing_var_arg = true)]
@@ -92,7 +92,6 @@ pub enum CustomTaskSubcommand {
         args: Vec<String>,
     },
     /// Install command.
-    /// It will be passed to the package manager's install command currently.
     #[command(disable_help_flag = true, alias = "i")]
     Install {
         #[clap(allow_hyphen_values = true, trailing_var_arg = true)]
@@ -611,6 +610,11 @@ pub async fn main(
     // Get args from parameter or env::args()
     // When running from NAPI, args should be passed explicitly to skip node/script paths
     let args_vec: Vec<String> = args.unwrap_or_else(|| env::args().skip(1).collect());
+    let args_vec = normalize_help_args(args_vec);
+    if should_print_help(&args_vec) {
+        print_help();
+        return Ok(ExitStatus::SUCCESS);
+    }
 
     // Parse CLI args using vite_task::CLIArgs
     // Prepend "vite" as program name for clap
@@ -701,6 +705,47 @@ pub async fn main(
             Ok(session.execute(plan, Box::new(reporter)).await.err().unwrap_or(ExitStatus::SUCCESS))
         }
     }
+}
+
+fn normalize_help_args(args: Vec<String>) -> Vec<String> {
+    args
+}
+
+fn should_print_help(args: &[String]) -> bool {
+    matches!(
+        args,
+        [arg] if arg == "-h" || arg == "--help"
+    )
+}
+
+fn print_help() {
+    let version = env!("CARGO_PKG_VERSION");
+    let bold = "\x1b[1m";
+    let bold_underline = "\x1b[1;4m";
+    let reset = "\x1b[0m";
+    println!(
+        "vite+/{version}
+
+{bold_underline}Usage:{reset} {bold}vite{reset} <COMMAND>
+
+{bold_underline}Vite+ Commands:{reset}
+  {bold}dev{reset}        Run development server
+  {bold}build{reset}      Build for production
+  {bold}preview{reset}    Preview production build
+  {bold}lint{reset}       Lint code
+  {bold}test{reset}       Run tests
+  {bold}fmt{reset}        Format code
+  {bold}lib{reset}        Build library
+  {bold}doc{reset}        Build documentation
+  {bold}run{reset}        Run tasks
+  {bold}cache{reset}      Manage the task cache
+
+{bold_underline}Package Manager Commands:{reset}
+  {bold}install{reset}    Install all dependencies
+
+Options:
+  -h, --help  Print help"
+    );
 }
 
 pub fn init_tracing() {

--- a/packages/cli/snap-tests/command-helper/snap.txt
+++ b/packages/cli/snap-tests/command-helper/snap.txt
@@ -1,21 +1,22 @@
 > vite -h # help message
-Vite+<repeat>
+vite+/<semver>
 
-Usage: vite <COMMAND>
+[1;4mUsage:[0m [1mvite[0m <COMMAND>
 
-Commands:
-  run      Run tasks
-  lint     Lint code
-  fmt      Format code
-  build    Build application
-  test     Run test
-  lib      Build library
-  dev      Run development server
-  preview  Preview production build
-  doc      Build documentation
-  install  Install command. It will be passed to the package manager's install command currently
-  cache    Manage the task cache
-  help     Print this message or the help of the given subcommand(s)
+[1;4mVite+ Commands:[0m
+  [1mdev[0m        Run development server
+  [1mbuild[0m      Build for production
+  [1mpreview[0m    Preview production build
+  [1mlint[0m       Lint code
+  [1mtest[0m       Run tests
+  [1mfmt[0m        Format code
+  [1mlib[0m        Build library
+  [1mdoc[0m        Build documentation
+  [1mrun[0m        Run tasks
+  [1mcache[0m      Manage the task cache
+
+[1;4mPackage Manager Commands:[0m
+  [1minstall[0m    Install all dependencies
 
 Options:
   -h, --help  Print help

--- a/packages/global/binding/src/cli.rs
+++ b/packages/global/binding/src/cli.rs
@@ -1,6 +1,6 @@
 use std::process::ExitStatus;
 
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
 use vite_error::Error;
 use vite_install::commands::{
     add::SaveDependencyType, install::InstallCommandOptions, outdated::Format,
@@ -15,16 +15,7 @@ use crate::commands::{
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
-#[command(
-    disable_help_subcommand = true,
-    help_template = "\
-vite+/{version}
-
-{usage-heading} {usage}
-
-{all-args}{after-help}
-"
-)]
+#[command(disable_help_subcommand = true)]
 pub struct Args {
     #[clap(subcommand)]
     pub commands: Commands,
@@ -406,6 +397,24 @@ pub enum Commands {
         #[arg(last = true, allow_hyphen_values = true)]
         pass_through_args: Option<Vec<String>>,
     },
+    /// View package information from registry
+    #[command(alias = "view", alias = "show")]
+    Info {
+        /// Package name with optional version
+        #[arg(required = true)]
+        package: String,
+
+        /// Specific field to view
+        field: Option<String>,
+
+        /// Output in JSON format
+        #[arg(long)]
+        json: bool,
+
+        /// Additional arguments to pass through to the package manager
+        #[arg(last = true, allow_hyphen_values = true)]
+        pass_through_args: Option<Vec<String>>,
+    },
     /// Link packages for local development
     #[command(alias = "ln")]
     Link {
@@ -433,7 +442,7 @@ pub enum Commands {
         #[arg(allow_hyphen_values = true, trailing_var_arg = true)]
         args: Vec<String>,
     },
-    /// Package manager utilities
+    /// Forward command to the package manager.
     #[command(subcommand)]
     Pm(PmCommands),
     /// Execute a package binary without installing it as a dependency
@@ -1064,6 +1073,17 @@ pub async fn main(cwd: AbsolutePathBuf, mut args: Args) -> Result<std::process::
                 .await?;
             return Ok(exit_status);
         }
+        Commands::Info { package, field, json, pass_through_args } => {
+            let exit_status = PmCommand::new(cwd)
+                .execute(PmCommands::View {
+                    package: package.clone(),
+                    field: field.clone(),
+                    json: *json,
+                    pass_through_args: pass_through_args.clone(),
+                })
+                .await?;
+            return Ok(exit_status);
+        }
         Commands::Pm(pm_command) => {
             let exit_status = PmCommand::new(cwd).execute(pm_command.clone()).await?;
             return Ok(exit_status);
@@ -1076,6 +1096,53 @@ pub async fn main(cwd: AbsolutePathBuf, mut args: Args) -> Result<std::process::
         }
         _ => unreachable!(),
     };
+}
+
+pub fn command_with_help() -> clap::Command {
+    let bold = "\x1b[1m";
+    let bold_underline = "\x1b[1;4m";
+    let reset = "\x1b[0m";
+    let version = env!("CARGO_PKG_VERSION");
+
+    let after_help = format!(
+        "{bold_underline}Vite+ Commands:{reset}
+  {bold}dev{reset}        Run development server
+  {bold}build{reset}      Build for production
+  {bold}lint{reset}       Lint code
+  {bold}test{reset}       Run tests
+  {bold}fmt{reset}        Format code
+  {bold}doc{reset}        Build documentation
+  {bold}lib{reset}        Build library
+  {bold}migrate{reset}    Migrate an existing project to Vite+
+  {bold}cache{reset}      Manage the task cache
+  {bold}new{reset}        Generate a new project
+  {bold}run{reset}        Run tasks
+
+{bold_underline}Package Manager Commands:{reset}
+  {bold}install{reset}    Install all dependencies, or add packages if package names are provided
+  {bold}add{reset}        Add packages to dependencies
+  {bold}remove{reset}     Remove packages from dependencies
+  {bold}dedupe{reset}     Deduplicate dependencies by removing older versions
+  {bold}dlx{reset}        Execute a package binary without installing it as a dependency
+  {bold}info{reset}       View package information from registry
+  {bold}link{reset}       Link packages for local development
+  {bold}outdated{reset}   Check for outdated packages
+  {bold}pm{reset}         Forward command to the package manager
+  {bold}unlink{reset}     Unlink packages
+  {bold}update{reset}     Update packages to their latest versions
+  {bold}why{reset}        Show why a package is installed
+"
+    );
+    let help_template = format!(
+        "vite+/{version}
+
+{{usage-heading}} {{usage}}{{after-help}}
+{bold_underline}Options:{reset}
+{{options}}
+"
+    );
+
+    Args::command().after_help(after_help).help_template(help_template)
 }
 
 pub fn init_tracing() {

--- a/packages/global/binding/src/commands/pm.rs
+++ b/packages/global/binding/src/commands/pm.rs
@@ -15,7 +15,7 @@ use crate::{
     cli::{ConfigCommands, OwnerCommands, PmCommands},
 };
 
-/// Package manager utilities command.
+/// Forward command to the package manager.
 ///
 /// This command provides a unified interface to package manager utilities
 /// across pnpm, npm, and yarn.

--- a/packages/global/binding/src/lib.rs
+++ b/packages/global/binding/src/lib.rs
@@ -6,7 +6,9 @@ mod migration;
 mod package_manager;
 mod utils;
 
-use clap::Parser as _;
+use std::ffi::{OsStr, OsString};
+
+use clap::FromArgMatches as _;
 use napi::{anyhow, bindgen_prelude::*};
 use napi_derive::napi;
 pub use utils::run_command;
@@ -90,5 +92,19 @@ pub async fn run(options: CliOptions) -> Result<i32> {
 
 fn parse_args() -> Args {
     // Parse CLI arguments (skip first arg which is the node binary)
-    Args::parse_from(std::env::args_os().skip(1))
+    let args = normalize_help_args(std::env::args_os().skip(1).collect());
+    let matches = crate::cli::command_with_help().get_matches_from(args);
+    Args::from_arg_matches(&matches).unwrap_or_else(|e| e.exit())
+}
+
+fn normalize_help_args(args: Vec<OsString>) -> Vec<OsString> {
+    if matches!(args.first(), Some(arg) if arg == OsStr::new("help")) {
+        return vec![OsString::from("--help")];
+    }
+
+    if args.len() >= 2 && args[1] == OsStr::new("help") {
+        return vec![args[0].clone(), OsString::from("--help")];
+    }
+
+    args
 }

--- a/packages/global/snap-tests/cli-helper-message/snap.txt
+++ b/packages/global/snap-tests/cli-helper-message/snap.txt
@@ -3,29 +3,32 @@ vite+/<semver>
 
 Usage: vite <COMMAND>
 
-Commands:
-  install   Install all dependencies, or add packages if package names are provided
-  add       Add packages to dependencies
-  remove    Remove packages from dependencies
-  update    Update packages to their latest versions
-  dedupe    Deduplicate dependencies by removing older versions
-  outdated  Check for outdated packages
-  why       Show why a package is installed
-  link      Link packages for local development
-  unlink    Unlink packages
-  pm        Package manager utilities
-  dlx       Execute a package binary without installing it as a dependency
-  gen       Generate a new project
-  migrate   Migrate an existing project to vite+<repeat>
-  dev       Run development server
-  build     Build application
-  test      Run test
-  lint      Lint code
-  fmt       Format code
-  lib       Build library
-  doc       Build documentation
-  run       Run tasks
-  cache     Manage the task cache
+Vite+ Commands:
+  dev        Run development server
+  build      Build for production
+  lint       Lint code
+  test       Run tests
+  fmt        Format code
+  doc        Build documentation
+  lib        Build library
+  migrate    Migrate an existing project to Vite+<repeat>
+  cache      Manage the task cache
+  new        Generate a new project
+  run        Run tasks
+
+Package Manager Commands:
+  install    Install all dependencies, or add packages if package names are provided
+  add        Add packages to dependencies
+  remove     Remove packages from dependencies
+  dedupe     Deduplicate dependencies by removing older versions
+  dlx        Execute a package binary without installing it as a dependency
+  info       View package information from registry
+  link       Link packages for local development
+  outdated   Check for outdated packages
+  pm         Forward command to the package manager
+  unlink     Unlink packages
+  update     Update packages to their latest versions
+  why        Show why a package is installed
 
 Options:
   -h, --help     Print help
@@ -235,7 +238,7 @@ Options:
   -h, --help                   Print help
 
 > vite pm -h # show pm help message
-Package manager utilities
+Forward command to the package manager
 
 Usage: vite pm <COMMAND>
 


### PR DESCRIPTION
This PR updates the output of the help command. It groups commands into "Vite+Commands" and "Package Manager Commands" to make the separation obvious. It also reorders the commands roughly based on importance, and mirrors the original Vite's order (dev, build, etc.).

I also added the info command to forward `vite info` to package managers. This is one of the commands I use all the time, so I think it's good to have at the top level, especially since it takes many args and would be confusing.

![CleanShot 2026-01-14 at 17.36.51@2x.png](https://app.graphite.com/user-attachments/assets/c82284b3-d432-4591-ae52-53103174362a.png)

The output of the local cli was aligned as well, and looks like this now: https://github.com/voidzero-dev/vite-plus/blob/help-update/packages/cli/snap-tests/command-helper/snap.txt#L6