### PR TITLE
feat: Extend the help command to show help for sub-commands.

### DIFF
--- a/packages/cli/binding/src/cli.rs
+++ b/packages/cli/binding/src/cli.rs
@@ -794,7 +794,17 @@ pub async fn main(
 }
 
 fn normalize_help_args(args: Vec<String>) -> Vec<String> {
-    args
+    match args.as_slice() {
+        [arg] if arg == "help" => vec!["--help".to_string()],
+        [first, command, rest @ ..] if first == "help" => {
+            let mut normalized = Vec::with_capacity(rest.len() + 2);
+            normalized.push(command.to_string());
+            normalized.push("--help".to_string());
+            normalized.extend(rest.iter().cloned());
+            normalized
+        }
+        _ => args,
+    }
 }
 
 fn should_print_help(args: &[String]) -> bool {

--- a/packages/global/snap-tests/migration-agent-claude/snap.txt
+++ b/packages/global/snap-tests/migration-agent-claude/snap.txt
@@ -1,4 +1,4 @@
-> vite migration --agent claude # migration with --agent claude should write CLAUDE.md
+> vite migrate --agent claude --no-interactive # migration with --agent claude should write CLAUDE.md
 ┌  VITE+(⚡︎) - The Unified Toolchain for the Web
 │
 ●  Using default package manager: pnpm

--- a/packages/global/snap-tests/migration-agent-claude/steps.json
+++ b/packages/global/snap-tests/migration-agent-claude/steps.json
@@ -3,7 +3,7 @@
     "VITE_DISABLE_AUTO_INSTALL": "1"
   },
   "commands": [
-    "vite migration --agent claude # migration with --agent claude should write CLAUDE.md",
+    "vite migrate --agent claude --no-interactive # migration with --agent claude should write CLAUDE.md",
     "cat CLAUDE.md | head -3 # verify CLAUDE.md was created"
   ]
 }

--- a/packages/global/snap-tests/migration-auto-create-vite-config/snap.txt
+++ b/packages/global/snap-tests/migration-auto-create-vite-config/snap.txt
@@ -1,4 +1,4 @@
-> vite migration # migration should auto create vite.config.ts and remove oxlintrc and oxfmtrc
+> vite migrate --no-interactive # migration should auto create vite.config.ts and remove oxlintrc and oxfmtrc
 ┌  VITE+(⚡︎) - The Unified Toolchain for the Web
 │
 ●  Using default package manager: pnpm

--- a/packages/global/snap-tests/migration-auto-create-vite-config/steps.json
+++ b/packages/global/snap-tests/migration-auto-create-vite-config/steps.json
@@ -3,7 +3,7 @@
     "VITE_DISABLE_AUTO_INSTALL": "1"
   },
   "commands": [
-    "vite migration # migration should auto create vite.config.ts and remove oxlintrc and oxfmtrc",
+    "vite migrate --no-interactive # migration should auto create vite.config.ts and remove oxlintrc and oxfmtrc",
     "cat vite.config.ts # check vite.config.ts",
     "cat .oxlintrc.json && exit 1 || true # check .oxlintrc.json is removed",
     "cat .oxfmtrc.json && exit 1 || true # check .oxfmtrc.json is removed",

--- a/packages/global/snap-tests/migration-check/snap.txt
+++ b/packages/global/snap-tests/migration-check/snap.txt
@@ -1,26 +1,28 @@
-> vite migration --help # show help
-Usage: vite migration [PATH] [OPTIONS]
+> vite migrate --help # show help
+VITE+(⚡︎) - The Unified Toolchain for the Web
 
-Migrate standalone vite, vitest, oxlint, and oxfmt to unified vite-plus.
+USAGE: vite migrate [PATH] [OPTIONS]
 
-Arguments:
+Migrate standalone Vite, Vitest, Oxlint, and Oxfmt projects to unified Vite+.
+
+ARGUMENTS:
   PATH                       Target directory to migrate (default: current directory)
 
-Options:
+OPTIONS:
   --agent NAME               Write agent instructions file into the project (e.g. chatgpt, claude, opencode).
   --no-agent                 Skip writing agent instructions file
   --no-interactive           Run in non-interactive mode (skip prompts and use defaults)
+  --non-interactive          Alias for --no-interactive
   -h, --help                 Show this help message
 
-Examples:
+EXAMPLES:
   # Migrate current package
-  vite migration
+  vite migrate
 
   # Migrate specific directory
-  vite migration my-app
+  vite migrate my-app
 
   # Non-interactive mode
-  vite migration --no-interactive
+  vite migrate --no-interactive
 
-Aliases: migrate
 

--- a/packages/global/snap-tests/migration-check/steps.json
+++ b/packages/global/snap-tests/migration-check/steps.json
@@ -1,3 +1,3 @@
 {
-  "commands": ["vite migration --help # show help"]
+  "commands": ["vite migrate --help # show help"]
 }

--- a/packages/global/snap-tests/migration-from-tsdown-json-config/snap.txt
+++ b/packages/global/snap-tests/migration-from-tsdown-json-config/snap.txt
@@ -1,4 +1,4 @@
-> vite migration # migration should rewrite imports to vite-plus
+> vite migrate --no-interactive # migration should rewrite imports to vite-plus
 ┌  VITE+(⚡︎) - The Unified Toolchain for the Web
 │
 ●  Using default package manager: pnpm
@@ -56,7 +56,7 @@ export default defineConfig({
   "packageManager": "pnpm@<semver>"
 }
 
-> vite migration # run migration again to check if it is idempotent
+> vite migrate --no-interactive # run migration again to check if it is idempotent
 ┌  VITE+(⚡︎) - The Unified Toolchain for the Web
 │
 ●  pnpm@<semver> installing...

--- a/packages/global/snap-tests/migration-from-tsdown-json-config/steps.json
+++ b/packages/global/snap-tests/migration-from-tsdown-json-config/steps.json
@@ -3,11 +3,11 @@
     "VITE_DISABLE_AUTO_INSTALL": "1"
   },
   "commands": [
-    "vite migration # migration should rewrite imports to vite-plus",
+    "vite migrate --no-interactive # migration should rewrite imports to vite-plus",
     "cat tsdown.config.json && exit 1 || true # check tsdown.config.json should be removed",
     "cat vite.config.ts # check vite.config.ts",
     "cat package.json # check package.json",
-    "vite migration # run migration again to check if it is idempotent",
+    "vite migrate --no-interactive # run migration again to check if it is idempotent",
     "cat vite.config.ts # check vite.config.ts",
     "cat package.json # check package.json"
   ]

--- a/packages/global/snap-tests/migration-from-tsdown/snap.txt
+++ b/packages/global/snap-tests/migration-from-tsdown/snap.txt
@@ -1,4 +1,4 @@
-> vite migration # migration should rewrite imports to vite-plus
+> vite migrate --no-interactive # migration should rewrite imports to vite-plus
 ┌  VITE+(⚡︎) - The Unified Toolchain for the Web
 │
 ●  Using default package manager: pnpm
@@ -63,7 +63,7 @@ export default defineConfig({
   "packageManager": "pnpm@<semver>"
 }
 
-> vite migration # run migration again to check if it is idempotent
+> vite migrate --no-interactive # run migration again to check if it is idempotent
 ┌  VITE+(⚡︎) - The Unified Toolchain for the Web
 │
 ●  pnpm@<semver> installing...

--- a/packages/global/snap-tests/migration-from-tsdown/steps.json
+++ b/packages/global/snap-tests/migration-from-tsdown/steps.json
@@ -3,11 +3,11 @@
     "VITE_DISABLE_AUTO_INSTALL": "1"
   },
   "commands": [
-    "vite migration # migration should rewrite imports to vite-plus",
+    "vite migrate --no-interactive # migration should rewrite imports to vite-plus",
     "cat tsdown.config.ts # check tsdown.config.ts",
     "cat vite.config.ts # check vite.config.ts",
     "cat package.json # check package.json",
-    "vite migration # run migration again to check if it is idempotent",
+    "vite migrate --no-interactive # run migration again to check if it is idempotent",
     "cat tsdown.config.ts # check tsdown.config.ts",
     "cat vite.config.ts # check vite.config.ts",
     "cat package.json # check package.json"

--- a/packages/global/snap-tests/migration-from-vitest-config/snap.txt
+++ b/packages/global/snap-tests/migration-from-vitest-config/snap.txt
@@ -1,4 +1,4 @@
-> vite migration # migration should rewrite imports to vite-plus
+> vite migrate --no-interactive # migration should rewrite imports to vite-plus
 ┌  VITE+(⚡︎) - The Unified Toolchain for the Web
 │
 ●  Using default package manager: pnpm

--- a/packages/global/snap-tests/migration-from-vitest-config/steps.json
+++ b/packages/global/snap-tests/migration-from-vitest-config/steps.json
@@ -3,7 +3,7 @@
     "VITE_DISABLE_AUTO_INSTALL": "1"
   },
   "commands": [
-    "vite migration # migration should rewrite imports to vite-plus",
+    "vite migrate --no-interactive # migration should rewrite imports to vite-plus",
     "cat vitest.config.ts # check vitest.config.ts",
     "cat package.json # check package.json"
   ]

--- a/packages/global/snap-tests/migration-from-vitest-files/snap.txt
+++ b/packages/global/snap-tests/migration-from-vitest-files/snap.txt
@@ -1,4 +1,4 @@
-> vite migration # migration should rewrite imports to vite-plus
+> vite migrate --no-interactive # migration should rewrite imports to vite-plus
 ┌  VITE+(⚡︎) - The Unified Toolchain for the Web
 │
 ●  Using default package manager: pnpm

--- a/packages/global/snap-tests/migration-from-vitest-files/steps.json
+++ b/packages/global/snap-tests/migration-from-vitest-files/steps.json
@@ -3,7 +3,7 @@
     "VITE_DISABLE_AUTO_INSTALL": "1"
   },
   "commands": [
-    "vite migration # migration should rewrite imports to vite-plus",
+    "vite migrate --no-interactive # migration should rewrite imports to vite-plus",
     "cat package.json # check package.json",
     "cat test/hello.ts # check test/hello.ts"
   ]

