### PR TITLE
fix: rename `./lib` to `./pack` in sync-remote-deps.ts

### DIFF
--- a/packages/tools/src/sync-remote-deps.ts
+++ b/packages/tools/src/sync-remote-deps.ts
@@ -759,8 +759,8 @@ export async function syncRemote() {
     pluginutilsPackage,
   );
 
-  // additional tsdown exports
-  mergedExports['./lib'] = {
+  // additional tsdown exports (vp pack)
+  mergedExports['./pack'] = {
     default: './dist/tsdown/index.js',
     types: './dist/tsdown/index-types.d.ts',
   };


### PR DESCRIPTION
The `vp lib` → `vp pack` rename (#575) missed updating the hardcoded
`./lib` export key in the sync-remote-deps script, causing the daily
upstream upgrade PR to re-add a stale `./lib` export.