### PR TITLE
feat(vite-plus): update vite-task integration for cacheScripts and RunConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1712,7 +1712,7 @@ dependencies = [
 [[package]]
 name = "fspy"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=d1824f23d28fdac7024c80c25f8e84b24b4f7704#d1824f23d28fdac7024c80c25f8e84b24b4f7704"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=5ea9649f48940bf01493b74fa1d03fa484a41b41#5ea9649f48940bf01493b74fa1d03fa484a41b41"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1747,7 +1747,7 @@ dependencies = [
 [[package]]
 name = "fspy_detours_sys"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=d1824f23d28fdac7024c80c25f8e84b24b4f7704#d1824f23d28fdac7024c80c25f8e84b24b4f7704"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=5ea9649f48940bf01493b74fa1d03fa484a41b41#5ea9649f48940bf01493b74fa1d03fa484a41b41"
 dependencies = [
  "cc",
  "winapi",
@@ -1756,7 +1756,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_unix"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=d1824f23d28fdac7024c80c25f8e84b24b4f7704#d1824f23d28fdac7024c80c25f8e84b24b4f7704"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=5ea9649f48940bf01493b74fa1d03fa484a41b41#5ea9649f48940bf01493b74fa1d03fa484a41b41"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1771,7 +1771,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_windows"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=d1824f23d28fdac7024c80c25f8e84b24b4f7704#d1824f23d28fdac7024c80c25f8e84b24b4f7704"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=5ea9649f48940bf01493b74fa1d03fa484a41b41#5ea9649f48940bf01493b74fa1d03fa484a41b41"
 dependencies = [
  "bincode",
  "constcat",
@@ -1787,7 +1787,7 @@ dependencies = [
 [[package]]
 name = "fspy_seccomp_unotify"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=d1824f23d28fdac7024c80c25f8e84b24b4f7704#d1824f23d28fdac7024c80c25f8e84b24b4f7704"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=5ea9649f48940bf01493b74fa1d03fa484a41b41#5ea9649f48940bf01493b74fa1d03fa484a41b41"
 dependencies = [
  "bincode",
  "futures-util",
@@ -1804,7 +1804,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=d1824f23d28fdac7024c80c25f8e84b24b4f7704#d1824f23d28fdac7024c80c25f8e84b24b4f7704"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=5ea9649f48940bf01493b74fa1d03fa484a41b41#5ea9649f48940bf01493b74fa1d03fa484a41b41"
 dependencies = [
  "allocator-api2",
  "bincode",
@@ -1822,7 +1822,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared_unix"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=d1824f23d28fdac7024c80c25f8e84b24b4f7704#d1824f23d28fdac7024c80c25f8e84b24b4f7704"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=5ea9649f48940bf01493b74fa1d03fa484a41b41#5ea9649f48940bf01493b74fa1d03fa484a41b41"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1840,7 +1840,7 @@ dependencies = [
 [[package]]
 name = "fspy_test_utils"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=d1824f23d28fdac7024c80c25f8e84b24b4f7704#d1824f23d28fdac7024c80c25f8e84b24b4f7704"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=5ea9649f48940bf01493b74fa1d03fa484a41b41#5ea9649f48940bf01493b74fa1d03fa484a41b41"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -6996,7 +6996,7 @@ dependencies = [
 [[package]]
 name = "vite_glob"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=d1824f23d28fdac7024c80c25f8e84b24b4f7704#d1824f23d28fdac7024c80c25f8e84b24b4f7704"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=5ea9649f48940bf01493b74fa1d03fa484a41b41#5ea9649f48940bf01493b74fa1d03fa484a41b41"
 dependencies = [
  "thiserror 2.0.17",
  "wax",
@@ -7005,7 +7005,7 @@ dependencies = [
 [[package]]
 name = "vite_graph_ser"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=d1824f23d28fdac7024c80c25f8e84b24b4f7704#d1824f23d28fdac7024c80c25f8e84b24b4f7704"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=5ea9649f48940bf01493b74fa1d03fa484a41b41#5ea9649f48940bf01493b74fa1d03fa484a41b41"
 dependencies = [
  "petgraph 0.8.3",
  "serde",
@@ -7084,7 +7084,7 @@ dependencies = [
 [[package]]
 name = "vite_path"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=d1824f23d28fdac7024c80c25f8e84b24b4f7704#d1824f23d28fdac7024c80c25f8e84b24b4f7704"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=5ea9649f48940bf01493b74fa1d03fa484a41b41#5ea9649f48940bf01493b74fa1d03fa484a41b41"
 dependencies = [
  "bincode",
  "diff-struct",
@@ -7105,7 +7105,7 @@ dependencies = [
 [[package]]
 name = "vite_shell"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=d1824f23d28fdac7024c80c25f8e84b24b4f7704#d1824f23d28fdac7024c80c25f8e84b24b4f7704"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=5ea9649f48940bf01493b74fa1d03fa484a41b41#5ea9649f48940bf01493b74fa1d03fa484a41b41"
 dependencies = [
  "bincode",
  "brush-parser",
@@ -7118,7 +7118,7 @@ dependencies = [
 [[package]]
 name = "vite_str"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=d1824f23d28fdac7024c80c25f8e84b24b4f7704#d1824f23d28fdac7024c80c25f8e84b24b4f7704"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=5ea9649f48940bf01493b74fa1d03fa484a41b41#5ea9649f48940bf01493b74fa1d03fa484a41b41"
 dependencies = [
  "bincode",
  "compact_str",
@@ -7129,7 +7129,7 @@ dependencies = [
 [[package]]
 name = "vite_task"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=d1824f23d28fdac7024c80c25f8e84b24b4f7704#d1824f23d28fdac7024c80c25f8e84b24b4f7704"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=5ea9649f48940bf01493b74fa1d03fa484a41b41#5ea9649f48940bf01493b74fa1d03fa484a41b41"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7163,7 +7163,7 @@ dependencies = [
 [[package]]
 name = "vite_task_graph"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=d1824f23d28fdac7024c80c25f8e84b24b4f7704#d1824f23d28fdac7024c80c25f8e84b24b4f7704"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=5ea9649f48940bf01493b74fa1d03fa484a41b41#5ea9649f48940bf01493b74fa1d03fa484a41b41"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7184,7 +7184,7 @@ dependencies = [
 [[package]]
 name = "vite_task_plan"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=d1824f23d28fdac7024c80c25f8e84b24b4f7704#d1824f23d28fdac7024c80c25f8e84b24b4f7704"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=5ea9649f48940bf01493b74fa1d03fa484a41b41#5ea9649f48940bf01493b74fa1d03fa484a41b41"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7209,7 +7209,7 @@ dependencies = [
 [[package]]
 name = "vite_workspace"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=d1824f23d28fdac7024c80c25f8e84b24b4f7704#d1824f23d28fdac7024c80c25f8e84b24b4f7704"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=5ea9649f48940bf01493b74fa1d03fa484a41b41#5ea9649f48940bf01493b74fa1d03fa484a41b41"
 dependencies = [
  "petgraph 0.8.3",
  "rustc-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ dunce = "1.0.5"
 fast-glob = "1.0.0"
 flate2 = { version = "=1.1.5", features = ["zlib-rs"] }
 form_urlencoded = "1.2.1"
-fspy = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "d1824f23d28fdac7024c80c25f8e84b24b4f7704" }
+fspy = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "5ea9649f48940bf01493b74fa1d03fa484a41b41" }
 futures = "0.3.31"
 futures-util = "0.3.31"
 glob = "0.3.2"
@@ -155,14 +155,14 @@ vfs = "0.12.1"
 vite_command = { path = "crates/vite_command" }
 vite_error = { path = "crates/vite_error" }
 vite_js_runtime = { path = "crates/vite_js_runtime" }
-vite_glob = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "d1824f23d28fdac7024c80c25f8e84b24b4f7704" }
+vite_glob = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "5ea9649f48940bf01493b74fa1d03fa484a41b41" }
 vite_install = { path = "crates/vite_install" }
 vite_migration = { path = "crates/vite_migration" }
 vite_shared = { path = "crates/vite_shared" }
-vite_path = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "d1824f23d28fdac7024c80c25f8e84b24b4f7704" }
-vite_str = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "d1824f23d28fdac7024c80c25f8e84b24b4f7704" }
-vite_task = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "d1824f23d28fdac7024c80c25f8e84b24b4f7704" }
-vite_workspace = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "d1824f23d28fdac7024c80c25f8e84b24b4f7704" }
+vite_path = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "5ea9649f48940bf01493b74fa1d03fa484a41b41" }
+vite_str = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "5ea9649f48940bf01493b74fa1d03fa484a41b41" }
+vite_task = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "5ea9649f48940bf01493b74fa1d03fa484a41b41" }
+vite_workspace = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "5ea9649f48940bf01493b74fa1d03fa484a41b41" }
 walkdir = "2.5.0"
 wax = "0.6.0"
 which = "8.0.0"

--- a/packages/cli/binding/src/cli.rs
+++ b/packages/cli/binding/src/cli.rs
@@ -16,8 +16,8 @@ use vite_str::Str;
 use vite_task::{
     CLIArgs, LabeledReporter, Session, SessionCallbacks, TaskSynthesizer,
     config::{
-        UserConfigFile,
-        user::{EnabledCacheConfig, UserCacheConfig, UserConfigTasks, UserTaskOptions},
+        UserRunConfig,
+        user::{EnabledCacheConfig, UserCacheConfig, UserTaskOptions},
     },
     loader::UserConfigLoader,
     plan_request::SyntheticPlanRequest,
@@ -31,7 +31,7 @@ pub struct ResolvedUniversalViteConfig {
     pub config_file: Option<String>,
     pub lint: Option<serde_json::Value>,
     pub fmt: Option<serde_json::Value>,
-    pub tasks: Option<serde_json::Value>,
+    pub run: Option<serde_json::Value>,
 }
 
 /// Result type for resolved commands from JavaScript
@@ -591,7 +591,7 @@ impl UserConfigLoader for VitePlusConfigLoader {
     async fn load_user_config_file(
         &self,
         package_path: &AbsolutePath,
-    ) -> anyhow::Result<UserConfigFile> {
+    ) -> anyhow::Result<Option<UserRunConfig>> {
         let package_path_str = package_path
             .as_path()
             .to_str()
@@ -603,12 +603,11 @@ impl UserConfigLoader for VitePlusConfigLoader {
                 tracing::error!("Failed to parse vite config: {config_json}");
             })?;
 
-        let tasks = if let Some(tasks) = resolved.tasks {
-            serde_json::from_value(tasks)?
-        } else {
-            UserConfigTasks::default()
+        let run_config = match resolved.run {
+            Some(run) => serde_json::from_value(run)?,
+            None => UserRunConfig::default(),
         };
-        Ok(UserConfigFile { tasks })
+        Ok(Some(run_config))
     }
 }
 
@@ -869,25 +868,25 @@ pub fn init_tracing() {
 mod tests {
     use std::path::PathBuf;
 
-    use vite_task::config::user::UserConfigTasks;
+    use vite_task::config::UserRunConfig;
 
     #[test]
-    fn task_config_types_in_sync() {
+    fn run_config_types_in_sync() {
         // Remove \r for cross-platform consistency
-        let ts_type = UserConfigTasks::TS_TYPE.replace('\r', "");
+        let ts_type = UserRunConfig::TS_TYPE.replace('\r', "");
         let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
-        let task_config_path = PathBuf::from(manifest_dir).join("../src/task-config.ts");
+        let run_config_path = PathBuf::from(manifest_dir).join("../src/run-config.ts");
 
         if std::env::var("VITE_UPDATE_TASK_TYPES").as_deref() == Ok("1") {
-            std::fs::write(&task_config_path, &ts_type).expect("Failed to write task-config.ts");
+            std::fs::write(&run_config_path, &ts_type).expect("Failed to write run-config.ts");
         } else {
-            let current = std::fs::read_to_string(&task_config_path)
-                .expect("Failed to read task-config.ts")
+            let current = std::fs::read_to_string(&run_config_path)
+                .expect("Failed to read run-config.ts")
                 .replace('\r', "");
             pretty_assertions::assert_eq!(
                 current,
                 ts_type,
-                "task-config.ts is out of sync. Run `VITE_UPDATE_TASK_TYPES=1 cargo test -p vite-plus-cli task_config_types_in_sync` to update."
+                "run-config.ts is out of sync. Run `VITE_UPDATE_TASK_TYPES=1 cargo test -p vite-plus-cli run_config_types_in_sync` to update."
             );
         }
     }

--- a/packages/cli/snap-tests/cache-scripts-default/hello.mjs
+++ b/packages/cli/snap-tests/cache-scripts-default/hello.mjs
@@ -1,0 +1,1 @@
+console.log('hello from script');

--- a/packages/cli/snap-tests/cache-scripts-default/package.json
+++ b/packages/cli/snap-tests/cache-scripts-default/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "cache-scripts-default-test",
+  "scripts": {
+    "hello": "node hello.mjs"
+  }
+}

--- a/packages/cli/snap-tests/cache-scripts-default/snap.txt
+++ b/packages/cli/snap-tests/cache-scripts-default/snap.txt
@@ -1,0 +1,35 @@
+> vite run hello # cache should be disabled by default for package.json scripts
+$ node hello.mjs ⊘ cache disabled: no cache config
+hello from script
+
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    Vite+ Task Runner • Execution Summary
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Statistics:   1 tasks • 0 cache hits • 0 cache misses • 1 cache disabled 
+Performance:  0% cache hit rate
+
+Task Details:
+────────────────────────────────────────────────
+  [1] cache-scripts-default-test#hello: $ node hello.mjs ✓
+      → Cache disabled in task configuration
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+> vite run hello # second run should also show cache disabled
+$ node hello.mjs ⊘ cache disabled: no cache config
+hello from script
+
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    Vite+ Task Runner • Execution Summary
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Statistics:   1 tasks • 0 cache hits • 0 cache misses • 1 cache disabled 
+Performance:  0% cache hit rate
+
+Task Details:
+────────────────────────────────────────────────
+  [1] cache-scripts-default-test#hello: $ node hello.mjs ✓
+      → Cache disabled in task configuration
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/packages/cli/snap-tests/cache-scripts-default/steps.json
+++ b/packages/cli/snap-tests/cache-scripts-default/steps.json
@@ -1,0 +1,9 @@
+{
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": [
+    "vite run hello # cache should be disabled by default for package.json scripts",
+    "vite run hello # second run should also show cache disabled"
+  ]
+}

--- a/packages/cli/snap-tests/cache-scripts-enabled/hello.mjs
+++ b/packages/cli/snap-tests/cache-scripts-enabled/hello.mjs
@@ -1,0 +1,1 @@
+console.log('hello from script');

--- a/packages/cli/snap-tests/cache-scripts-enabled/package.json
+++ b/packages/cli/snap-tests/cache-scripts-enabled/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "cache-scripts-enabled-test",
+  "scripts": {
+    "hello": "node hello.mjs"
+  }
+}

--- a/packages/cli/snap-tests/cache-scripts-enabled/snap.txt
+++ b/packages/cli/snap-tests/cache-scripts-enabled/snap.txt
@@ -1,0 +1,35 @@
+> vite run hello # first run should be cache miss
+$ node hello.mjs
+hello from script
+
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    Vite+ Task Runner • Execution Summary
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Statistics:   1 tasks • 0 cache hits • 1 cache misses 
+Performance:  0% cache hit rate
+
+Task Details:
+────────────────────────────────────────────────
+  [1] cache-scripts-enabled-test#hello: $ node hello.mjs ✓
+      → Cache miss: no previous cache entry found
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+> vite run hello # second run should be cache hit
+$ node hello.mjs ✓ cache hit, replaying
+hello from script
+
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    Vite+ Task Runner • Execution Summary
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Statistics:   1 tasks • 1 cache hits • 0 cache misses 
+Performance:  100% cache hit rate, <variable>ms saved in total
+
+Task Details:
+────────────────────────────────────────────────
+  [1] cache-scripts-enabled-test#hello: $ node hello.mjs ✓
+      → Cache hit - output replayed - <variable>ms saved
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/packages/cli/snap-tests/cache-scripts-enabled/steps.json
+++ b/packages/cli/snap-tests/cache-scripts-enabled/steps.json
@@ -1,0 +1,9 @@
+{
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": [
+    "vite run hello # first run should be cache miss",
+    "vite run hello # second run should be cache hit"
+  ]
+}

--- a/packages/cli/snap-tests/cache-scripts-enabled/vite.config.ts
+++ b/packages/cli/snap-tests/cache-scripts-enabled/vite.config.ts
@@ -1,0 +1,5 @@
+export default {
+  run: {
+    cacheScripts: true,
+  },
+};

--- a/packages/cli/snap-tests/change-passthrough-env-config/vite.config.ts
+++ b/packages/cli/snap-tests/change-passthrough-env-config/vite.config.ts
@@ -1,11 +1,13 @@
 const passThroughEnvs = process.env.VITE_TASK_PASS_THROUGH_ENVS?.split(',') ?? ['MY_ENV'];
 
 export default {
-  tasks: {
-    hello: {
-      command: 'node -p process.env.MY_ENV',
-      passThroughEnvs,
-      cache: true,
+  run: {
+    tasks: {
+      hello: {
+        command: 'node -p process.env.MY_ENV',
+        passThroughEnvs,
+        cache: true,
+      },
     },
   },
 };

--- a/packages/cli/snap-tests/exit-code/vite.config.ts
+++ b/packages/cli/snap-tests/exit-code/vite.config.ts
@@ -1,0 +1,5 @@
+export default {
+  run: {
+    cacheScripts: true,
+  },
+};

--- a/packages/cli/snap-tests/fingerprint-ignore-test/vite.config.ts
+++ b/packages/cli/snap-tests/fingerprint-ignore-test/vite.config.ts
@@ -1,10 +1,12 @@
 export default {
-  tasks: {
-    'create-files': {
-      command:
-        'mkdir -p node_modules/pkg-a dist && echo \'{"name":"pkg-a","version":"1.0.0"}\' > node_modules/pkg-a/package.json && echo \'module.exports = {}\' > node_modules/pkg-a/index.js && echo \'output\' > dist/bundle.js',
-      cache: true,
-      fingerprintIgnores: ['node_modules/**/*', '!node_modules/**/package.json', 'dist/**/*'],
+  run: {
+    tasks: {
+      'create-files': {
+        command:
+          'mkdir -p node_modules/pkg-a dist && echo \'{"name":"pkg-a","version":"1.0.0"}\' > node_modules/pkg-a/package.json && echo \'module.exports = {}\' > node_modules/pkg-a/index.js && echo \'output\' > dist/bundle.js',
+        cache: true,
+        fingerprintIgnores: ['node_modules/**/*', '!node_modules/**/package.json', 'dist/**/*'],
+      },
     },
   },
 };

--- a/packages/cli/snap-tests/pass-no-color-env/vite.config.ts
+++ b/packages/cli/snap-tests/pass-no-color-env/vite.config.ts
@@ -1,0 +1,5 @@
+export default {
+  run: {
+    cacheScripts: true,
+  },
+};

--- a/packages/cli/snap-tests/plain-terminal-ui/vite.config.ts
+++ b/packages/cli/snap-tests/plain-terminal-ui/vite.config.ts
@@ -2,13 +2,15 @@ const passThroughEnvs = process.env.VITE_TASK_PASS_THROUGH_ENVS?.split(',');
 const cwd = process.env.VITE_TASK_CWD;
 
 export default {
-  tasks: {
-    hello: {
-      command: 'node hello.mjs',
-      envs: ['FOO', 'BAR'],
-      cache: true,
-      ...(passThroughEnvs && { passThroughEnvs }),
-      ...(cwd && { cwd }),
+  run: {
+    tasks: {
+      hello: {
+        command: 'node hello.mjs',
+        envs: ['FOO', 'BAR'],
+        cache: true,
+        ...(passThroughEnvs && { passThroughEnvs }),
+        ...(cwd && { cwd }),
+      },
     },
   },
 };

--- a/packages/cli/snap-tests/task-config-cwd/vite.config.ts
+++ b/packages/cli/snap-tests/task-config-cwd/vite.config.ts
@@ -1,9 +1,11 @@
 export default {
-  tasks: {
-    hello: {
-      command: 'node a.js',
-      cwd: 'subfolder',
-      cache: true,
+  run: {
+    tasks: {
+      hello: {
+        command: 'node a.js',
+        cwd: 'subfolder',
+        cache: true,
+      },
     },
   },
 };

--- a/packages/cli/snap-tests/vite-config-task/vite.config.ts
+++ b/packages/cli/snap-tests/vite-config-task/vite.config.ts
@@ -1,8 +1,10 @@
 export default {
-  tasks: {
-    build: {
-      command: "echo 'build from vite.config.ts'",
-      dependsOn: [],
+  run: {
+    tasks: {
+      build: {
+        command: "echo 'build from vite.config.ts'",
+        dependsOn: [],
+      },
     },
   },
 };

--- a/packages/cli/snap-tests/vite-task-path-env-include-pm/vite.config.ts
+++ b/packages/cli/snap-tests/vite-task-path-env-include-pm/vite.config.ts
@@ -1,0 +1,5 @@
+export default {
+  run: {
+    cacheScripts: true,
+  },
+};

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,7 +4,7 @@ import { defineConfig } from './define-config.js';
 import type { LibUserConfig } from './lib';
 import type { FormatOptions } from './oxfmt-config';
 import type { OxlintConfig } from './oxlint-config';
-import type { Tasks } from './task-config';
+import type { RunConfig } from './run-config';
 
 declare module '@voidzero-dev/vite-plus-core' {
   interface UserConfig {
@@ -17,7 +17,7 @@ declare module '@voidzero-dev/vite-plus-core' {
 
     lib?: LibUserConfig | LibUserConfig[];
 
-    tasks?: Tasks;
+    run?: RunConfig;
 
     // temporary solution to load plugins lazily
     // We need to support this in the upstream vite

--- a/packages/cli/src/resolve-vite-config.ts
+++ b/packages/cli/src/resolve-vite-config.ts
@@ -11,7 +11,7 @@ export async function resolveUniversalViteConfig(err: null | Error, viteConfigCw
         configFile: config.configFile,
         lint: config.lint,
         fmt: config.fmt,
-        tasks: config.tasks,
+        run: config.run,
       }),
     );
   } catch (err) {

--- a/packages/cli/src/run-config.ts
+++ b/packages/cli/src/run-config.ts
@@ -36,4 +36,16 @@ export type Task = {
     }
 );
 
-export type Tasks = { [key in string]?: Task };
+export type RunConfig = {
+  /**
+   * Enable cache for all scripts from package.json.
+   *
+   * This option can only be set in the workspace root's config file.
+   * Setting it in a package's config will result in an error.
+   */
+  cacheScripts?: boolean;
+  /**
+   * Task definitions
+   */
+  tasks?: { [key in string]?: Task };
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -71,18 +71,20 @@ export default defineConfig({
       order: 'asc',
     },
   },
-  tasks: {
-    'build:src': {
-      command: [
-        'vite run @rolldown/pluginutils#build',
-        'vite run rolldown#build-binding:release',
-        'vite run rolldown#build-node',
-        'vite run vite#build-types',
-        'vite run @voidzero-dev/vite-plus-core#build',
-        'vite run @voidzero-dev/vite-plus-test#build',
-        'vite run vite-plus#build',
-        'vite run vite-plus-cli#build',
-      ].join(' && '),
+  run: {
+    tasks: {
+      'build:src': {
+        command: [
+          'vite run @rolldown/pluginutils#build',
+          'vite run rolldown#build-binding:release',
+          'vite run rolldown#build-node',
+          'vite run vite#build-types',
+          'vite run @voidzero-dev/vite-plus-core#build',
+          'vite run @voidzero-dev/vite-plus-test#build',
+          'vite run vite-plus#build',
+          'vite run vite-plus-cli#build',
+        ].join(' && '),
+      },
     },
   },
 });


### PR DESCRIPTION
Adapt vite-plus to the latest vite-task API changes:
- Rename config field from `tasks` to `run` (now `RunConfig` with `cacheScripts` + `tasks`)
- Update `UserConfigFile`/`UserConfigTasks` → `UserRunConfig`
- `load_user_config_file` now returns `Option<UserRunConfig>`
- Rename `task-config.ts` → `run-config.ts`
- Point Cargo.toml to local ../vite-task via patch section
- Add `cacheScripts: true` to existing tests to preserve cache behavior
- Add snap tests for cacheScripts disabled (default) and enabled

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>