### PR TITLE
test(e2e): add happy-dom ecosystem-ci test case

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -236,6 +236,12 @@ jobs:
               vite run type-check:tsgo
               vite run build
               vite run test navigation-utils.test.ts real-browser-flicker.test.tsx workflow-parallel-limit.test.tsx
+          - name: happy-dom
+            node-version: 24
+            command: |
+              vite run compile
+              vite run lint
+              vite run test
         exclude:
           # frm-stack uses Docker (testcontainers) which doesn't work the same way on Windows
           - os: windows-latest
@@ -245,6 +251,10 @@ jobs:
           - os: windows-latest
             project:
               name: dify
+          # happy-dom only runs on Linux
+          - os: windows-latest
+            project:
+              name: happy-dom
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/ecosystem-ci/repo.json
+++ b/ecosystem-ci/repo.json
@@ -49,5 +49,10 @@
     "repository": "https://github.com/itaymendel/oxlint-plugin-complexity.git",
     "branch": "main",
     "hash": "0db2fd94497ca21952ba0a000a8ce81fd4854e36"
+  },
+  "happy-dom": {
+    "repository": "https://github.com/capricorn86/happy-dom.git",
+    "branch": "master",
+    "hash": "aa2dbb813416e54c4b34c77e3834952cdcc8dd6d"
   }
 }


### PR DESCRIPTION
Add happy-dom (https://github.com/capricorn86/happy-dom) to the ecosystem-ci
test suite. Runs compile, lint, and test commands on Ubuntu only.