### PR TITLE
fix(test): use platform neutral for vendor leaf dep bundling to fix browser tests

### DIFF
--- a/packages/test/build.ts
+++ b/packages/test/build.ts
@@ -720,7 +720,7 @@ async function bundleLeafDeps(leafDeps: Set<string>): Promise<Map<string, string
         entryFileNames: '[name].mjs',
         chunkFileNames: 'shared-[hash].mjs',
       },
-      platform: 'node',
+      platform: 'neutral',
       treeshake: false,
       external: [
         // Keep node built-ins external
@@ -736,6 +736,7 @@ async function bundleLeafDeps(leafDeps: Set<string>): Promise<Map<string, string
       ],
       resolve: {
         conditionNames: ['node', 'import', 'default'],
+        mainFields: ['module', 'main'],
       },
       logLevel: 'warn',
     });
@@ -1150,17 +1151,25 @@ async function fixCjsNamedExports(vendorFilePath: string, specifier: string) {
   // Match pattern like: export default require_xxx();
   // and: export {  };
   const defaultExportMatch = content.match(/export default (require_\w+)\(\);/);
-  const emptyExportMatch = content.match(/export \{\s*\};/);
 
-  if (defaultExportMatch && emptyExportMatch) {
+  if (defaultExportMatch) {
     const requireFn = defaultExportMatch[1];
     console.log(`      Fixing CJS named exports for ${specifier}...`);
 
-    // Replace empty export with named exports from the default
-    content = content.replace(
-      /export default (require_\w+)\(\);\s*\nexport \{\s*\};/,
-      `const __cjs_export__ = ${requireFn}();\nexport const { expectTypeOf } = __cjs_export__;\nexport default __cjs_export__;`,
-    );
+    const emptyExportMatch = content.match(/export \{\s*\};/);
+    if (emptyExportMatch) {
+      // Pattern: export default require_xxx();\nexport {  };
+      content = content.replace(
+        /export default (require_\w+)\(\);\s*\nexport \{\s*\};/,
+        `const __cjs_export__ = ${requireFn}();\nexport const { expectTypeOf } = __cjs_export__;\nexport default __cjs_export__;`,
+      );
+    } else {
+      // Pattern: export default require_xxx(); (no empty export block)
+      content = content.replace(
+        /export default (require_\w+)\(\);/,
+        `const __cjs_export__ = ${requireFn}();\nexport const { expectTypeOf } = __cjs_export__;\nexport default __cjs_export__;`,
+      );
+    }
 
     await writeFile(vendorFilePath, content, 'utf-8');
   }


### PR DESCRIPTION
The leaf dependency bundling step used `platform: 'node'`, which caused
rolldown to generate a shared runtime chunk with `createRequire` from
`node:module`. Since vendor files (pathe, chai, tinyrainbow, etc.) are
loaded by @vitest/runner and @vitest/expect in the browser during vitest
browser mode, the browser hit the externalized `node:module` and threw:

  Module "node:module" has been externalized for browser compatibility.
  Cannot access "node:module.createRequire" in client code.

This caused browser tests to hang indefinitely.

Changes:
- Switch `platform: 'node'` to `platform: 'neutral'` so rolldown emits
  pure JS CJS interop helpers without Node.js built-in imports
- Add `mainFields: ['module', 'main']` so CJS-only packages like
  expect-type can still be resolved under neutral platform
- Fix `fixCjsNamedExports()` to handle the case where rolldown emits
  `export default require_xxx()` without an accompanying `export {}`
  block (the previous regex required both patterns to match)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the bundling configuration and post-processing of generated vendor code; risk is moderate because it can affect module resolution and runtime behavior across both Node and browser test environments.
> 
> **Overview**
> Fixes vitest browser-mode hangs by changing the leaf-dependency bundling step to emit browser-safe output.
> 
> `bundleLeafDeps()` now builds with `platform: 'neutral'` (avoiding Node-only helpers like `node:module.createRequire`) and adds `resolve.mainFields: ['module','main']` so CJS-only packages still resolve correctly. The `fixCjsNamedExports()` post-processing was broadened to also patch outputs that contain `export default require_xxx()` without an `export {}` block, ensuring named exports like `expectTypeOf` are consistently re-exported.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ace4c368e5277cbda7e2700fb73a43aed4439f98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->