### PR TITLE
ci: print subcommands help after build

### DIFF
--- a/.github/actions/build-upstream/action.yml
+++ b/.github/actions/build-upstream/action.yml
@@ -4,6 +4,9 @@ inputs:
   target:
     description: 'The target platform'
     required: true
+  print-after-build:
+    description: 'Print the output after the build'
+    required: false
 
 runs:
   using: 'composite'
@@ -81,6 +84,17 @@ runs:
         pnpm --filter=vite-plus-cli build-native --target ${{ inputs.target }}
       env:
         DEBUG: napi:*
+
+    - name: Print output after build
+      shell: bash
+      if: inputs.print-after-build == 'true'
+      run: |
+        pnpm vite -h
+        pnpm vite run -h
+        pnpm vite lint -h
+        pnpm vite test -h
+        pnpm vite build -h
+        pnpm vite fmt -h
 
     - name: Save NAPI binding cache
       if: steps.cache-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/upgrade-deps.yml
+++ b/.github/workflows/upgrade-deps.yml
@@ -57,6 +57,7 @@ jobs:
         continue-on-error: true
         with:
           target: x86_64-unknown-linux-gnu
+          print-after-build: 'true'
         env:
           RELEASE_BUILD: 'true'
 
@@ -85,6 +86,13 @@ jobs:
             - If deps in our `Cargo.toml` need to be upgraded, you can refer to the `./.claude/agents/cargo-workspace-merger.md`
               - If `Cargo.toml` has been modified, you need to run `cargo shear` to ensure there is nothing wrong with our dependencies.
               - Run `cargo check --all-targets --all-features` to ensure everything works fine if any Rust related codes are modified.
+            - Run the following commands to ensure everything works fine:
+              vite -h
+              vite run -h
+              vite lint -h
+              vite test -h
+              vite build -h
+              vite fmt -h
 
             Help me fix the errors in `build-upstream` steps, no need to commit changes after your fixing.
           claude_args: |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adds extra post-build commands; main impact is slightly longer workflows and potential noise/failures if CLI help output breaks.
> 
> **Overview**
> Adds a `print-after-build` input to the `build-upstream` composite action and, when enabled, runs `pnpm vite -h` plus help output for key subcommands (`run`, `lint`, `test`, `build`, `fmt`) after the build.
> 
> Enables this flag in `upgrade-deps.yml` and updates the Claude failure-recovery prompt to explicitly validate the same CLI help commands.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05707707fe27bd647d006a150493f01bf5c6793b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->