### PR TITLE
ci: add x86 macOS release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
         settings:
           - target: aarch64-apple-darwin
             os: namespace-profile-mac-default
+          - target: x86_64-apple-darwin
+            os: namespace-profile-mac-default
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
           - target: x86_64-unknown-linux-gnu

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -313,6 +313,7 @@
     "packageName": "@voidzero-dev/vite-plus",
     "targets": [
       "aarch64-apple-darwin",
+      "x86_64-apple-darwin",
       "aarch64-unknown-linux-gnu",
       "x86_64-unknown-linux-gnu",
       "x86_64-pc-windows-msvc"

--- a/packages/global/package.json
+++ b/packages/global/package.json
@@ -52,6 +52,7 @@
     "packageName": "@voidzero-dev/vite-plus-cli",
     "targets": [
       "aarch64-apple-darwin",
+      "x86_64-apple-darwin",
       "aarch64-unknown-linux-gnu",
       "x86_64-unknown-linux-gnu",
       "x86_64-pc-windows-msvc"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates the release build matrix and published native targets, which can affect release pipeline behavior and artifact completeness for macOS users.
> 
> **Overview**
> **Intel macOS release support**: the release workflow now builds Rust/N-API artifacts for `x86_64-apple-darwin` in addition to existing targets.
> 
> Both `packages/cli` and `packages/global` expand their `napi.targets` lists to include `x86_64-apple-darwin`, enabling publishing/installing native binaries for Intel Macs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a94751daaa478cd74e3d03c39fe3ea627d8a54ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->