### PR TITLE
build: add `build:src` task

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -71,4 +71,18 @@ export default <UserConfig>{
       order: 'asc',
     },
   },
+  tasks: {
+    'build:src': {
+      command: [
+        'vite run @rolldown/pluginutils#build',
+        'vite run rolldown#build-binding:release',
+        'vite run rolldown#build-node',
+        'vite run vite#build-types',
+        'vite run @voidzero-dev/vite-plus-core#build',
+        'vite run @voidzero-dev/vite-plus-test#build',
+        'vite run vite-plus#build',
+        'vite run vite-plus-cli#build',
+      ].join(' && '),
+    },
+  },
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a composite build task to centralize building source packages.
> 
> - Introduces `tasks.build:src` in `vite.config.ts` that chains builds for `@rolldown/pluginutils`, `rolldown` (binding:release and node), `vite` types, `@voidzero-dev/vite-plus-core`, `@voidzero-dev/vite-plus-test`, `vite-plus`, and `vite-plus-cli` via `vite run ... &&` pipeline
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1404c4aeff3839989ae81c672896b083912dcc6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->