### PR TITLE
feat(pack): add `--exe` flag and upgrade tsdown to 0.21.0-beta.2

### DIFF
--- a/packages/cli/snap-tests-global/command-pack-exe-error/package.json
+++ b/packages/cli/snap-tests-global/command-pack-exe-error/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "command-pack-exe-error",
+  "version": "1.0.0",
+  "type": "module",
+  "engines": {
+    "node": "22.22.0"
+  }
+}

--- a/packages/cli/snap-tests-global/command-pack-exe-error/snap.txt
+++ b/packages/cli/snap-tests-global/command-pack-exe-error/snap.txt
@@ -1,0 +1,6 @@
+[1]> vp pack src/index.ts --exe
+ℹ entry: src/index.ts
+ℹ target: node22.22.0
+
+ ERROR  Error: Node.js version v<semver> does not support `exe` option. Please upgrade to Node.js <semver> or later.
+

--- a/packages/cli/snap-tests-global/command-pack-exe-error/src/index.ts
+++ b/packages/cli/snap-tests-global/command-pack-exe-error/src/index.ts
@@ -1,0 +1,1 @@
+export const hello = 'world';

--- a/packages/cli/snap-tests-global/command-pack-exe-error/steps.json
+++ b/packages/cli/snap-tests-global/command-pack-exe-error/steps.json
@@ -1,0 +1,7 @@
+{
+  "ignoredPlatforms": ["win32"],
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": ["vp pack src/index.ts --exe"]
+}

--- a/packages/cli/snap-tests-global/command-pack-exe-error/vite.config.ts
+++ b/packages/cli/snap-tests-global/command-pack-exe-error/vite.config.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/packages/cli/snap-tests-global/command-pack-exe/package.json
+++ b/packages/cli/snap-tests-global/command-pack-exe/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "command-pack-exe",
+  "version": "1.0.0",
+  "type": "module",
+  "engines": {
+    "node": "25.7.0"
+  }
+}

--- a/packages/cli/snap-tests-global/command-pack-exe/snap.txt
+++ b/packages/cli/snap-tests-global/command-pack-exe/snap.txt
@@ -1,0 +1,17 @@
+> vp pack src/index.ts --exe
+ℹ entry: src/index.ts
+ℹ target: node25.7.0
+ℹ `exe` option is experimental and may change in future releases.
+ℹ Build start
+ℹ dist/index.mjs  <variable> kB │ gzip: <variable> kB
+ℹ 1 files, total: <variable> kB
+✔ Build complete in <variable>ms
+ℹ dist/index  <variable> MB
+✔ Built executable: dist/index (<variable>ms)
+
+> ls dist
+index
+index.mjs
+
+> ./dist/index
+hello from exe

--- a/packages/cli/snap-tests-global/command-pack-exe/src/index.ts
+++ b/packages/cli/snap-tests-global/command-pack-exe/src/index.ts
@@ -1,0 +1,1 @@
+console.log('hello from exe');

--- a/packages/cli/snap-tests-global/command-pack-exe/steps.json
+++ b/packages/cli/snap-tests-global/command-pack-exe/steps.json
@@ -1,0 +1,8 @@
+{
+  "ignoredPlatforms": ["win32"],
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": ["vp pack src/index.ts --exe", "ls dist", "./dist/index"],
+  "after": ["rm -rf dist"]
+}

--- a/packages/cli/snap-tests-global/command-pack-exe/vite.config.ts
+++ b/packages/cli/snap-tests-global/command-pack-exe/vite.config.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/packages/cli/snap-tests/command-helper/snap.txt
+++ b/packages/cli/snap-tests/command-helper/snap.txt
@@ -70,6 +70,7 @@ Options:
   -W, --workspace [dir]     Enable workspace mode 
   -F, --filter <pattern>    Filter configs (cwd or name), e.g. /pkg-name$/ or pkg-name 
   --exports                 Generate export-related metadata for package.json (experimental) 
+  --exe                     Bundle as executable using Node.js SEA (experimental) 
   -h, --help                Display this message 
 
 > vp fmt -h # fmt help message

--- a/packages/cli/snap-tests/command-pack/snap.txt
+++ b/packages/cli/snap-tests/command-pack/snap.txt
@@ -47,6 +47,7 @@ Options:
   -W, --workspace [dir]     Enable workspace mode 
   -F, --filter <pattern>    Filter configs (cwd or name), e.g. /pkg-name$/ or pkg-name 
   --exports                 Generate export-related metadata for package.json (experimental) 
+  --exe                     Bundle as executable using Node.js SEA (experimental) 
   -h, --help                Display this message 
 
 > vp run pack # should build the library

