### PR TITLE
fix(test): `@vitest/*` types path are not patched

### DIFF
--- a/packages/test/build.ts
+++ b/packages/test/build.ts
@@ -753,6 +753,7 @@ async function rewriteVitestImports(leafDepToVendorPath: Map<string, string>) {
     join(distDir, '*.js'),
     join(distDir, '*.d.ts'),
     join(distDir, 'chunks/*.js'),
+    join(distDir, 'chunks/*.d.ts'),
   ]);
 
   for await (const file of jsFiles) {


### PR DESCRIPTION
Close VP-165


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures TypeScript declaration files in built chunks are also rewritten so type imports are correctly patched.
> 
> - Extend rewrite scan to include `dist/chunks/*.d.ts`, alongside existing `*.js` and `*.d.ts` paths
> - Fixes unpatched type specifiers for `@vitest/*`, `vitest/*`, and vendor deps within chunked `.d.ts` files
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7cb66f1b7d14d6857d5eda0866723937b40f6cf1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->