--- a/packages/global/snap-tests/migration-lintstagedrc-json/snap.txt
+++ b/packages/global/snap-tests/migration-lintstagedrc-json/snap.txt
@@ -1,31 +1,33 @@
-> vite migration -h # migration help message
-Usage: vite migration [PATH] [OPTIONS]
+> vite migrate -h # migration help message
+VITE+(⚡︎) - The Unified Toolchain for the Web
 
-Migrate standalone vite, vitest, oxlint, and oxfmt to unified vite-plus.
+USAGE: vite migrate [PATH] [OPTIONS]
 
-Arguments:
+Migrate standalone Vite, Vitest, Oxlint, and Oxfmt projects to unified Vite+.
+
+ARGUMENTS:
   PATH                       Target directory to migrate (default: current directory)
 
-Options:
+OPTIONS:
   --agent NAME               Write agent instructions file into the project (e.g. chatgpt, claude, opencode).
   --no-agent                 Skip writing agent instructions file
   --no-interactive           Run in non-interactive mode (skip prompts and use defaults)
+  --non-interactive          Alias for --no-interactive
   -h, --help                 Show this help message
 
-Examples:
+EXAMPLES:
   # Migrate current package
-  vite migration
+  vite migrate
 
   # Migrate specific directory
-  vite migration my-app
+  vite migrate my-app
 
   # Non-interactive mode
-  vite migration --no-interactive
-
-Aliases: migrate
+  vite migrate --no-interactive
 
 
-> vite migration # migration work with lintstagedrc.json
+
+> vite migrate --no-interactive # migration work with lintstagedrc.json
 ┌  VITE+(⚡︎) - The Unified Toolchain for the Web
 │
 ●  Using default package manager: pnpm

--- a/packages/global/snap-tests/migration-lintstagedrc-json/steps.json
+++ b/packages/global/snap-tests/migration-lintstagedrc-json/steps.json
@@ -3,8 +3,8 @@
     "VITE_DISABLE_AUTO_INSTALL": "1"
   },
   "commands": [
-    "vite migration -h # migration help message",
-    "vite migration # migration work with lintstagedrc.json",
+    "vite migrate -h # migration help message",
+    "vite migrate --no-interactive # migration work with lintstagedrc.json",
     "cat .lintstagedrc.json # check lintstagedrc.json",
     "cat package.json # check package.json"
   ]

--- a/packages/global/snap-tests/migration-lintstagedrc-not-support/snap.txt
+++ b/packages/global/snap-tests/migration-lintstagedrc-not-support/snap.txt
@@ -1,4 +1,4 @@
-> vite migration # migration should not support non-json format lintstagedrc
+> vite migrate --no-interactive # migration should not support non-json format lintstagedrc
 ┌  VITE+(⚡︎) - The Unified Toolchain for the Web
 │
 ●  Using default package manager: pnpm