--- a/packages/cli/src/pack-bin.ts
+++ b/packages/cli/src/pack-bin.ts
@@ -74,6 +74,7 @@ cli
   .option('-W, --workspace [dir]', 'Enable workspace mode')
   .option('-F, --filter <pattern>', 'Filter configs (cwd or name), e.g. /pkg-name$/ or pkg-name')
   .option('--exports', 'Generate export-related metadata for package.json (experimental)')
+  .option('--exe', 'Bundle as executable using Node.js SEA (experimental)')
   .action(async (input: string[], flags: InlineConfig) => {
     if (input.length > 0) {
       flags.entry = input;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -204,6 +204,6 @@
   "bundledVersions": {
     "vite": "8.0.0-beta.15",
     "rolldown": "1.0.0-rc.5",
-    "tsdown": "0.20.3"
+    "tsdown": "0.21.0-beta.2"
   }
 }

--- a/packages/tools/src/utils.ts
+++ b/packages/tools/src/utils.ts
@@ -89,11 +89,11 @@ export function replaceUnstableOutput(output: string, cwd?: string) {
       // vite modules transformed count
       .replaceAll(/✓ \d+ modules? transformed/g, '✓ <variable> modules transformed')
       // replace size for tsdown
-      .replaceAll(/ \d+(\.\d+)? ([km]?B)/g, ' <variable> $2')
+      .replaceAll(/ \d+(\.\d+)? ([kKmMgG]?B)/g, ' <variable> $2')
       // replace npm notice size:
       // "npm notice 5.6kB snap.txt"
       // "npm notice 619B steps.json"
-      .replaceAll(/ \d+(\.\d+)?([km]?B) /g, ' <variable>$2 ')
+      .replaceAll(/ \d+(\.\d+)?([kKmMgG]?B) /g, ' <variable>$2 ')
       // '"size": 821' => '"size": <variable>'
       // '"unpackedSize": 2720' => '"unpackedSize": <variable>'
       .replaceAll(/"(size|unpackedSize)": \d+/g, '"$1": <variable>')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,7 +197,7 @@ catalogs:
       version: 4.53.3
     semver:
       specifier: ^7.7.3
-      version: 7.7.3
+      version: 7.7.4
     serve-static:
       specifier: ^2.0.0
       version: 2.2.0
@@ -223,8 +223,8 @@ catalogs:
       specifier: ^1.0.1
       version: 1.0.2
     tsdown:
-      specifier: ^0.20.3
-      version: 0.20.3
+      specifier: ^0.21.0-beta.2
+      version: 0.21.0-beta.2
     typescript:
       specifier: ^5.9.3
       version: 5.9.3
@@ -431,10 +431,10 @@ importers:
         version: 0.22.1(@typescript/native-preview@7.0.0-dev.20260122.2)(oxc-resolver@11.14.0)(rolldown@rolldown+packages+rolldown)(typescript@5.9.3)
       semver:
         specifier: 'catalog:'
-        version: 7.7.3
+        version: 7.7.4
       tsdown:
         specifier: 'catalog:'
-        version: 0.20.3(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260122.2)(@vitejs/devtools@0.0.0-alpha.32(@pnpm/logger@1001.0.1)(typescript@5.9.3)(vite@packages+core)(vue@3.5.27(typescript@5.9.3)))(oxc-resolver@11.14.0)(publint@0.3.17)(typescript@5.9.3)(unplugin-lightningcss@0.4.3)(unplugin-unused@0.5.6)
+        version: 0.21.0-beta.2(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260122.2)(@vitejs/devtools@0.0.0-alpha.32(@pnpm/logger@1001.0.1)(typescript@5.9.3)(vite@packages+core)(vue@3.5.27(typescript@5.9.3)))(oxc-resolver@11.14.0)(publint@0.3.17)(typescript@5.9.3)(unplugin-lightningcss@0.4.3)(unplugin-unused@0.5.6)
       validate-npm-package-name:
         specifier: 'catalog:'
         version: 7.0.2
@@ -567,7 +567,7 @@ importers:
         version: 3.6.0(picomatch@4.0.3)(rollup@4.53.3)
       semver:
         specifier: ^7.7.3
-        version: 7.7.3
+        version: 7.7.4
       tinyglobby:
         specifier: ^0.2.15
         version: 0.2.15
@@ -576,7 +576,7 @@ importers:
         version: 1.2.2
       tsdown:
         specifier: 'catalog:'
-        version: 0.20.3(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260122.2)(@vitejs/devtools@0.0.0-alpha.32(@pnpm/logger@1001.0.1)(typescript@5.9.3)(vite@packages+core)(vue@3.5.27(typescript@5.9.3)))(oxc-resolver@11.14.0)(publint@0.3.17)(typescript@5.9.3)(unplugin-lightningcss@0.4.3)(unplugin-unused@0.5.6)
+        version: 0.21.0-beta.2(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260122.2)(@vitejs/devtools@0.0.0-alpha.32(@pnpm/logger@1001.0.1)(typescript@5.9.3)(vite@packages+core)(vue@3.5.27(typescript@5.9.3)))(oxc-resolver@11.14.0)(publint@0.3.17)(typescript@5.9.3)(unplugin-lightningcss@0.4.3)(unplugin-unused@0.5.6)
       vite:
         specifier: workspace:@voidzero-dev/vite-plus-core@*
         version: 'link:'
@@ -608,7 +608,7 @@ importers:
         version: 1.3.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.20.3(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260122.2)(publint@0.3.17)(typescript@5.9.3)(unplugin-lightningcss@0.4.3)(unplugin-unused@0.5.6)
+        version: 0.21.0-beta.2(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260122.2)(publint@0.3.17)(typescript@5.9.3)(unplugin-lightningcss@0.4.3)(unplugin-unused@0.5.6)
 
   packages/test:
     dependencies:
@@ -775,7 +775,7 @@ importers:
         version: 10.1.1
       semver:
         specifier: 'catalog:'
-        version: 7.7.3
+        version: 7.7.4
       yaml:
         specifier: 'catalog:'
         version: 2.8.2
@@ -8182,8 +8182,8 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.7.3:
-    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -8596,6 +8596,31 @@ packages:
       unplugin-unused:
         optional: true
 
+  tsdown@0.21.0-beta.2:
+    resolution: {integrity: sha512-OKj8mKf0ws1ucxuEi3mO/OGyfRQxO9MY2D6SoIE/7RZcbojsZSBhJr4xC4MNivMqrQvi3Ke2e+aRZDemPBWPCw==}
+    engines: {node: '>=20.19.0'}
+    hasBin: true
+    peerDependencies:
+      '@arethetypeswrong/core': ^0.18.1
+      '@vitejs/devtools': '*'
+      publint: ^0.3.0
+      typescript: ^5.0.0
+      unplugin-lightningcss: ^0.4.0
+      unplugin-unused: ^0.5.0
+    peerDependenciesMeta:
+      '@arethetypeswrong/core':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      publint:
+        optional: true
+      typescript:
+        optional: true
+      unplugin-lightningcss:
+        optional: true
+      unplugin-unused:
+        optional: true
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -8656,6 +8681,9 @@ packages:
 
   unconfig-core@7.4.2:
     resolution: {integrity: sha512-VgPCvLWugINbXvMQDf8Jh0mlbvNjNC6eSUziHsBCMpxR05OPrNrvDnyatdMjRgcHaaNsCqz+wjNXxNw1kRLHUg==}
+
+  unconfig-core@7.5.0:
+    resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
 
   unconfig@7.4.2:
     resolution: {integrity: sha512-nrMlWRQ1xdTjSnSUqvYqJzbTBFugoqHobQj58B2bc8qxHKBBHMNNsWQFP3Cd3/JZK907voM2geYPWqD4VK3MPQ==}
@@ -8765,8 +8793,8 @@ packages:
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
-  unrun@0.2.27:
-    resolution: {integrity: sha512-Mmur1UJpIbfxasLOhPRvox/QS4xBiDii71hMP7smfRthGcwFL2OAmYRgduLANOAU4LUkvVamuP+02U+c90jlrw==}
+  unrun@0.2.28:
+    resolution: {integrity: sha512-LqMrI3ZEUMZ2476aCsbUTfy95CHByqez05nju4AQv4XFPkxh5yai7Di1/Qb0FoELHEEPDWhQi23EJeFyrBV0Og==}
     engines: {node: '>=20.19.0'}
     hasBin: true
     peerDependencies:
@@ -9215,7 +9243,7 @@ snapshots:
       cjs-module-lexer: 1.4.3
       fflate: 0.8.2
       lru-cache: 11.2.2
-      semver: 7.7.3
+      semver: 7.7.4
       typescript: 5.6.1-rc
       validate-npm-package-name: 5.0.1
 
@@ -10014,7 +10042,7 @@ snapshots:
     dependencies:
       '@simple-libs/child-process-utils': 1.0.1
       '@simple-libs/stream-utils': 1.1.0
-      semver: 7.7.3
+      semver: 7.7.4
     optionalDependencies:
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.2.1
@@ -10415,7 +10443,7 @@ snapshots:
       emnapi: 1.7.1(node-addon-api@7.1.1)
       es-toolkit: 1.42.0
       js-yaml: 4.1.1
-      semver: 7.7.3
+      semver: 7.7.4
       typanion: 3.14.0
     optionalDependencies:
       '@emnapi/runtime': 1.7.1
@@ -11529,7 +11557,7 @@ snapshots:
       '@pnpm/logger': 1001.0.1
       '@pnpm/semver.peer-range': 1000.0.0
       '@pnpm/types': 1001.3.0
-      semver: 7.7.3
+      semver: 7.7.4
 
   '@pnpm/read-project-manifest@1001.2.4(@pnpm/logger@1001.0.1)':
     dependencies:
@@ -11550,7 +11578,7 @@ snapshots:
 
   '@pnpm/semver.peer-range@1000.0.0':
     dependencies:
-      semver: 7.7.3
+      semver: 7.7.4
 
   '@pnpm/text.comments-parser@1000.0.0':
     dependencies:
@@ -11582,7 +11610,7 @@ snapshots:
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
-      semver: 7.7.3
+      semver: 7.7.4
       tar-fs: 3.1.1
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -12101,7 +12129,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.54.0
       debug: 4.4.3(supports-color@8.1.1)
       minimatch: 9.0.5
-      semver: 7.7.3
+      semver: 7.7.4
       tinyglobby: 0.2.15
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -12355,7 +12383,7 @@ snapshots:
       picocolors: 1.1.1
       prompts: 2.4.2
       publint: 0.3.17
-      semver: 7.7.3
+      semver: 7.7.4
     transitivePeerDependencies:
       - conventional-commits-filter
 
@@ -13182,7 +13210,7 @@ snapshots:
       conventional-commits-filter: 5.0.0
       handlebars: 4.7.8
       meow: 13.2.0
-      semver: 7.7.3
+      semver: 7.7.4
 
   conventional-changelog@7.1.1(conventional-commits-filter@5.0.0):
     dependencies:
@@ -13514,7 +13542,7 @@ snapshots:
   eslint-compat-utils@0.5.1(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       eslint: 9.39.2(jiti@2.6.1)
-      semver: 7.7.3
+      semver: 7.7.4
 
   eslint-import-context@0.1.9(unrs-resolver@1.11.1):
     dependencies:
@@ -13539,7 +13567,7 @@ snapshots:
       eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
       is-glob: 4.0.3
       minimatch: 10.1.1
-      semver: 7.7.3
+      semver: 7.7.4
       stable-hash-x: 0.2.0
       unrs-resolver: 1.11.1
     optionalDependencies:
@@ -13557,7 +13585,7 @@ snapshots:
       globals: 15.15.0
       globrex: 0.1.2
       ignore: 5.3.2
-      semver: 7.7.3
+      semver: 7.7.4
       ts-declaration-location: 1.0.7(typescript@5.9.3)
     transitivePeerDependencies:
       - typescript
@@ -14733,13 +14761,13 @@ snapshots:
   normalize-package-data@7.0.1:
     dependencies:
       hosted-git-info: 8.1.0
-      semver: 7.7.3
+      semver: 7.7.4
       validate-npm-package-license: 3.0.4
 
   normalize-package-data@8.0.0:
     dependencies:
       hosted-git-info: 9.0.2
-      semver: 7.7.3
+      semver: 7.7.4
       validate-npm-package-license: 3.0.4
 
   normalize-path@3.0.0: {}
@@ -15760,7 +15788,7 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.7.3: {}
+  semver@7.7.4: {}
 
   send@1.2.0:
     dependencies:
@@ -16140,7 +16168,7 @@ snapshots:
       picomatch: 4.0.3
       typescript: 5.9.3
 
-  tsdown@0.20.3(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260122.2)(@vitejs/devtools@0.0.0-alpha.32(@pnpm/logger@1001.0.1)(typescript@5.9.3)(vite@packages+core)(vue@3.5.27(typescript@5.9.3)))(oxc-resolver@11.14.0)(publint@0.3.17)(typescript@5.9.3)(unplugin-lightningcss@0.4.3)(unplugin-unused@0.5.6):
+  tsdown@0.20.3(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260122.2)(publint@0.3.17)(typescript@5.9.3)(unplugin-lightningcss@0.4.3)(unplugin-unused@0.5.6):
     dependencies:
       ansis: 4.2.0
       cac: 6.7.14
@@ -16152,12 +16180,43 @@ snapshots:
       picomatch: 4.0.3
       rolldown: link:rolldown/packages/rolldown
       rolldown-plugin-dts: 0.22.1(@typescript/native-preview@7.0.0-dev.20260122.2)(oxc-resolver@11.14.0)(rolldown@rolldown+packages+rolldown)(typescript@5.9.3)
-      semver: 7.7.3
+      semver: 7.7.4
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
-      unconfig-core: 7.4.2
-      unrun: 0.2.27
+      unconfig-core: 7.5.0
+      unrun: 0.2.28
+    optionalDependencies:
+      '@arethetypeswrong/core': 0.18.2
+      publint: 0.3.17
+      typescript: 5.9.3
+      unplugin-lightningcss: 0.4.3
+      unplugin-unused: 0.5.6
+    transitivePeerDependencies:
+      - '@ts-macro/tsc'
+      - '@typescript/native-preview'
+      - oxc-resolver
+      - synckit
+      - vue-tsc
+
+  tsdown@0.21.0-beta.2(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260122.2)(@vitejs/devtools@0.0.0-alpha.32(@pnpm/logger@1001.0.1)(typescript@5.9.3)(vite@packages+core)(vue@3.5.27(typescript@5.9.3)))(oxc-resolver@11.14.0)(publint@0.3.17)(typescript@5.9.3)(unplugin-lightningcss@0.4.3)(unplugin-unused@0.5.6):
+    dependencies:
+      ansis: 4.2.0
+      cac: 6.7.14
+      defu: 6.1.4
+      empathic: 2.0.0
+      hookable: 6.0.1
+      import-without-cache: 0.2.5
+      obug: 2.1.1
+      picomatch: 4.0.3
+      rolldown: link:rolldown/packages/rolldown
+      rolldown-plugin-dts: 0.22.1(@typescript/native-preview@7.0.0-dev.20260122.2)(oxc-resolver@11.14.0)(rolldown@rolldown+packages+rolldown)(typescript@5.9.3)
+      semver: 7.7.4
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+      unconfig-core: 7.5.0
+      unrun: 0.2.28
     optionalDependencies:
       '@arethetypeswrong/core': 0.18.2
       '@vitejs/devtools': 0.0.0-alpha.32(@pnpm/logger@1001.0.1)(typescript@5.9.3)(vite@packages+core)(vue@3.5.27(typescript@5.9.3))
@@ -16172,7 +16231,7 @@ snapshots:
       - synckit
       - vue-tsc
 
-  tsdown@0.20.3(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260122.2)(publint@0.3.17)(typescript@5.9.3)(unplugin-lightningcss@0.4.3)(unplugin-unused@0.5.6):
+  tsdown@0.21.0-beta.2(@arethetypeswrong/core@0.18.2)(@typescript/native-preview@7.0.0-dev.20260122.2)(publint@0.3.17)(typescript@5.9.3)(unplugin-lightningcss@0.4.3)(unplugin-unused@0.5.6):
     dependencies:
       ansis: 4.2.0
       cac: 6.7.14
@@ -16184,12 +16243,12 @@ snapshots:
       picomatch: 4.0.3
       rolldown: link:rolldown/packages/rolldown
       rolldown-plugin-dts: 0.22.1(@typescript/native-preview@7.0.0-dev.20260122.2)(oxc-resolver@11.14.0)(rolldown@rolldown+packages+rolldown)(typescript@5.9.3)
-      semver: 7.7.3
+      semver: 7.7.4
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
-      unconfig-core: 7.4.2
-      unrun: 0.2.27
+      unconfig-core: 7.5.0
+      unrun: 0.2.28
     optionalDependencies:
       '@arethetypeswrong/core': 0.18.2
       publint: 0.3.17
@@ -16254,6 +16313,11 @@ snapshots:
     optional: true
 
   unconfig-core@7.4.2:
+    dependencies:
+      '@quansync/fs': 1.0.0
+      quansync: 1.0.0
+
+  unconfig-core@7.5.0:
     dependencies:
       '@quansync/fs': 1.0.0
       quansync: 1.0.0
@@ -16386,7 +16450,7 @@ snapshots:
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
 
-  unrun@0.2.27:
+  unrun@0.2.28:
     dependencies:
       rolldown: link:rolldown/packages/rolldown
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -102,7 +102,7 @@ catalog:
   terser: ^5.44.1
   tinybench: ^6.0.0
   tinyexec: ^1.0.1
-  tsdown: ^0.20.3
+  tsdown: ^0.21.0-beta.2
   tsx: ^4.20.6
   typescript: ^5.9.3
   unified: ^11.0.5

--- a/rfcs/pack-command.md
+++ b/rfcs/pack-command.md
@@ -1,0 +1,380 @@
+# RFC: `vp pack` Command
+
+## Summary
+
+`vp pack` bundles TypeScript/JavaScript libraries using tsdown (Rolldown-powered bundler). Configured via `vite.config.ts` under the `pack` key.
+
+## Motivation
+
+Unified library bundling integrated into the Vite+ toolchain, replacing standalone `tsdown` CLI usage. A single config file (`vite.config.ts`) manages all tools — dev server, build, test, lint, and now pack.
+
+### Current Pain Points
+
+```bash
+# Standalone tsdown requires its own config file
+npx tsdown src/index.ts --format esm --dts
+
+# Separate config from the rest of the Vite ecosystem
+# tsdown.config.ts vs vite.config.ts — fragmented tooling
+```
+
+### Proposed Solution
+
+```bash
+# Integrated into vp CLI
+vp pack src/index.ts --format esm --dts
+
+# Config lives in vite.config.ts alongside everything else
+# vite.config.ts
+export default {
+  pack: { entry: 'src/index.ts', format: ['esm', 'cjs'], dts: true }
+}
+```
+
+## Command Syntax
+
+```bash
+vp pack [...files] [options]
+```
+
+### Usage Examples
+
+```bash
+# Bundle with defaults (ESM, node platform)
+vp pack src/index.ts
+
+# Multiple formats
+vp pack src/index.ts --format esm --format cjs
+
+# With declaration files
+vp pack src/index.ts --dts
+
+# Watch mode with success hook
+vp pack src/index.ts --watch --on-success 'node dist/index.mjs'
+
+# Workspace mode
+vp pack --workspace --filter my-lib
+
+# Bundle as executable (experimental, Node.js >= 25.5.0)
+vp pack src/cli.ts --exe
+```
+
+## CLI Options
+
+### Input
+
+- `[...files]` — Entry files to bundle
+- `--config-loader <loader>` — Config loader to use: `auto`, `native`, `unrun` (default: `auto`)
+- `--no-config` — Disable config file
+- `--from-vite [vitest]` — Reuse config from Vite or Vitest
+
+### Output
+
+- `-f, --format <format>` — Bundle format: `esm`, `cjs`, `iife`, `umd` (default: `esm`)
+- `-d, --out-dir <dir>` — Output directory (default: `dist`)
+- `--clean` — Clean output directory, `--no-clean` to disable
+- `--sourcemap` — Generate source map (default: `false`)
+- `--shims` — Enable CJS and ESM shims (default: `false`)
+- `--minify` — Minify output
+
+### Declaration Files
+
+- `--dts` — Generate `.d.ts` files
+
+### Platform & Target
+
+- `--platform <platform>` — Target platform: `node`, `browser`, `neutral` (default: `node`)
+- `--target <target>` — Bundle target, e.g., `es2015`, `esnext`
+
+### Dependencies
+
+- `--external <module>` — Mark dependencies as external
+- `--treeshake` — Tree-shake bundle (default: `true`)
+
+### Quality Checks
+
+- `--publint` — Enable publint (default: `false`)
+- `--attw` — Enable Are the types wrong integration (default: `false`)
+- `--unused` — Enable unused dependencies check (default: `false`)
+
+### Watch Mode
+
+- `-w, --watch [path]` — Watch mode
+- `--ignore-watch <path>` — Ignore custom paths in watch mode
+- `--on-success <command>` — Command to run on success
+
+### Environment
+
+- `--env.* <value>` — Define compile-time env variables
+- `--env-file <file>` — Load environment variables from a file (variables in `--env` take precedence)
+- `--env-prefix <prefix>` — Prefix for env variables to inject into the bundle (default: `VITE_PACK_,TSDOWN_`)
+
+### Workspace
+
+- `-W, --workspace [dir]` — Enable workspace mode
+- `-F, --filter <pattern>` — Filter configs (cwd or name), e.g., `/pkg-name$/` or `pkg-name`
+
+### Other
+
+- `--copy <dir>` — Copy files to output dir
+- `--public-dir <dir>` — Alias for `--copy` (deprecated)
+- `--tsconfig <tsconfig>` — Set tsconfig path
+- `--unbundle` — Unbundle mode
+- `--report` — Size report (default: `true`)
+- `--exports` — Generate export-related metadata for package.json (experimental)
+- `--debug [feat]` — Show debug logs
+- `-l, --logLevel <level>` — Set log level: `info`, `warn`, `error`, `silent`
+- `--fail-on-warn` — Fail on warnings (default: `true`)
+- `--no-write` — Disable writing files to disk, incompatible with watch mode
+- `--devtools` — Enable devtools integration
+
+### Executable (Experimental)
+
+- `--exe` — Bundle as Node.js Single Executable Application (SEA)
+  - Requires Node.js >= 25.5.0
+  - Single entry point only
+  - Auto-sets format to CJS, disables DTS and code splitting
+  - On macOS, applies ad-hoc codesigning automatically
+
+## Configuration
+
+Config is specified in `vite.config.ts` under the `pack` key:
+
+```ts
+// Single config
+export default {
+  pack: {
+    entry: 'src/index.ts',
+    format: ['esm', 'cjs'],
+    dts: true,
+  },
+};
+
+// Array for multiple configs
+export default {
+  pack: [
+    { entry: 'src/index.ts', format: ['esm'], dts: true },
+    { entry: 'src/cli.ts', format: ['cjs'] },
+  ],
+};
+```
+
+CLI flags override config file values. When both are provided, CLI flags take precedence.
+
+## Architecture
+
+### Command Dispatch
+
+```
+Global CLI (Rust) ─── Category C delegation ───▸ Local CLI (pack-bin.ts) ───▸ tsdown
+```
+
+1. **Global CLI** (`crates/vite_global_cli/src/cli.rs`): The `Pack` command variant uses `trailing_var_arg` to capture all arguments, then unconditionally delegates to the local CLI.
+2. **Local CLI** (`packages/cli/src/pack-bin.ts`): Parses CLI options with `cac`, resolves config from `vite.config.ts`, and calls tsdown's `resolveUserConfig` + `buildWithConfigs`.
+3. **tsdown**: Handles all bundling logic, including the new SEA/exe feature.
+
+### Config Resolution
+
+```
+vite.config.ts (pack key) ──▸ merge with CLI flags ──▸ resolveUserConfig() ──▸ buildWithConfigs()
+```
+
+The local CLI:
+
+1. Resolves Vite config via `resolveConfig()` to find `vite.config.ts`
+2. Reads the `pack` key (object or array)
+3. Merges each pack config with CLI flags (CLI wins)
+4. Passes through to tsdown's `resolveUserConfig` for full resolution
+5. Calls `buildWithConfigs` with all resolved configs
+
+### Environment Variable Prefix
+
+- Default prefix: `VITE_PACK_` (primary) and `TSDOWN_` (migration compatibility)
+- Variables matching these prefixes are injected into the bundle at compile time
+- Customizable via `--env-prefix`
+
+### tsdown Integration
+
+tsdown is bundled inside `@voidzero-dev/vite-plus-core/pack`:
+
+- `packages/core/build.ts` bundles tsdown's JS, CJS dependencies, and types
+- `packages/core/package.json` tracks `bundledVersions.tsdown`
+- Re-exported via `packages/cli/src/pack.ts`
+
+## `--exe` Feature (Experimental)
+
+The `--exe` flag bundles the output as a Node.js Single Executable Application (SEA).
+
+### Requirements
+
+- Node.js >= 25.5.0 (uses the `node --experimental-sea` API)
+- Single entry point only
+
+### Behavior
+
+When `--exe` is passed:
+
+1. tsdown auto-sets format to CJS
+2. DTS generation and code splitting are disabled
+3. The bundle is embedded into a Node.js SEA blob
+4. On macOS, ad-hoc codesigning is applied automatically
+5. The resulting executable is a standalone binary
+
+### Error Handling
+
+If Node.js version is too old:
+
+```
+Node.js version v22.22.0 does not support `exe` option. Please upgrade to Node.js 25.5.0 or later.
+```
+
+## Relationship with `vp pm pack`
+
+These are distinct commands:
+
+| Command      | Purpose                       | Output              |
+| ------------ | ----------------------------- | ------------------- |
+| `vp pack`    | Library bundling via tsdown   | `dist/` directory   |
+| `vp pm pack` | Tarball creation via npm/pnpm | `.tgz` package file |
+
+## Design Decisions
+
+### 1. Config in `vite.config.ts` (Not `tsdown.config.ts`)
+
+**Decision**: Pack config lives under the `pack` key in `vite.config.ts`.
+
+**Rationale**:
+
+- Single config file for the entire Vite+ toolchain
+- Consistent with how `vp build`, `vp test`, etc. are configured
+- Reduces config file proliferation in projects
+
+### 2. `VITE_PACK_` Env Prefix (+ `TSDOWN_` for Migration)
+
+**Decision**: Default env prefix is `VITE_PACK_` with `TSDOWN_` as a migration-compatible fallback.
+
+**Rationale**:
+
+- `VITE_PACK_` follows Vite+ naming conventions
+- `TSDOWN_` ensures projects migrating from standalone tsdown continue to work
+- Users can override with `--env-prefix`
+
+### 3. tsdown Bundled Inside Core
+
+**Decision**: tsdown is bundled inside `@voidzero-dev/vite-plus-core/pack` rather than used as a direct dependency.
+
+**Rationale**:
+
+- Ensures consistent tsdown version across all vite-plus users
+- Avoids version conflicts in monorepos
+- The core build process bundles JS, CJS deps, and types together
+
+### 4. Category C Delegation
+
+**Decision**: The global CLI unconditionally delegates to the local CLI for `pack`.
+
+**Rationale**:
+
+- Pack requires project context (config file, dependencies, etc.)
+- Follows the same pattern as `build`, `test`, `lint`
+- No meaningful global-only behavior for bundling
+
+## CLI Help Output
+
+```bash
+$ vp pack -h
+vp pack
+
+Usage:
+  $ vp pack [...files]
+
+Commands:
+  [...files]  Bundle files
+
+Options:
+  --config-loader <loader>  Config loader to use: auto, native, unrun (default: auto)
+  --no-config               Disable config file
+  -f, --format <format>     Bundle format: esm, cjs, iife, umd (default: esm)
+  --clean                   Clean output directory, --no-clean to disable
+  --external <module>       Mark dependencies as external
+  --minify                  Minify output
+  --devtools                Enable devtools integration
+  --debug [feat]            Show debug logs
+  --target <target>         Bundle target, e.g "es2015", "esnext"
+  -l, --logLevel <level>    Set log level: info, warn, error, silent
+  --fail-on-warn            Fail on warnings (default: true)
+  --no-write                Disable writing files to disk, incompatible with watch mode
+  -d, --out-dir <dir>       Output directory (default: dist)
+  --treeshake               Tree-shake bundle (default: true)
+  --sourcemap               Generate source map (default: false)
+  --shims                   Enable cjs and esm shims (default: false)
+  --platform <platform>     Target platform (default: node)
+  --dts                     Generate dts files
+  --publint                 Enable publint (default: false)
+  --attw                    Enable Are the types wrong integration (default: false)
+  --unused                  Enable unused dependencies check (default: false)
+  -w, --watch [path]        Watch mode
+  --ignore-watch <path>     Ignore custom paths in watch mode
+  --from-vite [vitest]      Reuse config from Vite or Vitest
+  --report                  Size report (default: true)
+  --env.* <value>           Define compile-time env variables
+  --env-file <file>         Load environment variables from a file
+  --env-prefix <prefix>     Prefix for env variables to inject into the bundle
+  --on-success <command>    Command to run on success
+  --copy <dir>              Copy files to output dir
+  --public-dir <dir>        Alias for --copy, deprecated
+  --tsconfig <tsconfig>     Set tsconfig path
+  --unbundle                Unbundle mode
+  -W, --workspace [dir]     Enable workspace mode
+  -F, --filter <pattern>    Filter configs (cwd or name)
+  --exports                 Generate export-related metadata for package.json (experimental)
+  --exe                     Bundle as executable using Node.js SEA (experimental)
+  -h, --help                Display this message
+```
+
+## Snap Tests
+
+### Local CLI Test: `command-pack`
+
+**Location**: `packages/cli/snap-tests/command-pack/`
+
+Tests `vp pack -h` (help output includes all options including `--exe`) and `vp run pack` (build and cache hit).
+
+### Local CLI Test: `command-pack-exe`
+
+**Location**: `packages/cli/snap-tests/command-pack-exe/`
+
+Tests `vp pack src/index.ts --exe` error behavior when Node.js version is below 25.5.0.
+
+## Backward Compatibility
+
+This RFC documents an existing command with no breaking changes:
+
+- All existing `vp pack` options continue to work
+- The new `--exe` flag is purely additive
+- Config format in `vite.config.ts` is unchanged
+
+## Future Enhancements
+
+### 1. Programmatic `ExeOptions`
+
+```ts
+export default {
+  pack: {
+    entry: 'src/cli.ts',
+    exe: {
+      // Future: configure SEA options
+      icon: 'assets/icon.ico',
+      name: 'my-cli',
+    },
+  },
+};
+```
+
+### 2. Cross-Platform Executable Building
+
+Support building executables for different platforms from a single host.
+
+## Conclusion
+
+`vp pack` integrates tsdown-powered library bundling into the Vite+ toolchain. By using `vite.config.ts` for configuration and following the Category C delegation pattern, it provides a consistent developer experience alongside `vp build`, `vp test`, and `vp lint`. The new `--exe` flag (experimental) enables bundling as standalone Node.js executables via the SEA API.


### PR DESCRIPTION
## Summary

- Upgrade tsdown from `0.20.3` to `0.21.0-beta.2` for experimental Node.js SEA support
- Add `--exe` CLI option to `vp pack` for bundling as a standalone Node.js executable
- Add RFC document for the full `vp pack` command
- Add global snap tests for `--exe` success (Node.js 25.7.0) and error (Node.js < 25.5.0) cases
- Fix size replacement regex in snap test utils to handle uppercase units (MB, GB)

## Test plan

- [x] `pnpm -F vite-plus snap-test-local command-pack` — help output includes `--exe`, build/cache unchanged
- [x] `pnpm -F vite-plus snap-test-global command-pack-exe` — successful exe build with Node.js 25.7.0
- [x] `pnpm -F vite-plus snap-test-global command-pack-exe-error` — clear error on Node.js < 25.5.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)