### PR TITLE
Add AGENTS.md.

### DIFF
--- a/packages/cli/binding/src/cli.rs
+++ b/packages/cli/binding/src/cli.rs
@@ -73,7 +73,7 @@ pub enum CustomTaskSubcommand {
         #[clap(allow_hyphen_values = true, trailing_var_arg = true)]
         args: Vec<String>,
     },
-    /// Run development server
+    /// Run the development server
     #[command(disable_help_flag = true)]
     Dev {
         #[clap(allow_hyphen_values = true, trailing_var_arg = true)]
@@ -729,7 +729,7 @@ fn print_help() {
 {bold_underline}Usage:{reset} {bold}vite{reset} <COMMAND>
 
 {bold_underline}Vite+ Commands:{reset}
-  {bold}dev{reset}        Run development server
+  {bold}dev{reset}        Run the development server
   {bold}build{reset}      Build for production
   {bold}preview{reset}    Preview production build
   {bold}lint{reset}       Lint code

--- a/packages/cli/snap-tests/command-helper/snap.txt
+++ b/packages/cli/snap-tests/command-helper/snap.txt
@@ -4,7 +4,7 @@ vite+/<semver>
 [1;4mUsage:[0m [1mvite[0m <COMMAND>
 
 [1;4mVite+ Commands:[0m
-  [1mdev[0m        Run development server
+  [1mdev[0m        Run the development server
   [1mbuild[0m      Build for production
   [1mpreview[0m    Preview production build
   [1mlint[0m       Lint code

--- a/packages/global/AGENTS.md
+++ b/packages/global/AGENTS.md
@@ -1,3 +1,52 @@
+<!--VITE PLUS START-->
 # Using Vite+, the Unified Toolchain for the Web
 
-*TODO*
+This project is using Vite+, a modern toolchain built on top of Vite, Rolldown, Vitest, tsdown, Oxlint, and Oxfmt. Vite+ wraps these tools and package manager commands in a single, global CLI called `vite`. Vite+ is distinct from Vite, but it invokes Vite through `vite dev` and `vite build`.
+
+## Vite+ Workflow
+
+`vite` is a global binary that handles the full development lifecycle. Run `vite help` to print a list of commands and `vite <command> --help` for information about a specific command.
+
+### Vite+ Commands
+
+- dev - Run the development server
+- build - Build for production
+- lint - Lint code
+- test - Run tests
+- fmt - Format code
+- lib - Build library
+- new - Create a new monorepo package (in-project) or a new project (global)
+- run - Run tasks from `package.json` scripts
+
+These commands map to their corresponding tools. For example, `vite dev --port 3000` runs Vite's dev server and works the same as Vite. `vite test` runs JavaScript tests through the bundled Vitest. The versions of individual tools can be checked using `vite <command> --version`. For example, `vite lint --version` prints the bundled Oxlint version, and `vite test --version` prints the bundled Vitest version. This is useful when researching documentation, features, and bugs.
+
+### Package Manager Commands
+
+Vite+ automatically detects and wraps the underlying package manager such as pnpm, npm, or Yarn through the `packageManager` field in `package.json` or package manager-specific lockfiles.
+
+- install - Install all dependencies, or add packages if package names are provided
+- add - Add packages to dependencies
+- remove - Remove packages from dependencies
+- dlx - Execute a package binary without installing it as a dependency
+- info - View package information from the registry, including latest versions
+- link - Link packages for local development
+- outdated - Check for outdated packages
+- pm - Forward a command to the package manager
+- unlink - Unlink packages
+- update - Update packages to their latest versions
+- why - Show why a package is installed
+
+## Common Pitfalls
+
+- **Using the package manager directly:** Do not use pnpm, npm, or Yarn directly. Vite+ can handle all package manager operations.
+- **Always use Vite commands to run tools:** Don't attempt to run `vite vitest` or `vite oxlint`. They do not exist. Use `vite test` and `vite lint` instead.
+- **Running scripts:** Vite+ commands take precedence over `package.json` scripts. If there is a `test` script defined in `scripts` that conflicts with the built-in `vite test` command, run it using `vite run test`.
+- **Do not install Vitest, Oxlint, Oxfmt, or tsdown directly:** Vite+ wraps these tools. They must not be installed directly. You cannot upgrade these tools by installing their latest versions. Always use Vite+ commands.
+- **Import JavaScript modules from `vite-plus`:** Instead of importing from `vite` or `vitest`, all modules should be imported from the project's `vite-plus` dependency. For example, `import { defineConfig } from 'vite-plus';` or `import { expect, test, vi } from 'vite-plus/test';`. You must not install `vitest` to import test utilities.
+- **Type-Aware Linting:** There is no need to install `oxlint-tsgolint`, `vite lint --type-aware` works out of the box.
+
+## Review Checklist for Agents
+
+- [ ] Run `vite install` after pulling remote changes and before getting started.
+- [ ] Run `vite lint`, `vite fmt`, and `vite test` to validate changes.
+<!--VITE PLUS END-->

--- a/packages/global/binding/src/cli.rs
+++ b/packages/global/binding/src/cli.rs
@@ -397,7 +397,7 @@ pub enum Commands {
         #[arg(last = true, allow_hyphen_values = true)]
         pass_through_args: Option<Vec<String>>,
     },
-    /// View package information from registry
+    /// View package information from the registry
     #[command(alias = "view", alias = "show")]
     Info {
         /// Package name with optional version
@@ -442,7 +442,7 @@ pub enum Commands {
         #[arg(allow_hyphen_values = true, trailing_var_arg = true)]
         args: Vec<String>,
     },
-    /// Forward command to the package manager.
+    /// Forward a command to the package manager.
     #[command(subcommand)]
     Pm(PmCommands),
     /// Execute a package binary without installing it as a dependency
@@ -477,7 +477,7 @@ pub enum Commands {
     },
 
     // below commands only used to show help message, not actually executed
-    /// Run development server
+    /// Run the development server
     Dev,
     /// Build application
     Build,
@@ -609,7 +609,7 @@ pub enum PmCommands {
         pass_through_args: Option<Vec<String>>,
     },
 
-    /// View package information from registry
+    /// View package information from the registry
     #[command(alias = "info", alias = "show")]
     View {
         /// Package name with optional version
@@ -1107,7 +1107,7 @@ pub fn command_with_help() -> clap::Command {
 
     let after_help = format!(
         "{bold_underline}Vite+ Commands:{reset}
-  {bold}dev{reset}        Run development server
+  {bold}dev{reset}        Run the development server
   {bold}build{reset}      Build for production
   {bold}lint{reset}       Lint code
   {bold}test{reset}       Run tests
@@ -1124,10 +1124,10 @@ pub fn command_with_help() -> clap::Command {
   {bold}remove{reset}     Remove packages from dependencies
   {bold}dedupe{reset}     Deduplicate dependencies by removing older versions
   {bold}dlx{reset}        Execute a package binary without installing it as a dependency
-  {bold}info{reset}       View package information from registry
+  {bold}info{reset}       View package information from the registry
   {bold}link{reset}       Link packages for local development
   {bold}outdated{reset}   Check for outdated packages
-  {bold}pm{reset}         Forward command to the package manager
+  {bold}pm{reset}         Forward a command to the package manager
   {bold}unlink{reset}     Unlink packages
   {bold}update{reset}     Update packages to their latest versions
   {bold}why{reset}        Show why a package is installed

--- a/packages/global/binding/src/commands/pm.rs
+++ b/packages/global/binding/src/commands/pm.rs
@@ -15,7 +15,7 @@ use crate::{
     cli::{ConfigCommands, OwnerCommands, PmCommands},
 };
 
-/// Forward command to the package manager.
+/// Forward a command to the package manager.
 ///
 /// This command provides a unified interface to package manager utilities
 /// across pnpm, npm, and yarn.

--- a/packages/global/snap-tests/cli-helper-message/snap.txt
+++ b/packages/global/snap-tests/cli-helper-message/snap.txt
@@ -4,7 +4,7 @@ vite+/<semver>
 Usage: vite <COMMAND>
 
 Vite+ Commands:
-  dev        Run development server
+  dev        Run the development server
   build      Build for production
   lint       Lint code
   test       Run tests
@@ -21,10 +21,10 @@ Package Manager Commands:
   remove     Remove packages from dependencies
   dedupe     Deduplicate dependencies by removing older versions
   dlx        Execute a package binary without installing it as a dependency
-  info       View package information from registry
+  info       View package information from the registry
   link       Link packages for local development
   outdated   Check for outdated packages
-  pm         Forward command to the package manager
+  pm         Forward a command to the package manager
   unlink     Unlink packages
   update     Update packages to their latest versions
   why        Show why a package is installed
@@ -237,7 +237,7 @@ Options:
   -h, --help                   Print help
 
 > vite pm -h # show pm help message
-Forward command to the package manager
+Forward a command to the package manager
 
 Usage: vite pm <COMMAND>
 
@@ -245,7 +245,7 @@ Commands:
   prune    Remove unnecessary packages
   pack     Create a tarball of the package
   list     List installed packages
-  view     View package information from registry
+  view     View package information from the registry
   publish  Publish package to registry
   owner    Manage package owners
   cache    Manage package cache

--- a/packages/global/snap-tests/command-view-pnpm10/snap.txt
+++ b/packages/global/snap-tests/command-view-pnpm10/snap.txt
@@ -1,5 +1,5 @@
 > vite pm view --help # should show help
-View package information from registry
+View package information from the registry
 
 Usage: vite pm view [OPTIONS] <PACKAGE> [FIELD] [-- <PASS_THROUGH_ARGS>...]
 

--- a/rfcs/pm-command-group.md
+++ b/rfcs/pm-command-group.md
@@ -89,7 +89,7 @@ vite pm <subcommand> [OPTIONS] [ARGS...]
 1. **prune**: Remove unnecessary packages
 2. **pack**: Create a tarball of the package
 3. **list** (alias: **ls**): List installed packages
-4. **view**: View package information from registry
+4. **view**: View package information from the registry
 5. **publish**: Publish package to registry
 6. **owner**: Manage package owners
 7. **cache**: Manage package cache
@@ -864,7 +864,7 @@ pub enum PmCommands {
         args: Vec<String>,
     },
 
-    /// View package information from registry
+    /// View package information from the registry
     View {
         /// Package name with optional version
         package: String,
@@ -1565,7 +1565,7 @@ Commands:
   prune    Remove unnecessary packages
   pack     Create a tarball of the package
   list     List installed packages (alias: ls)
-  view     View package information from registry
+  view     View package information from the registry
   publish  Publish package to registry
   owner    Manage package owners
   cache    Manage package cache


### PR DESCRIPTION
This PR specs out the `AGENTS.md` file that is copied into projects via `vite new` or `vite migrate`. It's an initial version meant to steer LLMs and reduce confusion. It focused on:

- Vite+ is not Vite
- Do not install the individual tools like Oxlint
- Do not try to import from or invoke individual tools like Vitest
- Ask the LLM to always use `vite`, and captures a few gotchas like `vite test` not invoking the package.json "scripts.test".
- Brevity

This version is probably not perfect. It intentionally does not list every single command (agents can run `vite help`). My suggestion is to ship it, use it, and then iterate it when we find issues.

I fixed a few typos in the CLI's help output.

_Handwritten, no AI._