--- a/packages/global/snap-tests/migration-lintstagedrc-not-support/steps.json
+++ b/packages/global/snap-tests/migration-lintstagedrc-not-support/steps.json
@@ -3,7 +3,7 @@
     "VITE_DISABLE_AUTO_INSTALL": "1"
   },
   "commands": [
-    "vite migration # migration should not support non-json format lintstagedrc",
+    "vite migrate --no-interactive # migration should not support non-json format lintstagedrc",
     "cat .lintstagedrc # check .lintstagedrc is not updated",
     "cat .lintstagedrc.yaml # check .lintstagedrc.yaml is not updated",
     "cat lint-staged.config.mjs # check lint-staged.config.mjs is not updated",

--- a/packages/global/snap-tests/migration-merge-vite-config-js/snap.txt
+++ b/packages/global/snap-tests/migration-merge-vite-config-js/snap.txt
@@ -1,4 +1,4 @@
-> vite migration # migration should merge vite.config.js and remove oxlintrc
+> vite migrate --no-interactive # migration should merge vite.config.js and remove oxlintrc
 ┌  VITE+(⚡︎) - The Unified Toolchain for the Web
 │
 ●  Using default package manager: pnpm

--- a/packages/global/snap-tests/migration-merge-vite-config-js/steps.json
+++ b/packages/global/snap-tests/migration-merge-vite-config-js/steps.json
@@ -3,7 +3,7 @@
     "VITE_DISABLE_AUTO_INSTALL": "1"
   },
   "commands": [
-    "vite migration # migration should merge vite.config.js and remove oxlintrc",
+    "vite migrate --no-interactive # migration should merge vite.config.js and remove oxlintrc",
     "cat vite.config.js # check vite.config.js",
     "cat .oxlintrc.json && exit 1 || true # check .oxlintrc.json is removed",
     "cat package.json # check package.json"

--- a/packages/global/snap-tests/migration-merge-vite-config-ts/snap.txt
+++ b/packages/global/snap-tests/migration-merge-vite-config-ts/snap.txt
@@ -1,4 +1,4 @@
-> vite migration # migration should merge vite.config.ts and remove oxlintrc and oxfmtrc
+> vite migrate --no-interactive # migration should merge vite.config.ts and remove oxlintrc and oxfmtrc
 ┌  VITE+(⚡︎) - The Unified Toolchain for the Web
 │
 ●  Using default package manager: pnpm

--- a/packages/global/snap-tests/migration-merge-vite-config-ts/steps.json
+++ b/packages/global/snap-tests/migration-merge-vite-config-ts/steps.json
@@ -3,7 +3,7 @@
     "VITE_DISABLE_AUTO_INSTALL": "1"
   },
   "commands": [
-    "vite migration # migration should merge vite.config.ts and remove oxlintrc and oxfmtrc",
+    "vite migrate --no-interactive # migration should merge vite.config.ts and remove oxlintrc and oxfmtrc",
     "cat vite.config.ts # check vite.config.ts",
     "cat .oxlintrc.json && exit 1 || true # check .oxlintrc.json is removed",
     "cat .oxfmtrc.json && exit 1 || true # check .oxfmtrc.json is removed",

--- a/packages/global/snap-tests/migration-monorepo-pnpm-overrides-dependency-selector/snap.txt
+++ b/packages/global/snap-tests/migration-monorepo-pnpm-overrides-dependency-selector/snap.txt
@@ -1,4 +1,4 @@
-> vite migration # migration should merge pnpm overrides with dependency selector
+> vite migrate --no-interactive # migration should merge pnpm overrides with dependency selector
 ┌  VITE+(⚡︎) - The Unified Toolchain for the Web
 │
 ●  pnpm@<semver> installing...

--- a/packages/global/snap-tests/migration-monorepo-pnpm-overrides-dependency-selector/steps.json
+++ b/packages/global/snap-tests/migration-monorepo-pnpm-overrides-dependency-selector/steps.json
@@ -3,7 +3,7 @@
     "VITE_DISABLE_AUTO_INSTALL": "1"
   },
   "commands": [
-    "vite migration # migration should merge pnpm overrides with dependency selector",
+    "vite migrate --no-interactive # migration should merge pnpm overrides with dependency selector",
     "cat vite.config.ts # check vite.config.ts",
     "cat package.json # check package.json",
     "cat pnpm-workspace.yaml # check pnpm-workspace.yaml",

--- a/packages/global/snap-tests/migration-monorepo-pnpm/snap.txt
+++ b/packages/global/snap-tests/migration-monorepo-pnpm/snap.txt
@@ -1,4 +1,4 @@
-> vite migration # migration should merge vite.config.ts and remove oxlintrc and oxfmtrc
+> vite migrate --no-interactive # migration should merge vite.config.ts and remove oxlintrc and oxfmtrc
 ┌  VITE+(⚡︎) - The Unified Toolchain for the Web
 │
 ●  pnpm@<semver> installing...

--- a/packages/global/snap-tests/migration-monorepo-pnpm/steps.json
+++ b/packages/global/snap-tests/migration-monorepo-pnpm/steps.json
@@ -3,7 +3,7 @@
     "VITE_DISABLE_AUTO_INSTALL": "1"
   },
   "commands": [
-    "vite migration # migration should merge vite.config.ts and remove oxlintrc and oxfmtrc",
+    "vite migrate --no-interactive # migration should merge vite.config.ts and remove oxlintrc and oxfmtrc",
     "cat vite.config.ts # check vite.config.ts",
     "cat .oxlintrc.json && exit 1 || true # check .oxlintrc.json is removed",
     "cat .oxfmtrc.json && exit 1 || true # check .oxfmtrc.json is removed",

--- a/packages/global/snap-tests/migration-monorepo-skip-vite-peer-dependency/snap.txt
+++ b/packages/global/snap-tests/migration-monorepo-skip-vite-peer-dependency/snap.txt
@@ -1,4 +1,4 @@
-> vite migration # migration should check each package's peerDependencies
+> vite migrate --no-interactive # migration should check each package's peerDependencies
 ┌  VITE+(⚡︎) - The Unified Toolchain for the Web
 │
 ●  pnpm@latest installing...

--- a/packages/global/snap-tests/migration-monorepo-skip-vite-peer-dependency/steps.json
+++ b/packages/global/snap-tests/migration-monorepo-skip-vite-peer-dependency/steps.json
@@ -3,7 +3,7 @@
     "VITE_DISABLE_AUTO_INSTALL": "1"
   },
   "commands": [
-    "vite migration # migration should check each package's peerDependencies",
+    "vite migrate --no-interactive # migration should check each package's peerDependencies",
     "cat packages/vite-plugin/src/index.ts # vite-plugin has vite in peerDeps: vite NOT rewritten, vitest rewritten",
     "cat package.json # check root package.json (no peerDependencies)",
     "cat packages/vite-plugin/package.json # has vite in peerDependencies"

--- a/packages/global/snap-tests/migration-monorepo-yarn4/snap.txt
+++ b/packages/global/snap-tests/migration-monorepo-yarn4/snap.txt
@@ -1,4 +1,4 @@
-> vite migration # migration should merge vite.config.ts and remove oxlintrc
+> vite migrate --no-interactive # migration should merge vite.config.ts and remove oxlintrc
 ┌  VITE+(⚡︎) - The Unified Toolchain for the Web
 │
 ●  yarn@<semver> installing...

--- a/packages/global/snap-tests/migration-monorepo-yarn4/steps.json
+++ b/packages/global/snap-tests/migration-monorepo-yarn4/steps.json
@@ -3,7 +3,7 @@
     "VITE_DISABLE_AUTO_INSTALL": "1"
   },
   "commands": [
-    "vite migration # migration should merge vite.config.ts and remove oxlintrc",
+    "vite migrate --no-interactive # migration should merge vite.config.ts and remove oxlintrc",
     "cat vite.config.ts # check vite.config.ts",
     "cat .oxlintrc.json && exit 1 || true # check .oxlintrc.json is removed",
     "cat package.json # check package.json",

--- a/packages/global/snap-tests/migration-no-agent/snap.txt
+++ b/packages/global/snap-tests/migration-no-agent/snap.txt
@@ -1,4 +1,4 @@
-> vite migration --no-agent # migration with --no-agent should skip agent instructions
+> vite migrate --no-agent --no-interactive # migration with --no-agent should skip agent instructions
 ┌  VITE+(⚡︎) - The Unified Toolchain for the Web
 │
 ●  Using default package manager: pnpm

--- a/packages/global/snap-tests/migration-no-agent/steps.json
+++ b/packages/global/snap-tests/migration-no-agent/steps.json
@@ -3,7 +3,7 @@
     "VITE_DISABLE_AUTO_INSTALL": "1"
   },
   "commands": [
-    "vite migration --no-agent # migration with --no-agent should skip agent instructions",
+    "vite migrate --no-agent --no-interactive # migration with --no-agent should skip agent instructions",
     "ls -la | grep -E '(AGENTS|CLAUDE)' || echo 'No agent file created' # verify no agent file was created"
   ]
 }

