### PR TITLE
fix(e2e): remove package.json and pnpm-workspace.yaml to isolate test project

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -230,6 +230,8 @@ jobs:
           npm install -g ../../tmp/tgz/vite-plus-cli-0.0.0.tgz
           # avoid the vite migration using the wrong ignore file
           rm -f ../.gitignore
+          # remove package.json and pnpm-workspace.yaml from root workspace to make the test project not belong to the vite+ monorepo
+          rm -f ../../package.json ../../pnpm-workspace.yaml
           node ../patch-project.ts ${{ matrix.project.name }}
           vite install --no-frozen-lockfile
 


### PR DESCRIPTION
The test projects were being incorrectly recognized as part of the vite+ monorepo during testing, which could lead to unexpected behavior. By removing these configuration files during the test setup, we ensure that each test project is treated as a standalone project, providing a more accurate testing environment.