### PR TITLE
fix(ci): bump snapshot version prefix from 0.0.0 to 0.0.2

### DIFF
--- a/.github/actions/set-snapshot-version/action.yml
+++ b/.github/actions/set-snapshot-version/action.yml
@@ -1,5 +1,5 @@
 name: Set Snapshot Version
-description: Set snapshot version (0.0.0-g{sha}.{timestamp}) for pre-release builds
+description: Set snapshot version (0.0.2-g{sha}.{timestamp}) for pre-release builds
 
 outputs:
   version:
@@ -15,5 +15,5 @@ runs:
       run: |
         SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-8)
         BUILD_TIME=$(date -u +%Y%m%d-%H%M)
-        VERSION="0.0.0-g${SHORT_SHA}.${BUILD_TIME}"
+        VERSION="0.0.2-g${SHORT_SHA}.${BUILD_TIME}"
         echo "version=${VERSION}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Renovate considers 0.0.1 newer than 0.0.0-xxx per semver
(0.0.0-pre < 0.0.0 < 0.0.1). By using 0.0.2 as the prefix,
snapshot versions like 0.0.2-g{sha}.{timestamp} are higher than
0.0.1, preventing unwanted upgrade suggestions.