### PR TITLE
fix: Clean `dist` folders when running `just init`.

### DIFF
--- a/justfile
+++ b/justfile
@@ -9,6 +9,7 @@ _default:
 alias r := ready
 
 init:
+  rm -rf packages/*/dist
   cargo binstall watchexec-cli cargo-insta typos-cli cargo-shear dprint taplo-cli -y
   node packages/tools/src/index.ts sync-remote
   pnpm install


### PR DESCRIPTION
When pulling main, deps tend to be updated and the `dist` files get out of sync, leading to failures during `just build`. This is frequently confusing.

`just init` now cleans `dist` files, fixing this issue.