--- a/packages/global/snap-tests/migration-not-supported-npm8.2/snap.txt
+++ b/packages/global/snap-tests/migration-not-supported-npm8.2/snap.txt
@@ -1,4 +1,4 @@
-[1]> vite migration # migration should fail because npm version is not supported
+[1]> vite migrate --no-interactive # migration should fail because npm version is not supported
 ┌  VITE+(⚡︎) - The Unified Toolchain for the Web
 │
 ●  npm@<semver> installing...

--- a/packages/global/snap-tests/migration-not-supported-npm8.2/steps.json
+++ b/packages/global/snap-tests/migration-not-supported-npm8.2/steps.json
@@ -3,7 +3,7 @@
     "VITE_DISABLE_AUTO_INSTALL": "1"
   },
   "commands": [
-    "vite migration # migration should fail because npm version is not supported",
+    "vite migrate --no-interactive # migration should fail because npm version is not supported",
     "cat package.json # check package.json is not updated"
   ]
 }

--- a/packages/global/snap-tests/migration-not-supported-pnpm9.4/snap.txt
+++ b/packages/global/snap-tests/migration-not-supported-pnpm9.4/snap.txt
@@ -1,4 +1,4 @@
-[1]> vite migration # migration should fail because pnpm version is not supported
+[1]> vite migrate --no-interactive # migration should fail because pnpm version is not supported
 ┌  VITE+(⚡︎) - The Unified Toolchain for the Web
 │
 ●  pnpm@<semver> installing...

--- a/packages/global/snap-tests/migration-not-supported-pnpm9.4/steps.json
+++ b/packages/global/snap-tests/migration-not-supported-pnpm9.4/steps.json
@@ -3,7 +3,7 @@
     "VITE_DISABLE_AUTO_INSTALL": "1"
   },
   "commands": [
-    "vite migration # migration should fail because pnpm version is not supported",
+    "vite migrate --no-interactive # migration should fail because pnpm version is not supported",
     "cat package.json # check package.json is not updated"
   ]
 }

--- a/packages/global/snap-tests/migration-not-supported-vite6/snap.txt
+++ b/packages/global/snap-tests/migration-not-supported-vite6/snap.txt
@@ -1,5 +1,5 @@
 > vite install # install dependencies first
-[1]> vite migration # migration should fail because vite version is not supported
+[1]> vite migrate --no-interactive # migration should fail because vite version is not supported
 ┌  VITE+(⚡︎) - The Unified Toolchain for the Web
 │
 ●  pnpm@<semver> installing...

--- a/packages/global/snap-tests/migration-not-supported-vite6/steps.json
+++ b/packages/global/snap-tests/migration-not-supported-vite6/steps.json
@@ -7,7 +7,7 @@
       "command": "vite install # install dependencies first",
       "ignoreOutput": true
     },
-    "vite migration # migration should fail because vite version is not supported",
+    "vite migrate --no-interactive # migration should fail because vite version is not supported",
     "cat package.json # check package.json is not updated"
   ]
 }

--- a/packages/global/snap-tests/migration-not-supported-vitest3/snap.txt
+++ b/packages/global/snap-tests/migration-not-supported-vitest3/snap.txt
@@ -1,5 +1,5 @@
 > vite install # install dependencies first
-[1]> vite migration # migration should fail because vitest version is not supported
+[1]> vite migrate --no-interactive # migration should fail because vitest version is not supported
 ┌  VITE+(⚡︎) - The Unified Toolchain for the Web
 │
 ●  pnpm@<semver> installing...

--- a/packages/global/snap-tests/migration-not-supported-vitest3/steps.json
+++ b/packages/global/snap-tests/migration-not-supported-vitest3/steps.json
@@ -7,7 +7,7 @@
       "command": "vite install # install dependencies first",
       "ignoreOutput": true
     },
-    "vite migration # migration should fail because vitest version is not supported",
+    "vite migrate --no-interactive # migration should fail because vitest version is not supported",
     "cat package.json # check package.json is not updated"
   ]
 }

--- a/packages/global/snap-tests/migration-rewrite-declare-module/snap.txt
+++ b/packages/global/snap-tests/migration-rewrite-declare-module/snap.txt
@@ -1,4 +1,4 @@
-> vite migration # migration should rewrite imports to vite-plus
+> vite migrate --no-interactive # migration should rewrite imports to vite-plus
 ┌  VITE+(⚡︎) - The Unified Toolchain for the Web
 │
 ●  Using default package manager: pnpm

--- a/packages/global/snap-tests/migration-rewrite-declare-module/steps.json
+++ b/packages/global/snap-tests/migration-rewrite-declare-module/steps.json
@@ -3,7 +3,7 @@
     "VITE_DISABLE_AUTO_INSTALL": "1"
   },
   "commands": [
-    "vite migration # migration should rewrite imports to vite-plus",
+    "vite migrate --no-interactive # migration should rewrite imports to vite-plus",
     "cat src/index.ts # check src/index.ts",
     "cat package.json # check package.json"
   ]

--- a/packages/global/snap-tests/migration-skip-vite-dependency/snap.txt
+++ b/packages/global/snap-tests/migration-skip-vite-dependency/snap.txt
@@ -1,4 +1,4 @@
-> vite migration # migration should skip rewriting vite imports when vite is in dependencies
+> vite migrate --no-interactive # migration should skip rewriting vite imports when vite is in dependencies
 ┌  VITE+(⚡︎) - The Unified Toolchain for the Web
 │
 ●  Using default package manager: pnpm

