### PR TITLE
feat(new): add --no-rolldown flag to create-vite calls

### DIFF
--- a/packages/global/src/new/templates/remote.ts
+++ b/packages/global/src/new/templates/remote.ts
@@ -89,6 +89,8 @@ function autoFixRemoteTemplateCommand(templateInfo: TemplateInfo, workspaceInfo:
     // don't run dev server after installation
     // https://github.com/vitejs/vite/blob/main/packages/create-vite/src/index.ts#L46
     templateInfo.args.push('--no-immediate');
+    // don't present rolldown option to users
+    templateInfo.args.push('--no-rolldown');
   }
 
   if (workspaceInfo.isMonorepo) {


### PR DESCRIPTION
Prevent users from being presented with the rolldown option when
creating new projects via create-vite.