### PR TITLE
feat(env): show full file path in `vp env which` and `vp env doctor` source display

### DIFF
--- a/crates/vite_global_cli/src/commands/env/doctor.rs
+++ b/crates/vite_global_cli/src/commands/env/doctor.rs
@@ -543,7 +543,12 @@ async fn check_current_resolution(cwd: &AbsolutePathBuf) {
 
     match resolve_version(cwd).await {
         Ok(resolution) => {
-            print_check(" ", "Source", &resolution.source);
+            let source_display = resolution
+                .source_path
+                .as_ref()
+                .map(|p| p.as_path().display().to_string())
+                .unwrap_or(resolution.source);
+            print_check(" ", "Source", &source_display);
             print_check(" ", "Version", &resolution.version.bright_green().to_string());
 
             // Check if Node.js is installed

--- a/crates/vite_global_cli/src/commands/env/which.rs
+++ b/crates/vite_global_cli/src/commands/env/which.rs
@@ -10,7 +10,7 @@ use std::process::ExitStatus;
 
 use chrono::Local;
 use owo_colors::OwoColorize;
-use vite_path::AbsolutePathBuf;
+use vite_path::{AbsolutePath, AbsolutePathBuf};
 use vite_shared::output;
 
 use super::{
@@ -77,7 +77,7 @@ async fn execute_core_tool(cwd: AbsolutePathBuf, tool: &str) -> Result<ExitStatu
     println!("{}", tool_path.as_path().display());
 
     // Print metadata
-    let source_display = format_source(&resolution.source);
+    let source_display = format_source(&resolution.source, resolution.source_path.as_deref());
     println!("  {:<LABEL_WIDTH$}  {}", "Version:".dimmed(), resolution.version.bright_green());
     println!("  {:<LABEL_WIDTH$}  {}", "Source:".dimmed(), source_display.dimmed());
 
@@ -85,11 +85,17 @@ async fn execute_core_tool(cwd: AbsolutePathBuf, tool: &str) -> Result<ExitStatu
 }
 
 /// Format the resolution source for human-friendly display.
-fn format_source(source: &str) -> String {
+///
+/// When a `source_path` is available, shows the full file path instead of just the source type name.
+/// For env var and lts sources, annotations like `(session)` and `(fallback)` are preserved.
+fn format_source(source: &str, source_path: Option<&AbsolutePath>) -> String {
     match source {
         s if s == VERSION_ENV_VAR => format!("{s} (session)"),
         "lts" => "lts (fallback)".to_string(),
-        other => other.to_string(),
+        _ => match source_path {
+            Some(path) => path.as_path().display().to_string(),
+            None => source.to_string(),
+        },
     }
 }
 

--- a/packages/cli/snap-tests-global/command-env-which/snap.txt
+++ b/packages/cli/snap-tests-global/command-env-which/snap.txt
@@ -4,17 +4,17 @@ v20.18.0
 > vp env which node # Core tool - shows resolved Node.js binary path
 <vite-plus-home>/js_runtime/node/<semver>/bin/node
   [2mVersion:  [0m  [92m20.18.0[39m
-  [2mSource:   [0m  [2m.node-version[0m
+  [2mSource:   [0m  [2m<cwd>/.node-version[0m
 
 > vp env which npm # Core tool - shows resolved npm binary path
 <vite-plus-home>/js_runtime/node/<semver>/bin/npm
   [2mVersion:  [0m  [92m20.18.0[39m
-  [2mSource:   [0m  [2m.node-version[0m
+  [2mSource:   [0m  [2m<cwd>/.node-version[0m
 
 > vp env which npx # Core tool - shows resolved npx binary path
 <vite-plus-home>/js_runtime/node/<semver>/bin/npx
   [2mVersion:  [0m  [92m20.18.0[39m
-  [2mSource:   [0m  [2m.node-version[0m
+  [2mSource:   [0m  [2m<cwd>/.node-version[0m
 
 > vp install -g cowsay@1.6.0 # Install a global package via vp
   Installing cowsay@<semver> globally...

--- a/rfcs/env-command.md
+++ b/rfcs/env-command.md
@@ -1307,12 +1307,12 @@ Shows the path to the tool binary that would be executed. The first line is alwa
 $ vp env which node
 /Users/user/.vite-plus/js_runtime/node/20.18.0/bin/node
   Version:    20.18.0
-  Source:     .node-version
+  Source:     /Users/user/projects/my-app/.node-version
 
 $ vp env which npm
 /Users/user/.vite-plus/js_runtime/node/20.18.0/bin/npm
   Version:    20.18.0
-  Source:     .node-version
+  Source:     /Users/user/projects/my-app/.node-version
 ```
 
 When using session override:


### PR DESCRIPTION
When the version source is a file (.node-version, package.json engines.node,
etc.), display the full absolute path instead of just the source type name.
This helps users identify which file was used when .node-version is found
in a parent directory rather than cwd.

Session (VITE_PLUS_NODE_VERSION) and fallback (lts) sources retain their
existing annotations.