### PR TITLE
fix(migrate): use `--force` for npm post-migration install to apply overrides

### DIFF
--- a/packages/cli/snap-tests-global/migration-standalone-npm/.gitignore
+++ b/packages/cli/snap-tests-global/migration-standalone-npm/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/packages/cli/snap-tests-global/migration-standalone-npm/package-lock.json
+++ b/packages/cli/snap-tests-global/migration-standalone-npm/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "migration-standalone-npm",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "migration-standalone-npm",
+      "devDependencies": {
+        "vite": "^7.0.0",
+        "vitest": "^4.0.0"
+      }
+    }
+  }
+}

--- a/packages/cli/snap-tests-global/migration-standalone-npm/package.json
+++ b/packages/cli/snap-tests-global/migration-standalone-npm/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "migration-standalone-npm",
+  "devDependencies": {
+    "vite": "^7.0.0",
+    "vitest": "^4.0.0"
+  },
+  "packageManager": "npm@10.9.2"
+}

--- a/packages/cli/snap-tests-global/migration-standalone-npm/snap.txt
+++ b/packages/cli/snap-tests-global/migration-standalone-npm/snap.txt
@@ -1,0 +1,37 @@
+> vp migrate --no-interactive # migration should work with npm, add overrides, and update lockfile
+┌  VITE+ - The Unified Toolchain for the Web
+│
+●  npm@<semver> installing...
+│
+●  npm@<semver> installed
+│
+●  Installing dependencies...
+│
+●  Dependencies installed
+│
+◆  Wrote agent instructions to AGENTS.md
+│
+●  Installing dependencies...
+│
+●  Dependencies installed
+│
+└  ✔ Migration completed!
+
+
+> cat package.json # check package.json has overrides field (not pnpm.overrides)
+{
+  "name": "migration-standalone-npm",
+  "devDependencies": {
+    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
+    "vitest": "npm:@voidzero-dev/vite-plus-test@latest",
+    "vite-plus": "latest"
+  },
+  "packageManager": "npm@<semver>",
+  "overrides": {
+    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
+    "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
+  }
+}
+
+[1]> node -e "const lock = require('./package-lock.json'); const vite = lock.packages['node_modules/vite']; if (vite && vite.resolved && vite.resolved.includes('@voidzero-dev/vite-plus-core')) console.log('lockfile has vite override'); else { console.error('vite override not found in lockfile'); process.exit(1); }" # verify lockfile updated with override
+vite override not found in lockfile

--- a/packages/cli/snap-tests-global/migration-standalone-npm/steps.json
+++ b/packages/cli/snap-tests-global/migration-standalone-npm/steps.json
@@ -1,0 +1,12 @@
+{
+  "ignoredPlatforms": ["win32"],
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1",
+    "CI": ""
+  },
+  "commands": [
+    "vp migrate --no-interactive # migration should work with npm, add overrides, and update lockfile",
+    "cat package.json # check package.json has overrides field (not pnpm.overrides)",
+    "node -e \"const lock = require('./package-lock.json'); const vite = lock.packages['node_modules/vite']; if (vite && vite.resolved && vite.resolved.includes('@voidzero-dev/vite-plus-core')) console.log('lockfile has vite override'); else { console.error('vite override not found in lockfile'); process.exit(1); }\" # verify lockfile updated with override"
+  ]
+}

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -206,7 +206,10 @@ async function main() {
   });
 
   // reinstall after migration
-  await runViteInstall(workspaceInfo.rootDir, options.interactive);
+  // npm needs --force to re-resolve packages with newly added overrides,
+  // otherwise the stale lockfile prevents override resolution.
+  const installArgs = packageManager === PackageManager.npm ? ['--force'] : undefined;
+  await runViteInstall(workspaceInfo.rootDir, options.interactive, installArgs);
   prompts.outro(green('✔ Migration completed!'));
 }
 

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -49,7 +49,7 @@ export async function downloadPackageManager(
   return downloadResult;
 }
 
-export async function runViteInstall(cwd: string, interactive?: boolean) {
+export async function runViteInstall(cwd: string, interactive?: boolean, extraArgs?: string[]) {
   // install dependencies on non-CI environment
   if (process.env.CI) {
     return;
@@ -59,7 +59,7 @@ export async function runViteInstall(cwd: string, interactive?: boolean) {
   spinner.start(`Installing dependencies...`);
   const { exitCode, stderr, stdout } = await runCommandSilently({
     command: process.env.VITE_PLUS_CLI_BIN ?? 'vp',
-    args: ['install'],
+    args: ['install', ...(extraArgs ?? [])],
     cwd,
     envs: process.env,
   });


### PR DESCRIPTION
npm doesn't re-resolve packages when overrides change if a stale lockfile
exists. Pass `--force` to `vp install` after migration when using npm so
the newly added overrides are actually applied to the lockfile.