### PR TITLE
Fix build.

### DIFF
--- a/packages/global/package.json
+++ b/packages/global/package.json
@@ -18,7 +18,7 @@
   "type": "module",
   "scripts": {
     "build": "pnpm build-ts && pnpm build-native",
-    "build-ts": "rolldown -c rolldown.config.ts",
+    "build-ts": "pnpm --filter=@voidzero-dev/vite-plus-prompts build && rolldown -c rolldown.config.ts",
     "build-native": "oxnode -C dev ./build.ts",
     "copy-binding": "cp ./binding/*.node ./dist",
     "snap-test": "tool snap-test",


### PR DESCRIPTION
All the e2e tests started failing after merging https://github.com/voidzero-dev/vite-plus/pull/587, see https://github.com/voidzero-dev/vite-plus/actions/runs/21872859706/job/63134846956

I *believe* this is due to an ordering issue and it's why I added the explicit first build step earlier, but I removed it. This change ensures the prompts package is built before the global CLI.

Please let me know if there is a quick way to verify this locally since the usual tests all seem to pass without this change.
