### PR TITLE
fix(core): fix module runner dynamicRequest relative URL resolution

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -212,6 +212,7 @@ jobs:
               vp run build
               vp test run -r __tests__/unit
               vp run tests-e2e#test
+              VITE_TEST_BUILD=1 vp run tests-e2e#test
               vp run tests-init#test
           - name: tanstack-start-helloworld
             node-version: 24

--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -94,6 +94,31 @@ async function buildVite() {
         // Add RewriteImportsPlugin to handle vite/rolldown import rewrites
         RewriteImportsPlugin,
         {
+          name: 'fix-module-runner-dynamic-request-url',
+          transform(_, id, meta) {
+            if (id.endsWith(join('vite', 'src', 'module-runner', 'runner.ts'))) {
+              const { magicString } = meta;
+              if (magicString) {
+                // Fix dynamicRequest to use the server-normalized module URL
+                // (mod.url) instead of the raw URL parameter for relative path
+                // resolution. The raw `url` can be a file:// URL (e.g. from
+                // VitePress's `import(pathToFileURL(entryPath).href)`) which
+                // pathe.resolve cannot handle as an absolute path, producing
+                // malformed paths like "<cwd>/file:<path>".
+                // mod.url is always a server-normalized URL (e.g. /@fs/...)
+                // that posixResolve handles correctly.
+                magicString.replace(
+                  `if (dep[0] === '.') {\n        dep = posixResolve(posixDirname(url), dep)\n      }`,
+                  `if (dep[0] === '.') {\n        dep = posixResolve(posixDirname(mod.url), dep)\n      }`,
+                );
+                return {
+                  code: magicString,
+                };
+              }
+            }
+          },
+        },
+        {
           name: 'rewrite-static-paths',
           transform(_, id, meta) {
             if (id.endsWith(join('vite', 'src', 'node', 'constants.ts'))) {


### PR DESCRIPTION
## Summary

- Fix a bug in vite's `ModuleRunner.directRequest()` where `dynamicRequest` uses the raw URL for relative path resolution, which breaks for `file://` URLs
- Re-enable the `VITE_TEST_BUILD=1 vp run tests-e2e#test` VitePress E2E test in CI

Stacked on #597.

## Root Cause

In `ModuleRunner.directRequest()` (`runner.ts:347-352`), the `dynamicRequest` closure resolves relative deps with:

```typescript
dep = posixResolve(posixDirname(url), dep)
```

The `url` captured here is the **raw, unnormalized URL** that flows through `import()` → `cachedRequest()` → `directRequest()`. But the server already resolved and normalized this URL — the normalized version is stored in `mod.url` (e.g. `/@fs/path/.temp/app.js`). The code uses the wrong one.

When `url` is a `file://` URL (e.g. `file:///path/.temp/app.js` from VitePress's `import(pathToFileURL(entryPath).href)`), `pathe.resolve` doesn't recognize it as absolute (it starts with `f`, not `/`), so it prepends CWD, producing malformed paths like `<cwd>/file:/path/.temp/page.md.js`.

### Why it doesn't happen with vanilla vitest

With vanilla vitest, VitePress is a regular npm dependency living in `node_modules/`. Vitest's externalization check (`id.includes('/node_modules/')`) returns `true`, so VitePress is **externalized** — loaded via native Node.js `import()` which handles `file://` URLs correctly. The module runner's `dynamicRequest` is never involved.

In vite-plus's ecosystem-ci, VitePress is a `workspace:*` dependency. Its files aren't in `node_modules/`, so it's **inlined** (SSR-transformed). Its `import(pathToFileURL(...))` becomes `__vite_ssr_dynamic_import__('file://...')`, which flows through `dynamicRequest` and hits the bug.

### Why it didn't fail before #588

Before #588, `vp test` commands had caching enabled. When CI ran `vp run tests-e2e#test` (without `VITE_TEST_BUILD`), it succeeded and created a cache entry. The next step `VITE_TEST_BUILD=1 vp run tests-e2e#test` ignored `VITE_TEST_BUILD` since it wasn't in the fingerprinted envs, hit the cache, and `vp test` never actually ran with `VITE_TEST_BUILD=1`. #588 disabled caching on `vp test` commands, so the second step actually ran for the first time and exposed the bug.

## Fix

Use `mod.url` (the server-normalized URL) instead of the raw `url` parameter in the `dynamicRequest` closure:

```typescript
// Before (broken for file:// URLs):
dep = posixResolve(posixDirname(url), dep)

// After (uses server-normalized URL):
dep = posixResolve(posixDirname(mod.url), dep)
```

`mod.url` is always a properly normalized URL from the server (e.g. `/@fs/...` or `/src/...`) that `posixResolve` handles correctly. Applied as a build-time transform in `packages/core/build.ts`.