### PR TITLE
feat(new): add --no-install and --no-toolchain flags to @tanstack/create-start calls

### DIFF
--- a/packages/global/src/new/templates/remote.ts
+++ b/packages/global/src/new/templates/remote.ts
@@ -91,6 +91,11 @@ function autoFixRemoteTemplateCommand(templateInfo: TemplateInfo, workspaceInfo:
     templateInfo.args.push('--no-immediate');
     // don't present rolldown option to users
     templateInfo.args.push('--no-rolldown');
+  } else if (packageName === '@tanstack/create-start') {
+    // don't run npm install after project creation
+    templateInfo.args.push('--no-install');
+    // don't setup toolchain automatically
+    templateInfo.args.push('--no-toolchain');
   }
 
   if (workspaceInfo.isMonorepo) {


### PR DESCRIPTION
Prevents automatic dependency installation and toolchain setup when
creating new TanStack Start projects.