### PR TITLE
feat(release): add Windows ARM64 (aarch64-pc-windows-msvc) support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,8 @@ jobs:
             os: ubuntu-latest
           - target: x86_64-pc-windows-msvc
             os: windows-latest
+          - target: aarch64-pc-windows-msvc
+            os: windows-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/clone
@@ -63,14 +65,6 @@ jobs:
 
       - name: Rustup Adds Target
         run: rustup target add ${{ matrix.settings.target }}
-
-      - name: Add musl target (x86_64)
-        if: ${{ matrix.settings.target == 'x86_64-unknown-linux-gnu' }}
-        run: rustup target add x86_64-unknown-linux-musl
-
-      - name: Add musl target (aarch64)
-        if: ${{ matrix.settings.target == 'aarch64-unknown-linux-gnu' }}
-        run: rustup target add aarch64-unknown-linux-musl
 
       - uses: oxc-project/setup-node@fdbf0dfd334c4e6d56ceeb77d91c76339c2a0885 # v1.0.4
 

--- a/.github/workflows/test-standalone-install.yml
+++ b/.github/workflows/test-standalone-install.yml
@@ -108,7 +108,7 @@ jobs:
         run: |
           # --check queries npm registry and prints update status
           vp upgrade --check
-          vp upgrade 0.0.0-f74442ad.20260222-0755
+          vp upgrade 0.0.0-gbe8891a5.20260227-1615
           vp --version
           # rollback to the previous version (should succeed after a real update)
           vp upgrade --rollback
@@ -168,7 +168,7 @@ jobs:
 
               # Verify upgrade
               vp upgrade --check
-              vp upgrade 0.0.0-f74442ad.20260222-0755
+              vp upgrade 0.0.0-gbe8891a5.20260227-1615
               vp --version
               vp upgrade --rollback
               vp --version
@@ -249,7 +249,74 @@ jobs:
         shell: powershell
         run: |
           vp upgrade --check
-          vp upgrade 0.0.0-f74442ad.20260222-0755
+          vp upgrade 0.0.0-gbe8891a5.20260227-1615
+          vp --version
+          vp upgrade --rollback
+          vp --version
+
+  test-install-ps1-arm64:
+    name: Test install.ps1 (Windows ARM64)
+    runs-on: windows-11-arm
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Run install.ps1
+        shell: pwsh
+        run: |
+          & ./packages/cli/install.ps1
+
+      - name: Set PATH
+        shell: bash
+        run: |
+          echo "$USERPROFILE\.vite-plus\bin" >> $GITHUB_PATH
+
+      - name: Verify installation
+        shell: pwsh
+        working-directory: ${{ runner.temp }}
+        run: |
+          Write-Host "PATH: $env:Path"
+          vp --version
+          vp --help
+          vp create vite --no-interactive --no-agent -- hello --no-interactive -t vanilla
+          cd hello
+          vp run build
+          vp --version
+
+      - name: Verify bin setup
+        shell: pwsh
+        run: |
+          $binPath = "$env:USERPROFILE\.vite-plus\bin"
+          Get-ChildItem -Force $binPath
+          if (-not (Test-Path $binPath)) {
+            Write-Error "Bin directory not found: $binPath"
+            exit 1
+          }
+
+          $expectedShims = @("node.cmd", "npm.cmd", "npx.cmd")
+          foreach ($shim in $expectedShims) {
+            $shimFile = Join-Path $binPath $shim
+            if (-not (Test-Path $shimFile)) {
+              Write-Error "Shim not found: $shimFile"
+              exit 1
+            }
+            Write-Host "Found shim: $shimFile"
+          }
+          where.exe node
+          where.exe npm
+          where.exe npx
+          where.exe vp
+
+          $env:Path = "$env:USERPROFILE\.vite-plus\bin;$env:Path"
+          vp env doctor
+          vp env run --node 24 -- node -p "process.versions"
+
+      - name: Verify upgrade
+        shell: pwsh
+        run: |
+          vp upgrade --check
+          vp upgrade 0.0.0-gbe8891a5.20260227-1615
           vp --version
           vp upgrade --rollback
           vp --version
@@ -277,7 +344,7 @@ jobs:
         run: |
           # --check queries npm registry and prints update status
           vp upgrade --check
-          vp upgrade 0.0.0-f74442ad.20260222-0755
+          vp upgrade 0.0.0-gbe8891a5.20260227-1615
           vp --version
           # rollback to the previous version (should succeed after a real update)
           vp upgrade --rollback

--- a/docs/vite/guide/index.md
+++ b/docs/vite/guide/index.md
@@ -32,6 +32,21 @@ For Windows:
 irm https://staging.viteplus.dev/install.ps1 | iex
 ```
 
+::: details Supported platforms
+
+Prebuilt binaries are distributed for the following platforms (grouped by [Node.js v24 platform support tier](https://github.com/nodejs/node/blob/v24.x/BUILDING.md#platform-list)):
+
+- Tier 1
+  - Linux x64 glibc (`x86_64-unknown-linux-gnu`)
+  - Linux arm64 glibc (`aarch64-unknown-linux-gnu`)
+  - Windows x64 (`x86_64-pc-windows-msvc`)
+  - macOS x64 (`x86_64-apple-darwin`)
+  - macOS arm64 (`aarch64-apple-darwin`)
+- Tier 2
+  - Windows arm64 (`aarch64-pc-windows-msvc`)
+
+:::
+
 ## Node.js Version Manager
 
 Vite+ includes a built-in Node.js version manager. During installation, you can opt-in to let Vite+ manage your Node.js versions.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -339,7 +339,8 @@
       "x86_64-apple-darwin",
       "aarch64-unknown-linux-gnu",
       "x86_64-unknown-linux-gnu",
-      "x86_64-pc-windows-msvc"
+      "x86_64-pc-windows-msvc",
+      "aarch64-pc-windows-msvc"
     ]
   },
   "engines": {


### PR DESCRIPTION
## Summary

- Add `aarch64-pc-windows-msvc` as a build target in the release pipeline, NAPI config, and publish scripts
- Add install test job for Windows ARM64 (`windows-11-arm` runner)
- Document supported platforms in the getting started guide

https://github.com/voidzero-dev/vite-plus-discussions/issues/13