### PR TITLE
fix(migrate): `vite --version` should migrate to `vp --version`, not `vp dev --version`

### DIFF
--- a/crates/vite_migration/src/package.rs
+++ b/crates/vite_migration/src/package.rs
@@ -78,6 +78,18 @@ mod tests {
     use super::*;
 
     const RULES_YAML: &str = r#"
+# vite --version / vite -v => vp --version / vp -v (global flags, not dev-specific)
+---
+id: replace-vite-version
+language: bash
+rule:
+  kind: command_name
+  regex: '^vite$'
+  inside:
+    kind: command
+    regex: 'vite\s+(-v|--version)'
+fix: vp
+
 # vite => vp dev (handles all cases: with/without env var prefix and flag args)
 # Match command_name to preserve env var prefix and arguments
 # Excludes subcommands like "vite build", "vite test", etc.
@@ -156,6 +168,9 @@ fix: vp pack
         assert_eq!(rewrite_script("vp fmt", &rules), "vp fmt");
         assert_eq!(rewrite_script("vp pack", &rules), "vp pack");
         assert_eq!(rewrite_script("vp dev --port 3000", &rules), "vp dev --port 3000");
+        // vite version flags (global, not dev-specific)
+        assert_eq!(rewrite_script("vite --version", &rules), "vp --version");
+        assert_eq!(rewrite_script("vite -v", &rules), "vp -v");
         // vite commands
         assert_eq!(rewrite_script("vite", &rules), "vp dev");
         assert_eq!(rewrite_script("vite dev", &rules), "vp dev");

--- a/packages/cli/rules/vite-tools.yml
+++ b/packages/cli/rules/vite-tools.yml
@@ -1,3 +1,16 @@
+# vite --version / vite -v => vp --version / vp -v (global flags, not dev-specific)
+---
+id: replace-vite-version
+language: bash
+rule:
+  kind: command_name
+  regex: '^vite$'
+  inside:
+    kind: command
+    regex: 'vite\s+(-v|--version)'
+fix: vp
+
+
 # vite => vp dev (handles all cases: with/without env var prefix and flag args)
 # Match command_name to preserve env var prefix and arguments
 # Excludes subcommands like "vite build", "vite test", etc.

--- a/packages/cli/snap-tests-global/migration-vite-version/package.json
+++ b/packages/cli/snap-tests-global/migration-vite-version/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "migration-vite-version",
+  "scripts": {
+    "version": "vite --version",
+    "version:short": "vite -v"
+  },
+  "devDependencies": {
+    "vite": "^7.0.0"
+  }
+}

--- a/packages/cli/snap-tests-global/migration-vite-version/snap.txt
+++ b/packages/cli/snap-tests-global/migration-vite-version/snap.txt
@@ -1,0 +1,33 @@
+> vp migrate --no-interactive # migration should rewrite vite --version to vp --version
+┌  VITE+ - The Unified Toolchain for the Web
+│
+●  Using default package manager: pnpm
+│
+●  pnpm@latest installing...
+│
+●  pnpm@<semver> installed
+│
+◆  Wrote agent instructions to AGENTS.md
+│
+└  ✔ Migration completed!
+
+
+> cat package.json # check package.json
+{
+  "name": "migration-vite-version",
+  "scripts": {
+    "version": "vp --version",
+    "version:short": "vp -v"
+  },
+  "devDependencies": {
+    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
+    "vite-plus": "latest"
+  },
+  "pnpm": {
+    "overrides": {
+      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
+      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
+    }
+  },
+  "packageManager": "pnpm@<semver>"
+}

--- a/packages/cli/snap-tests-global/migration-vite-version/steps.json
+++ b/packages/cli/snap-tests-global/migration-vite-version/steps.json
@@ -1,0 +1,6 @@
+{
+  "commands": [
+    "vp migrate --no-interactive # migration should rewrite vite --version to vp --version",
+    "cat package.json # check package.json"
+  ]
+}

--- a/packages/cli/src/migration/__tests__/__snapshots__/migrator.spec.ts.snap
+++ b/packages/cli/src/migration/__tests__/__snapshots__/migrator.spec.ts.snap
@@ -82,6 +82,8 @@ exports[`rewritePackageJson > should rewrite package.json scripts 1`] = `
     "ready_new": "vp install && vp fmt && vp lint --type-aware && vp test -r && vp build -r",
     "test": "vp test",
     "test_run": "vp test run && vp test --ui",
+    "version": "vp --version",
+    "version_short": "vp -v",
   },
 }
 `;

--- a/packages/cli/src/migration/__tests__/migrator.spec.ts
+++ b/packages/cli/src/migration/__tests__/migrator.spec.ts
@@ -31,6 +31,8 @@ describe('rewritePackageJson', () => {
         dev: 'vite',
         dev_cjs: 'VITE_CJS_IGNORE_WARNING=true vite',
         dev_cjs_cross_env: 'cross-env VITE_CJS_IGNORE_WARNING=true vite',
+        version: 'vite --version',
+        version_short: 'vite -v',
         dev_help: 'vite --help && vite -h',
         dev_port: 'vite --port 3000',
         dev_host: 'vite --host 0.0.0.0',


### PR DESCRIPTION
Add a `replace-vite-version` ast-grep rule before `replace-vite` to intercept
version flags (`--version`, `-v`) so they map to `vp` instead of `vp dev`.

closes VP-205