### PR TITLE
ci: cleanup after download rolldown npm binary

### DIFF
--- a/.github/actions/download-rolldown-binaries/action.yml
+++ b/.github/actions/download-rolldown-binaries/action.yml
@@ -43,3 +43,9 @@ runs:
         name: rolldown-binaries
         path: ./package/rolldown-binding.*.node
         if-no-files-found: error
+
+    - name: Clean up
+      shell: bash
+      run: |
+        rm -rf package
+        rm *.tgz


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds post-run cleanup to the `download-rolldown-binaries` composite action to remove temporary artifacts.
> 
> - New "Clean up" step deletes extracted `package/` directory and `*.tgz` files after (optional) artifact upload
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0448eb2ba235df5ddea38b56d5cac0407762f216. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->