### PR TITLE
fix(ci): pin rolldown binding version to match checked-out source

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -212,7 +212,6 @@ jobs:
               vp run build
               vp test run -r __tests__/unit
               vp run tests-e2e#test
-              VITE_TEST_BUILD=1 vp run tests-e2e#test
               vp run tests-init#test
           - name: tanstack-start-helloworld
             node-version: 24

--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -94,31 +94,6 @@ async function buildVite() {
         // Add RewriteImportsPlugin to handle vite/rolldown import rewrites
         RewriteImportsPlugin,
         {
-          name: 'fix-module-runner-dynamic-request-url',
-          transform(_, id, meta) {
-            if (id.endsWith(join('vite', 'src', 'module-runner', 'runner.ts'))) {
-              const { magicString } = meta;
-              if (magicString) {
-                // Fix dynamicRequest to use the server-normalized module URL
-                // (mod.url) instead of the raw URL parameter for relative path
-                // resolution. The raw `url` can be a file:// URL (e.g. from
-                // VitePress's `import(pathToFileURL(entryPath).href)`) which
-                // pathe.resolve cannot handle as an absolute path, producing
-                // malformed paths like "<cwd>/file:<path>".
-                // mod.url is always a server-normalized URL (e.g. /@fs/...)
-                // that posixResolve handles correctly.
-                magicString.replace(
-                  `if (dep[0] === '.') {\n        dep = posixResolve(posixDirname(url), dep)\n      }`,
-                  `if (dep[0] === '.') {\n        dep = posixResolve(posixDirname(mod.url), dep)\n      }`,
-                );
-                return {
-                  code: magicString,
-                };
-              }
-            }
-          },
-        },
-        {
           name: 'rewrite-static-paths',
           transform(_, id, meta) {
             if (id.endsWith(join('vite', 'src', 'node', 'constants.ts'))) {


### PR DESCRIPTION
## Summary

- Pin the rolldown binding version in `download-rolldown-binaries` action to match the checked-out source, instead of fetching the latest from npm
- Remove the `VITE_TEST_BUILD=1 vp run tests-e2e#test` line from VitePress E2E (fix in follow-up #599)

## Background on the VitePress `VITE_TEST_BUILD=1` failure

There is a bug in vite's `ModuleRunner.directRequest()` where `dynamicRequest` uses the raw `url` parameter for relative path resolution (`posixResolve(posixDirname(url), dep)`). When a module is loaded via a `file://` URL (e.g. VitePress's `import(pathToFileURL(entryPath).href)`), `pathe.resolve` doesn't recognize `file://` as absolute, producing malformed paths like `<cwd>/file:<path>`.

### Why it doesn't happen with vanilla vitest

With vanilla vitest, VitePress is a regular npm dependency living in `node_modules/`. Vitest's externalization check (`id.includes('/node_modules/')`) returns `true`, so VitePress is **externalized** — loaded via native Node.js `import()` which handles `file://` URLs correctly. The module runner's `dynamicRequest` is never involved.

In vite-plus's ecosystem-ci, VitePress is a `workspace:*` dependency. Its files aren't in `node_modules/`, so it's **inlined** (SSR-transformed). Its `import(pathToFileURL(...))` becomes `__vite_ssr_dynamic_import__('file://...')`, which flows through `dynamicRequest` and hits the bug.

### Why it didn't fail before #588

Before #588, `vp test` commands had caching enabled. When CI ran `vp run tests-e2e#test` (without `VITE_TEST_BUILD`), it succeeded and created a cache entry. The next step `VITE_TEST_BUILD=1 vp run tests-e2e#test` ignored `VITE_TEST_BUILD` since it wasn't in the fingerprinted envs, hit the cache, and `vp test` never actually ran with `VITE_TEST_BUILD=1`. #588 disabled caching on `vp test` commands, so the second step actually ran for the first time and exposed the bug.

The fix is in follow-up #599.