### PR TITLE
Fix issues with new/migrate clis.

### DIFF
--- a/packages/global/snap-tests/migration-already-vite-plus/package.json
+++ b/packages/global/snap-tests/migration-already-vite-plus/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "migration-already-vite-plus",
+  "devDependencies": {
+    "vite-plus": "latest"
+  }
+}

--- a/packages/global/snap-tests/migration-already-vite-plus/snap.txt
+++ b/packages/global/snap-tests/migration-already-vite-plus/snap.txt
@@ -1,0 +1,5 @@
+> vite migrate --no-interactive # should detect existing vite-plus and exit
+┌  VITE+(⚡︎) - The Unified Toolchain for the Web
+│
+└  This project is already using Vite+! Happy coding!
+

--- a/packages/global/snap-tests/migration-already-vite-plus/steps.json
+++ b/packages/global/snap-tests/migration-already-vite-plus/steps.json
@@ -1,0 +1,3 @@
+{
+  "commands": ["vite migrate --no-interactive # should detect existing vite-plus and exit"]
+}

--- a/packages/global/snap-tests/migration-from-tsdown-json-config/snap.txt
+++ b/packages/global/snap-tests/migration-from-tsdown-json-config/snap.txt
@@ -59,13 +59,7 @@ export default defineConfig({
 > vite migrate --no-interactive # run migration again to check if it is idempotent
 ┌  VITE+(⚡︎) - The Unified Toolchain for the Web
 │
-●  pnpm@<semver> installing...
-│
-●  pnpm@<semver> installed
-│
-●  Skipped writing AGENTS.md (already exists)
-│
-└  ✔ Migration completed!
+└  This project is already using Vite+! Happy coding!
 
 
 > cat vite.config.ts # check vite.config.ts

--- a/packages/global/snap-tests/migration-from-tsdown/snap.txt
+++ b/packages/global/snap-tests/migration-from-tsdown/snap.txt
@@ -66,15 +66,7 @@ export default defineConfig({
 > vite migrate --no-interactive # run migration again to check if it is idempotent
 ┌  VITE+(⚡︎) - The Unified Toolchain for the Web
 │
-●  pnpm@<semver> installing...
-│
-●  pnpm@<semver> installed
-│
-●  Please manually merge tsdown.config.ts into vite.config.ts, see https://viteplus.dev/migration/#tsdown
-│
-●  Skipped writing AGENTS.md (already exists)
-│
-└  ✔ Migration completed!
+└  This project is already using Vite+! Happy coding!
 
 
 > cat tsdown.config.ts # check tsdown.config.ts

--- a/packages/global/src/local/bin.ts
+++ b/packages/global/src/local/bin.ts
@@ -6,29 +6,25 @@ import * as prompts from '@clack/prompts';
 import { detectWorkspace as detectWorkspaceBinding } from '../../binding/index.js';
 import { runCommand } from '../utils/command.js';
 import { VITE_PLUS_NAME } from '../utils/constants.js';
-import { detectPackageMetadata, readNearestPackageJson } from '../utils/package.js';
+import {
+  detectPackageMetadata,
+  hasVitePlusDependency,
+  readNearestPackageJson,
+} from '../utils/package.js';
 import { cancelAndExit, defaultInteractive, runViteInstall } from '../utils/prompts.js';
+import type { PackageDependencies } from '../utils/types.js';
 
 const cwd = process.cwd();
 const interactive = defaultInteractive();
 let localCliMetadata = detectPackageMetadata(cwd, VITE_PLUS_NAME);
 let startPrompts = false;
 
-// check local CLI already added to devDependencies but not installed
 if (!localCliMetadata) {
-  const pkg = readNearestPackageJson<{
-    devDependencies?: Record<string, string>;
-    dependencies?: Record<string, string>;
-  }>(cwd);
-  if (pkg?.devDependencies?.[VITE_PLUS_NAME] || pkg?.dependencies?.[VITE_PLUS_NAME]) {
-    prompts.intro(`Local "${VITE_PLUS_NAME}" package was not found`);
+  if (hasVitePlusDependency(readNearestPackageJson<PackageDependencies>(cwd))) {
+    prompts.intro(`Installing "${VITE_PLUS_NAME}"…`);
     startPrompts = true;
-    // run vite install and detect package metadata again
     await runViteInstall(cwd, interactive);
     localCliMetadata = detectPackageMetadata(cwd, VITE_PLUS_NAME);
-    if (localCliMetadata) {
-      prompts.outro(`Using local Vite+ CLI`);
-    }
   }
 }
 

--- a/packages/global/src/migration/bin.ts
+++ b/packages/global/src/migration/bin.ts
@@ -8,6 +8,7 @@ import semver from 'semver';
 
 import { PackageManager, type WorkspaceInfo } from '../types/index.js';
 import { selectAgentTargetPath, writeAgentInstructions } from '../utils/agent.js';
+import { hasVitePlusDependency, readNearestPackageJson } from '../utils/package.js';
 import {
   cancelAndExit,
   defaultInteractive,
@@ -17,6 +18,7 @@ import {
   upgradeYarn,
 } from '../utils/prompts.js';
 import { accent, getVitePlusHeader, headline, log, muted } from '../utils/terminal.js';
+import type { PackageDependencies } from '../utils/types.js';
 import { detectWorkspace } from '../utils/workspace.js';
 import {
   checkVitestVersion,
@@ -106,6 +108,16 @@ async function main() {
 
   prompts.intro(await getVitePlusHeader());
 
+  const workspaceInfoOptional = await detectWorkspace(projectPath);
+  if (
+    hasVitePlusDependency(
+      readNearestPackageJson<PackageDependencies>(workspaceInfoOptional.rootDir),
+    )
+  ) {
+    prompts.outro(`This project is already using Vite+! ${accent(`Happy coding!`)}`);
+    return;
+  }
+
   if (options.interactive) {
     prompts.log.info(
       [
@@ -124,7 +136,6 @@ async function main() {
     }
   }
 
-  const workspaceInfoOptional = await detectWorkspace(projectPath);
   const packageManager =
     workspaceInfoOptional.packageManager ?? (await selectPackageManager(options.interactive));
 

--- a/packages/global/src/new/bin.ts
+++ b/packages/global/src/new/bin.ts
@@ -35,6 +35,7 @@ import {
   executeMonorepoTemplate,
   executeRemoteTemplate,
 } from './templates/index.js';
+import { InitialMonorepoAppDir } from './templates/monorepo.js';
 import { BuiltinTemplate, TemplateType } from './templates/types.js';
 import { formatTargetDir } from './utils.js';
 
@@ -432,8 +433,10 @@ Use \`vite new --list\` to list all available templates, or run \`vite new --hel
     workspaceInfo.rootDir = fullPath;
     rewriteMonorepo(workspaceInfo);
     await runViteInstall(fullPath, options.interactive);
-    prompts.outro(success(`✔ Created ${accent(projectDir)}!`));
-    showNextSteps(projectDir, false);
+    prompts.outro(`✔ Created ${accent(projectDir)}!`);
+    log(`${styleText('bold', 'Next steps:')}`);
+    log(`  ${accent(`cd ${projectDir}`)}`);
+    log(`  ${accent(`vite dev ${InitialMonorepoAppDir}`)}`);
     return;
   }
   // #endregion
@@ -548,7 +551,7 @@ Use \`vite new --list\` to list all available templates, or run \`vite new --hel
     await runViteInstall(fullPath, options.interactive);
   }
 
-  prompts.outro(success(`✔ Created ${accent(projectDir)}!`));
+  prompts.outro(`✔ Created ${accent(projectDir)}!`);
 
   showNextSteps(projectDir, isMonorepo);
   // #endregion

--- a/packages/global/src/new/templates/monorepo.ts
+++ b/packages/global/src/new/templates/monorepo.ts
@@ -15,6 +15,8 @@ import { copyDir, setPackageName } from '../utils.js';
 import { runRemoteTemplateCommand } from './remote.js';
 import { type BuiltinTemplateInfo } from './types.js';
 
+export const InitialMonorepoAppDir = 'apps/website';
+
 // Execute vite:monorepo - copy from templates/monorepo
 export async function executeMonorepoTemplate(
   workspaceInfo: WorkspaceInfo,
@@ -117,10 +119,9 @@ export async function executeMonorepoTemplate(
   // Automatically create a default application in apps/website
   prompts.log.step('Creating default application in apps/website...');
 
-  const appDir = 'apps/website';
   const appTemplateInfo = discoverTemplate(
     'create-vite@latest',
-    [appDir, '--template', 'vanilla-ts', '--no-interactive'],
+    [InitialMonorepoAppDir, '--template', 'vanilla-ts', '--no-interactive'],
     workspaceInfo,
   );
   const appResult = await runRemoteTemplateCommand(workspaceInfo, fullPath, appTemplateInfo);
@@ -133,7 +134,7 @@ export async function executeMonorepoTemplate(
   const appPackageName = workspaceInfo.monorepoScope
     ? `${workspaceInfo.monorepoScope}/website`
     : 'website';
-  const appProjectPath = path.join(fullPath, appDir);
+  const appProjectPath = path.join(fullPath, InitialMonorepoAppDir);
   setPackageName(appProjectPath, appPackageName);
   // Perform auto-migration on the created app
   rewriteMonorepoProject(appProjectPath, workspaceInfo.packageManager);

--- a/packages/global/src/utils/package.ts
+++ b/packages/global/src/utils/package.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 
+import { VITE_PLUS_NAME } from './constants.js';
 import { readJsonFile } from './json.js';
 
 export function getScopeFromPackageName(packageName: string): string {
@@ -51,4 +52,13 @@ export function readNearestPackageJson<T = Record<string, any>>(currentDir: stri
     currentDir = path.dirname(currentDir);
   } while (currentDir !== path.dirname(currentDir));
   return null;
+}
+
+export function hasVitePlusDependency(
+  pkg?: {
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+  } | null,
+) {
+  return Boolean(pkg?.dependencies?.[VITE_PLUS_NAME] || pkg?.devDependencies?.[VITE_PLUS_NAME]);
 }

--- a/packages/global/src/utils/types.ts
+++ b/packages/global/src/utils/types.ts
@@ -1,0 +1,4 @@
+export type PackageDependencies = {
+  devDependencies?: Record<string, string>;
+  dependencies?: Record<string, string>;
+};


### PR DESCRIPTION
This PR fixes two bugs:

* `vite migrate` exits early when the project is already using Vite+
* `vite new` now correctly prints the next steps:
  * When creating a monorepo, it prints `cd <path> && vite dev apps/website`
  * In a monorepo, it prints `vite dev <path>` after creating a new package (we might need to update this to only do it for specific packages)
  * In a regular project it prints `cd <path> && vite dev`

Both issues were reported by Simek.