### PR TITLE
fix: use vp instead of vite in CLI references

### DIFF
--- a/.github/workflows/upgrade-deps.yml
+++ b/.github/workflows/upgrade-deps.yml
@@ -87,12 +87,12 @@ jobs:
               - If `Cargo.toml` has been modified, you need to run `cargo shear` to ensure there is nothing wrong with our dependencies.
               - Run `cargo check --all-targets --all-features` to ensure everything works fine if any Rust related codes are modified.
             - Run the following commands to ensure everything works fine:
-              vite -h
-              vite run -h
-              vite lint -h
-              vite test -h
-              vite build -h
-              vite fmt -h
+              vp -h
+              vp run -h
+              vp lint -h
+              vp test -h
+              vp build -h
+              vp fmt -h
 
             Help me fix the errors in `build-upstream` steps, no need to commit changes after your fixing.
           claude_args: |

--- a/bench/generate-monorepo.ts
+++ b/bench/generate-monorepo.ts
@@ -255,9 +255,9 @@ module.exports = { ${pkg.name.replace('-', '_')} };
       private: true,
       workspaces: ['packages/*'],
       scripts: {
-        'build:all': 'vite run build',
-        'test:all': 'vite run test',
-        'lint:all': 'vite run lint',
+        'build:all': 'vp run build',
+        'test:all': 'vp run test',
+        'lint:all': 'vp run lint',
       },
       devDependencies: {
         'vite-plus': '*',

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "copy-cli-binding": "pnpm --filter=vite-plus-cli copy-binding",
     "install-global-cli": "pnpm copy-cli-binding && tool install-global-cli",
     "tsgo": "tsgo -b tsconfig.json",
-    "lint": "vite lint --type-aware --threads 4",
-    "test": "vite test run && pnpm -r snap-test",
-    "fmt": "vite fmt",
-    "test:unit": "vite test run",
+    "lint": "vp lint --type-aware --threads 4",
+    "test": "vp test run && pnpm -r snap-test",
+    "fmt": "vp fmt",
+    "test:unit": "vp test run",
     "docs:dev": "pnpm --filter=./docs dev",
     "docs:build": "pnpm --filter=./docs build",
     "prepare": "husky"
@@ -40,8 +40,8 @@
   },
   "lint-staged": {
     "*.@(js|ts|tsx)": [
-      "vite run lint --fix",
-      "vite fmt --no-error-on-unmatched-pattern"
+      "vp run lint --fix",
+      "vp fmt --no-error-on-unmatched-pattern"
     ],
     "*.rs": [
       "cargo fmt --"

--- a/packages/global/AGENTS.md
+++ b/packages/global/AGENTS.md
@@ -2,11 +2,11 @@
 
 # Using Vite+, the Unified Toolchain for the Web
 
-This project is using Vite+, a modern toolchain built on top of Vite, Rolldown, Vitest, tsdown, Oxlint, and Oxfmt. Vite+ wraps these tools and package manager commands in a single, global CLI called `vite`. Vite+ is distinct from Vite, but it invokes Vite through `vite dev` and `vite build`.
+This project is using Vite+, a modern toolchain built on top of Vite, Rolldown, Vitest, tsdown, Oxlint, and Oxfmt. Vite+ wraps these tools and package manager commands in a single, global CLI called `vp`. Vite+ is distinct from Vite, but it invokes Vite through `vp dev` and `vp build`.
 
 ## Vite+ Workflow
 
-`vite` is a global binary that handles the full development lifecycle. Run `vite help` to print a list of commands and `vite <command> --help` for information about a specific command.
+`vp` is a global binary that handles the full development lifecycle. Run `vp help` to print a list of commands and `vp <command> --help` for information about a specific command.
 
 ### Vite+ Commands
 
@@ -20,7 +20,7 @@ This project is using Vite+, a modern toolchain built on top of Vite, Rolldown, 
 - new - Create a new monorepo package (in-project) or a new project (global)
 - run - Run tasks from `package.json` scripts
 
-These commands map to their corresponding tools. For example, `vite dev --port 3000` runs Vite's dev server and works the same as Vite. `vite test` runs JavaScript tests through the bundled Vitest. The version of all tools can be checked using `vite --version`. This is useful when researching documentation, features, and bugs.
+These commands map to their corresponding tools. For example, `vp dev --port 3000` runs Vite's dev server and works the same as Vite. `vp test` runs JavaScript tests through the bundled Vitest. The version of all tools can be checked using `vp --version`. This is useful when researching documentation, features, and bugs.
 
 ### Package Manager Commands
 
@@ -41,14 +41,14 @@ Vite+ automatically detects and wraps the underlying package manager such as pnp
 ## Common Pitfalls
 
 - **Using the package manager directly:** Do not use pnpm, npm, or Yarn directly. Vite+ can handle all package manager operations.
-- **Always use Vite commands to run tools:** Don't attempt to run `vite vitest` or `vite oxlint`. They do not exist. Use `vite test` and `vite lint` instead.
-- **Running scripts:** Vite+ commands take precedence over `package.json` scripts. If there is a `test` script defined in `scripts` that conflicts with the built-in `vite test` command, run it using `vite run test`.
+- **Always use Vite commands to run tools:** Don't attempt to run `vp vitest` or `vp oxlint`. They do not exist. Use `vp test` and `vp lint` instead.
+- **Running scripts:** Vite+ commands take precedence over `package.json` scripts. If there is a `test` script defined in `scripts` that conflicts with the built-in `vp test` command, run it using `vp run test`.
 - **Do not install Vitest, Oxlint, Oxfmt, or tsdown directly:** Vite+ wraps these tools. They must not be installed directly. You cannot upgrade these tools by installing their latest versions. Always use Vite+ commands.
 - **Import JavaScript modules from `vite-plus`:** Instead of importing from `vite` or `vitest`, all modules should be imported from the project's `vite-plus` dependency. For example, `import { defineConfig } from 'vite-plus';` or `import { expect, test, vi } from 'vite-plus/test';`. You must not install `vitest` to import test utilities.
-- **Type-Aware Linting:** There is no need to install `oxlint-tsgolint`, `vite lint --type-aware` works out of the box.
+- **Type-Aware Linting:** There is no need to install `oxlint-tsgolint`, `vp lint --type-aware` works out of the box.
 
 ## Review Checklist for Agents
 
-- [ ] Run `vite install` after pulling remote changes and before getting started.
-- [ ] Run `vite lint`, `vite fmt`, and `vite test` to validate changes.
+- [ ] Run `vp install` after pulling remote changes and before getting started.
+- [ ] Run `vp lint`, `vp fmt`, and `vp test` to validate changes.
 <!--VITE PLUS END-->

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -75,14 +75,14 @@ export default defineConfig({
     tasks: {
       'build:src': {
         command: [
-          'vite run @rolldown/pluginutils#build',
-          'vite run rolldown#build-binding:release',
-          'vite run rolldown#build-node',
-          'vite run vite#build-types',
-          'vite run @voidzero-dev/vite-plus-core#build',
-          'vite run @voidzero-dev/vite-plus-test#build',
-          'vite run vite-plus#build',
-          'vite run vite-plus-cli#build',
+          'vp run @rolldown/pluginutils#build',
+          'vp run rolldown#build-binding:release',
+          'vp run rolldown#build-node',
+          'vp run vite#build-types',
+          'vp run @voidzero-dev/vite-plus-core#build',
+          'vp run @voidzero-dev/vite-plus-test#build',
+          'vp run vite-plus#build',
+          'vp run vite-plus-cli#build',
         ].join(' && '),
       },
     },


### PR DESCRIPTION
Updates calls previously done to `vite` to `vp`, as well as AGENTS.md

Please double check occurrences, I might've missed some or accidentally changed too much!

Co-authored-by: Alexander Lichter <github@lichter.io>
Supersedes #568