### PR TITLE
feat(migration): add --no-agent flag to skip agent instructions

### DIFF
--- a/ecosystem-ci/patch-project.ts
+++ b/ecosystem-ci/patch-project.ts
@@ -20,7 +20,7 @@ const tgzPath = join(projectDir, '..', 'tmp', 'tgz');
 async function migrateProject(project: string) {
   const repoRoot = join(projectDir, project);
   // run vite migrate
-  execSync('vite migrate', {
+  execSync('vite migrate --no-agent', {
     cwd: repoRoot,
     stdio: 'inherit',
     env: {

--- a/packages/global/snap-tests/migration-agent-claude/package.json
+++ b/packages/global/snap-tests/migration-agent-claude/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "migration-agent-claude",
+  "dependencies": {
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/global/snap-tests/migration-agent-claude/snap.txt
+++ b/packages/global/snap-tests/migration-agent-claude/snap.txt
@@ -1,0 +1,18 @@
+> vite migration --agent claude # migration with --agent claude should write CLAUDE.md
+┌  VITE+(⚡︎) - The Unified Toolchain for the Web
+│
+●  Using default package manager: pnpm
+│
+●  pnpm@latest installing...
+│
+●  pnpm@<semver> installed
+│
+◆  Wrote agent instructions to CLAUDE.md
+│
+└  ✨ Migration completed!
+
+
+> cat CLAUDE.md | head -3 # verify CLAUDE.md was created
+<!--VITE PLUS START-->
+# Using Vite+, the Unified Toolchain for the Web
+

--- a/packages/global/snap-tests/migration-agent-claude/src/index.ts
+++ b/packages/global/snap-tests/migration-agent-claude/src/index.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('example', () => {
+  it('should work', () => {
+    expect(1 + 1).toBe(2);
+  });
+});

--- a/packages/global/snap-tests/migration-agent-claude/steps.json
+++ b/packages/global/snap-tests/migration-agent-claude/steps.json
@@ -1,0 +1,9 @@
+{
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": [
+    "vite migration --agent claude # migration with --agent claude should write CLAUDE.md",
+    "cat CLAUDE.md | head -3 # verify CLAUDE.md was created"
+  ]
+}

--- a/packages/global/snap-tests/migration-check/snap.txt
+++ b/packages/global/snap-tests/migration-check/snap.txt
@@ -7,7 +7,8 @@ Arguments:
   PATH                       Target directory to migrate (default: current directory)
 
 Options:
-  --agent NAME              Write agent instructions file into the project (e.g. chatgpt, claude, opencode).
+  --agent NAME               Write agent instructions file into the project (e.g. chatgpt, claude, opencode).
+  --no-agent                 Skip writing agent instructions file
   --no-interactive           Run in non-interactive mode (skip prompts and use defaults)
   -h, --help                 Show this help message
 

--- a/packages/global/snap-tests/migration-lintstagedrc-json/snap.txt
+++ b/packages/global/snap-tests/migration-lintstagedrc-json/snap.txt
@@ -7,7 +7,8 @@ Arguments:
   PATH                       Target directory to migrate (default: current directory)
 
 Options:
-  --agent NAME              Write agent instructions file into the project (e.g. chatgpt, claude, opencode).
+  --agent NAME               Write agent instructions file into the project (e.g. chatgpt, claude, opencode).
+  --no-agent                 Skip writing agent instructions file
   --no-interactive           Run in non-interactive mode (skip prompts and use defaults)
   -h, --help                 Show this help message
 

--- a/packages/global/snap-tests/migration-no-agent/package.json
+++ b/packages/global/snap-tests/migration-no-agent/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "migration-no-agent",
+  "dependencies": {
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/global/snap-tests/migration-no-agent/snap.txt
+++ b/packages/global/snap-tests/migration-no-agent/snap.txt
@@ -1,0 +1,14 @@
+> vite migration --no-agent # migration with --no-agent should skip agent instructions
+┌  VITE+(⚡︎) - The Unified Toolchain for the Web
+│
+●  Using default package manager: pnpm
+│
+●  pnpm@latest installing...
+│
+●  pnpm@<semver> installed
+│
+└  ✨ Migration completed!
+
+
+> ls -la | grep -E '(AGENTS|CLAUDE)' || echo 'No agent file created' # verify no agent file was created
+No agent file created

--- a/packages/global/snap-tests/migration-no-agent/src/index.ts
+++ b/packages/global/snap-tests/migration-no-agent/src/index.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('example', () => {
+  it('should work', () => {
+    expect(1 + 1).toBe(2);
+  });
+});

--- a/packages/global/snap-tests/migration-no-agent/steps.json
+++ b/packages/global/snap-tests/migration-no-agent/steps.json
@@ -1,0 +1,9 @@
+{
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": [
+    "vite migration --no-agent # migration with --no-agent should skip agent instructions",
+    "ls -la | grep -E '(AGENTS|CLAUDE)' || echo 'No agent file created' # verify no agent file was created"
+  ]
+}

--- a/packages/global/src/migration/bin.ts
+++ b/packages/global/src/migration/bin.ts
@@ -37,7 +37,8 @@ Arguments:
   PATH                       Target directory to migrate (default: current directory)
 
 Options:
-  --agent NAME              Write agent instructions file into the project (e.g. chatgpt, claude, opencode).
+  --agent NAME               Write agent instructions file into the project (e.g. chatgpt, claude, opencode).
+  --no-agent                 Skip writing agent instructions file
   --no-interactive           Run in non-interactive mode (skip prompts and use defaults)
   -h, --help                 Show this help message
 
@@ -57,7 +58,7 @@ Aliases: ${gray('migrate')}
 export interface MigrationOptions {
   interactive: boolean;
   help?: boolean;
-  agent?: string;
+  agent?: string | false;
 }
 
 function parseArgs() {
@@ -66,11 +67,10 @@ function parseArgs() {
   const parsed = mri<{
     help?: boolean;
     interactive?: boolean;
-    agent?: string;
+    agent?: string | false;
   }>(args, {
     alias: { h: 'help' },
     boolean: ['help', 'interactive'],
-    string: ['agent'],
     default: { interactive: defaultInteractive() },
   });
 

--- a/packages/global/src/utils/agent.ts
+++ b/packages/global/src/utils/agent.ts
@@ -35,9 +35,14 @@ export async function selectAgentTargetPath({
   onCancel,
 }: {
   interactive: boolean;
-  agent?: string;
+  agent?: string | false;
   onCancel: () => void;
 }) {
+  // Skip entirely if --no-agent is passed
+  if (agent === false) {
+    return undefined;
+  }
+
   if (interactive && !agent) {
     const selectedAgent = await prompts.select({
       message: 'Which agent are you using?',


### PR DESCRIPTION
When running `vite migrate --no-interactive`, users can now explicitly
skip writing agent instructions by passing `--no-agent`.