### PR TITLE
Add a random name generator for project names.

### DIFF
--- a/packages/global/package.json
+++ b/packages/global/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@clack/prompts": "catalog:",
     "@napi-rs/cli": "catalog:",
+    "@nkzw/safe-word-list": "catalog:",
     "@oxc-node/core": "catalog:",
     "@types/cross-spawn": "catalog:",
     "@types/semver": "catalog:",

--- a/packages/global/src/new/bin.ts
+++ b/packages/global/src/new/bin.ts
@@ -30,6 +30,7 @@ import {
 import type { ExecutionResult } from './command.js';
 import { discoverTemplate, inferParentDir } from './discovery.js';
 import { cancelAndExit, checkProjectDirExists, promptPackageNameAndTargetDir } from './prompts.js';
+import { getRandomProjectName } from './random-name.js';
 import {
   executeBuiltinTemplate,
   executeMonorepoTemplate,
@@ -344,16 +345,16 @@ Use \`vp new --list\` to list all available templates, or run \`vp new --help\` 
   if (isBuiltinTemplate && !targetDir) {
     if (selectedTemplateName === BuiltinTemplate.monorepo) {
       const selected = await promptPackageNameAndTargetDir(
-        'vite-plus-monorepo',
+        getRandomProjectName({ fallbackName: 'vite-plus-monorepo' }),
         options.interactive,
       );
       packageName = selected.packageName;
       targetDir = selected.targetDir;
     } else {
-      let defaultPackageName = `vite-plus-${selectedTemplateName.split(':')[1]}`;
-      if (workspaceInfoOptional.monorepoScope) {
-        defaultPackageName = `${workspaceInfoOptional.monorepoScope}/${defaultPackageName}`;
-      }
+      const defaultPackageName = getRandomProjectName({
+        scope: workspaceInfoOptional.monorepoScope,
+        fallbackName: `vite-plus-${selectedTemplateName.split(':')[1]}`,
+      });
       const selected = await promptPackageNameAndTargetDir(defaultPackageName, options.interactive);
       packageName = selected.packageName;
       targetDir = selectedParentDir
@@ -447,10 +448,10 @@ Use \`vp new --list\` to list all available templates, or run \`vp new --help\` 
   if (templateInfo.type === TemplateType.builtin) {
     // prompt for package name if not provided
     if (!targetDir) {
-      let defaultPackageName = `vite-plus-${templateInfo.command.split(':')[1]}`;
-      if (workspaceInfo.monorepoScope) {
-        defaultPackageName = `${workspaceInfo.monorepoScope}/${defaultPackageName}`;
-      }
+      const defaultPackageName = getRandomProjectName({
+        scope: workspaceInfo.monorepoScope,
+        fallbackName: `vite-plus-${templateInfo.command.split(':')[1]}`,
+      });
       const selected = await promptPackageNameAndTargetDir(defaultPackageName, options.interactive);
       packageName = selected.packageName;
       targetDir = templateInfo.parentDir

--- a/packages/global/src/new/random-name.ts
+++ b/packages/global/src/new/random-name.ts
@@ -1,0 +1,23 @@
+import { getRandomWord } from '@nkzw/safe-word-list';
+
+const isTest = process.env.VITE_PLUS_CLI_TEST === '1';
+
+export default function getRandomWords(): ReadonlyArray<string> {
+  const first = getRandomWord();
+  let second: string;
+  do {
+    second = getRandomWord();
+  } while (second === first);
+  return [first, second];
+}
+
+export function getRandomProjectName(
+  options: {
+    scope?: string;
+    fallbackName?: string;
+  } = {},
+): string {
+  const { scope, fallbackName } = options;
+  const projectName = isTest && fallbackName ? fallbackName : getRandomWords().join('-');
+  return scope ? `${scope}/${projectName}` : projectName;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ catalogs:
     '@napi-rs/wasm-runtime':
       specifier: ^1.0.0
       version: 1.1.1
+    '@nkzw/safe-word-list':
+      specifier: ^3.1.0
+      version: 3.1.0
     '@oxc-node/cli':
       specifier: ^0.0.35
       version: 0.0.35
@@ -558,6 +561,9 @@ importers:
       '@napi-rs/cli':
         specifier: 'catalog:'
         version: 3.4.1(@emnapi/runtime@1.7.1)(@types/node@24.10.3)(node-addon-api@7.1.1)
+      '@nkzw/safe-word-list':
+        specifier: 'catalog:'
+        version: 3.1.0
       '@oxc-node/core':
         specifier: 'catalog:'
         version: 0.0.35
@@ -2910,6 +2916,9 @@ packages:
   '@napi-rs/wasm-tools@1.0.1':
     resolution: {integrity: sha512-enkZYyuCdo+9jneCPE/0fjIta4wWnvVN9hBo2HuiMpRF0q3lzv1J6b/cl7i0mxZUKhBrV3aCKDBQnCOhwKbPmQ==}
     engines: {node: '>= 10'}
+
+  '@nkzw/safe-word-list@3.1.0':
+    resolution: {integrity: sha512-yU6NAne/aU8n4BnYwlOu451PD/FH9AVKsOsQbITxAPYg4HEcBMv7v13woPOpxAS0lC87N2TOQdBZ7OjiK+5sIA==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -10372,6 +10381,8 @@ snapshots:
       '@napi-rs/wasm-tools-win32-arm64-msvc': 1.0.1
       '@napi-rs/wasm-tools-win32-ia32-msvc': 1.0.1
       '@napi-rs/wasm-tools-win32-x64-msvc': 1.0.1
+
+  '@nkzw/safe-word-list@3.1.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,7 @@ catalog:
   '@clack/prompts': ^0.11.0
   '@napi-rs/cli': ^3.4.1
   '@napi-rs/wasm-runtime': ^1.0.0
+  '@nkzw/safe-word-list': ^3.1.0
   '@oxc-node/cli': ^0.0.35
   '@oxc-node/core': ^0.0.35
   '@oxc-project/runtime': =0.112.0
@@ -124,18 +125,19 @@ ignoreScripts: true
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - '@napi-rs/*'
-  - '@oxc-project/*'
-  - '@rolldown/*'
-  - '@vitest/*'
-  - '@vitejs/*'
-  - '@types/*'
-  - '@oxlint/*'
+  - '@nkzw/*'
   - '@oxc-minify/*'
   - '@oxc-parser/*'
+  - '@oxc-project/*'
   - '@oxc-resolver/*'
   - '@oxc-transform/*'
   - '@oxfmt/*'
   - '@oxlint-tsgolint/*'
+  - '@oxlint/*'
+  - '@rolldown/*'
+  - '@types/*'
+  - '@vitejs/*'
+  - '@vitest/*'
   - oxc-minify
   - oxc-parser
   - oxc-transform
@@ -146,10 +148,10 @@ minimumReleaseAgeExclude:
   - rolldown-plugin-dts
   - rolldown-vite
   - tsdown
+  - unrun
   - vite
   - vitepress
   - vitest
-  - unrun
 overrides:
   '@rolldown/pluginutils': 'workspace:@rolldown/pluginutils@*'
   rolldown: 'workspace:rolldown@*'


### PR DESCRIPTION
Currently we only support fixed default names for new projects. This PR changes Vite+ to auto-generate the package name instead. This is similar to what Astro does.

The word list is chosen from here and contains about 2700 words: https://github.com/nkzw-tech/safe-word-list

### Example
![CleanShot 2026-02-09 at 15.01.16@2x.png](https://app.graphite.com/user-attachments/assets/f5f7034d-2e28-4de5-b461-ecaa6f2048f8.png)

