### PR TITLE
chore: Improve Rust-based help command printing.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7136,6 +7136,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
+ "owo-colors",
  "petgraph 0.8.3",
  "pretty_assertions",
  "rolldown_binding",

--- a/crates/vite_global_cli/src/cli.rs
+++ b/crates/vite_global_cli/src/cli.rs
@@ -6,6 +6,7 @@
 use std::process::ExitStatus;
 
 use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
+use owo_colors::OwoColorize;
 use vite_install::commands::{
     add::SaveDependencyType, install::InstallCommandOptions, outdated::Format,
 };
@@ -1843,9 +1844,19 @@ pub async fn run_command(cwd: AbsolutePathBuf, args: Args) -> Result<ExitStatus,
             commands::delegate::execute(cwd, "pack", &args).await
         }
 
-        Commands::Run { args } => commands::run_or_delegate::execute(cwd, &args).await,
+        Commands::Run { args } => {
+            if help::maybe_print_unified_delegate_help("run", &args) {
+                return Ok(ExitStatus::default());
+            }
+            commands::run_or_delegate::execute(cwd, &args).await
+        }
 
-        Commands::Exec { args } => commands::delegate::execute(cwd, "exec", &args).await,
+        Commands::Exec { args } => {
+            if help::maybe_print_unified_delegate_help("exec", &args) {
+                return Ok(ExitStatus::default());
+            }
+            commands::delegate::execute(cwd, "exec", &args).await
+        }
 
         Commands::Preview { args } => {
             if help::maybe_print_unified_delegate_help("preview", &args) {
@@ -1854,7 +1865,12 @@ pub async fn run_command(cwd: AbsolutePathBuf, args: Args) -> Result<ExitStatus,
             commands::delegate::execute(cwd, "preview", &args).await
         }
 
-        Commands::Cache { args } => commands::delegate::execute(cwd, "cache", &args).await,
+        Commands::Cache { args } => {
+            if help::maybe_print_unified_delegate_help("cache", &args) {
+                return Ok(ExitStatus::default());
+            }
+            commands::delegate::execute(cwd, "cache", &args).await
+        }
 
         Commands::Env(args) => commands::env::execute(cwd, args).await,
 
@@ -1895,15 +1911,14 @@ pub fn command_with_help() -> clap::Command {
 
 /// Apply custom help formatting to a clap Command to match the JS CLI output.
 fn apply_custom_help(cmd: clap::Command) -> clap::Command {
-    let version = env!("CARGO_PKG_VERSION");
     let after_help = help::render_help_doc(&help::top_level_help_doc());
-    let help_template = format!(
-        "Vite+/{version}\
-{{after-help}}
-Options:
-{{options}}
-"
-    );
+    let options_heading = help::render_heading("Options");
+    let header = if help::should_style_help() {
+        "VITE+ - The Unified Toolchain for the Web".bold().to_string()
+    } else {
+        "VITE+ - The Unified Toolchain for the Web".to_string()
+    };
+    let help_template = format!("{header}{{after-help}}\n{options_heading}\n{{options}}\n");
 
     cmd.after_help(after_help).help_template(help_template)
 }

--- a/crates/vite_global_cli/src/commands/env/mod.rs
+++ b/crates/vite_global_cli/src/commands/env/mod.rs
@@ -120,18 +120,18 @@ pub async fn execute(cwd: AbsolutePathBuf, args: EnvArgs) -> Result<ExitStatus, 
         return print_env(cwd).await;
     }
 
-    // No flags provided - show help (use clap's built-in help printer)
-    use clap::CommandFactory;
-    let bin_name = crate::cli::Args::command().get_bin_name().unwrap_or("vp").to_string();
-    let display_name: &'static str = Box::leak(format!("{bin_name} env").into_boxed_str());
-    crate::cli::Args::command()
-        .find_subcommand("env")
-        .unwrap()
-        .clone()
-        .name(display_name)
-        .disable_help_subcommand(true)
-        .print_help()
-        .ok();
+    // No flags provided - show unified help to match `vp env --help`.
+    if !crate::help::print_unified_clap_help_for_path(&["env"]) {
+        // Fallback to clap's built-in help printer if unified rendering fails.
+        use clap::CommandFactory;
+        crate::cli::Args::command()
+            .find_subcommand("env")
+            .unwrap()
+            .clone()
+            .disable_help_subcommand(true)
+            .print_help()
+            .ok();
+    }
     Ok(ExitStatus::default())
 }
 

--- a/crates/vite_global_cli/src/commands/version.rs
+++ b/crates/vite_global_cli/src/commands/version.rs
@@ -1,33 +1,169 @@
-//! Version command (Category B: JavaScript Command).
+//! Version command.
 
-use std::process::ExitStatus;
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+    process::ExitStatus,
+};
 
+use owo_colors::OwoColorize;
+use serde::Deserialize;
 use vite_path::AbsolutePathBuf;
 
-use crate::{error::Error, js_executor::JsExecutor};
+use crate::{error::Error, help};
 
