### PR TITLE
Add Rolldown version to `vite --version`.

### DIFF
--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -402,10 +402,12 @@ async function bundleVitepress() {
 
 async function mergePackageJson() {
   const tsdownPkgPath = join(tsdownSourceDir, 'package.json');
+  const rolldownPkgPath = join(rolldownSourceDir, 'package.json');
   const vitePkgPath = join(rolldownViteSourceDir, 'package.json');
   const destPkgPath = resolve(projectDir, 'package.json');
 
   const tsdownPkg = JSON.parse(await readFile(tsdownPkgPath, 'utf-8'));
+  const rolldownPkg = JSON.parse(await readFile(rolldownPkgPath, 'utf-8'));
   const vitePkg = JSON.parse(await readFile(vitePkgPath, 'utf-8'));
   const destPkg = JSON.parse(await readFile(destPkgPath, 'utf-8'));
 
@@ -424,6 +426,7 @@ async function mergePackageJson() {
   destPkg.bundledVersions = {
     ...destPkg.bundledVersions,
     vite: vitePkg.version,
+    rolldown: rolldownPkg.version,
     tsdown: tsdownPkg.version,
   };
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -197,6 +197,7 @@
   },
   "bundledVersions": {
     "vite": "8.0.0-beta.8",
+    "rolldown": "1.0.0-beta.60",
     "tsdown": "0.20.0-beta.3"
   }
 }

--- a/packages/global/AGENTS.md
+++ b/packages/global/AGENTS.md
@@ -18,7 +18,7 @@ This project is using Vite+, a modern toolchain built on top of Vite, Rolldown, 
 - new - Create a new monorepo package (in-project) or a new project (global)
 - run - Run tasks from `package.json` scripts
 
-These commands map to their corresponding tools. For example, `vite dev --port 3000` runs Vite's dev server and works the same as Vite. `vite test` runs JavaScript tests through the bundled Vitest. The versions of individual tools can be checked using `vite <command> --version`. For example, `vite lint --version` prints the bundled Oxlint version, and `vite test --version` prints the bundled Vitest version. This is useful when researching documentation, features, and bugs.
+These commands map to their corresponding tools. For example, `vite dev --port 3000` runs Vite's dev server and works the same as Vite. `vite test` runs JavaScript tests through the bundled Vitest. The version of all tools can be checked using `vite --version`. This is useful when researching documentation, features, and bugs.
 
 ### Package Manager Commands
 

--- a/packages/global/src/version.ts
+++ b/packages/global/src/version.ts
@@ -128,6 +128,12 @@ export async function printVersion(cwd: string) {
       bundledVersionKey: 'vite',
     },
     {
+      command: 'rolldown',
+      displayName: 'rolldown',
+      packageName: '@voidzero-dev/vite-plus-core',
+      bundledVersionKey: 'rolldown',
+    },
+    {
       command: 'test',
       displayName: 'vitest',
       packageName: '@voidzero-dev/vite-plus-test',


### PR DESCRIPTION
This PR adds the version of Rolldown to `vite --version` and it updates `AGENTS.md` with the new explanation since the version numbers are now all in one place.