--- a/packages/global/snap-tests/migration-skip-vite-dependency/steps.json
+++ b/packages/global/snap-tests/migration-skip-vite-dependency/steps.json
@@ -3,7 +3,7 @@
     "VITE_DISABLE_AUTO_INSTALL": "1"
   },
   "commands": [
-    "vite migration # migration should skip rewriting vite imports when vite is in dependencies",
+    "vite migrate --no-interactive # migration should skip rewriting vite imports when vite is in dependencies",
     "cat src/index.ts # vite imports should NOT be rewritten, vitest imports SHOULD be rewritten",
     "cat package.json # check package.json"
   ]

--- a/packages/global/snap-tests/migration-skip-vite-peer-dependency/snap.txt
+++ b/packages/global/snap-tests/migration-skip-vite-peer-dependency/snap.txt
@@ -1,4 +1,4 @@
-> vite migration # migration should skip rewriting vite imports when vite is in peerDependencies
+> vite migrate --no-interactive # migration should skip rewriting vite imports when vite is in peerDependencies
 ┌  VITE+(⚡︎) - The Unified Toolchain for the Web
 │
 ●  Using default package manager: pnpm

--- a/packages/global/snap-tests/migration-skip-vite-peer-dependency/steps.json
+++ b/packages/global/snap-tests/migration-skip-vite-peer-dependency/steps.json
@@ -3,7 +3,7 @@
     "VITE_DISABLE_AUTO_INSTALL": "1"
   },
   "commands": [
-    "vite migration # migration should skip rewriting vite imports when vite is in peerDependencies",
+    "vite migrate --no-interactive # migration should skip rewriting vite imports when vite is in peerDependencies",
     "cat src/index.ts # vite imports should NOT be rewritten, vitest imports SHOULD be rewritten",
     "cat package.json # check package.json"
   ]

--- a/packages/global/snap-tests/migration-subpath/snap.txt
+++ b/packages/global/snap-tests/migration-subpath/snap.txt
@@ -1,4 +1,4 @@
-> vite migration foo # migration work with subpath
+> vite migrate foo --no-interactive # migration work with subpath
 ┌  VITE+(⚡︎) - The Unified Toolchain for the Web
 │
 ●  Using default package manager: pnpm

--- a/packages/global/snap-tests/migration-subpath/steps.json
+++ b/packages/global/snap-tests/migration-subpath/steps.json
@@ -1,6 +1,6 @@
 {
   "commands": [
-    "vite migration foo # migration work with subpath",
+    "vite migrate foo --no-interactive # migration work with subpath",
     "cat foo/package.json # check package.json"
   ]
 }

