### PR TITLE
fix(test): add @standard-schema/spec to EXTERNAL_BLOCKLIST

### DIFF
--- a/packages/test/BUNDLING.md
+++ b/packages/test/BUNDLING.md
@@ -72,15 +72,16 @@ These remain in `dependencies` and are installed with the package:
 
 These packages are explicitly kept external in `EXTERNAL_BLOCKLIST` during the Rolldown build:
 
-| Package            | Reason                                    |
-| ------------------ | ----------------------------------------- |
-| `playwright`       | Native bindings, user must install        |
-| `webdriverio`      | Native bindings, user must install        |
-| `debug`            | Environment detection breaks when bundled |
-| `happy-dom`        | Optional peer dependency                  |
-| `jsdom`            | Optional peer dependency                  |
-| `@edge-runtime/vm` | Optional peer dependency                  |
-| `msw`, `msw/*`     | Optional peer dependency for mocking      |
+| Package                 | Reason                                    |
+| ----------------------- | ----------------------------------------- |
+| `playwright`            | Native bindings, user must install        |
+| `webdriverio`           | Native bindings, user must install        |
+| `debug`                 | Environment detection breaks when bundled |
+| `happy-dom`             | Optional peer dependency                  |
+| `jsdom`                 | Optional peer dependency                  |
+| `@edge-runtime/vm`      | Optional peer dependency                  |
+| `@standard-schema/spec` | Types-only import from @vitest/expect     |
+| `msw`, `msw/*`          | Optional peer dependency for mocking      |
 
 ### Browser Plugin Exclude List
 
@@ -398,6 +399,7 @@ const EXTERNAL_BLOCKLIST = new Set([
   // Peer dependencies - consumers must provide these
   '@edge-runtime/vm',
   '@opentelemetry/api',
+  '@standard-schema/spec', // Types-only import from @vitest/expect
   'happy-dom',
   'jsdom',
 

--- a/packages/test/build.ts
+++ b/packages/test/build.ts
@@ -145,6 +145,7 @@ const EXTERNAL_BLOCKLIST = new Set([
   // Peer dependencies - consumers must provide these
   '@edge-runtime/vm',
   '@opentelemetry/api',
+  '@standard-schema/spec', // Types-only import from @vitest/expect
   'happy-dom',
   'jsdom',
 

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -256,6 +256,7 @@
     "build": "oxnode -C dev ./build.ts"
   },
   "dependencies": {
+    "@standard-schema/spec": "^1.1.0",
     "@types/chai": "^5.2.2",
     "@voidzero-dev/vite-plus-core": "workspace:*",
     "es-module-lexer": "^1.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -609,6 +609,9 @@ importers:
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.0
+      '@standard-schema/spec':
+        specifier: ^1.1.0
+        version: 1.1.0
       '@types/chai':
         specifier: ^5.2.2
         version: 5.2.3
@@ -4284,8 +4287,8 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
-  '@standard-schema/spec@1.0.0':
-    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@swc/helpers@0.5.18':
     resolution: {integrity: sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==}
@@ -11330,7 +11333,7 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@standard-schema/spec@1.0.0': {}
+  '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.18':
     dependencies:
@@ -11972,7 +11975,7 @@ snapshots:
 
   '@vitest/expect@4.0.17':
     dependencies:
-      '@standard-schema/spec': 1.0.0
+      '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
       '@vitest/spy': 4.0.17
       '@vitest/utils': 4.0.17


### PR DESCRIPTION
@vitest/expect imports StandardSchemaV1 from @standard-schema/spec in
its type definitions only (not in JS files). Since collectLeafDependencies()
only scans .js files, this package was not detected and bundled.

Fix by adding @standard-schema/spec to EXTERNAL_BLOCKLIST and as a
runtime dependency, allowing TypeScript to resolve types through
normal node_modules resolution.

> TypeCheckError: Cannot find module '@standard-schema/spec' or its corresponding type declarations.
 ❯ ../../node_modules/.pnpm/@voidzero-dev+vite-plus-test@0.0.0-4d2367587d11c412d283847253d95e4e36ace419_@types+node_b06a8e0da48f743d40c7a7d8079f73e5/node_modules/@voidzero-dev/vite-plus-test/dist/@vitest/expect/index.d.ts:6:34

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures @standard-schema/spec (types used by `@vitest/expect`) is installed and not bundled so TypeScript can resolve it while Rolldown keeps it external.
> 
> - Add `@standard-schema/spec` to `EXTERNAL_BLOCKLIST` in `build.ts` and document it in `BUNDLING.md`
> - Declare `@standard-schema/spec@^1.1.0` in `packages/test/package.json`; update lockfile and align `@vitest/expect` to use 1.1.0
> 
> This fixes missing-type errors without changing runtime code paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c3a2d6fe199a257b1f6e0bda888c08d08b2bb53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->