### PR TITLE
fix: prefix snapshot version SHA with `g` to avoid semver leading zero error

### DIFF
--- a/.github/actions/set-snapshot-version/action.yml
+++ b/.github/actions/set-snapshot-version/action.yml
@@ -1,5 +1,5 @@
 name: Set Snapshot Version
-description: Set snapshot version (0.0.0-{sha}.{timestamp}) for pre-release builds
+description: Set snapshot version (0.0.0-g{sha}.{timestamp}) for pre-release builds
 
 outputs:
   version:
@@ -15,5 +15,5 @@ runs:
       run: |
         SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-8)
         BUILD_TIME=$(date -u +%Y%m%d-%H%M)
-        VERSION="0.0.0-${SHORT_SHA}.${BUILD_TIME}"
+        VERSION="0.0.0-g${SHORT_SHA}.${BUILD_TIME}"
         echo "version=${VERSION}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

- Release workflow failed because `cargo metadata` rejects semver pre-release identifiers with leading zeros (e.g. `0.0.0-07710393.20260225-0413`)
- Prefix the short SHA with `g` (git convention) so the identifier is alphanumeric (`g07710393`), bypassing the numeric leading-zero rule
- This affects ~6.25% of commits (those whose SHA starts with `0`)

## Test plan

- [x] Verified the only consumer is `release.yml` which uses the version string opaquely
- [ ] Re-run the release workflow to confirm it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)