--- a/packages/global/src/index.ts
+++ b/packages/global/src/index.ts
@@ -1,5 +1,10 @@
-// Parse command line arguments to intercept 'new', 'gen', and 'migration' commands
-const args = process.argv.slice(2);
+// Parse command line arguments to intercept 'new', and 'migrate' commands
+let args = process.argv.slice(2);
+
+if (args[0] === 'help' && args[1]) {
+  args = [args[1], '--help', ...args.slice(2)];
+  process.argv = process.argv.slice(0, 2).concat(args);
+}
 
 const LOCAL_CLI_COMMANDS = [
   'dev',
@@ -19,7 +24,7 @@ const command = args[0];
 
 if (command === 'new') {
   import('./new/bin.js');
-} else if (command === 'migration' || command === 'migrate') {
+} else if (command === 'migrate') {
   import('./migration/bin.js');
 } else if (LOCAL_CLI_COMMANDS.includes(command)) {
   import('./local/bin.js');

--- a/packages/global/src/migration/bin.ts
+++ b/packages/global/src/migration/bin.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { styleText } from 'node:util';
 
 import * as prompts from '@clack/prompts';
 import mri from 'mri';
@@ -15,7 +16,7 @@ import {
   selectPackageManager,
   upgradeYarn,
 } from '../utils/prompts.js';
-import { getVitePlusHeader, log } from '../utils/terminal.js';
+import { accent, getVitePlusHeader, headline, log, muted } from '../utils/terminal.js';
 import { detectWorkspace } from '../utils/workspace.js';
 import {
   checkVitestVersion,
@@ -24,34 +25,34 @@ import {
   rewriteStandaloneProject,
 } from './migrator.js';
 
-const { green, gray } = colors;
+const { green } = colors;
 
 // prettier-ignore
 const helpMessage = `\
-Usage: vite migration [PATH] [OPTIONS]
+${headline(`Usage:`)} ${styleText('bold', `vite migrate [PATH] [OPTIONS]`)}
 
-Migrate standalone vite, vitest, oxlint, and oxfmt to unified vite-plus.
+Migrate standalone Vite, Vitest, Oxlint, and Oxfmt projects to unified Vite+.
 
-Arguments:
+${headline(`Arguments:`)}
   PATH                       Target directory to migrate (default: current directory)
 
-Options:
+${headline(`Options:`)}
   --agent NAME               Write agent instructions file into the project (e.g. chatgpt, claude, opencode).
   --no-agent                 Skip writing agent instructions file
   --no-interactive           Run in non-interactive mode (skip prompts and use defaults)
+  --non-interactive          Alias for --no-interactive
   -h, --help                 Show this help message
 
-Examples:
-  ${gray('# Migrate current package')}
-  vite migration
+${headline(`Examples:`)}
+  ${muted('# Migrate current package')}
+  ${accent(`vite migrate`)}
 
-  ${gray('# Migrate specific directory')}
-  vite migration my-app
+  ${muted('# Migrate specific directory')}
+  ${accent(`vite migrate my-app`)}
 
-  ${gray('# Non-interactive mode')}
-  vite migration --no-interactive
+  ${muted('# Non-interactive mode')}
+  ${accent(`vite migrate --no-interactive`)}
 
-Aliases: ${gray('migrate')}
 `;
 
 export interface MigrationOptions {
@@ -61,17 +62,21 @@ export interface MigrationOptions {
 }
 
 function parseArgs() {
-  const args = process.argv.slice(3); // Skip 'node', 'vite', 'migration'
+  const args = process.argv.slice(3); // Skip 'node', 'vite', 'migrate'
 
   const parsed = mri<{
     help?: boolean;
     interactive?: boolean;
+    nonInteractive?: boolean;
+    'non-interactive'?: boolean;
     agent?: string | false;
   }>(args, {
     alias: { h: 'help' },
-    boolean: ['help', 'interactive'],
+    boolean: ['help', 'interactive', 'non-interactive', 'nonInteractive'],
     default: { interactive: defaultInteractive() },
   });
+  const nonInteractive = parsed['non-interactive'] ?? parsed.nonInteractive;
+  const interactive = nonInteractive ? false : parsed.interactive;
 
   let projectPath = parsed._[0] as string;
   if (projectPath) {
@@ -83,7 +88,7 @@ function parseArgs() {
   return {
     projectPath,
     options: {
-      interactive: parsed.interactive,
+      interactive,
       help: parsed.help,
       agent: parsed.agent,
     } as MigrationOptions,
@@ -94,11 +99,30 @@ async function main() {
   const { projectPath, options } = parseArgs();
 
   if (options.help) {
+    log((await getVitePlusHeader()) + '\n');
     log(helpMessage);
     return;
   }
 
   prompts.intro(await getVitePlusHeader());
+
+  if (options.interactive) {
+    prompts.log.info(
+      [
+        styleText('bold', 'Migration plan:'),
+        '- Inspect workspace and package manager',
+        `- Run ${accent('vite install')} to prepare dependencies`,
+        '- Rewrite configs and dependencies for Vite+',
+      ].join('\n'),
+    );
+    const approved = await prompts.confirm({
+      message: 'Migrate this project to Vite+?',
+      initialValue: true,
+    });
+    if (prompts.isCancel(approved) || !approved) {
+      cancelAndExit('Migration cancelled');
+    }
+  }
 
   const workspaceInfoOptional = await detectWorkspace(projectPath);
   const packageManager =

--- a/packages/global/src/new/bin.ts
+++ b/packages/global/src/new/bin.ts
@@ -91,7 +91,7 @@ export interface Options {
 
 // Parse CLI arguments: split on '--' separator
 function parseArgs() {
-  const args = process.argv.slice(3); // Skip 'node', 'vite', 'gen'
+  const args = process.argv.slice(3); // Skip 'node', 'vite'
   const separatorIndex = args.indexOf('--');
 
   // Arguments before -- are Vite+ options

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ catalogs:
       specifier: ^8.18.0
       version: 8.18.1
     '@typescript/native-preview':
-      specifier: 7.0.0-dev.20260117.1
-      version: 7.0.0-dev.20260117.1
+      specifier: 7.0.0-dev.20260122.2
+      version: 7.0.0-dev.20260122.2
     '@yarnpkg/fslib':
       specifier: ^3.1.3
       version: 3.1.4
@@ -288,7 +288,7 @@ importers:
         version: 24.10.3
       '@typescript/native-preview':
         specifier: 'catalog:'
-        version: 7.0.0-dev.20260117.1
+        version: 7.0.0-dev.20260122.2
       '@voidzero-dev/vite-plus-tools':
         specifier: workspace:*
         version: link:packages/tools
@@ -376,10 +376,10 @@ importers:
         version: link:../../rolldown/packages/rolldown
       rolldown-plugin-dts:
         specifier: 'catalog:'
-        version: 0.20.0(@typescript/native-preview@7.0.0-dev.20260117.1)(oxc-resolver@11.14.0)(rolldown@rolldown+packages+rolldown)(typescript@5.9.3)
+        version: 0.20.0(@typescript/native-preview@7.0.0-dev.20260122.2)(oxc-resolver@11.14.0)(rolldown@rolldown+packages+rolldown)(typescript@5.9.3)
       tsdown:
         specifier: 'catalog:'
-        version: 0.20.0-beta.4(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260117.1)(@vitejs/devtools@0.0.0-alpha.26(@pnpm/logger@1001.0.1)(vite@packages+core)(vue@3.5.25(typescript@5.9.3)))(oxc-resolver@11.14.0)(publint@0.3.16)(typescript@5.9.3)(unplugin-lightningcss@0.4.3)(unplugin-unused@0.5.6)
+        version: 0.20.0-beta.4(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260122.2)(@vitejs/devtools@0.0.0-alpha.26(@pnpm/logger@1001.0.1)(vite@packages+core)(vue@3.5.25(typescript@5.9.3)))(oxc-resolver@11.14.0)(publint@0.3.16)(typescript@5.9.3)(unplugin-lightningcss@0.4.3)(unplugin-unused@0.5.6)
       vite:
         specifier: workspace:@voidzero-dev/vite-plus-core@*
         version: link:../core
@@ -497,7 +497,7 @@ importers:
         version: link:../../rolldown/packages/rolldown
       rolldown-plugin-dts:
         specifier: 'catalog:'
-        version: 0.20.0(@typescript/native-preview@7.0.0-dev.20260117.1)(oxc-resolver@11.14.0)(rolldown@rolldown+packages+rolldown)(typescript@5.9.3)
+        version: 0.20.0(@typescript/native-preview@7.0.0-dev.20260122.2)(oxc-resolver@11.14.0)(rolldown@rolldown+packages+rolldown)(typescript@5.9.3)
       rollup:
         specifier: ^4.18.0
         version: 4.53.3
@@ -515,7 +515,7 @@ importers:
         version: 1.2.2
       tsdown:
         specifier: 'catalog:'
-        version: 0.20.0-beta.4(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260117.1)(@vitejs/devtools@0.0.0-alpha.26(@pnpm/logger@1001.0.1)(vite@packages+core)(vue@3.5.25(typescript@5.9.3)))(oxc-resolver@11.14.0)(publint@0.3.16)(typescript@5.9.3)(unplugin-lightningcss@0.4.3)(unplugin-unused@0.5.6)
+        version: 0.20.0-beta.4(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260122.2)(@vitejs/devtools@0.0.0-alpha.26(@pnpm/logger@1001.0.1)(vite@packages+core)(vue@3.5.25(typescript@5.9.3)))(oxc-resolver@11.14.0)(publint@0.3.16)(typescript@5.9.3)(unplugin-lightningcss@0.4.3)(unplugin-unused@0.5.6)
       vite:
         specifier: workspace:@voidzero-dev/vite-plus-core@*
         version: 'link:'
@@ -710,7 +710,7 @@ importers:
         version: link:../../rolldown/packages/rolldown
       rolldown-plugin-dts:
         specifier: 'catalog:'
-        version: 0.20.0(@typescript/native-preview@7.0.0-dev.20260117.1)(oxc-resolver@11.14.0)(rolldown@rolldown+packages+rolldown)(typescript@5.9.3)
+        version: 0.20.0(@typescript/native-preview@7.0.0-dev.20260122.2)(oxc-resolver@11.14.0)(rolldown@rolldown+packages+rolldown)(typescript@5.9.3)
       tinyrainbow:
         specifier: ^3.0.3
         version: 3.0.3
@@ -915,7 +915,7 @@ importers:
         version: 1.1.1
       tsdown:
         specifier: ^0.18.4
-        version: 0.18.4(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260117.1)(publint@0.3.16)(typescript@5.9.3)(unplugin-lightningcss@0.4.3)(unplugin-unused@0.5.6)
+        version: 0.18.4(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260122.2)(publint@0.3.16)(typescript@5.9.3)(unplugin-lightningcss@0.4.3)(unplugin-unused@0.5.6)
 
   rolldown-vite/packages/plugin-legacy:
     dependencies:
@@ -967,7 +967,7 @@ importers:
         version: 1.1.1
       tsdown:
         specifier: ^0.18.4
-        version: 0.18.4(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260117.1)(publint@0.3.16)(typescript@5.9.3)(unplugin-lightningcss@0.4.3)(unplugin-unused@0.5.6)
+        version: 0.18.4(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260122.2)(publint@0.3.16)(typescript@5.9.3)(unplugin-lightningcss@0.4.3)(unplugin-unused@0.5.6)
       vite:
         specifier: workspace:@voidzero-dev/vite-plus-core@*
         version: link:../../../packages/core
@@ -1154,7 +1154,7 @@ importers:
         version: 2.0.3
       rolldown-plugin-dts:
         specifier: ^0.20.0
-        version: 0.20.0(@typescript/native-preview@7.0.0-dev.20260117.1)(oxc-resolver@11.14.0)(rolldown@rolldown+packages+rolldown)(typescript@5.9.3)
+        version: 0.20.0(@typescript/native-preview@7.0.0-dev.20260122.2)(oxc-resolver@11.14.0)(rolldown@rolldown+packages+rolldown)(typescript@5.9.3)
       rollup:
         specifier: ^4.43.0
         version: 4.53.3
@@ -1322,7 +1322,7 @@ importers:
         version: 'link:'
       rolldown-plugin-dts:
         specifier: 'catalog:'
-        version: 0.20.0(@typescript/native-preview@7.0.0-dev.20260117.1)(oxc-resolver@11.14.0)(rolldown@rolldown+packages+rolldown)(typescript@5.9.3)
+        version: 0.20.0(@typescript/native-preview@7.0.0-dev.20260122.2)(oxc-resolver@11.14.0)(rolldown@rolldown+packages+rolldown)(typescript@5.9.3)
       rollup:
         specifier: 'catalog:'
         version: 4.53.3
@@ -4460,43 +4460,43 @@ packages:
     resolution: {integrity: sha512-LZ2NqIHFhvFwxG0qZeLL9DvdNAHPGCY5dIRwBhyYeU+LfLhcStE1ImjsuTG/WaVh3XysGaeLW8Rqq7cGkPCFvw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260117.1':
-    resolution: {integrity: sha512-sf8/7keXq1auS7XI0vyAs3t/vgss4/EwACZmzSYtO75dug8TRmuSQDPHxx4R16VURijO/GQ3Bz6rA8VivREzsA==}
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260122.2':
+    resolution: {integrity: sha512-rpy7WzXpETCIc+QBfE8J1RpNxvb/5pnKh98DbC4gXpxHKrkjkg0LX86CJSoPaCF6xGcfRsegi49q+bXrtH4LWQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260117.1':
-    resolution: {integrity: sha512-3DhQdRUbDq7YduIaRYJtH5MXqCzOry+GT4DjkLPJ08vOGOFypZjgd6G+moEQHgitnefisC1PkNcL1baF4B7+og==}
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260122.2':
+    resolution: {integrity: sha512-s1Zn16TqesG2x4wx5cKciyfmffZRhJO2fBSN4fQ6bBWbrZHT8KnjJUpoRd8t+JAXsHfxDy4S/S0DcmX5eRfAHQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260117.1':
-    resolution: {integrity: sha512-R9h8cX5C0yBtE8xnpAxZBSHWPiVW3d5o3mup0ei1n/8w98lwtMFLWURnPD8N4kRgql9L40IbRXW6jqWdjDUe4Q==}
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260122.2':
+    resolution: {integrity: sha512-dMIOprNNvILRLKLlevs9fEE6Q6Bhikjv9OiQb3Sma3lcV/4lvh8DJ5hVKj2/aiGrK1000EC54UzwB6rLxnuw0w==}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260117.1':
-    resolution: {integrity: sha512-RKSKINs23agj0MJJ2Tzkhe/MuwhcPqRNRRfLmpVRjrNWI43Ta6a5+5Lah+7GYjt00wHUOhay94ZT3iHJkeHATg==}
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260122.2':
+    resolution: {integrity: sha512-ybrJVEuB9TmLWwdNl1ryUHeAm6KV3QcOKZUdfKhp6TjmuesOd1/2rdnGHmEcZlQDQt5+RtsCaxHWadvqDF1h3Q==}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260117.1':
-    resolution: {integrity: sha512-KI5UprUMIVT4wehBcbGZQm0I3z1uls8fsOmCUzdEpmaLpVu8NbTahgJPVtMyS/nDUiN3At4Uj8ciL36kgbqRmQ==}
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260122.2':
+    resolution: {integrity: sha512-bbgb8a3dETxTTFUbSsCF7sSQ2oCsnyg7/HcFXi12TxdXscu1qod4/MxznBNOvwG/eYcrsLmI14k6BVRVSiGFoQ==}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260117.1':
-    resolution: {integrity: sha512-dUJTLMD24TQ4XiyYAxxqKs6hPrq8wS9BiFt+ucjCuWXBGQLbnfiT4bgYz2a4yfbtyxVkG7mxV8udo+gRXtaWRQ==}
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260122.2':
+    resolution: {integrity: sha512-JxPwmsaV6wuijnOo4qg5aIMrzQarTNVHqUaVP5pijkon8Y6dCvJ+3lYNEe4E6baiiw1u3npUQY4l/cvx2RL1eQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260117.1':
-    resolution: {integrity: sha512-SdKCAtNZee2TMdZ/bGjfKWX43qIAZhBwLlkPU1G0uxKqmDG1mVRbg/krxm5MnKOjFL00X/gozth6d3LmimonnA==}
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260122.2':
+    resolution: {integrity: sha512-TJH+sSn7vxcGvaSm+fhcpW//dfSGBZGHrxoy0edAbE7UpFf8ub/3cILL5V1pCsF7w3aLNNgVKRpUkowdUgYcPQ==}
     cpu: [x64]
     os: [win32]
 
-  '@typescript/native-preview@7.0.0-dev.20260117.1':
-    resolution: {integrity: sha512-5peFvGyf+TOlU6KYMLzfPiPJdxYwG0O/oQN4Z+EzDOzrN8tbY/H58+QOQww4Lo8m4b7+4o/0r+zopD/sYR6uMw==}
+  '@typescript/native-preview@7.0.0-dev.20260122.2':
+    resolution: {integrity: sha512-+bVirfVpvhDG/oJWzA1c9HX6fC5Wu2hPv3LdBcpf0UtOu0KoWBN+B4L0wYY9gvxvvoxGmupdRCqaM8hRNlXzaw==}
     hasBin: true
 
   '@ungap/structured-clone@1.3.0':
@@ -11333,36 +11333,36 @@ snapshots:
       '@typescript-eslint/types': 8.53.0
       eslint-visitor-keys: 4.2.1
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260117.1':
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260122.2':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260117.1':
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260122.2':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260117.1':
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260122.2':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260117.1':
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260122.2':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260117.1':
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260122.2':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260117.1':
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260122.2':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260117.1':
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260122.2':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20260117.1':
+  '@typescript/native-preview@7.0.0-dev.20260122.2':
     optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260117.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260117.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260117.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260117.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260117.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260117.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260117.1
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260122.2
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260122.2
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260122.2
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260122.2
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260122.2
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260122.2
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260122.2
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -14536,7 +14536,7 @@ snapshots:
 
   rgb2hex@0.2.5: {}
 
-  rolldown-plugin-dts@0.20.0(@typescript/native-preview@7.0.0-dev.20260117.1)(oxc-resolver@11.14.0)(rolldown@rolldown+packages+rolldown)(typescript@5.9.3):
+  rolldown-plugin-dts@0.20.0(@typescript/native-preview@7.0.0-dev.20260122.2)(oxc-resolver@11.14.0)(rolldown@rolldown+packages+rolldown)(typescript@5.9.3):
     dependencies:
       '@babel/generator': 7.28.6
       '@babel/parser': 7.28.6
@@ -14548,12 +14548,12 @@ snapshots:
       obug: 2.1.1
       rolldown: link:rolldown/packages/rolldown
     optionalDependencies:
-      '@typescript/native-preview': 7.0.0-dev.20260117.1
+      '@typescript/native-preview': 7.0.0-dev.20260122.2
       typescript: 5.9.3
     transitivePeerDependencies:
       - oxc-resolver
 
-  rolldown-plugin-dts@0.21.5(@typescript/native-preview@7.0.0-dev.20260117.1)(oxc-resolver@11.14.0)(rolldown@rolldown+packages+rolldown)(typescript@5.9.3):
+  rolldown-plugin-dts@0.21.5(@typescript/native-preview@7.0.0-dev.20260122.2)(oxc-resolver@11.14.0)(rolldown@rolldown+packages+rolldown)(typescript@5.9.3):
     dependencies:
       '@babel/generator': 8.0.0-beta.4
       '@babel/parser': 8.0.0-beta.4
@@ -14565,7 +14565,7 @@ snapshots:
       obug: 2.1.1
       rolldown: link:rolldown/packages/rolldown
     optionalDependencies:
-      '@typescript/native-preview': 7.0.0-dev.20260117.1
+      '@typescript/native-preview': 7.0.0-dev.20260122.2
       typescript: 5.9.3
     transitivePeerDependencies:
       - oxc-resolver
@@ -15136,7 +15136,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  tsdown@0.18.4(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260117.1)(publint@0.3.16)(typescript@5.9.3)(unplugin-lightningcss@0.4.3)(unplugin-unused@0.5.6):
+  tsdown@0.18.4(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260122.2)(publint@0.3.16)(typescript@5.9.3)(unplugin-lightningcss@0.4.3)(unplugin-unused@0.5.6):
     dependencies:
       ansis: 4.2.0
       cac: 6.7.14
@@ -15147,7 +15147,7 @@ snapshots:
       obug: 2.1.1
       picomatch: 4.0.3
       rolldown: link:rolldown/packages/rolldown
-      rolldown-plugin-dts: 0.20.0(@typescript/native-preview@7.0.0-dev.20260117.1)(oxc-resolver@11.14.0)(rolldown@rolldown+packages+rolldown)(typescript@5.9.3)
+      rolldown-plugin-dts: 0.20.0(@typescript/native-preview@7.0.0-dev.20260122.2)(oxc-resolver@11.14.0)(rolldown@rolldown+packages+rolldown)(typescript@5.9.3)
       semver: 7.7.3
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
@@ -15167,7 +15167,7 @@ snapshots:
       - synckit
       - vue-tsc
 
-  tsdown@0.20.0-beta.4(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260117.1)(@vitejs/devtools@0.0.0-alpha.26(@pnpm/logger@1001.0.1)(vite@packages+core)(vue@3.5.25(typescript@5.9.3)))(oxc-resolver@11.14.0)(publint@0.3.16)(typescript@5.9.3)(unplugin-lightningcss@0.4.3)(unplugin-unused@0.5.6):
+  tsdown@0.20.0-beta.4(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260122.2)(@vitejs/devtools@0.0.0-alpha.26(@pnpm/logger@1001.0.1)(vite@packages+core)(vue@3.5.25(typescript@5.9.3)))(oxc-resolver@11.14.0)(publint@0.3.16)(typescript@5.9.3)(unplugin-lightningcss@0.4.3)(unplugin-unused@0.5.6):
     dependencies:
       ansis: 4.2.0
       cac: 6.7.14
@@ -15178,7 +15178,7 @@ snapshots:
       obug: 2.1.1
       picomatch: 4.0.3
       rolldown: link:rolldown/packages/rolldown
-      rolldown-plugin-dts: 0.21.5(@typescript/native-preview@7.0.0-dev.20260117.1)(oxc-resolver@11.14.0)(rolldown@rolldown+packages+rolldown)(typescript@5.9.3)
+      rolldown-plugin-dts: 0.21.5(@typescript/native-preview@7.0.0-dev.20260122.2)(oxc-resolver@11.14.0)(rolldown@rolldown+packages+rolldown)(typescript@5.9.3)
       semver: 7.7.3
       tinyexec: 1.0.2
       tinyglobby: 0.2.15

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,7 +36,7 @@ catalog:
   '@types/strip-comments': ^2.0.4
   '@types/validate-npm-package-name': ^4.0.2
   '@types/ws': ^8.18.0
-  '@typescript/native-preview': 7.0.0-dev.20260117.1
+  '@typescript/native-preview': 7.0.0-dev.20260122.2
   '@vitest/browser': ^4.0.9
   '@vitest/browser-playwright': ^4.0.9
   '@vueuse/core': ^14.0.0


### PR DESCRIPTION
This PR makes several changes:

* Splits `vite migrate` into an interactive and non-interactive mode. For now, the interactive mode explains what it is going to do and asks for approval. It was too easy before to accidentally run it and have tons of unwanted changes.
* Redesigns `vite migrate --help` to align with `vite new --help`.
* Adds support for `vite help <command>`, which forwards to `view command --help`.
* Removes the `migration` alias. There is now only `vite migrate`.
* Updates `@typescript/native-preview` which comes with a fix for TypeScript in VS Code which kept crashing all the time.

![CleanShot 2026-01-23 at 15.35.54@2x.png](https://app.graphite.com/user-attachments/assets/5a23ad61-e7c6-47ca-a869-2f1ee7d92470.png)

![CleanShot 2026-01-23 at 15.36.01@2x.png](https://app.graphite.com/user-attachments/assets/07029f94-967d-43d1-a675-df9a628f053d.png)

