### PR TITLE
ci: always run claude code on upgrade deps pipeline

### DIFF
--- a/.github/actions/build-upstream/action.yml
+++ b/.github/actions/build-upstream/action.yml
@@ -4,6 +4,10 @@ inputs:
   target:
     description: 'The target platform'
     required: true
+  print-after-build:
+    description: 'Print the output after the build'
+    required: false
+    default: 'false'
 
 runs:
   using: 'composite'

--- a/.github/workflows/upgrade-deps.yml
+++ b/.github/workflows/upgrade-deps.yml
@@ -62,14 +62,13 @@ jobs:
           RELEASE_BUILD: 'true'
 
       - uses: anthropics/claude-code-action@a017b830c03e23789b11fb69ed571ea61c12e45c # v1.0.0
-        if: steps.build-upstream.outcome == 'failure'
         env:
           RELEASE_BUILD: 'true'
         with:
           claude_code_oauth_token: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
-            Check why the build-upstream steps failed and fix them.
+            Check if the build-upstream steps failed and fix them.
             ### Background
             - The build-upstream steps are at ./.github/actions/build-upstream/action.yml
             - The deps upgrade script is at ./.github/scripts/upgrade-deps.mjs
@@ -79,10 +78,12 @@ jobs:
             - We are aiming to upgrade all dependencies to the latest versions in this workflow, so don't downgrade any dependencies.
             - Check `.claude/agents/cargo-workspace-merger.md` if rolldown hash is changed.
             - Run the steps in `build-upstream` action.yml after your fixing. If no errors are found, you can safe to exit.
-            - Your final step is to run `just build` to ensure all builds are successful.
+            - Install global CLI after the build-upstream steps are successful, by running the following commands:
+              - `pnpm bootstrap-cli:ci`
+              - `echo "$HOME/.vite-plus/bin" >> $GITHUB_PATH`
             - Run `pnpm run lint` to check if there are any issues after the build, if has, deep investigate it and fix it. You need to run `just build` before you can run `pnpm run lint`.
             - Run `pnpm run test` after `just build` to ensure all tests are successful.
-            - The snapshot tests in `pnpm run test` are always successful, you need to check the updated snapshot to see if there is anything wrong after our deps upgrade.
+            - The snapshot tests in `pnpm run test` are always successful, you need to check the snapshot diffs in git to see if there is anything wrong after our deps upgrade.
             - If deps in our `Cargo.toml` need to be upgraded, you can refer to the `./.claude/agents/cargo-workspace-merger.md`
               - If `Cargo.toml` has been modified, you need to run `cargo shear` to ensure there is nothing wrong with our dependencies.
               - Run `cargo check --all-targets --all-features` to ensure everything works fine if any Rust related codes are modified.
@@ -93,8 +94,10 @@ jobs:
               vp test -h
               vp build -h
               vp fmt -h
+            - Your final step is to run `just build` to ensure all builds are successful.
 
-            Help me fix the errors in `build-upstream` steps, no need to commit changes after your fixing.
+            Help me fix the errors in `build-upstream` steps if exists.
+            No need to commit changes after your fixing we have a following step to commit all file changes.
           claude_args: |
             --model opus --allowedTools "Bash,Edit,Replace,NotebookEditCell"
           additional_permissions: |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes CI behavior to always invoke a third-party `claude-code-action`, which can increase runtime/cost and affects automated remediation flow if the build succeeds/fails unexpectedly.
> 
> **Overview**
> The `upgrade-deps` workflow now **always runs** `anthropics/claude-code-action` instead of only when `build-upstream` fails, and updates the prompt to conditionally investigate/fix failures and clarify that changes should not be committed in that step.
> 
> The `build-upstream` composite action adds an optional `print-after-build` input, and the workflow enables it to print `vp` command help output after the build for easier debugging/verification.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7fe0dc78f8e31f69fd2a86436d125d2583fa50ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->