### PR TITLE
Remove `doc` command from help for now.

### DIFF
--- a/packages/cli/binding/src/cli.rs
+++ b/packages/cli/binding/src/cli.rs
@@ -86,7 +86,7 @@ pub enum CustomTaskSubcommand {
         args: Vec<String>,
     },
     /// Build documentation
-    #[command(disable_help_flag = true)]
+    #[command(disable_help_flag = true, hide = true)]
     Doc {
         #[clap(allow_hyphen_values = true, trailing_var_arg = true)]
         args: Vec<String>,
@@ -736,7 +736,6 @@ fn print_help() {
   {bold}test{reset}       Run tests
   {bold}fmt{reset}        Format code
   {bold}lib{reset}        Build library
-  {bold}doc{reset}        Build documentation
   {bold}run{reset}        Run tasks
   {bold}cache{reset}      Manage the task cache
 

--- a/packages/cli/snap-tests/command-helper/snap.txt
+++ b/packages/cli/snap-tests/command-helper/snap.txt
@@ -11,7 +11,6 @@ vite+/<semver>
   [1mtest[0m       Run tests
   [1mfmt[0m        Format code
   [1mlib[0m        Build library
-  [1mdoc[0m        Build documentation
   [1mrun[0m        Run tasks
   [1mcache[0m      Manage the task cache
 

--- a/packages/global/binding/src/cli.rs
+++ b/packages/global/binding/src/cli.rs
@@ -489,6 +489,7 @@ pub enum Commands {
     Fmt,
     /// Build library
     Lib,
+    #[command(hide = true)]
     /// Build documentation
     Doc,
     /// Run tasks
@@ -1111,7 +1112,6 @@ pub fn command_with_help() -> clap::Command {
   {bold}lint{reset}       Lint code
   {bold}test{reset}       Run tests
   {bold}fmt{reset}        Format code
-  {bold}doc{reset}        Build documentation
   {bold}lib{reset}        Build library
   {bold}migrate{reset}    Migrate an existing project to Vite+
   {bold}cache{reset}      Manage the task cache

--- a/packages/global/snap-tests/cli-helper-message/snap.txt
+++ b/packages/global/snap-tests/cli-helper-message/snap.txt
@@ -9,7 +9,6 @@ Vite+ Commands:
   lint       Lint code
   test       Run tests
   fmt        Format code
-  doc        Build documentation
   lib        Build library
   migrate    Migrate an existing project to Vite+<repeat>
   cache      Manage the task cache


### PR DESCRIPTION
The `doc` command is broken right now. This change hides it from the `help` command.