-/// Execute the `--version` command by delegating to local or global vite-plus.
-///
-/// Uses the CLI's own runtime instead of the project's runtime to avoid
-/// side effects (e.g., writing `.node-version` in the caller's directory).
-pub async fn execute(cwd: AbsolutePathBuf) -> Result<ExitStatus, Error> {
-    // Pass the Rust binary's version to JS so it can display the correct global version,
-    // even when delegation resolves to a local node_modules copy.
-    unsafe {
-        std::env::set_var(
-            vite_shared::env_vars::VITE_PLUS_GLOBAL_VERSION,
-            env!("CARGO_PKG_VERSION"),
-        );
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PackageJson {
+    version: String,
+    #[serde(default)]
+    bundled_versions: BTreeMap<String, String>,
+}
+
+#[derive(Debug)]
+struct LocalVitePlus {
+    version: String,
+    package_dir: PathBuf,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ToolSpec {
+    display_name: &'static str,
+    package_name: &'static str,
+    bundled_version_key: Option<&'static str>,
+}
+
+const TOOL_SPECS: [ToolSpec; 7] = [
+    ToolSpec {
+        display_name: "vite",
+        package_name: "@voidzero-dev/vite-plus-core",
+        bundled_version_key: Some("vite"),
+    },
+    ToolSpec {
+        display_name: "rolldown",
+        package_name: "@voidzero-dev/vite-plus-core",
+        bundled_version_key: Some("rolldown"),
+    },
+    ToolSpec {
+        display_name: "vitest",
+        package_name: "@voidzero-dev/vite-plus-test",
+        bundled_version_key: Some("vitest"),
+    },
+    ToolSpec { display_name: "oxfmt", package_name: "oxfmt", bundled_version_key: None },
+    ToolSpec { display_name: "oxlint", package_name: "oxlint", bundled_version_key: None },
+    ToolSpec {
+        display_name: "oxlint-tsgolint",
+        package_name: "oxlint-tsgolint",
+        bundled_version_key: None,
+    },
+    ToolSpec {
+        display_name: "tsdown",
+        package_name: "@voidzero-dev/vite-plus-core",
+        bundled_version_key: Some("tsdown"),
+    },
+];
+
+fn read_package_json(package_json_path: &Path) -> Option<PackageJson> {
+    let content = fs::read_to_string(package_json_path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+fn find_local_vite_plus(start: &Path) -> Option<LocalVitePlus> {
+    let mut current = Some(start);
+    while let Some(dir) = current {
+        let package_json_path = dir.join("node_modules").join("vite-plus").join("package.json");
+        if let Some(pkg) = read_package_json(&package_json_path) {
+            let package_dir = package_json_path.parent()?.to_path_buf();
+            return Some(LocalVitePlus { version: pkg.version, package_dir });
+        }
+        current = dir.parent();
     }
-    let mut executor = JsExecutor::new(None);
-    executor.delegate_with_cli_runtime(&cwd, &["--version".to_string()]).await
+    None
+}
+
+fn resolve_package_json(base_dir: &Path, package_name: &str) -> Option<PackageJson> {
+    let mut current = Some(base_dir);
+    while let Some(dir) = current {
+        let package_json_path = dir.join("node_modules").join(package_name).join("package.json");
+        if let Some(pkg) = read_package_json(&package_json_path) {
+            return Some(pkg);
+        }
+        current = dir.parent();
+    }
+    None
+}
+
+fn resolve_tool_version(local: &LocalVitePlus, tool: ToolSpec) -> Option<String> {
+    let pkg = resolve_package_json(&local.package_dir, tool.package_name)?;
+    if let Some(key) = tool.bundled_version_key
+        && let Some(version) = pkg.bundled_versions.get(key)
+    {
+        return Some(version.clone());
+    }
+    Some(pkg.version)
+}
+
+fn accent(text: &str) -> String {
+    if help::should_style_help() { text.bright_blue().to_string() } else { text.to_string() }
+}
+
+fn print_rows(title: &str, rows: &[(&str, String)]) {
+    println!("{}", help::render_heading(title));
+    let label_width = rows.iter().map(|(label, _)| label.chars().count()).max().unwrap_or(0);
+    for (label, value) in rows {
+        let padding = " ".repeat(label_width.saturating_sub(label.chars().count()));
+        println!("  {}{}  {value}", accent(label), padding);
+    }
+}
+
+fn format_version(version: Option<String>) -> String {
+    match version {
+        Some(v) => format!("v{v}"),
+        None => "Not found".to_string(),
+    }
+}
+
+/// Execute the `--version` command.
+pub async fn execute(cwd: AbsolutePathBuf) -> Result<ExitStatus, Error> {
+    let header = if help::should_style_help() {
+        "VITE+ - The Unified Toolchain for the Web".bold().to_string()
+    } else {
+        "VITE+ - The Unified Toolchain for the Web".to_string()
+    };
+    println!("{header}");
+    println!();
+
+    println!("vp v{}", env!("CARGO_PKG_VERSION"));
+    println!();
+
+    let local = find_local_vite_plus(cwd.as_path());
+    print_rows(
+        "Local vite-plus",
+        &[("vite-plus", format_version(local.as_ref().map(|pkg| pkg.version.clone())))],
+    );
+    println!();
+
+    let tool_rows = TOOL_SPECS
+        .iter()
+        .map(|tool| {
+            let version =
+                local.as_ref().and_then(|local_pkg| resolve_tool_version(local_pkg, *tool));
+            (tool.display_name, format_version(version))
+        })
+        .collect::<Vec<_>>();
+    print_rows("Tools", &tool_rows);
+
+    Ok(ExitStatus::default())
 }
 
 #[cfg(test)]
 mod tests {
+    use super::format_version;
+
     #[test]
-    fn test_version_command_module_exists() {
-        // Basic test to ensure the module compiles
-        assert!(true);
+    fn format_version_values() {
+        assert_eq!(format_version(Some("1.2.3".to_string())), "v1.2.3");
+        assert_eq!(format_version(None), "Not found");
     }
 }

--- a/crates/vite_global_cli/src/help.rs
+++ b/crates/vite_global_cli/src/help.rs
@@ -55,16 +55,16 @@ fn section_lines(title: &'static str, lines: Vec<&'static str>) -> HelpSection {
     HelpSection::Lines { title, lines }
 }
 
-fn render_heading(title: &str) -> String {
+pub fn render_heading(title: &str) -> String {
     let heading = format!("{title}:");
-    if should_style_help() { heading.bold().underline().to_string() } else { heading }
+    if should_style_help() { heading.bold().to_string() } else { heading }
 }
 
 fn render_usage_value(usage: &str) -> String {
     if should_style_help() { usage.bold().to_string() } else { usage.to_string() }
 }
 
-fn should_style_help() -> bool {
+pub fn should_style_help() -> bool {
     std::io::stdout().is_terminal()
         && std::env::var_os("NO_COLOR").is_none()
         && std::env::var("CLICOLOR").map_or(true, |value| value != "0")
@@ -117,6 +117,22 @@ fn render_owned_rows(rows: &[OwnedHelpRow]) -> Vec<String> {
     output
 }
 
+fn split_comment_suffix(line: &str) -> Option<(&str, &str)> {
+    line.find(" #").map(|index| line.split_at(index))
+}
+
+fn render_muted_comment_suffix(line: &str) -> String {
+    if !should_style_help() {
+        return line.to_string();
+    }
+
+    if let Some((prefix, suffix)) = split_comment_suffix(line) {
+        return format!("{}{}", prefix, suffix.bright_black());
+    }
+
+    line.to_string()
+}
+
 pub fn render_help_doc(doc: &HelpDoc) -> String {
     let mut output = String::new();
 
@@ -141,7 +157,7 @@ pub fn render_help_doc(doc: &HelpDoc) -> String {
             HelpSection::Lines { title, lines } => {
                 let _ = writeln!(output, "{}", render_heading(title));
                 for line in lines {
-                    let _ = writeln!(output, "{line}");
+                    let _ = writeln!(output, "{}", render_muted_comment_suffix(line));
                 }
             }
         }
@@ -174,7 +190,7 @@ fn render_owned_help_doc(doc: &OwnedHelpDoc) -> String {
             OwnedHelpSection::Lines { title, lines } => {
                 let _ = writeln!(output, "{}", render_heading(title));
                 for line in lines {
-                    let _ = writeln!(output, "{line}");
+                    let _ = writeln!(output, "{}", render_muted_comment_suffix(line));
                 }
             }
         }
@@ -250,9 +266,47 @@ fn parse_rows(lines: &[String]) -> Vec<OwnedHelpRow> {
     rows
 }
 
+fn strip_ansi(value: &str) -> String {
+    let mut output = String::with_capacity(value.len());
+    let mut chars = value.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '\u{1b}' {
+            match chars.peek().copied() {
+                // CSI sequence (for example: \x1b[1m)
+                Some('[') => {
+                    let _ = chars.next();
+                    for c in chars.by_ref() {
+                        if ('@'..='~').contains(&c) {
+                            break;
+                        }
+                    }
+                }
+                // OSC sequence (for example: hyperlinks)
+                Some(']') => {
+                    let _ = chars.next();
+                    let mut prev = '\0';
+                    for c in chars.by_ref() {
+                        if c == '\u{7}' || (prev == '\u{1b}' && c == '\\') {
+                            break;
+                        }
+                        prev = c;
+                    }
+                }
+                _ => {}
+            }
+            continue;
+        }
+
+        output.push(ch);
+    }
+
+    output
+}
+
 fn parse_clap_help_to_doc(raw_help: &str) -> Option<OwnedHelpDoc> {
     let normalized = raw_help.replace("\r\n", "\n");
-    let lines: Vec<String> = normalized.lines().map(str::to_string).collect();
+    let lines: Vec<String> = normalized.lines().map(strip_ansi).collect();
     let usage_index = lines.iter().position(|line| line.starts_with("Usage: "))?;
     let usage = lines[usage_index].trim_start_matches("Usage: ").trim().to_string();
 
@@ -575,6 +629,117 @@ fn delegated_help_doc(command: &str) -> Option<HelpDoc> {
                 ),
             ],
         }),
+        "run" => Some(HelpDoc {
+            usage: "vp run [OPTIONS] [TASK_SPECIFIER] [ADDITIONAL_ARGS]...",
+            summary: vec!["Run tasks."],
+            sections: vec![
+                section_rows(
+                    "Arguments",
+                    vec![
+                        row(
+                            "[TASK_SPECIFIER]",
+                            "`packageName#taskName` or `taskName`. If omitted, lists all available tasks",
+                        ),
+                        row("[ADDITIONAL_ARGS]...", "Additional arguments to pass to the tasks"),
+                    ],
+                ),
+                section_rows(
+                    "Options",
+                    vec![
+                        row("-r, --recursive", "Select all packages in the workspace"),
+                        row(
+                            "-t, --transitive",
+                            "Select the current package and its transitive dependencies",
+                        ),
+                        row("-w, --workspace-root", "Select the workspace root package"),
+                        row(
+                            "-F, --filter <FILTERS>",
+                            "Match packages by name, directory, or glob pattern",
+                        ),
+                        row(
+                            "--ignore-depends-on",
+                            "Do not run dependencies specified in `dependsOn` fields",
+                        ),
+                        row("-v, --verbose", "Show full detailed summary after execution"),
+                        row("--last-details", "Display the detailed summary of the last run"),
+                        row("-h, --help", "Print help (see more with '--help')"),
+                    ],
+                ),
+                section_lines(
+                    "Filter Patterns",
+                    vec![
+                        "  --filter <pattern>        Select by package name (e.g. foo, @scope/*)",
+                        "  --filter ./<dir>          Select packages under a directory",
+                        "  --filter {<dir>}          Same as ./<dir>, but allows traversal suffixes",
+                        "  --filter <pattern>...     Select package and its dependencies",
+                        "  --filter ...<pattern>     Select package and its dependents",
+                        "  --filter <pattern>^...    Select only the dependencies (exclude the package itself)",
+                        "  --filter !<pattern>       Exclude packages matching the pattern",
+                    ],
+                ),
+            ],
+        }),
+        "exec" => Some(HelpDoc {
+            usage: "vp exec [OPTIONS] [COMMAND]...",
+            summary: vec!["Execute a command from local node_modules/.bin."],
+            sections: vec![
+                section_rows(
+                    "Arguments",
+                    vec![row("[COMMAND]...", "Command and arguments to execute")],
+                ),
+                section_rows(
+                    "Options",
+                    vec![
+                        row("-r, --recursive", "Select all packages in the workspace"),
+                        row(
+                            "-t, --transitive",
+                            "Select the current package and its transitive dependencies",
+                        ),
+                        row("-w, --workspace-root", "Select the workspace root package"),
+                        row(
+                            "-F, --filter <FILTERS>",
+                            "Match packages by name, directory, or glob pattern",
+                        ),
+                        row("-c, --shell-mode", "Execute the command within a shell environment"),
+                        row("--parallel", "Run concurrently without topological ordering"),
+                        row("--reverse", "Reverse execution order"),
+                        row("--resume-from <RESUME_FROM>", "Resume from a specific package"),
+                        row("--report-summary", "Save results to vp-exec-summary.json"),
+                        row("-h, --help", "Print help (see more with '--help')"),
+                    ],
+                ),
+                section_lines(
+                    "Filter Patterns",
+                    vec![
+                        "  --filter <pattern>        Select by package name (e.g. foo, @scope/*)",
+                        "  --filter ./<dir>          Select packages under a directory",
+                        "  --filter {<dir>}          Same as ./<dir>, but allows traversal suffixes",
+                        "  --filter <pattern>...     Select package and its dependencies",
+                        "  --filter ...<pattern>     Select package and its dependents",
+                        "  --filter <pattern>^...    Select only the dependencies (exclude the package itself)",
+                        "  --filter !<pattern>       Exclude packages matching the pattern",
+                    ],
+                ),
+                section_lines(
+                    "Examples",
+                    vec![
+                        "  vp exec node --version                             # Run local node",
+                        "  vp exec tsc --noEmit                               # Run local TypeScript compiler",
+                        "  vp exec -c 'tsc --noEmit && prettier --check .'    # Shell mode",
+                        "  vp exec -r -- tsc --noEmit                         # Run in all workspace packages",
+                        "  vp exec --filter 'app...' -- tsc                   # Run in filtered packages",
+                    ],
+                ),
+            ],
+        }),
+        "cache" => Some(HelpDoc {
+            usage: "vp cache <COMMAND>",
+            summary: vec!["Manage the task cache."],
+            sections: vec![
+                section_rows("Commands", vec![row("clean", "Clean up all the cache")]),
+                section_rows("Options", vec![row("-h, --help", "Print help")]),
+            ],
+        }),
         _ => None,
     }
 }
@@ -655,21 +820,11 @@ pub fn maybe_print_unified_clap_subcommand_help(argv: &[String]) -> bool {
         return false;
     }
 
-    let mut help_args = vec!["vp".to_string()];
-    help_args.extend(command_path);
-    help_args.push("--help".to_string());
-
-    let raw_help = match crate::cli::try_parse_args_from(help_args) {
-        Err(error) if matches!(error.kind(), ErrorKind::DisplayHelp) => error.to_string(),
-        _ => return false,
-    };
-
-    let Some(doc) = parse_clap_help_to_doc(&raw_help) else {
-        return false;
-    };
-
-    println!("{}", render_owned_help_doc(&doc));
-    true
+    let mut command_path_refs = Vec::with_capacity(command_path.len());
+    for segment in &command_path {
+        command_path_refs.push(segment.as_str());
+    }
+    print_unified_clap_help_for_path(&command_path_refs)
 }
 
 pub fn should_print_unified_delegate_help(args: &[String]) -> bool {
@@ -689,9 +844,30 @@ pub fn maybe_print_unified_delegate_help(command: &str, args: &[String]) -> bool
     true
 }
 
+pub fn print_unified_clap_help_for_path(command_path: &[&str]) -> bool {
+    let mut help_args = vec!["vp".to_string()];
+    help_args.extend(command_path.iter().map(ToString::to_string));
+    help_args.push("--help".to_string());
+
+    let raw_help = match crate::cli::try_parse_args_from(help_args) {
+        Err(error) if matches!(error.kind(), ErrorKind::DisplayHelp) => error.to_string(),
+        _ => return false,
+    };
+
+    let Some(doc) = parse_clap_help_to_doc(&raw_help) else {
+        return false;
+    };
+
+    println!("{}", render_owned_help_doc(&doc));
+    true
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{has_help_flag_before_terminator, parse_clap_help_to_doc, parse_rows};
+    use super::{
+        has_help_flag_before_terminator, parse_clap_help_to_doc, parse_rows, split_comment_suffix,
+        strip_ansi,
+    };
 
     #[test]
     fn parse_rows_supports_wrapped_option_labels() {
@@ -739,5 +915,44 @@ Options:
     fn help_flag_after_terminator_is_ignored() {
         let args = vec!["vpx".to_string(), "--".to_string(), "--help".to_string()];
         assert!(!has_help_flag_before_terminator(&args));
+    }
+
+    #[test]
+    fn strip_ansi_removes_csi_sequences() {
+        let input = "\u{1b}[1mOptions:\u{1b}[0m";
+        assert_eq!(strip_ansi(input), "Options:");
+    }
+
+    #[test]
+    fn parse_clap_help_with_ansi_sequences() {
+        let raw_help = "\
+\u{1b}[1mAdd packages to dependencies\u{1b}[0m
+
+\u{1b}[1mUsage:\u{1b}[0m vp add [OPTIONS] <PACKAGES>...
+
+\u{1b}[1mArguments:\u{1b}[0m
+  <PACKAGES>...  Packages to add
+
+\u{1b}[1mOptions:\u{1b}[0m
+  -h, --help  Print help
+";
+
+        let doc = parse_clap_help_to_doc(raw_help).expect("should parse clap help text");
+        assert_eq!(doc.usage, "vp add [OPTIONS] <PACKAGES>...");
+        assert_eq!(doc.summary, vec!["Add packages to dependencies"]);
+        assert_eq!(doc.sections.len(), 2);
+    }
+
+    #[test]
+    fn split_comment_suffix_extracts_command_comment() {
+        let line = "  vp env list-remote 20         # List Node.js 20.x versions";
+        let (prefix, suffix) = split_comment_suffix(line).expect("expected comment suffix");
+        assert_eq!(prefix, "  vp env list-remote 20        ");
+        assert_eq!(suffix, " # List Node.js 20.x versions");
+    }
+
+    #[test]
+    fn split_comment_suffix_returns_none_without_comment() {
+        assert!(split_comment_suffix("  vp env list").is_none());
     }
 }

--- a/crates/vite_global_cli/src/js_executor.rs
+++ b/crates/vite_global_cli/src/js_executor.rs
@@ -229,6 +229,7 @@ impl JsExecutor {
     /// when no version source exists in the project directory.
     ///
     /// Use this for read-only / side-effect-free commands like `--version`.
+    #[allow(dead_code)] // kept for future read-only delegations
     pub async fn delegate_with_cli_runtime(
         &mut self,
         project_path: &AbsolutePath,

--- a/crates/vite_global_cli/src/main.rs
+++ b/crates/vite_global_cli/src/main.rs
@@ -17,6 +17,7 @@ mod tips;
 
 use std::process::ExitCode;
 
+use clap::error::{ContextKind, ContextValue};
 use owo_colors::OwoColorize;
 use vite_shared::output;
 
@@ -52,6 +53,40 @@ fn normalize_args(args: Vec<String>) -> Vec<String> {
         // No transformation needed
         _ => args,
     }
+}
+
+fn extract_invalid_subcommand_details(error: &clap::Error) -> Option<(String, Option<String>)> {
+    let invalid_subcommand = match error.get(ContextKind::InvalidSubcommand) {
+        Some(ContextValue::String(value)) => value.as_str(),
+        _ => return None,
+    };
+
+    let suggestion = match error.get(ContextKind::SuggestedSubcommand) {
+        Some(ContextValue::String(value)) => Some(value.to_owned()),
+        Some(ContextValue::Strings(values)) => {
+            vite_shared::string_similarity::pick_best_suggestion(invalid_subcommand, values)
+        }
+        _ => None,
+    };
+
+    Some((invalid_subcommand.to_owned(), suggestion))
+}
+
+fn print_invalid_subcommand_error(error: &clap::Error) -> bool {
+    let Some((invalid_subcommand, suggestion)) = extract_invalid_subcommand_details(error) else {
+        return false;
+    };
+
+    let highlighted_subcommand = invalid_subcommand.bright_blue().to_string();
+    output::error(&format!("Command '{highlighted_subcommand}' not found"));
+
+    if let Some(suggestion) = suggestion {
+        eprintln!();
+        let highlighted_suggestion = format!("`vp {suggestion}`").bright_blue().to_string();
+        eprintln!("Did you mean {highlighted_suggestion}?");
+    }
+
+    true
 }
 
 #[tokio::main]
@@ -97,8 +132,15 @@ async fn main() -> ExitCode {
     let exit_code = match try_parse_args_from(normalized_args) {
         Err(e) => {
             use clap::error::ErrorKind;
-            // Print the clap error/help/version
-            e.print().ok();
+            // Print custom unknown-command output to align with JS CLI, otherwise fall back to clap.
+            let printed = if matches!(e.kind(), ErrorKind::InvalidSubcommand) {
+                print_invalid_subcommand_error(&e)
+            } else {
+                false
+            };
+            if !printed {
+                e.print().ok();
+            }
 
             // --help and --version are "errors" in clap but should exit successfully
             if matches!(e.kind(), ErrorKind::DisplayHelp | ErrorKind::DisplayVersion) {

--- a/crates/vite_shared/src/lib.rs
+++ b/crates/vite_shared/src/lib.rs
@@ -6,6 +6,7 @@ mod home;
 pub mod output;
 mod package_json;
 mod path_env;
+pub mod string_similarity;
 mod tracing;
 
 pub use env_config::{EnvConfig, TestEnvGuard};

--- a/crates/vite_shared/src/string_similarity.rs
+++ b/crates/vite_shared/src/string_similarity.rs
@@ -1,0 +1,51 @@
+//! String similarity helpers shared by CLI crates.
+
+/// Compute Levenshtein distance between two strings.
+#[must_use]
+pub fn levenshtein_distance(left: &str, right: &str) -> usize {
+    let left_chars: Vec<char> = left.chars().collect();
+    let right_chars: Vec<char> = right.chars().collect();
+
+    let mut prev: Vec<usize> = (0..=right_chars.len()).collect();
+    let mut curr = vec![0; right_chars.len() + 1];
+
+    for (i, left_char) in left_chars.iter().enumerate() {
+        curr[0] = i + 1;
+        for (j, right_char) in right_chars.iter().enumerate() {
+            let cost = usize::from(left_char != right_char);
+            let deletion = prev[j + 1] + 1;
+            let insertion = curr[j] + 1;
+            let substitution = prev[j] + cost;
+            curr[j + 1] = deletion.min(insertion).min(substitution);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+
+    prev[right_chars.len()]
+}
+
+/// Pick the best suggestion by Levenshtein distance and then shortest length.
+#[must_use]
+pub fn pick_best_suggestion(input: &str, candidates: &[String]) -> Option<String> {
+    candidates
+        .iter()
+        .min_by_key(|candidate| (levenshtein_distance(input, candidate), candidate.len()))
+        .cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{levenshtein_distance, pick_best_suggestion};
+
+    #[test]
+    fn distance_works_for_simple_inputs() {
+        assert_eq!(levenshtein_distance("fnt", "fmt"), 1);
+        assert_eq!(levenshtein_distance("fnt", "lint"), 2);
+    }
+
+    #[test]
+    fn pick_best_prefers_closest_match() {
+        let candidates = vec!["lint".to_string(), "fmt".to_string()];
+        assert_eq!(pick_best_suggestion("fnt", &candidates), Some("fmt".to_string()));
+    }
+}

--- a/packages/cli/binding/Cargo.toml
+++ b/packages/cli/binding/Cargo.toml
@@ -15,6 +15,7 @@ rustc-hash = { workspace = true }
 napi = { workspace = true }
 napi-derive = { workspace = true }
 petgraph = { workspace = true }
+owo-colors = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }

--- a/packages/cli/binding/src/cli.rs
+++ b/packages/cli/binding/src/cli.rs
@@ -5,7 +5,11 @@
 
 use std::{env, ffi::OsStr, future::Future, iter, path::PathBuf, pin::Pin, sync::Arc};
 
-use clap::{Parser, Subcommand};
+use clap::{
+    Parser, Subcommand,
+    error::{ContextKind, ContextValue, ErrorKind},
+};
+use owo_colors::OwoColorize;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use tokio::fs::write;
@@ -903,9 +907,7 @@ pub async fn main(
     let args_with_program = std::iter::once("vp".to_string()).chain(args_vec.iter().cloned());
     let cli_args = match CLIArgs::try_parse_from(args_with_program) {
         Ok(args) => args,
-        Err(err) => {
-            err.exit();
-        }
+        Err(err) => return handle_cli_parse_error(err),
     };
 
     match cli_args {
@@ -913,6 +915,15 @@ pub async fn main(
         CLIArgs::ViteTask(command) => execute_vite_task_command(command, cwd, options).await,
         CLIArgs::Exec(exec_args) => crate::exec::execute(exec_args, &cwd).await,
     }
+}
+
+fn handle_cli_parse_error(err: clap::Error) -> Result<ExitStatus, Error> {
+    if matches!(err.kind(), ErrorKind::InvalidSubcommand) && print_invalid_subcommand_error(&err) {
+        return Ok(ExitStatus(err.exit_code() as u8));
+    }
+
+    err.print().map_err(|e| Error::Anyhow(e.into()))?;
+    Ok(ExitStatus(err.exit_code() as u8))
 }
 
 fn normalize_help_args(args: Vec<String>) -> Vec<String> {
@@ -931,6 +942,40 @@ fn normalize_help_args(args: Vec<String>) -> Vec<String> {
 
 fn should_print_help(args: &[String]) -> bool {
     args.is_empty() || matches!(args, [arg] if arg == "-h" || arg == "--help")
+}
+
+fn extract_invalid_subcommand_details(error: &clap::Error) -> Option<(String, Option<String>)> {
+    let invalid_subcommand = match error.get(ContextKind::InvalidSubcommand) {
+        Some(ContextValue::String(value)) => value.as_str(),
+        _ => return None,
+    };
+
+    let suggestion = match error.get(ContextKind::SuggestedSubcommand) {
+        Some(ContextValue::String(value)) => Some(value.to_owned()),
+        Some(ContextValue::Strings(values)) => {
+            vite_shared::string_similarity::pick_best_suggestion(invalid_subcommand, values)
+        }
+        _ => None,
+    };
+
+    Some((invalid_subcommand.to_owned(), suggestion))
+}
+
+fn print_invalid_subcommand_error(error: &clap::Error) -> bool {
+    let Some((invalid_subcommand, suggestion)) = extract_invalid_subcommand_details(error) else {
+        return false;
+    };
+
+    let highlighted_subcommand = invalid_subcommand.bright_blue().to_string();
+    output::error(&format!("Command '{highlighted_subcommand}' not found"));
+
+    if let Some(suggestion) = suggestion {
+        eprintln!();
+        let highlighted_suggestion = format!("`vp {suggestion}`").bright_blue().to_string();
+        eprintln!("Did you mean {highlighted_suggestion}?");
+    }
+
+    true
 }
 
 fn print_help() {

--- a/packages/cli/binding/src/exec/workspace.rs
+++ b/packages/cli/binding/src/exec/workspace.rs
@@ -1,5 +1,6 @@
 use std::{collections::BTreeMap, process::Stdio, sync::Arc};
 
+use owo_colors::OwoColorize;
 use petgraph::prelude::DiGraphMap;
 use vite_error::Error;
 use vite_path::AbsolutePathBuf;
@@ -216,10 +217,15 @@ pub(super) async fn execute_exec_workspace(
             ) {
                 Ok(cmd) => cmd,
                 Err(Error::CannotFindBinaryPath(_)) if single_package => {
+                    let command = args.command[0].bright_blue().to_string();
+                    let vp_install = "`vp install`".bright_blue().to_string();
+                    let vpx = "`vpx`".bright_blue().to_string();
                     vite_shared::output::error(&vite_str::format!(
                         "Command '{}' not found in node_modules/.bin\n\n\
-                         Hint: Run 'vp install' to install dependencies, or use 'vpx' for remote fallback.",
-                        args.command[0]
+                         Run {} to install dependencies, or use {} for invoking remote commands.",
+                        command,
+                        vp_install,
+                        vpx
                     ));
                     return Ok(ExitStatus(1));
                 }

--- a/packages/cli/snap-tests-global/cli-helper-message/snap.txt
+++ b/packages/cli/snap-tests-global/cli-helper-message/snap.txt
@@ -1,5 +1,5 @@
 > vp -h # show help message
-Vite+/<semver>
+VITE+ - The Unified Toolchain for the Web
 
 Usage: vp [COMMAND]
 
@@ -44,10 +44,19 @@ Options:
 > vp -V # show version
 VITE+ - The Unified Toolchain for the Web
 
-Package Versions:
-  global vite-plus  v<semver>
-  local vite-plus   Not found
+vp v<semver>
 
+Local vite-plus:
+  vite-plus  Not found
+
+Tools:
+  vite             Not found
+  rolldown         Not found
+  vitest           Not found
+  oxfmt            Not found
+  oxlint           Not found
+  oxlint-tsgolint  Not found
+  tsdown           Not found
 
 > vp install -h # show install help message
 Usage: vp install [OPTIONS] [PACKAGES]... [-- <PASS_THROUGH_ARGS>...]
@@ -292,9 +301,9 @@ Options:
 
 
 > vp env # show env help message
-Manage Node.js versions
-
 Usage: vp env [OPTIONS] [COMMAND]
+
+Manage Node.js versions
 
 Commands:
   default      Set or show the global default Node.js version
@@ -313,10 +322,10 @@ Commands:
   use          Use a specific Node.js version for this shell session
 
 Options:
-      --current  Show current environment information
-      --json     Output in JSON format
-      --print    Print shell snippet to set environment for current session
-  -h, --help     Print help
+  --current   Show current environment information
+  --json      Output in JSON format
+  --print     Print shell snippet to set environment for current session
+  -h, --help  Print help
 
 Examples:
   vp env setup                  # Create shims for node, npm, npx
@@ -351,6 +360,7 @@ Global Packages:
   vp uninstall -g <package>     # Uninstall a global package
   vp update -g [package]        # Update global package(s)
   vp list -g [package]          # List installed global packages
+
 
 > vp upgrade -h # show upgrade help message
 Usage: vp upgrade [OPTIONS] [VERSION]

--- a/packages/cli/snap-tests-global/command-exec/snap.txt
+++ b/packages/cli/snap-tests-global/command-exec/snap.txt
@@ -15,52 +15,33 @@ hi
 hello from shell
 
 > vp exec --help # should show help message
-Execute a command from local node_modules/.bin
-
 Usage: vp exec [OPTIONS] [COMMAND]...
 
+Execute a command from local node_modules/.bin.
+
 Arguments:
-  [COMMAND]...
-          Command and arguments to execute
+  [COMMAND]...  Command and arguments to execute
 
 Options:
-  -r, --recursive
-          Select all packages in the workspace
+  -r, --recursive              Select all packages in the workspace
+  -t, --transitive             Select the current package and its transitive dependencies
+  -w, --workspace-root         Select the workspace root package
+  -F, --filter <FILTERS>       Match packages by name, directory, or glob pattern
+  -c, --shell-mode             Execute the command within a shell environment
+  --parallel                   Run concurrently without topological ordering
+  --reverse                    Reverse execution order
+  --resume-from <RESUME_FROM>  Resume from a specific package
+  --report-summary             Save results to vp-exec-summary.json
+  -h, --help                   Print help (see more with '--help')
 
-  -t, --transitive
-          Select the current package and its transitive dependencies
-
-  -w, --workspace-root
-          Select the workspace root package
-
-  -F, --filter <FILTERS>
-          Match packages by name, directory, or glob pattern.
-          
-            --filter <pattern>        Select by package name (e.g. foo, @scope/*)
-            --filter ./<dir>          Select packages under a directory
-            --filter {<dir>}          Same as ./<dir>, but allows traversal suffixes
-            --filter <pattern>...     Select package and its dependencies
-            --filter ...<pattern>     Select package and its dependents
-            --filter <pattern>^...    Select only the dependencies (exclude the package itself)
-            --filter !<pattern>       Exclude packages matching the pattern
-
-  -c, --shell-mode
-          Execute the command within a shell environment
-
-      --parallel
-          Run concurrently without topological ordering
-
-      --reverse
-          Reverse execution order
-
-      --resume-from <RESUME_FROM>
-          Resume from a specific package
-
-      --report-summary
-          Save results to vp-exec-summary.json
-
-  -h, --help
-          Print help (see a summary with '-h')
+Filter Patterns:
+  --filter <pattern>        Select by package name (e.g. foo, @scope/*)
+  --filter ./<dir>          Select packages under a directory
+  --filter {<dir>}          Same as ./<dir>, but allows traversal suffixes
+  --filter <pattern>...     Select package and its dependencies
+  --filter ...<pattern>     Select package and its dependents
+  --filter <pattern>^...    Select only the dependencies (exclude the package itself)
+  --filter !<pattern>       Exclude packages matching the pattern
 
 Examples:
   vp exec node --version                             # Run local node
@@ -68,6 +49,7 @@ Examples:
   vp exec -c 'tsc --noEmit && prettier --check .'    # Shell mode
   vp exec -r -- tsc --noEmit                         # Run in all workspace packages
   vp exec --filter 'app...' -- tsc                   # Run in filtered packages
+
 
 [1]> vp exec # missing command should error
 error: 'vp exec' requires a command to run
@@ -81,4 +63,4 @@ Examples:
 [1]> vp exec nonexistent-cmd-12345 # command not found error
 error: Command 'nonexistent-cmd-12345' not found in node_modules/.bin
 
-Hint: Run 'vp install' to install dependencies, or use 'vpx' for remote fallback.
+Run `vp install` to install dependencies, or use `vpx` for invoking remote commands.

--- a/packages/cli/snap-tests-global/command-version-no-side-effects/snap.txt
+++ b/packages/cli/snap-tests-global/command-version-no-side-effects/snap.txt
@@ -1,10 +1,19 @@
 > vp --version # should print version
 VITE+ - The Unified Toolchain for the Web
 
-Package Versions:
-  global vite-plus  v<semver>
-  local vite-plus   Not found
+vp v<semver>
 
+Local vite-plus:
+  vite-plus  Not found
+
+Tools:
+  vite             Not found
+  rolldown         Not found
+  vitest           Not found
+  oxfmt            Not found
+  oxlint           Not found
+  oxlint-tsgolint  Not found
+  tsdown           Not found
 
 > test -f .node-version && echo 'FAIL: .node-version was created' || echo 'OK: no .node-version created'
 OK: no .node-version created

--- a/packages/cli/snap-tests/command-exec/snap.txt
+++ b/packages/cli/snap-tests/command-exec/snap.txt
@@ -87,7 +87,7 @@ Examples:
 [1]> vp exec nonexistent-cmd-12345 # command not found error
 error: Command 'nonexistent-cmd-12345' not found in node_modules/.bin
 
-Hint: Run 'vp install' to install dependencies, or use 'vpx' for remote fallback.
+Run `vp install` to install dependencies, or use `vpx` for invoking remote commands.
 
 > vp run foo # vp exec works in package.json scripts
 $ vp exec node -e "console.log(5173)" ⊘ cache disabled

--- a/packages/cli/snap-tests/command-version/snap.txt
+++ b/packages/cli/snap-tests/command-version/snap.txt
@@ -1,7 +1,17 @@
 > vp --version
 VITE+ - The Unified Toolchain for the Web
 
-Package Versions:
-  global vite-plus  Not found
-  local vite-plus   Not found
+vp v<semver>
+
+Local vite-plus:
+  vite-plus  v<semver>
+
+Tools:
+  vite             v<semver>
+  rolldown         v<semver>
+  vitest           v<semver>
+  oxfmt            v<semver>
+  oxlint           v<semver>
+  oxlint-tsgolint  v<semver>
+  tsdown           v<semver>
 

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { VITE_PLUS_NAME } from './utils/constants.js';
 import { renderCliDoc } from './utils/help.js';
 import { detectPackageMetadata } from './utils/package.js';
-import { getVitePlusHeader, log } from './utils/terminal.js';
+import { accent, getVitePlusHeader, log } from './utils/terminal.js';
 
 const require = createRequire(import.meta.url);
 
@@ -21,7 +21,6 @@ interface LocalPackageMetadata {
 }
 
 interface ToolVersionSpec {
-  command: string;
   displayName: string;
   packageName: string;
   bundledVersionKey?: string;
@@ -30,6 +29,11 @@ interface ToolVersionSpec {
 
 function getGlobalVersion(): string | null {
   return process.env.VITE_PLUS_GLOBAL_VERSION ?? null;
+}
+
+function getCliVersion(): string | null {
+  const pkg = resolvePackageJson(VITE_PLUS_NAME, process.cwd());
+  return pkg?.version ?? null;
 }
 
 function getLocalMetadata(cwd: string): LocalPackageMetadata | null {
@@ -92,77 +96,61 @@ function resolveToolVersion(tool: ToolVersionSpec, localPackagePath: string): st
   return null;
 }
 
-function formatToolVersion(tool: ToolVersionSpec, version: string | null): string {
-  return `${tool.displayName} ${version ? `v${version}` : `Not found`}`;
-}
-
 /**
  * Print version information
  */
 export async function printVersion(cwd: string) {
   const globalVersion = getGlobalVersion();
+  const cliVersion = getCliVersion();
   const localMetadata = getLocalMetadata(cwd);
   const localVersion = localMetadata?.version ?? null;
+  const vpVersion = globalVersion ?? cliVersion ?? localVersion ?? 'unknown';
 
-  log((await getVitePlusHeader()) + '\n');
+  log(await getVitePlusHeader());
+  log('');
+  log(`vp v${vpVersion}\n`);
 
   const sections = [
     {
-      title: 'Package Versions',
+      title: 'Local vite-plus',
       rows: [
         {
-          label: 'global vite-plus',
-          description: globalVersion ? `v${globalVersion}` : 'Not found',
-        },
-        {
-          label: 'local vite-plus',
+          label: accent('vite-plus'),
           description: localVersion ? `v${localVersion}` : 'Not found',
         },
       ],
     },
   ];
 
-  if (!localMetadata) {
-    log(renderCliDoc({ sections }));
-    return;
-  }
-
   const tools: ToolVersionSpec[] = [
     {
-      command: 'vite',
       displayName: 'vite',
       packageName: '@voidzero-dev/vite-plus-core',
       bundledVersionKey: 'vite',
     },
     {
-      command: 'rolldown',
       displayName: 'rolldown',
       packageName: '@voidzero-dev/vite-plus-core',
       bundledVersionKey: 'rolldown',
     },
     {
-      command: 'test',
       displayName: 'vitest',
       packageName: '@voidzero-dev/vite-plus-test',
       bundledVersionKey: 'vitest',
     },
     {
-      command: 'fmt',
       displayName: 'oxfmt',
       packageName: 'oxfmt',
     },
     {
-      command: 'lint',
       displayName: 'oxlint',
       packageName: 'oxlint',
     },
     {
-      command: 'tsgolint',
       displayName: 'oxlint-tsgolint',
       packageName: 'oxlint-tsgolint',
     },
     {
-      command: 'pack',
       displayName: 'tsdown',
       packageName: '@voidzero-dev/vite-plus-core',
       bundledVersionKey: 'tsdown',
@@ -171,18 +159,14 @@ export async function printVersion(cwd: string) {
 
   const resolvedTools = tools.map((tool) => ({
     tool,
-    version: resolveToolVersion(tool, localMetadata.path),
+    version: localMetadata ? resolveToolVersion(tool, localMetadata.path) : null,
   }));
-  if (resolvedTools.some(({ tool, version }) => tool.bundledVersionKey && !version)) {
-    log(renderCliDoc({ sections }));
-    return;
-  }
 
   sections.push({
-    title: 'Bundled with vite-plus',
+    title: 'Tools',
     rows: resolvedTools.map(({ tool, version }) => ({
-      label: tool.command,
-      description: formatToolVersion(tool, version),
+      label: accent(tool.displayName),
+      description: version ? `v${version}` : 'Not found',
     })),
   });
 


### PR DESCRIPTION
Another step in providing more consistency for Vite+'s output. This PR:
* Aligns the output of Rust (help) commands with that of JS.
* Aligns and simplifies the output of mistyped commands or mistyped scripts, for example `vp fnt` or `vp exec notfound`.
* Updates the `vp --version` command to print something less confusing now that we only have global `vp` and a local `vite-plus` package.

There is still a lot more todo, and I will do do them in follow ups.