### PR TITLE
ci: activate RELEASE_BUILD in upgrade-deps

### DIFF
--- a/.github/workflows/upgrade-deps.yml
+++ b/.github/workflows/upgrade-deps.yml
@@ -57,9 +57,13 @@ jobs:
         continue-on-error: true
         with:
           target: x86_64-unknown-linux-gnu
+        env:
+          RELEASE_BUILD: 'true'
 
       - uses: anthropics/claude-code-action@a017b830c03e23789b11fb69ed571ea61c12e45c # v1.0.0
         if: steps.build-upstream.outcome == 'failure'
+        env:
+          RELEASE_BUILD: 'true'
         with:
           claude_code_oauth_token: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -73,14 +77,14 @@ jobs:
             - We are using `pnpm` as the package manager
             - We are aiming to upgrade all dependencies to the latest versions in this workflow, so don't downgrade any dependencies.
             - Check `.claude/agents/cargo-workspace-merger.md` if rolldown hash is changed.
-            - If deps in our `Cargo.toml` need to be upgraded, you can refer to the `./.claude/agents/cargo-workspace-merger.md`
-              - If `Cargo.toml` has been modified, you need to run `cargo shear` to ensure there is nothing wrong with our dependencies.
-              - Run `cargo check --all-targets --all-features` to ensure everything works fine if any Rust related codes are modified.
             - Run the steps in `build-upstream` action.yml after your fixing. If no errors are found, you can safe to exit.
             - Your final step is to run `just build` to ensure all builds are successful.
             - Run `pnpm run lint` to check if there are any issues after the build, if has, deep investigate it and fix it. You need to run `just build` before you can run `pnpm run lint`.
             - Run `pnpm run test` after `just build` to ensure all tests are successful.
             - The snapshot tests in `pnpm run test` are always successful, you need to check the updated snapshot to see if there is anything wrong after our deps upgrade.
+            - If deps in our `Cargo.toml` need to be upgraded, you can refer to the `./.claude/agents/cargo-workspace-merger.md`
+              - If `Cargo.toml` has been modified, you need to run `cargo shear` to ensure there is nothing wrong with our dependencies.
+              - Run `cargo check --all-targets --all-features` to ensure everything works fine if any Rust related codes are modified.
 
             Help me fix the errors in `build-upstream` steps, no need to commit changes after your fixing.
           claude_args: |
@@ -92,6 +96,11 @@ jobs:
         run: |
           pnpm install --no-frozen-lockfile
           pnpm dedupe
+
+      - name: Checkout binding files
+        run: |
+          git checkout packages/cli/binding/index.cjs
+          git checkout packages/cli/binding/index.d.cts
 
       - name: Format code
         run: pnpm fmt


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adjusts build flags and workflow steps; main risk is slightly different build artifacts/caching behavior during automated dependency upgrades.
> 
> **Overview**
> **Enables release-mode builds in the deps upgrade workflow.** `upgrade-deps.yml` now sets `RELEASE_BUILD: 'true'` for the `build-upstream` composite action and for the Claude fallback step so the upgrade validation matches release build conditions.
> 
> **Stabilizes PR output.** After updating the lockfile, the workflow checks out `packages/cli/binding/index.cjs` and `packages/cli/binding/index.d.cts` to discard generated binding changes before formatting/creating the PR.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e435c9487de8c963b2806a4072738633eb323d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->