### PR TITLE
fix(cache): forward cache command to local CLI and update cache path

### DIFF
--- a/packages/cli/binding/src/cli.rs
+++ b/packages/cli/binding/src/cli.rs
@@ -578,7 +578,7 @@ async fn handle_cache_command(
 ) -> Result<ExitStatus, Error> {
     // Get cache path - need to find workspace root first
     let (workspace_root, _) = vite_workspace::find_workspace_root(&cwd)?;
-    let cache_path = workspace_root.path.join(".vite-plus");
+    let cache_path = workspace_root.path.join("node_modules/.vite/task-cache");
 
     match subcmd {
         CacheSubcommand::Clean => {

--- a/packages/cli/snap-tests/cache-clean/package.json
+++ b/packages/cli/snap-tests/cache-clean/package.json
@@ -1,5 +1,5 @@
 {
   "scripts": {
-    "hello": "echo hello"
+    "hello": "vite fmt"
   }
 }

--- a/packages/cli/snap-tests/cache-clean/snap.txt
+++ b/packages/cli/snap-tests/cache-clean/snap.txt
@@ -1,73 +1,69 @@
 > vite run hello # create the cache for 'echo hello'
-$ echo hello ⊘ cache disabled: built-in command
-hello
+$ vite fmt
 
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
     Vite+ Task Runner • Execution Summary
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Statistics:   1 tasks • 0 cache hits • 0 cache misses • 1 cache disabled 
+Statistics:   1 tasks • 0 cache hits • 1 cache misses 
 Performance:  0% cache hit rate
 
 Task Details:
 ────────────────────────────────────────────────
-  [1] hello: $ echo hello ✓
-      → Cache disabled for built-in command
+  [1] hello: $ vite fmt ✓
+      → Cache miss: no previous cache entry found
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 > vite run hello # hit the cache
-$ echo hello ⊘ cache disabled: built-in command
-hello
+$ vite fmt ✓ cache hit, replaying
 
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
     Vite+ Task Runner • Execution Summary
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Statistics:   1 tasks • 0 cache hits • 0 cache misses • 1 cache disabled 
-Performance:  0% cache hit rate
+Statistics:   1 tasks • 1 cache hits • 0 cache misses 
+Performance:  100% cache hit rate, <variable>ms saved in total
 
 Task Details:
 ────────────────────────────────────────────────
-  [1] hello: $ echo hello ✓
-      → Cache disabled for built-in command
+  [1] hello: $ vite fmt ✓
+      → Cache hit - output replayed - <variable>ms saved
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 > vite cache clean # clean the cache
 > vite run hello # cache miss after clean
-$ echo hello ⊘ cache disabled: built-in command
-hello
+$ vite fmt
 
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
     Vite+ Task Runner • Execution Summary
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Statistics:   1 tasks • 0 cache hits • 0 cache misses • 1 cache disabled 
+Statistics:   1 tasks • 0 cache hits • 1 cache misses 
 Performance:  0% cache hit rate
 
 Task Details:
 ────────────────────────────────────────────────
-  [1] hello: $ echo hello ✓
-      → Cache disabled for built-in command
+  [1] hello: $ vite fmt ✓
+      → Cache miss: no previous cache entry found
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 > cd subfolder && vite cache clean # cache can be located and cleaned from subfolder
 > vite run hello # cache miss after clean
-$ echo hello ⊘ cache disabled: built-in command
-hello
+$ vite fmt
 
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
     Vite+ Task Runner • Execution Summary
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Statistics:   1 tasks • 0 cache hits • 0 cache misses • 1 cache disabled 
+Statistics:   1 tasks • 0 cache hits • 1 cache misses 
 Performance:  0% cache hit rate
 
 Task Details:
 ────────────────────────────────────────────────
-  [1] hello: $ echo hello ✓
-      → Cache disabled for built-in command
+  [1] hello: $ vite fmt ✓
+      → Cache miss: no previous cache entry found
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/packages/cli/snap-tests/cache-clean/src/index.ts
+++ b/packages/cli/snap-tests/cache-clean/src/index.ts
@@ -1,0 +1,1 @@
+export const hello = 'world';

--- a/packages/global/src/index.ts
+++ b/packages/global/src/index.ts
@@ -12,6 +12,7 @@ const LOCAL_CLI_COMMANDS = [
   'doc',
   'run',
   'preview',
+  'cache',
 ];
 
 const command = args[0];


### PR DESCRIPTION
- Add 'cache' to LOCAL_CLI_COMMANDS in global CLI to forward to local CLI
- Change task cache path from `.vite-plus` to `node_modules/.vite/task-cache`
- Update cache-clean snap test to use `vite fmt` instead of `echo hello`

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>