### PR TITLE
chore(ci): add timestamp to snapshot version for better readability

### DIFF
--- a/.github/actions/set-snapshot-version/action.yml
+++ b/.github/actions/set-snapshot-version/action.yml
@@ -1,0 +1,19 @@
+name: Set Snapshot Version
+description: Set snapshot version (0.0.0-{sha}.{timestamp}) for pre-release builds
+
+outputs:
+  version:
+    description: The computed version string
+    value: ${{ steps.version.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set snapshot version
+      id: version
+      shell: bash
+      run: |
+        SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-8)
+        BUILD_TIME=$(date -u +%Y%m%d-%H%M)
+        VERSION="0.0.0-${SHORT_SHA}.${BUILD_TIME}"
+        echo "version=${VERSION}" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,13 +8,26 @@ permissions: {}
 env:
   RELEASE_BUILD: 'true'
   DEBUG: 'napi:*'
-  VERSION: 0.0.0-${{ github.sha }}
 
 jobs:
-  build-rust:
-    runs-on: ${{ matrix.settings.os }}
+  prepare:
+    runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: ./.github/actions/set-snapshot-version
+        id: version
+
+  build-rust:
+    runs-on: ${{ matrix.settings.os }}
+    needs: prepare
+    permissions:
+      contents: read
+    env:
+      VERSION: ${{ needs.prepare.outputs.version }}
     strategy:
       fail-fast: false
       matrix:
@@ -109,11 +122,13 @@ jobs:
 
   Release:
     runs-on: ubuntu-latest
-    needs: build-rust
+    needs: [prepare, build-rust]
     permissions:
       contents: write
       packages: write
       id-token: write # Required for OIDC
+    env:
+      VERSION: ${{ needs.prepare.outputs.version }}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/clone


### PR DESCRIPTION
## Summary
- Add `.github/actions/set-snapshot-version` composite action to compute snapshot versions
- Change version format from `0.0.0-{sha}` to `0.0.0-{sha}.{timestamp}` for better readability
- Add `prepare` job to compute version once at workflow start and pass to downstream jobs

## Test plan
- [ ] Verify the release workflow runs successfully
- [ ] Check that the version string in release artifacts follows the new format

🤖 Generated with [Claude Code](https://claude.com/claude-code)