### PR TITLE
feat(cli): enable vpx tip

### DIFF
--- a/crates/vite_global_cli/src/tips/mod.rs
+++ b/crates/vite_global_cli/src/tips/mod.rs
@@ -33,7 +33,6 @@ impl TipContext {
         self.exit_code == 0
     }
 
-    #[expect(dead_code)]
     pub fn is_unknown_command_error(&self) -> bool {
         if let Some(err) = &self.clap_error {
             matches!(err.kind(), ClapErrorKind::InvalidSubcommand)

--- a/crates/vite_global_cli/src/tips/use_vpx_or_run.rs
+++ b/crates/vite_global_cli/src/tips/use_vpx_or_run.rs
@@ -2,38 +2,35 @@
 
 use super::{Tip, TipContext};
 
-/// Suggest `vpx <bin>` or `vp run <script>` when an unknown command is used.
+/// Suggest `vpx <pkg>` or `vp run <script>` when an unknown command is used.
 pub struct UseVpxOrRun;
 
 impl Tip for UseVpxOrRun {
-    fn matches(&self, _ctx: &TipContext) -> bool {
-        // TODO: Enable when `vpx` is supported
-        // ctx.is_unknown_command_error()
-        false
+    fn matches(&self, ctx: &TipContext) -> bool {
+        ctx.is_unknown_command_error()
     }
 
     fn message(&self) -> &'static str {
-        "Run a local binary with `vpx <bin>`, or a script with `vp run <script>`"
+        "Execute a package binary with `vpx <pkg[@version]>`, or a script with `vp run <script>`"
     }
 }
 
-// TODO: Re-enable tests when `vpx` is supported
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-//     use crate::tips::tip_context_from_command;
-//
-//     #[test]
-//     fn matches_on_unknown_command() {
-//         let ctx = tip_context_from_command("vp typecheck");
-//         assert!(UseVpxOrRun.matches(&ctx));
-//         assert!(ctx.is_unknown_command_error());
-//     }
-//
-//     #[test]
-//     fn does_not_match_on_known_command() {
-//         let ctx = tip_context_from_command("vp build");
-//         assert!(!UseVpxOrRun.matches(&ctx));
-//         assert!(!ctx.is_unknown_command_error());
-//     }
-// }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tips::tip_context_from_command;
+
+    #[test]
+    fn matches_on_unknown_command() {
+        let ctx = tip_context_from_command("vp typecheck");
+        assert!(UseVpxOrRun.matches(&ctx));
+        assert!(ctx.is_unknown_command_error());
+    }
+
+    #[test]
+    fn does_not_match_on_known_command() {
+        let ctx = tip_context_from_command("vp build");
+        assert!(!UseVpxOrRun.matches(&ctx));
+        assert!(!ctx.is_unknown_command_error());
+    }
+}


### PR DESCRIPTION
## Summary
- Enable the `UseVpxOrRun` tip that was disabled with a TODO pending `vpx` support
- Uncomment the tip logic and its tests in `use_vpx_or_run.rs`
- Remove `#[expect(dead_code)]` from `is_unknown_command_error()` since it's now used

When users run an unknown command (e.g. `vp typecheck`), they'll now see a tip suggesting `vpx <bin>` or `vp run <script>`.

## Test plan
- [ ] CI passes `cargo test -p vite_global_cli` with the newly enabled tests


🤖 Generated with [Claude Code](https://claude.com/claude-code)