### PR TITLE
chore: Further CLI color adjustments and fixes.

### DIFF
--- a/crates/vite_global_cli/src/cli.rs
+++ b/crates/vite_global_cli/src/cli.rs
@@ -20,6 +20,17 @@ use crate::{
     help,
 };
 
+#[derive(Clone, Copy, Debug)]
+pub struct RenderOptions {
+    pub show_header: bool,
+}
+
+impl Default for RenderOptions {
+    fn default() -> Self {
+        Self { show_header: true }
+    }
+}
+
 /// Vite+ Global CLI
 #[derive(Parser, Debug)]
 #[clap(
@@ -660,51 +671,34 @@ pub enum Commands {
 #[derive(clap::Args, Debug)]
 #[command(after_help = "\
 Examples:
-  vp env setup                  # Create shims for node, npm, npx
-  vp env setup --refresh        # Force refresh shims
-  vp env doctor                 # Check environment configuration
-  vp env default 20.18.0        # Set default Node.js version
-  vp env on                     # Use vite-plus managed Node.js
-  vp env off                    # Prefer system Node.js
-  vp env which node             # Show which node binary will be used
-  vp env pin 20.18.0            # Pin Node.js version in current directory
-  vp env pin lts                # Pin to latest LTS version
-  vp env unpin                  # Remove pinned version
-  vp env list                   # List locally installed Node.js versions
-  vp env list-remote            # List available remote Node.js versions
-  vp env list-remote --lts      # List only LTS versions
-  vp env list-remote 20         # List Node.js 20.x versions
-  vp env install 20.18.0        # Install Node.js 20.18.0
-  vp env install                # Install version from .node-version / package.json
-  vp env install lts            # Install latest LTS version
-  vp env uninstall 20.18.0      # Uninstall Node.js 20.18.0
-  vp env use 20                 # Use Node.js 20 for this shell session
-  vp env use lts                # Use latest LTS for this shell session
-  vp env use                    # Use project version for this shell session
-  vp env use --unset            # Remove session override
-  vp env exec --node 20 node -v # Execute 'node -v' with Node.js 20
-  vp env exec --node lts npm i  # Execute 'npm i' with latest LTS
-  vp env exec node -v           # Shim mode (version auto-resolved)
-  vp env exec npm install       # Shim mode (version auto-resolved)
+  Setup:
+    vp env setup                  # Create shims for node, npm, npx
+    vp env on                     # Use vite-plus managed Node.js
+    vp env print                  # Print shell snippet for this session
 
-Global Packages:
-  vp install -g <package>       # Install a global package
-  vp uninstall -g <package>     # Uninstall a global package
-  vp update -g [package]        # Update global package(s)
-  vp list -g [package]          # List installed global packages")]
+  Manage:
+    vp env pin lts                # Pin to latest LTS version
+    vp env install                # Install version from .node-version / package.json
+    vp env use 20                 # Use Node.js 20 for this shell session
+    vp env use --unset            # Remove session override
+
+  Inspect:
+    vp env current                # Show current resolved environment
+    vp env current --json         # JSON output for automation
+    vp env doctor                 # Check environment configuration
+    vp env which node             # Show which node binary will be used
+    vp env list-remote --lts      # List only LTS versions
+
+  Execute:
+    vp env exec --node lts npm i  # Execute 'npm i' with latest LTS
+    vp env exec node -v           # Shim mode (version auto-resolved)
+
+Related Commands:
+  vp install -g <package>       # Install a package globally
+  vp uninstall -g <package>     # Uninstall a package globally
+  vp update -g [package]        # Update global packages
+  vp list -g [package]          # List global packages")]
 pub struct EnvArgs {
-    /// Show current environment information
-    #[arg(long)]
-    pub current: bool,
-
-    /// Output in JSON format
-    #[arg(long, requires = "current")]
-    pub json: bool,
-
-    /// Print shell snippet to set environment for current session
-    #[arg(long)]
-    pub print: bool,
-
     /// Subcommand (e.g., 'default', 'setup', 'doctor', 'which')
     #[command(subcommand)]
     pub command: Option<EnvSubcommands>,
@@ -713,6 +707,16 @@ pub struct EnvArgs {
 /// Subcommands for the `env` command
 #[derive(clap::Subcommand, Debug)]
 pub enum EnvSubcommands {
+    /// Show current environment information
+    Current {
+        /// Output in JSON format
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Print shell snippet to set environment for current session
+    Print,
+
     /// Set or show the global default Node.js version
     Default {
         /// Version to set as default (e.g., "20.18.0", "lts", "latest")
@@ -1434,6 +1438,15 @@ fn determine_save_dependency_type(
 
 /// Run the CLI command.
 pub async fn run_command(cwd: AbsolutePathBuf, args: Args) -> Result<ExitStatus, Error> {
+    run_command_with_options(cwd, args, RenderOptions::default()).await
+}
+
+/// Run the CLI command with rendering options.
+pub async fn run_command_with_options(
+    cwd: AbsolutePathBuf,
+    args: Args,
+    render_options: RenderOptions,
+) -> Result<ExitStatus, Error> {
     // Handle --version flag (Category B: delegates to JS)
     if args.version {
         return commands::version::execute(cwd).await;
@@ -1442,7 +1455,11 @@ pub async fn run_command(cwd: AbsolutePathBuf, args: Args) -> Result<ExitStatus,
     // If no command provided, show help and exit
     let Some(command) = args.command else {
         // Use custom help formatting to match the JS CLI output
-        command_with_help().print_help().ok();
+        if render_options.show_header {
+            command_with_help().print_help().ok();
+        } else {
+            command_with_help_with_options(render_options).print_help().ok();
+        }
         println!();
         // Return a successful exit status since help was requested implicitly
         return Ok(std::process::ExitStatus::default());
@@ -1477,7 +1494,7 @@ pub async fn run_command(cwd: AbsolutePathBuf, args: Args) -> Result<ExitStatus,
             packages,
             pass_through_args,
         } => {
-            print_runtime_header();
+            print_runtime_header(render_options.show_header);
             // If packages are provided, redirect to Add command
             if let Some(pkgs) = packages
                 && !pkgs.is_empty()
@@ -1796,90 +1813,91 @@ pub async fn run_command(cwd: AbsolutePathBuf, args: Args) -> Result<ExitStatus,
 
         // Category C: Local CLI Delegation (stubs)
         Commands::Dev { args } => {
-            if help::maybe_print_unified_delegate_help("dev", &args) {
+            if help::maybe_print_unified_delegate_help("dev", &args, render_options.show_header) {
                 return Ok(ExitStatus::default());
             }
-            print_runtime_header();
+            print_runtime_header(render_options.show_header);
             commands::delegate::execute(cwd, "dev", &args).await
         }
 
         Commands::Build { args } => {
-            if help::maybe_print_unified_delegate_help("build", &args) {
+            if help::maybe_print_unified_delegate_help("build", &args, render_options.show_header) {
                 return Ok(ExitStatus::default());
             }
-            print_runtime_header();
+            print_runtime_header(render_options.show_header);
             commands::delegate::execute(cwd, "build", &args).await
         }
 
         Commands::Test { args } => {
-            if help::maybe_print_unified_delegate_help("test", &args) {
+            if help::maybe_print_unified_delegate_help("test", &args, render_options.show_header) {
                 return Ok(ExitStatus::default());
             }
-            print_runtime_header();
+            print_runtime_header(render_options.show_header);
             commands::delegate::execute(cwd, "test", &args).await
         }
 
         Commands::Lint { args } => {
-            if help::maybe_print_unified_delegate_help("lint", &args) {
+            if help::maybe_print_unified_delegate_help("lint", &args, render_options.show_header) {
                 return Ok(ExitStatus::default());
             }
-            print_runtime_header();
+            print_runtime_header(render_options.show_header);
             commands::delegate::execute(cwd, "lint", &args).await
         }
 
         Commands::Fmt { args } => {
-            if help::maybe_print_unified_delegate_help("fmt", &args) {
+            if help::maybe_print_unified_delegate_help("fmt", &args, render_options.show_header) {
                 return Ok(ExitStatus::default());
             }
-            print_runtime_header();
+            print_runtime_header(render_options.show_header);
             commands::delegate::execute(cwd, "fmt", &args).await
         }
 
         Commands::Check { args } => {
-            if help::maybe_print_unified_delegate_help("check", &args) {
+            if help::maybe_print_unified_delegate_help("check", &args, render_options.show_header) {
                 return Ok(ExitStatus::default());
             }
-            print_runtime_header();
+            print_runtime_header(render_options.show_header);
             commands::delegate::execute(cwd, "check", &args).await
         }
 
         Commands::Pack { args } => {
-            if help::maybe_print_unified_delegate_help("pack", &args) {
+            if help::maybe_print_unified_delegate_help("pack", &args, render_options.show_header) {
                 return Ok(ExitStatus::default());
             }
-            print_runtime_header();
+            print_runtime_header(render_options.show_header);
             commands::delegate::execute(cwd, "pack", &args).await
         }
 
         Commands::Run { args } => {
-            if help::maybe_print_unified_delegate_help("run", &args) {
+            if help::maybe_print_unified_delegate_help("run", &args, render_options.show_header) {
                 return Ok(ExitStatus::default());
             }
-            print_runtime_header();
+            print_runtime_header(render_options.show_header);
             commands::run_or_delegate::execute(cwd, &args).await
         }
 
         Commands::Exec { args } => {
-            if help::maybe_print_unified_delegate_help("exec", &args) {
+            if help::maybe_print_unified_delegate_help("exec", &args, render_options.show_header) {
                 return Ok(ExitStatus::default());
             }
-            print_runtime_header();
+            print_runtime_header(render_options.show_header);
             commands::delegate::execute(cwd, "exec", &args).await
         }
 
         Commands::Preview { args } => {
-            if help::maybe_print_unified_delegate_help("preview", &args) {
+            if help::maybe_print_unified_delegate_help("preview", &args, render_options.show_header)
+            {
                 return Ok(ExitStatus::default());
             }
-            print_runtime_header();
+            print_runtime_header(render_options.show_header);
             commands::delegate::execute(cwd, "preview", &args).await
         }
 
         Commands::Cache { args } => {
-            if help::maybe_print_unified_delegate_help("cache", &args) {
+            if help::maybe_print_unified_delegate_help("cache", &args, render_options.show_header) {
                 return Ok(ExitStatus::default());
             }
-            print_runtime_header();
+            print_runtime_header(render_options.show_header);
             commands::delegate::execute(cwd, "cache", &args).await
         }
 
@@ -1915,21 +1933,33 @@ pub(crate) fn exit_status(code: i32) -> ExitStatus {
     }
 }
 
-fn print_runtime_header() {
+fn print_runtime_header(show_header: bool) {
+    if !show_header {
+        return;
+    }
     println!("{}", vite_shared::header::vite_plus_header());
     println!();
 }
 
 /// Build a clap Command with custom help formatting matching the JS CLI output.
 pub fn command_with_help() -> clap::Command {
-    apply_custom_help(Args::command())
+    command_with_help_with_options(RenderOptions::default())
+}
+
+/// Build a clap Command with custom help formatting and rendering options.
+pub fn command_with_help_with_options(render_options: RenderOptions) -> clap::Command {
+    apply_custom_help(Args::command(), render_options)
 }
 
 /// Apply custom help formatting to a clap Command to match the JS CLI output.
-fn apply_custom_help(cmd: clap::Command) -> clap::Command {
+fn apply_custom_help(cmd: clap::Command, render_options: RenderOptions) -> clap::Command {
     let after_help = help::render_help_doc(&help::top_level_help_doc());
     let options_heading = help::render_heading("Options");
-    let header = vite_shared::header::vite_plus_header();
+    let header = if render_options.show_header {
+        vite_shared::header::vite_plus_header()
+    } else {
+        String::new()
+    };
     let help_template = format!("{header}{{after-help}}\n{options_heading}\n{{options}}\n");
 
     cmd.after_help(after_help).help_template(help_template)
@@ -1940,7 +1970,16 @@ fn apply_custom_help(cmd: clap::Command) -> clap::Command {
 pub fn try_parse_args_from(
     args: impl IntoIterator<Item = String>,
 ) -> Result<Args, clap::error::Error> {
-    let cmd = apply_custom_help(Args::command());
+    try_parse_args_from_with_options(args, RenderOptions::default())
+}
+
+/// Parse CLI arguments from a custom args iterator with rendering options.
+/// Returns `Err` with the clap error if parsing fails (e.g., unknown command).
+pub fn try_parse_args_from_with_options(
+    args: impl IntoIterator<Item = String>,
+    render_options: RenderOptions,
+) -> Result<Args, clap::error::Error> {
+    let cmd = apply_custom_help(Args::command(), render_options);
     let matches = cmd.try_get_matches_from(args)?;
     Args::from_arg_matches(&matches).map_err(|e| e.into())
 }

--- a/crates/vite_global_cli/src/commands/env/current.rs
+++ b/crates/vite_global_cli/src/commands/env/current.rs
@@ -4,13 +4,14 @@
 
 use std::process::ExitStatus;
 
+use owo_colors::OwoColorize;
 use serde::Serialize;
 use vite_path::AbsolutePathBuf;
 
 use super::config::resolve_version;
-use crate::error::Error;
+use crate::{error::Error, help};
 
-/// JSON output structure for --current --json
+/// JSON output structure for `vp env current --json`
 #[derive(Serialize)]
 struct CurrentEnvInfo {
     version: String,
@@ -26,6 +27,19 @@ struct ToolPaths {
     node: String,
     npm: String,
     npx: String,
+}
+
+fn accent(text: &str) -> String {
+    if help::should_style_help() { text.bright_blue().to_string() } else { text.to_string() }
+}
+
+fn print_rows(title: &str, rows: &[(&str, String)]) {
+    println!("{}", help::render_heading(title));
+    let label_width = rows.iter().map(|(label, _)| label.chars().count()).max().unwrap_or(0);
+    for (label, value) in rows {
+        let padding = " ".repeat(label_width.saturating_sub(label.chars().count()));
+        println!("  {}{}  {value}", accent(label), padding);
+    }
 }
 
 /// Execute the current command.
@@ -70,22 +84,25 @@ pub async fn execute(cwd: AbsolutePathBuf, json: bool) -> Result<ExitStatus, Err
         let json_str = serde_json::to_string_pretty(&info)?;
         println!("{json_str}");
     } else {
-        println!("Node.js Environment");
-        println!("===================");
-        println!();
-        println!("Version: {}", resolution.version);
-        println!("Source: {}", resolution.source);
+        let mut environment_rows =
+            vec![("Version", resolution.version.clone()), ("Source", resolution.source.clone())];
         if let Some(path) = &resolution.source_path {
-            println!("Source Path: {}", path.as_path().display());
+            environment_rows.push(("Source Path", path.as_path().display().to_string()));
         }
         if let Some(root) = &resolution.project_root {
-            println!("Project Root: {}", root.as_path().display());
+            environment_rows.push(("Project Root", root.as_path().display().to_string()));
         }
+
+        print_rows("Environment", &environment_rows);
         println!();
-        println!("Tool Paths:");
-        println!("  node: {}", node_path.as_path().display());
-        println!("  npm: {}", npm_path.as_path().display());
-        println!("  npx: {}", npx_path.as_path().display());
+        print_rows(
+            "Tool Paths",
+            &[
+                ("node", node_path.as_path().display().to_string()),
+                ("npm", npm_path.as_path().display().to_string()),
+                ("npx", npx_path.as_path().display().to_string()),
+            ],
+        );
     }
 
     Ok(ExitStatus::default())

--- a/crates/vite_global_cli/src/commands/env/doctor.rs
+++ b/crates/vite_global_cli/src/commands/env/doctor.rs
@@ -38,14 +38,18 @@ fn print_section(name: &str) {
 /// `status` should be a colored string like "✓".green(), "✗".red(), etc.
 /// Use `" "` for informational lines with no status.
 fn print_check(status: &str, key: &str, value: &str) {
-    println!("  {status} {key:<KEY_WIDTH$}{value}");
+    if status.trim().is_empty() {
+        println!("  {key:<KEY_WIDTH$}{value}");
+    } else if key.trim().is_empty() {
+        println!("  {status} {value}");
+    } else {
+        println!("  {status} {key:<KEY_WIDTH$}{value}");
+    }
 }
 
-/// Print a continuation/hint line (dimmed, aligned to value column).
+/// Print a continuation/hint line (dimmed).
 fn print_hint(text: &str) {
-    // 2 (indent) + 1 (status) + 1 (space) + KEY_WIDTH
-    let indent = 2 + 1 + 1 + KEY_WIDTH;
-    println!("{:indent$}{}", "", text.dimmed());
+    println!("  {}", format!("note: {text}").dimmed());
 }
 
 /// Abbreviate home directory to `~` for display.
@@ -416,24 +420,24 @@ fn print_path_fix(bin_dir: &vite_path::AbsolutePath) {
             home_path
         };
 
-        println!("    {}", "Add to your shell profile (~/.zshrc, ~/.bashrc, etc.):".dimmed());
+        println!("  {}", "Add to your shell profile (~/.zshrc, ~/.bashrc, etc.):".dimmed());
         println!();
-        println!("      . \"{home_path}/env\"");
+        println!("  . \"{home_path}/env\"");
         println!();
-        println!("    {}", "For fish shell, add to ~/.config/fish/config.fish:".dimmed());
+        println!("  {}", "For fish shell, add to ~/.config/fish/config.fish:".dimmed());
         println!();
-        println!("      source \"{home_path}/env.fish\"");
+        println!("  source \"{home_path}/env.fish\"");
         println!();
-        println!("    {}", "Then restart your terminal.".dimmed());
+        println!("  {}", "Then restart your terminal.".dimmed());
     }
 
     #[cfg(windows)]
     {
         let _ = bin_dir;
-        println!("    {}", "Add the bin directory to your PATH via:".dimmed());
-        println!("      System Properties -> Environment Variables -> Path");
+        println!("  {}", "Add the bin directory to your PATH via:".dimmed());
+        println!("  System Properties -> Environment Variables -> Path");
         println!();
-        println!("    {}", "Then restart your terminal.".dimmed());
+        println!("  {}", "Then restart your terminal.".dimmed());
     }
 }
 
@@ -510,29 +514,26 @@ fn print_ide_setup_guidance(bin_dir: &vite_path::AbsolutePath) {
 
         #[cfg(target_os = "macos")]
         {
-            println!("    {}", "macOS:".dimmed());
-            println!("      {}", "Add to ~/.zshenv or ~/.profile:".dimmed());
-            println!("        . \"{home_path}/env\"");
-            println!("      {}", "Then restart your IDE to apply changes.".dimmed());
+            println!("  {}", "macOS:".dimmed());
+            println!("  {}", "Add to ~/.zshenv or ~/.profile:".dimmed());
+            println!("  . \"{home_path}/env\"");
+            println!("  {}", "Then restart your IDE to apply changes.".dimmed());
         }
 
         #[cfg(target_os = "linux")]
         {
-            println!("    {}", "Linux:".dimmed());
-            println!("      {}", "Add to ~/.profile:".dimmed());
-            println!("        . \"{home_path}/env\"");
-            println!(
-                "      {}",
-                "Then log out and log back in for changes to take effect.".dimmed()
-            );
+            println!("  {}", "Linux:".dimmed());
+            println!("  {}", "Add to ~/.profile:".dimmed());
+            println!("  . \"{home_path}/env\"");
+            println!("  {}", "Then log out and log back in for changes to take effect.".dimmed());
         }
 
         // Fallback for other Unix platforms
         #[cfg(not(any(target_os = "macos", target_os = "linux")))]
         {
-            println!("    {}", "Add to your shell profile:".dimmed());
-            println!("      . \"{home_path}/env\"");
-            println!("    {}", "Then restart your IDE to apply changes.".dimmed());
+            println!("  {}", "Add to your shell profile:".dimmed());
+            println!("  . \"{home_path}/env\"");
+            println!("  {}", "Then restart your IDE to apply changes.".dimmed());
         }
     }
 }

--- a/crates/vite_global_cli/src/commands/env/mod.rs
+++ b/crates/vite_global_cli/src/commands/env/mod.rs
@@ -26,13 +26,38 @@ use std::process::ExitStatus;
 
 use vite_path::AbsolutePathBuf;
 
-use crate::{cli::EnvArgs, error::Error};
+use crate::{
+    cli::{EnvArgs, EnvSubcommands},
+    error::Error,
+};
+
+fn print_env_header() {
+    println!("{}", vite_shared::header::vite_plus_header());
+    println!();
+}
+
+fn should_print_env_header(subcommand: &EnvSubcommands) -> bool {
+    match subcommand {
+        EnvSubcommands::Current { json } => !json,
+        EnvSubcommands::List { json } => !json,
+        EnvSubcommands::ListRemote { json, .. } => !json,
+        // Keep these machine-consumable / passthrough commands header-free.
+        EnvSubcommands::Use { .. } | EnvSubcommands::Exec { .. } => false,
+        _ => true,
+    }
+}
 
 /// Execute the env command based on the provided arguments.
 pub async fn execute(cwd: AbsolutePathBuf, args: EnvArgs) -> Result<ExitStatus, Error> {
     // Handle subcommands first
     if let Some(subcommand) = args.command {
+        if should_print_env_header(&subcommand) {
+            print_env_header();
+        }
+
         return match subcommand {
+            crate::cli::EnvSubcommands::Current { json } => current::execute(cwd, json).await,
+            crate::cli::EnvSubcommands::Print => print_env(cwd).await,
             crate::cli::EnvSubcommands::Default { version } => default::execute(cwd, version).await,
             crate::cli::EnvSubcommands::On => on::execute().await,
             crate::cli::EnvSubcommands::Off => off::execute().await,
@@ -111,15 +136,6 @@ pub async fn execute(cwd: AbsolutePathBuf, args: EnvArgs) -> Result<ExitStatus, 
         };
     }
 
-    // Handle flags
-    if args.current {
-        return current::execute(cwd, args.json).await;
-    }
-
-    if args.print {
-        return print_env(cwd).await;
-    }
-
     // No flags provided - show unified help to match `vp env --help`.
     if !crate::help::print_unified_clap_help_for_path(&["env"]) {
         // Fallback to clap's built-in help printer if unified rendering fails.
@@ -137,7 +153,7 @@ pub async fn execute(cwd: AbsolutePathBuf, args: EnvArgs) -> Result<ExitStatus, 
     Ok(ExitStatus::default())
 }
 
-/// Print shell snippet for setting environment (--print flag)
+/// Print shell snippet for setting environment (`vp env print`)
 async fn print_env(cwd: AbsolutePathBuf) -> Result<ExitStatus, Error> {
     // Resolve the Node.js version for the current directory
     let resolution = config::resolve_version(&cwd).await?;

--- a/crates/vite_global_cli/src/commands/env/off.rs
+++ b/crates/vite_global_cli/src/commands/env/off.rs
@@ -5,8 +5,18 @@
 
 use std::process::ExitStatus;
 
+use owo_colors::OwoColorize;
+
 use super::config::{ShimMode, load_config, save_config};
-use crate::error::Error;
+use crate::{error::Error, help};
+
+fn accent_command(command: &str) -> String {
+    if help::should_style_help() {
+        format!("`{}`", command.bright_blue())
+    } else {
+        format!("`{command}`")
+    }
+}
 
 /// Execute the `vp env off` command.
 pub async fn execute() -> Result<ExitStatus, Error> {
@@ -14,7 +24,9 @@ pub async fn execute() -> Result<ExitStatus, Error> {
 
     if config.shim_mode == ShimMode::SystemFirst {
         println!("Shim mode is already set to system-first.");
-        println!("Shims will prefer system Node.js, falling back to managed if not found.");
+        println!(
+            "Shims will prefer system Node.js, falling back to Vite+ managed Node.js if not found."
+        );
         return Ok(ExitStatus::default());
     }
 
@@ -23,8 +35,11 @@ pub async fn execute() -> Result<ExitStatus, Error> {
 
     println!("\u{2713} Shim mode set to system-first.");
     println!();
-    println!("Shims will now prefer system Node.js, falling back to managed if not found.");
-    println!("Run 'vp env on' to always use vite-plus managed Node.js.");
+    println!(
+        "Shims will now prefer system Node.js, falling back to Vite+ managed Node.js if not found."
+    );
+    println!();
+    println!("Run {} to always use the Vite+ managed Node.js.", accent_command("vp env on"));
 
     Ok(ExitStatus::default())
 }

--- a/crates/vite_global_cli/src/commands/env/on.rs
+++ b/crates/vite_global_cli/src/commands/env/on.rs
@@ -4,8 +4,18 @@
 
 use std::process::ExitStatus;
 
+use owo_colors::OwoColorize;
+
 use super::config::{ShimMode, load_config, save_config};
-use crate::error::Error;
+use crate::{error::Error, help};
+
+fn accent_command(command: &str) -> String {
+    if help::should_style_help() {
+        format!("`{}`", command.bright_blue())
+    } else {
+        format!("`{command}`")
+    }
+}
 
 /// Execute the `vp env on` command.
 pub async fn execute() -> Result<ExitStatus, Error> {
@@ -13,7 +23,7 @@ pub async fn execute() -> Result<ExitStatus, Error> {
 
     if config.shim_mode == ShimMode::Managed {
         println!("Shim mode is already set to managed.");
-        println!("Shims will always use vite-plus managed Node.js.");
+        println!("Shims will always use the Vite+ managed Node.js.");
         return Ok(ExitStatus::default());
     }
 
@@ -22,8 +32,9 @@ pub async fn execute() -> Result<ExitStatus, Error> {
 
     println!("\u{2713} Shim mode set to managed.");
     println!();
-    println!("Shims will now always use vite-plus managed Node.js.");
-    println!("Run 'vp env off' to prefer system Node.js instead.");
+    println!("Shims will now always use the Vite+ managed Node.js.");
+    println!();
+    println!("Run {} to prefer system Node.js instead.", accent_command("vp env off"));
 
     Ok(ExitStatus::default())
 }

--- a/crates/vite_global_cli/src/commands/env/setup.rs
+++ b/crates/vite_global_cli/src/commands/env/setup.rs
@@ -15,11 +15,21 @@
 
 use std::process::ExitStatus;
 
+use owo_colors::OwoColorize;
+
 use super::config::{get_bin_dir, get_vite_plus_home};
-use crate::error::Error;
+use crate::{error::Error, help};
 
 /// Tools to create shims for (node, npm, npx, vpx)
 const SHIM_TOOLS: &[&str] = &["node", "npm", "npx", "vpx"];
+
+fn accent_command(command: &str) -> String {
+    if help::should_style_help() {
+        format!("`{}`", command.bright_blue())
+    } else {
+        format!("`{command}`")
+    }
+}
 
 /// Execute the setup command.
 pub async fn execute(refresh: bool, env_only: bool) -> Result<ExitStatus, Error> {
@@ -32,12 +42,16 @@ pub async fn execute(refresh: bool, env_only: bool) -> Result<ExitStatus, Error>
     create_env_files(&vite_plus_home).await?;
 
     if env_only {
+        println!("{}", help::render_heading("Setup"));
+        println!("  Updated shell environment files.");
+        println!("  Run {} to verify setup.", accent_command("vp env doctor"));
         return Ok(ExitStatus::default());
     }
 
     let bin_dir = get_bin_dir()?;
 
-    println!("Setting up vite-plus environment...");
+    println!("{}", help::render_heading("Setup"));
+    println!("  Preparing vite-plus environment.");
     println!();
 
     // Ensure bin directory exists
@@ -65,7 +79,7 @@ pub async fn execute(refresh: bool, env_only: bool) -> Result<ExitStatus, Error>
 
     // Print results
     if !created.is_empty() {
-        println!("Created shims:");
+        println!("{}", help::render_heading("Created Shims"));
         for tool in &created {
             let shim_path = bin_dir.join(shim_filename(tool));
             println!("  {}", shim_path.as_path().display());
@@ -73,13 +87,16 @@ pub async fn execute(refresh: bool, env_only: bool) -> Result<ExitStatus, Error>
     }
 
     if !skipped.is_empty() && !refresh {
-        println!("Skipped existing shims:");
+        if !created.is_empty() {
+            println!();
+        }
+        println!("{}", help::render_heading("Skipped Shims"));
         for tool in &skipped {
             let shim_path = bin_dir.join(shim_filename(tool));
             println!("  {}", shim_path.as_path().display());
         }
         println!();
-        println!("Use --refresh to update existing shims.");
+        println!("  Use --refresh to update existing shims.");
     }
 
     println!();
@@ -419,19 +436,20 @@ fn print_path_instructions(bin_dir: &vite_path::AbsolutePath) {
         home_path
     };
 
-    println!("Add to your shell profile (~/.zshrc, ~/.bashrc, etc.):");
+    println!("{}", help::render_heading("Next Steps"));
+    println!("  Add to your shell profile (~/.zshrc, ~/.bashrc, etc.):");
     println!();
     println!("  . \"{home_path}/env\"");
     println!();
-    println!("For fish shell, add to ~/.config/fish/config.fish:");
+    println!("  For fish shell, add to ~/.config/fish/config.fish:");
     println!();
     println!("  source \"{home_path}/env.fish\"");
     println!();
-    println!("For PowerShell, add to your $PROFILE:");
+    println!("  For PowerShell, add to your $PROFILE:");
     println!();
     println!("  . \"{home_path}/env.ps1\"");
     println!();
-    println!("For IDE support (VS Code, Cursor), ensure bin directory is in system PATH:");
+    println!("  For IDE support (VS Code, Cursor), ensure bin directory is in system PATH:");
 
     #[cfg(target_os = "macos")]
     {
@@ -449,7 +467,10 @@ fn print_path_instructions(bin_dir: &vite_path::AbsolutePath) {
     }
 
     println!();
-    println!("Restart your terminal and IDE, then run 'vp env doctor' to verify.");
+    println!(
+        "  Restart your terminal and IDE, then run {} to verify.",
+        accent_command("vp env doctor")
+    );
 }
 
 #[cfg(test)]

--- a/crates/vite_global_cli/src/help.rs
+++ b/crates/vite_global_cli/src/help.rs
@@ -57,11 +57,37 @@ fn section_lines(title: &'static str, lines: Vec<&'static str>) -> HelpSection {
 
 pub fn render_heading(title: &str) -> String {
     let heading = format!("{title}:");
-    if should_style_help() { heading.bold().to_string() } else { heading }
+    if !should_style_help() {
+        return heading;
+    }
+
+    if should_accent_heading(title) {
+        heading.bold().bright_blue().to_string()
+    } else {
+        heading.bold().to_string()
+    }
 }
 
 fn render_usage_value(usage: &str) -> String {
     if should_style_help() { usage.bold().to_string() } else { usage.to_string() }
+}
+
+fn should_accent_heading(title: &str) -> bool {
+    matches!(
+        title,
+        "Start"
+            | "Develop"
+            | "Execute"
+            | "Build"
+            | "Manage Dependencies"
+            | "Maintain"
+            | "Setup"
+            | "Manage"
+            | "Inspect"
+            | "Examples"
+            | "Options"
+            | "Related Commands"
+    )
 }
 
 pub fn should_style_help() -> bool {
@@ -369,48 +395,150 @@ pub fn top_level_help_doc() -> HelpDoc {
         summary: Vec::new(),
         sections: vec![
             section_rows(
-                "Core Commands",
+                "Start",
                 vec![
                     row("create", "Create a new project from a template"),
-                    row("dev", "Run the development server"),
-                    row("build", "Build for production"),
-                    row("test", "Run tests"),
-                    row("lint", "Lint code"),
-                    row("fmt", "Format code"),
-                    row("check", "Run format, lint, and type checks"),
-                    row("pack", "Build library"),
-                    row("run", "Run tasks"),
-                    row("exec", "Execute a command from local node_modules/.bin"),
-                    row("preview", "Preview production build"),
-                    row("env", "Manage Node.js versions"),
                     row("migrate", "Migrate an existing project to Vite+"),
-                    row("cache", "Manage the task cache"),
-                ],
-            ),
-            section_rows(
-                "Package Manager Commands",
-                vec![
                     row(
                         "install, i",
                         "Install all dependencies, or add packages if package names are provided",
                     ),
-                    row("add", "Add packages to dependencies"),
-                    row("remove, rm, un, uninstall", "Remove packages from dependencies"),
-                    row("dedupe", "Deduplicate dependencies by removing older versions"),
-                    row("dlx", "Execute a package binary without installing it as a dependency"),
-                    row("info, view, show", "View package information from the registry"),
-                    row("link, ln", "Link packages for local development"),
-                    row("list, ls", "List installed packages"),
-                    row("outdated", "Check for outdated packages"),
-                    row("pm", "Forward a command to the package manager"),
-                    row("unlink", "Unlink packages"),
-                    row("update, up", "Update packages to their latest versions"),
-                    row("why, explain", "Show why a package is installed"),
+                    row("env", "Manage Node.js versions"),
                 ],
             ),
             section_rows(
-                "Maintenance Commands",
+                "Develop",
+                vec![
+                    row("dev", "Run the development server"),
+                    row("check", "Run format, lint, and type checks"),
+                    row("lint", "Lint code"),
+                    row("fmt", "Format code"),
+                    row("test", "Run tests"),
+                ],
+            ),
+            section_rows(
+                "Execute",
+                vec![
+                    row("run", "Run tasks"),
+                    row("exec", "Execute a command from local node_modules/.bin"),
+                    row("dlx", "Execute a package binary without installing it as a dependency"),
+                    row("cache", "Manage the task cache"),
+                ],
+            ),
+            section_rows(
+                "Build",
+                vec![
+                    row("build", "Build for production"),
+                    row("pack", "Build library"),
+                    row("preview", "Preview production build"),
+                ],
+            ),
+            section_rows(
+                "Manage Dependencies",
+                vec![
+                    row("add", "Add packages to dependencies"),
+                    row("remove, rm, un, uninstall", "Remove packages from dependencies"),
+                    row("update, up", "Update packages to their latest versions"),
+                    row("dedupe", "Deduplicate dependencies by removing older versions"),
+                    row("outdated", "Check for outdated packages"),
+                    row("list, ls", "List installed packages"),
+                    row("why, explain", "Show why a package is installed"),
+                    row("info, view, show", "View package information from the registry"),
+                    row("link, ln", "Link packages for local development"),
+                    row("unlink", "Unlink packages"),
+                    row("pm", "Forward a command to the package manager"),
+                ],
+            ),
+            section_rows(
+                "Maintain",
                 vec![row("upgrade", "Update vp itself to the latest version")],
+            ),
+        ],
+    }
+}
+
+fn env_help_doc() -> HelpDoc {
+    HelpDoc {
+        usage: "vp env [COMMAND]",
+        summary: vec!["Manage Node.js versions"],
+        sections: vec![
+            section_rows(
+                "Setup",
+                vec![
+                    row("setup", "Create or update shims in VITE_PLUS_HOME/bin"),
+                    row("on", "Enable managed mode - shims always use vite-plus managed Node.js"),
+                    row(
+                        "off",
+                        "Enable system-first mode - shims prefer system Node.js, fallback to managed",
+                    ),
+                    row("print", "Print shell snippet to set environment for current session"),
+                ],
+            ),
+            section_rows(
+                "Manage",
+                vec![
+                    row("default", "Set or show the global default Node.js version"),
+                    row(
+                        "pin",
+                        "Pin a Node.js version in the current directory (creates .node-version)",
+                    ),
+                    row(
+                        "unpin",
+                        "Remove the .node-version file from current directory (alias for `pin --unpin`)",
+                    ),
+                    row("use", "Use a specific Node.js version for this shell session"),
+                    row("install", "Install a Node.js version [aliases: i]"),
+                    row("uninstall", "Uninstall a Node.js version [aliases: uni]"),
+                    row("exec", "Execute a command with a specific Node.js version [aliases: run]"),
+                ],
+            ),
+            section_rows(
+                "Inspect",
+                vec![
+                    row("current", "Show current environment information"),
+                    row("doctor", "Run diagnostics and show environment status"),
+                    row("which", "Show path to the tool that would be executed"),
+                    row("list", "List locally installed Node.js versions [aliases: ls]"),
+                    row(
+                        "list-remote",
+                        "List available Node.js versions from the registry [aliases: ls-remote]",
+                    ),
+                ],
+            ),
+            section_lines(
+                "Examples",
+                vec![
+                    "  Setup:",
+                    "    vp env setup                  # Create shims for node, npm, npx",
+                    "    vp env on                     # Use vite-plus managed Node.js",
+                    "    vp env print                  # Print shell snippet for this session",
+                    "",
+                    "  Manage:",
+                    "    vp env pin lts                # Pin to latest LTS version",
+                    "    vp env install                # Install version from .node-version / package.json",
+                    "    vp env use 20                 # Use Node.js 20 for this shell session",
+                    "    vp env use --unset            # Remove session override",
+                    "",
+                    "  Inspect:",
+                    "    vp env current                # Show current resolved environment",
+                    "    vp env current --json         # JSON output for automation",
+                    "    vp env doctor                 # Check environment configuration",
+                    "    vp env which node             # Show which node binary will be used",
+                    "    vp env list-remote --lts      # List only LTS versions",
+                    "",
+                    "  Execute:",
+                    "    vp env exec --node lts npm i  # Execute 'npm i' with latest LTS",
+                    "    vp env exec node -v           # Shim mode (version auto-resolved)",
+                ],
+            ),
+            section_lines(
+                "Related Commands",
+                vec![
+                    "  vp install -g <package>       # Install a package globally",
+                    "  vp uninstall -g <package>     # Uninstall a package globally",
+                    "  vp update -g [package]        # Update global packages",
+                    "  vp list -g [package]          # List global packages",
+                ],
             ),
         ],
     }
@@ -820,6 +948,13 @@ pub fn maybe_print_unified_clap_subcommand_help(argv: &[String]) -> bool {
         return false;
     }
 
+    if command_path.len() == 1 && command_path[0] == "env" {
+        println!("{}", vite_shared::header::vite_plus_header());
+        println!();
+        println!("{}", render_help_doc(&env_help_doc()));
+        return true;
+    }
+
     let mut command_path_refs = Vec::with_capacity(command_path.len());
     for segment in &command_path {
         command_path_refs.push(segment.as_str());
@@ -831,7 +966,11 @@ pub fn should_print_unified_delegate_help(args: &[String]) -> bool {
     matches!(args, [arg] if is_help_flag(arg))
 }
 
-pub fn maybe_print_unified_delegate_help(command: &str, args: &[String]) -> bool {
+pub fn maybe_print_unified_delegate_help(
+    command: &str,
+    args: &[String],
+    show_header: bool,
+) -> bool {
     if !should_print_unified_delegate_help(args) {
         return false;
     }
@@ -840,13 +979,22 @@ pub fn maybe_print_unified_delegate_help(command: &str, args: &[String]) -> bool
         return false;
     };
 
-    println!("{}", vite_shared::header::vite_plus_header());
-    println!();
+    if show_header {
+        println!("{}", vite_shared::header::vite_plus_header());
+        println!();
+    }
     println!("{}", render_help_doc(&doc));
     true
 }
 
 pub fn print_unified_clap_help_for_path(command_path: &[&str]) -> bool {
+    if command_path == ["env"] {
+        println!("{}", vite_shared::header::vite_plus_header());
+        println!();
+        println!("{}", render_help_doc(&env_help_doc()));
+        return true;
+    }
+
     let mut help_args = vec!["vp".to_string()];
     help_args.extend(command_path.iter().map(ToString::to_string));
     help_args.push("--help".to_string());

--- a/crates/vite_global_cli/src/main.rs
+++ b/crates/vite_global_cli/src/main.rs
@@ -15,14 +15,19 @@ mod js_executor;
 mod shim;
 mod tips;
 
-use std::process::ExitCode;
+use std::{
+    io::{IsTerminal, Write},
+    process::{ExitCode, ExitStatus},
+};
 
 use clap::error::{ContextKind, ContextValue};
 use owo_colors::OwoColorize;
 use vite_shared::output;
 
-use crate::cli::run_command;
 pub use crate::cli::try_parse_args_from;
+use crate::cli::{
+    RenderOptions, run_command, run_command_with_options, try_parse_args_from_with_options,
+};
 
 /// Normalize CLI arguments:
 /// - `vp list ...` / `vp ls ...` → `vp pm list ...`
@@ -55,7 +60,12 @@ fn normalize_args(args: Vec<String>) -> Vec<String> {
     }
 }
 
-fn extract_invalid_subcommand_details(error: &clap::Error) -> Option<(String, Option<String>)> {
+struct InvalidSubcommandDetails {
+    invalid_subcommand: String,
+    suggestion: Option<String>,
+}
+
+fn extract_invalid_subcommand_details(error: &clap::Error) -> Option<InvalidSubcommandDetails> {
     let invalid_subcommand = match error.get(ContextKind::InvalidSubcommand) {
         Some(ContextValue::String(value)) => value.as_str(),
         _ => return None,
@@ -69,24 +79,143 @@ fn extract_invalid_subcommand_details(error: &clap::Error) -> Option<(String, Op
         _ => None,
     };
 
-    Some((invalid_subcommand.to_owned(), suggestion))
+    Some(InvalidSubcommandDetails { invalid_subcommand: invalid_subcommand.to_owned(), suggestion })
 }
 
-fn print_invalid_subcommand_error(error: &clap::Error) -> bool {
-    let Some((invalid_subcommand, suggestion)) = extract_invalid_subcommand_details(error) else {
+fn print_invalid_subcommand_error(details: &InvalidSubcommandDetails) {
+    println!("{}", vite_shared::header::vite_plus_header());
+    println!();
+
+    let highlighted_subcommand = details.invalid_subcommand.bright_blue().to_string();
+    output::error(&format!("Command '{highlighted_subcommand}' not found"));
+}
+
+fn is_affirmative_response(input: &str) -> bool {
+    matches!(input.trim().to_ascii_lowercase().as_str(), "y" | "yes" | "ok" | "true" | "1")
+}
+
+fn should_prompt_for_correction() -> bool {
+    std::io::stdin().is_terminal() && std::io::stderr().is_terminal()
+}
+
+fn prompt_to_run_suggested_command(suggestion: &str) -> bool {
+    if !should_prompt_for_correction() {
+        return false;
+    }
+
+    eprintln!();
+    let highlighted_suggestion = format!("`vp {suggestion}`").bright_blue().to_string();
+    eprint!("Do you want to run {highlighted_suggestion}? (y/N): ");
+    if std::io::stderr().flush().is_err() {
+        return false;
+    }
+
+    let Some(input) = read_confirmation_input() else {
+        return false;
+    };
+
+    is_affirmative_response(input.trim())
+}
+
+fn read_confirmation_input() -> Option<String> {
+    let mut input = String::new();
+    std::io::stdin().read_line(&mut input).ok()?;
+    Some(input)
+}
+
+fn replace_top_level_typoed_subcommand(
+    raw_args: &[String],
+    invalid_subcommand: &str,
+    suggestion: &str,
+) -> Option<Vec<String>> {
+    let index = raw_args.iter().position(|arg| !arg.starts_with('-'))?;
+    if raw_args.get(index)? != invalid_subcommand {
+        return None;
+    }
+
+    let mut corrected = raw_args.to_vec();
+    corrected[index] = suggestion.to_owned();
+    Some(corrected)
+}
+
+fn exit_status_to_exit_code(exit_status: ExitStatus) -> ExitCode {
+    if exit_status.success() {
+        ExitCode::SUCCESS
+    } else {
+        #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+        exit_status.code().map_or(ExitCode::FAILURE, |c| ExitCode::from(c as u8))
+    }
+}
+
+async fn run_corrected_args(cwd: &vite_path::AbsolutePathBuf, raw_args: &[String]) -> ExitCode {
+    let render_options = RenderOptions { show_header: false };
+    let args_with_program = std::iter::once("vp".to_string()).chain(raw_args.iter().cloned());
+    let normalized_args = normalize_args(args_with_program.collect());
+
+    let parsed = match try_parse_args_from_with_options(normalized_args, render_options) {
+        Ok(args) => args,
+        Err(e) => {
+            e.print().ok();
+            #[allow(clippy::cast_sign_loss)]
+            return ExitCode::from(e.exit_code() as u8);
+        }
+    };
+
+    match run_command_with_options(cwd.clone(), parsed, render_options).await {
+        Ok(exit_status) => exit_status_to_exit_code(exit_status),
+        Err(e) => {
+            if matches!(&e, error::Error::UserMessage(_)) {
+                eprintln!("{e}");
+            } else {
+                output::error(&format!("{e}"));
+            }
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn extract_unknown_argument(error: &clap::Error) -> Option<String> {
+    match error.get(ContextKind::InvalidArg) {
+        Some(ContextValue::String(value)) => Some(value.to_owned()),
+        _ => None,
+    }
+}
+
+fn has_pass_as_value_suggestion(error: &clap::Error) -> bool {
+    let contains_pass_as_value = |suggestion: &str| suggestion.contains("as a value");
+
+    match error.get(ContextKind::Suggested) {
+        Some(ContextValue::String(suggestion)) => contains_pass_as_value(suggestion),
+        Some(ContextValue::Strings(suggestions)) => {
+            suggestions.iter().any(|suggestion| contains_pass_as_value(suggestion))
+        }
+        Some(ContextValue::StyledStr(suggestion)) => {
+            contains_pass_as_value(&suggestion.to_string())
+        }
+        Some(ContextValue::StyledStrs(suggestions)) => {
+            suggestions.iter().any(|suggestion| contains_pass_as_value(&suggestion.to_string()))
+        }
+        _ => false,
+    }
+}
+
+fn print_unknown_argument_error(error: &clap::Error) -> bool {
+    let Some(invalid_argument) = extract_unknown_argument(error) else {
         return false;
     };
 
     println!("{}", vite_shared::header::vite_plus_header());
     println!();
 
-    let highlighted_subcommand = invalid_subcommand.bright_blue().to_string();
-    output::error(&format!("Command '{highlighted_subcommand}' not found"));
+    let highlighted_argument = invalid_argument.bright_blue().to_string();
+    output::error(&format!("Unexpected argument '{highlighted_argument}'"));
 
-    if let Some(suggestion) = suggestion {
+    if has_pass_as_value_suggestion(error) {
         eprintln!();
-        let highlighted_suggestion = format!("`vp {suggestion}`").bright_blue().to_string();
-        eprintln!("Did you mean {highlighted_suggestion}?");
+        let pass_through_argument = format!("-- {invalid_argument}");
+        let highlighted_pass_through_argument =
+            format!("`{}`", pass_through_argument.bright_blue());
+        eprintln!("Use {highlighted_pass_through_argument} to pass the argument as a value");
     }
 
     true
@@ -135,54 +264,141 @@ async fn main() -> ExitCode {
     let exit_code = match try_parse_args_from(normalized_args) {
         Err(e) => {
             use clap::error::ErrorKind;
-            // Print custom unknown-command output to align with JS CLI, otherwise fall back to clap.
-            let printed = if matches!(e.kind(), ErrorKind::InvalidSubcommand) {
-                print_invalid_subcommand_error(&e)
-            } else {
-                false
-            };
-            if !printed {
-                e.print().ok();
-            }
 
-            // --help and --version are "errors" in clap but should exit successfully
+            // --help and --version are clap "errors" but should exit successfully.
             if matches!(e.kind(), ErrorKind::DisplayHelp | ErrorKind::DisplayVersion) {
+                e.print().ok();
                 ExitCode::SUCCESS
+            } else if matches!(e.kind(), ErrorKind::InvalidSubcommand) {
+                if let Some(details) = extract_invalid_subcommand_details(&e) {
+                    print_invalid_subcommand_error(&details);
+
+                    if let Some(suggestion) = &details.suggestion {
+                        if let Some(corrected_raw_args) = replace_top_level_typoed_subcommand(
+                            &tip_context.raw_args,
+                            &details.invalid_subcommand,
+                            suggestion,
+                        ) {
+                            if prompt_to_run_suggested_command(suggestion) {
+                                tip_context.raw_args = corrected_raw_args.clone();
+                                run_corrected_args(&cwd, &corrected_raw_args).await
+                            } else {
+                                let code = e.exit_code();
+                                tip_context.clap_error = Some(e);
+                                #[allow(clippy::cast_sign_loss)]
+                                ExitCode::from(code as u8)
+                            }
+                        } else {
+                            let code = e.exit_code();
+                            tip_context.clap_error = Some(e);
+                            #[allow(clippy::cast_sign_loss)]
+                            ExitCode::from(code as u8)
+                        }
+                    } else {
+                        let code = e.exit_code();
+                        tip_context.clap_error = Some(e);
+                        #[allow(clippy::cast_sign_loss)]
+                        ExitCode::from(code as u8)
+                    }
+                } else {
+                    e.print().ok();
+                    let code = e.exit_code();
+                    tip_context.clap_error = Some(e);
+                    #[allow(clippy::cast_sign_loss)]
+                    ExitCode::from(code as u8)
+                }
+            } else if matches!(e.kind(), ErrorKind::UnknownArgument) {
+                if !print_unknown_argument_error(&e) {
+                    e.print().ok();
+                }
+                let code = e.exit_code();
+                tip_context.clap_error = Some(e);
+                #[allow(clippy::cast_sign_loss)]
+                ExitCode::from(code as u8)
             } else {
+                e.print().ok();
                 let code = e.exit_code();
                 tip_context.clap_error = Some(e);
                 #[allow(clippy::cast_sign_loss)]
                 ExitCode::from(code as u8)
             }
         }
-        Ok(args) => {
-            match run_command(cwd.clone(), args).await {
-                Ok(exit_status) => {
-                    if exit_status.success() {
-                        ExitCode::SUCCESS
-                    } else {
-                        // Exit codes are typically 0-255 on Unix systems
-                        #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-                        exit_status.code().map_or(ExitCode::FAILURE, |c| ExitCode::from(c as u8))
-                    }
+        Ok(args) => match run_command(cwd.clone(), args).await {
+            Ok(exit_status) => exit_status_to_exit_code(exit_status),
+            Err(e) => {
+                if matches!(&e, error::Error::UserMessage(_)) {
+                    eprintln!("{e}");
+                } else {
+                    output::error(&format!("{e}"));
                 }
-                Err(e) => {
-                    if matches!(&e, error::Error::UserMessage(_)) {
-                        eprintln!("{e}");
-                    } else {
-                        output::error(&format!("{e}"));
-                    }
-                    ExitCode::FAILURE
-                }
+                ExitCode::FAILURE
             }
-        }
+        },
     };
 
     tip_context.exit_code = if exit_code == ExitCode::SUCCESS { 0 } else { 1 };
 
     if let Some(tip) = tips::get_tip(&tip_context) {
-        eprintln!("\n{}", format!("Tip: {tip}").bright_black());
+        eprintln!("\n{} {}", "tip:".bright_black().bold(), tip.bright_black());
     }
 
     exit_code
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::error::ErrorKind;
+
+    use super::{
+        extract_unknown_argument, has_pass_as_value_suggestion, is_affirmative_response,
+        replace_top_level_typoed_subcommand, try_parse_args_from,
+    };
+
+    #[test]
+    fn unknown_argument_detected_without_pass_as_value_hint() {
+        let error = try_parse_args_from(["vp".to_string(), "--cache".to_string()])
+            .expect_err("Expected parse error");
+        assert_eq!(error.kind(), ErrorKind::UnknownArgument);
+        assert_eq!(extract_unknown_argument(&error).as_deref(), Some("--cache"));
+        assert!(!has_pass_as_value_suggestion(&error));
+    }
+
+    #[test]
+    fn unknown_argument_detected_with_pass_as_value_hint() {
+        let error = try_parse_args_from([
+            "vp".to_string(),
+            "remove".to_string(),
+            "--stream".to_string(),
+            "foo".to_string(),
+        ])
+        .expect_err("Expected parse error");
+        assert_eq!(error.kind(), ErrorKind::UnknownArgument);
+        assert_eq!(extract_unknown_argument(&error).as_deref(), Some("--stream"));
+        assert!(has_pass_as_value_suggestion(&error));
+    }
+
+    #[test]
+    fn affirmative_response_detection() {
+        assert!(is_affirmative_response("y"));
+        assert!(is_affirmative_response("yes"));
+        assert!(is_affirmative_response("Y"));
+        assert!(!is_affirmative_response("Sure"));
+        assert!(!is_affirmative_response("n"));
+        assert!(!is_affirmative_response(""));
+    }
+
+    #[test]
+    fn replace_top_level_typoed_subcommand_preserves_trailing_args() {
+        let raw_args = vec!["fnt".to_string(), "--write".to_string(), "src".to_string()];
+        let corrected = replace_top_level_typoed_subcommand(&raw_args, "fnt", "fmt")
+            .expect("Expected typoed command to be replaced");
+        assert_eq!(corrected, vec!["fmt".to_string(), "--write".to_string(), "src".to_string()]);
+    }
+
+    #[test]
+    fn replace_top_level_typoed_subcommand_skips_nested_subcommands() {
+        let raw_args = vec!["env".to_string(), "typo".to_string()];
+        let corrected = replace_top_level_typoed_subcommand(&raw_args, "typo", "on");
+        assert!(corrected.is_none());
+    }
 }

--- a/crates/vite_shared/src/header.rs
+++ b/crates/vite_shared/src/header.rs
@@ -3,7 +3,7 @@
 //! Header coloring behavior:
 //! - Colorization and truecolor capability gates
 //! - Foreground color OSC query (`ESC ] 10 ; ? ESC \\`) with timeout
-//! - ANSI magenta palette query (`ESC ] 4 ; 5 ; ? ESC \\`) with timeout
+//! - ANSI palette queries for blue/magenta with timeout
 //! - Gradient/fade generation and RGB ANSI coloring
 
 use std::{io::IsTerminal, sync::OnceLock};
@@ -23,8 +23,9 @@ const RESET: &str = "\x1b[0m";
 const HEADER_SUFFIX: &str = " - The Unified Toolchain for the Web";
 
 const RESET_FG: &str = "\x1b[39m";
+const DEFAULT_BLUE: Rgb = Rgb(88, 146, 255);
 const DEFAULT_MAGENTA: Rgb = Rgb(187, 116, 247);
-#[cfg(unix)]
+const ANSI_BLUE_INDEX: u8 = 4;
 const ANSI_MAGENTA_INDEX: u8 = 5;
 const HEADER_SUFFIX_FADE_GAMMA: f64 = 1.35;
 
@@ -34,8 +35,12 @@ static HEADER_COLORS: OnceLock<HeaderColors> = OnceLock::new();
 struct Rgb(u8, u8, u8);
 
 struct HeaderColors {
-    magenta: Rgb,
+    blue: Rgb,
     suffix_gradient: Vec<Rgb>,
+}
+
+fn bold(text: &str, enabled: bool) -> String {
+    if enabled { format!("\x1b[1m{text}\x1b[22m") } else { text.to_string() }
 }
 
 fn fg_rgb(color: Rgb) -> String {
@@ -68,6 +73,32 @@ fn gradient_eased(count: usize, start: Rgb, end: Rgb, gamma: f64) -> Vec<Rgb> {
                 lerp(start.1 as f64, end.1 as f64, t).round() as u8,
                 lerp(start.2 as f64, end.2 as f64, t).round() as u8,
             )
+        })
+        .collect()
+}
+
+fn gradient_three_stop(count: usize, start: Rgb, middle: Rgb, end: Rgb, gamma: f64) -> Vec<Rgb> {
+    let n = count.max(1);
+    let denom = (n - 1).max(1) as f64;
+
+    (0..n)
+        .map(|i| {
+            let t = i as f64 / denom;
+            if t <= 0.5 {
+                let local_t = (t / 0.5).powf(gamma);
+                Rgb(
+                    lerp(start.0 as f64, middle.0 as f64, local_t).round() as u8,
+                    lerp(start.1 as f64, middle.1 as f64, local_t).round() as u8,
+                    lerp(start.2 as f64, middle.2 as f64, local_t).round() as u8,
+                )
+            } else {
+                let local_t = ((t - 0.5) / 0.5).powf(gamma);
+                Rgb(
+                    lerp(middle.0 as f64, end.0 as f64, local_t).round() as u8,
+                    lerp(middle.1 as f64, end.1 as f64, local_t).round() as u8,
+                    lerp(middle.2 as f64, end.2 as f64, local_t).round() as u8,
+                )
+            }
         })
         .collect()
 }
@@ -137,7 +168,7 @@ fn parse_osc4_rgb(buffer: &str, index: u8) -> Option<Rgb> {
 }
 
 #[cfg(unix)]
-fn query_terminal_colors() -> (Option<Rgb>, Option<Rgb>) {
+fn query_terminal_colors(palette_indices: &[u8]) -> (Option<Rgb>, Vec<(u8, Rgb)>) {
     use std::{
         fs::OpenOptions,
         os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd},
@@ -150,16 +181,16 @@ fn query_terminal_colors() -> (Option<Rgb>, Option<Rgb>) {
     };
 
     if std::env::var_os("CI").is_some() {
-        return (None, None);
+        return (None, vec![]);
     }
 
     let mut tty = match OpenOptions::new().read(true).write(true).open("/dev/tty") {
         Ok(file) => file,
-        Err(_) => return (None, None),
+        Err(_) => return (None, vec![]),
     };
 
     if !std::io::stdout().is_terminal() {
-        return (None, None);
+        return (None, vec![]);
     }
 
     struct RawGuard {
@@ -177,28 +208,32 @@ fn query_terminal_colors() -> (Option<Rgb>, Option<Rgb>) {
 
     let original = match tcgetattr(tty.as_fd()) {
         Ok(value) => value,
-        Err(_) => return (None, None),
+        Err(_) => return (None, vec![]),
     };
     let mut raw = original.clone();
     cfmakeraw(&mut raw);
     if tcsetattr(tty.as_fd(), SetArg::TCSANOW, &raw).is_err() {
-        return (None, None);
+        return (None, vec![]);
     }
     let _guard = RawGuard { fd: tty.as_raw_fd(), original };
 
-    let query = format!("{ESC}]10;?{ESC}\\{ESC}]4;{ANSI_MAGENTA_INDEX};?{ESC}\\");
+    let mut query = format!("{ESC}]10;?{ESC}\\");
+    for index in palette_indices {
+        query.push_str(&format!("{ESC}]4;{index};?{ESC}\\"));
+    }
     if tty.write_all(query.as_bytes()).is_err() {
-        return (None, None);
+        return (None, vec![]);
     }
     if tty.flush().is_err() {
-        return (None, None);
+        return (None, vec![]);
     }
 
     let deadline = Instant::now() + Duration::from_millis(100);
     let mut last_data = Instant::now();
     let mut buffer = String::new();
     let mut foreground = None;
-    let mut magenta = None;
+    let mut palette_colors: Vec<(u8, Option<Rgb>)> =
+        palette_indices.iter().copied().map(|index| (index, None)).collect();
 
     while Instant::now() < deadline {
         let remaining = deadline.saturating_duration_since(Instant::now());
@@ -239,40 +274,68 @@ fn query_terminal_colors() -> (Option<Rgb>, Option<Rgb>) {
         if foreground.is_none() {
             foreground = parse_osc10_rgb(&buffer);
         }
-        if magenta.is_none() {
-            magenta = parse_osc4_rgb(&buffer, ANSI_MAGENTA_INDEX);
+        for (index, color) in &mut palette_colors {
+            if color.is_none() {
+                *color = parse_osc4_rgb(&buffer, *index);
+            }
         }
 
-        if foreground.is_some() && magenta.is_some() {
+        if foreground.is_some() && palette_colors.iter().all(|(_, color)| color.is_some()) {
             break;
         }
     }
 
-    (foreground, magenta)
+    let resolved = palette_colors
+        .into_iter()
+        .filter_map(|(index, color)| color.map(|rgb| (index, rgb)))
+        .collect();
+    (foreground, resolved)
 }
 
 #[cfg(not(unix))]
-fn query_terminal_colors() -> (Option<Rgb>, Option<Rgb>) {
-    (None, None)
+fn query_terminal_colors(_palette_indices: &[u8]) -> (Option<Rgb>, Vec<(u8, Rgb)>) {
+    (None, vec![])
+}
+
+fn palette_color(palette: &[(u8, Rgb)], index: u8) -> Option<Rgb> {
+    palette.iter().find_map(|(palette_index, color)| (*palette_index == index).then_some(*color))
 }
 
 fn get_header_colors() -> &'static HeaderColors {
     HEADER_COLORS.get_or_init(|| {
-        let (foreground, magenta) = query_terminal_colors();
-        let magenta = magenta.unwrap_or(DEFAULT_MAGENTA);
+        let (foreground, palette) = query_terminal_colors(&[ANSI_BLUE_INDEX, ANSI_MAGENTA_INDEX]);
+        let blue = palette_color(&palette, ANSI_BLUE_INDEX).unwrap_or(DEFAULT_BLUE);
+        let magenta = palette_color(&palette, ANSI_MAGENTA_INDEX).unwrap_or(DEFAULT_MAGENTA);
 
         let suffix_gradient = match foreground {
-            Some(color) => gradient_eased(
+            Some(color) => gradient_three_stop(
                 HEADER_SUFFIX.chars().count(),
+                blue,
                 magenta,
                 color,
                 HEADER_SUFFIX_FADE_GAMMA,
             ),
-            None => vec![magenta; HEADER_SUFFIX.chars().count()],
+            None => gradient_eased(
+                HEADER_SUFFIX.chars().count(),
+                blue,
+                magenta,
+                HEADER_SUFFIX_FADE_GAMMA,
+            ),
         };
 
-        HeaderColors { magenta, suffix_gradient }
+        HeaderColors { blue, suffix_gradient }
     })
+}
+
+fn render_header_variant(
+    primary: Rgb,
+    suffix_colors: &[Rgb],
+    prefix_bold: bool,
+    suffix_bold: bool,
+) -> String {
+    let vite_plus = format!("{}VITE+{RESET_FG}", fg_rgb(primary));
+    let suffix = colorize(HEADER_SUFFIX, suffix_colors);
+    format!("{}{}", bold(&vite_plus, prefix_bold), bold(&suffix, suffix_bold))
 }
 
 /// Render the Vite+ CLI header string with JS-parity coloring behavior.
@@ -283,9 +346,7 @@ pub fn vite_plus_header() -> String {
     }
 
     let header_colors = get_header_colors();
-    let suffix = colorize(HEADER_SUFFIX, &header_colors.suffix_gradient);
-    let vite_plus = format!("{}VITE+{RESET_FG}", fg_rgb(header_colors.magenta));
-    format!("\x1b[1m{vite_plus}{suffix}\x1b[22m")
+    render_header_variant(header_colors.blue, &header_colors.suffix_gradient, true, true)
 }
 
 #[cfg(all(test, unix))]

--- a/packages/cli/binding/src/cli.rs
+++ b/packages/cli/binding/src/cli.rs
@@ -921,6 +921,9 @@ fn handle_cli_parse_error(err: clap::Error) -> Result<ExitStatus, Error> {
     if matches!(err.kind(), ErrorKind::InvalidSubcommand) && print_invalid_subcommand_error(&err) {
         return Ok(ExitStatus(err.exit_code() as u8));
     }
+    if matches!(err.kind(), ErrorKind::UnknownArgument) && print_unknown_argument_error(&err) {
+        return Ok(ExitStatus(err.exit_code() as u8));
+    }
 
     err.print().map_err(|e| Error::Anyhow(e.into()))?;
     Ok(ExitStatus(err.exit_code() as u8))
@@ -978,6 +981,50 @@ fn print_invalid_subcommand_error(error: &clap::Error) -> bool {
     true
 }
 
+fn extract_unknown_argument(error: &clap::Error) -> Option<String> {
+    match error.get(ContextKind::InvalidArg) {
+        Some(ContextValue::String(value)) => Some(value.to_owned()),
+        _ => None,
+    }
+}
+
+fn has_pass_as_value_suggestion(error: &clap::Error) -> bool {
+    let contains_pass_as_value = |suggestion: &str| suggestion.contains("as a value");
+
+    match error.get(ContextKind::Suggested) {
+        Some(ContextValue::String(suggestion)) => contains_pass_as_value(suggestion),
+        Some(ContextValue::Strings(suggestions)) => {
+            suggestions.iter().any(|suggestion| contains_pass_as_value(suggestion))
+        }
+        Some(ContextValue::StyledStr(suggestion)) => {
+            contains_pass_as_value(&suggestion.to_string())
+        }
+        Some(ContextValue::StyledStrs(suggestions)) => {
+            suggestions.iter().any(|suggestion| contains_pass_as_value(&suggestion.to_string()))
+        }
+        _ => false,
+    }
+}
+
+fn print_unknown_argument_error(error: &clap::Error) -> bool {
+    let Some(invalid_argument) = extract_unknown_argument(error) else {
+        return false;
+    };
+
+    let highlighted_argument = invalid_argument.bright_blue().to_string();
+    output::error(&format!("Unexpected argument '{highlighted_argument}'"));
+
+    if has_pass_as_value_suggestion(error) {
+        eprintln!();
+        let pass_through_argument = format!("-- {invalid_argument}");
+        let highlighted_pass_through_argument =
+            format!("`{}`", pass_through_argument.bright_blue());
+        eprintln!("Use {highlighted_pass_through_argument} to pass the argument as a value");
+    }
+
+    true
+}
+
 fn print_help() {
     let header = vite_shared::header::vite_plus_header();
     let bold = "\x1b[1m";
@@ -1015,7 +1062,10 @@ pub use vite_shared::init_tracing;
 mod tests {
     use std::path::PathBuf;
 
+    use clap::Parser;
     use vite_task::config::UserRunConfig;
+
+    use super::{CLIArgs, extract_unknown_argument, has_pass_as_value_suggestion};
 
     #[test]
     fn run_config_types_in_sync() {
@@ -1036,5 +1086,20 @@ mod tests {
                 "run-config.ts is out of sync. Run `VITE_UPDATE_TASK_TYPES=1 cargo test -p vite-plus-cli run_config_types_in_sync` to update."
             );
         }
+    }
+
+    #[test]
+    fn unknown_argument_detected_without_pass_as_value_hint() {
+        let error = CLIArgs::try_parse_from(["vp", "--cache"]).expect_err("Expected parse error");
+        assert_eq!(extract_unknown_argument(&error).as_deref(), Some("--cache"));
+        assert!(!has_pass_as_value_suggestion(&error));
+    }
+
+    #[test]
+    fn unknown_argument_detected_with_pass_as_value_hint() {
+        let error =
+            CLIArgs::try_parse_from(["vp", "run", "--yolo"]).expect_err("Expected parse error");
+        assert_eq!(extract_unknown_argument(&error).as_deref(), Some("--yolo"));
+        assert!(has_pass_as_value_suggestion(&error));
     }
 }

--- a/packages/cli/snap-tests-global/cli-helper-message/snap.txt
+++ b/packages/cli/snap-tests-global/cli-helper-message/snap.txt
@@ -3,38 +3,44 @@ VITE+ - The Unified Toolchain for the Web
 
 Usage: vp [COMMAND]
 
-Core Commands:
-  create   Create a new project from a template
-  dev      Run the development server
-  build    Build for production
-  test     Run tests
-  lint     Lint code
-  fmt      Format code
-  check    Run format, lint, and type checks
-  pack     Build library
-  run      Run tasks
-  exec     Execute a command from local node_modules/.bin
-  preview  Preview production build
-  env      Manage Node.js versions
-  migrate  Migrate an existing project to Vite+<repeat>
-  cache    Manage the task cache
+Start:
+  create      Create a new project from a template
+  migrate     Migrate an existing project to Vite+<repeat>
+  install, i  Install all dependencies, or add packages if package names are provided
+  env         Manage Node.js versions
 
-Package Manager Commands:
-  install, i                 Install all dependencies, or add packages if package names are provided
+Develop:
+  dev    Run the development server
+  check  Run format, lint, and type checks
+  lint   Lint code
+  fmt    Format code
+  test   Run tests
+
+Execute:
+  run    Run tasks
+  exec   Execute a command from local node_modules/.bin
+  dlx    Execute a package binary without installing it as a dependency
+  cache  Manage the task cache
+
+Build:
+  build    Build for production
+  pack     Build library
+  preview  Preview production build
+
+Manage Dependencies:
   add                        Add packages to dependencies
   remove, rm, un, uninstall  Remove packages from dependencies
+  update, up                 Update packages to their latest versions
   dedupe                     Deduplicate dependencies by removing older versions
-  dlx                        Execute a package binary without installing it as a dependency
+  outdated                   Check for outdated packages
+  list, ls                   List installed packages
+  why, explain               Show why a package is installed
   info, view, show           View package information from the registry
   link, ln                   Link packages for local development
-  list, ls                   List installed packages
-  outdated                   Check for outdated packages
-  pm                         Forward a command to the package manager
   unlink                     Unlink packages
-  update, up                 Update packages to their latest versions
-  why, explain               Show why a package is installed
+  pm                         Forward a command to the package manager
 
-Maintenance Commands:
+Maintain:
   upgrade  Update vp itself to the latest version
 
 Options:
@@ -325,65 +331,60 @@ Options:
 > vp env # show env help message
 VITE+ - The Unified Toolchain for the Web
 
-Usage: vp env [OPTIONS] [COMMAND]
+Usage: vp env [COMMAND]
 
 Manage Node.js versions
 
-Commands:
-  default      Set or show the global default Node.js version
-  on           Enable managed mode - shims always use vite-plus managed Node.js
-  off          Enable system-first mode - shims prefer system Node.js, fallback to managed
-  setup        Create or update shims in VITE_PLUS_HOME/bin
+Setup:
+  setup  Create or update shims in VITE_PLUS_HOME/bin
+  on     Enable managed mode - shims always use vite-plus managed Node.js
+  off    Enable system-first mode - shims prefer system Node.js, fallback to managed
+  print  Print shell snippet to set environment for current session
+
+Manage:
+  default    Set or show the global default Node.js version
+  pin        Pin a Node.js version in the current directory (creates .node-version)
+  unpin      Remove the .node-version file from current directory (alias for `pin --unpin`)
+  use        Use a specific Node.js version for this shell session
+  install    Install a Node.js version [aliases: i]
+  uninstall  Uninstall a Node.js version [aliases: uni]
+  exec       Execute a command with a specific Node.js version [aliases: run]
+
+Inspect:
+  current      Show current environment information
   doctor       Run diagnostics and show environment status
   which        Show path to the tool that would be executed
-  pin          Pin a Node.js version in the current directory (creates .node-version)
-  unpin        Remove the .node-version file from current directory (alias for `pin --unpin`)
   list         List locally installed Node.js versions [aliases: ls]
   list-remote  List available Node.js versions from the registry [aliases: ls-remote]
-  exec         Execute a command with a specific Node.js version [aliases: run]
-  uninstall    Uninstall a Node.js version [aliases: uni]
-  install      Install a Node.js version [aliases: i]
-  use          Use a specific Node.js version for this shell session
-
-Options:
-  --current   Show current environment information
-  --json      Output in JSON format
-  --print     Print shell snippet to set environment for current session
-  -h, --help  Print help
 
 Examples:
-  vp env setup                  # Create shims for node, npm, npx
-  vp env setup --refresh        # Force refresh shims
-  vp env doctor                 # Check environment configuration
-  vp env default <semver>        # Set default Node.js version
-  vp env on                     # Use vite-plus managed Node.js
-  vp env off                    # Prefer system Node.js
-  vp env which node             # Show which node binary will be used
-  vp env pin <semver>            # Pin Node.js version in current directory
-  vp env pin lts                # Pin to latest LTS version
-  vp env unpin                  # Remove pinned version
-  vp env list                   # List locally installed Node.js versions
-  vp env list-remote            # List available remote Node.js versions
-  vp env list-remote --lts      # List only LTS versions
-  vp env list-remote 20         # List Node.js 20.x versions
-  vp env install <semver>        # Install Node.js <semver>
-  vp env install                # Install version from .node-version / package.json
-  vp env install lts            # Install latest LTS version
-  vp env uninstall <semver>      # Uninstall Node.js <semver>
-  vp env use 20                 # Use Node.js 20 for this shell session
-  vp env use lts                # Use latest LTS for this shell session
-  vp env use                    # Use project version for this shell session
-  vp env use --unset            # Remove session override
-  vp env exec --node 20 node -v # Execute 'node -v' with Node.js 20
-  vp env exec --node lts npm i  # Execute 'npm i' with latest LTS
-  vp env exec node -v           # Shim mode (version auto-resolved)
-  vp env exec npm install       # Shim mode (version auto-resolved)
+  Setup:
+    vp env setup                  # Create shims for node, npm, npx
+    vp env on                     # Use vite-plus managed Node.js
+    vp env print                  # Print shell snippet for this session
 
-Global Packages:
-  vp install -g <package>       # Install a global package
-  vp uninstall -g <package>     # Uninstall a global package
-  vp update -g [package]        # Update global package(s)
-  vp list -g [package]          # List installed global packages
+  Manage:
+    vp env pin lts                # Pin to latest LTS version
+    vp env install                # Install version from .node-version / package.json
+    vp env use 20                 # Use Node.js 20 for this shell session
+    vp env use --unset            # Remove session override
+
+  Inspect:
+    vp env current                # Show current resolved environment
+    vp env current --json         # JSON output for automation
+    vp env doctor                 # Check environment configuration
+    vp env which node             # Show which node binary will be used
+    vp env list-remote --lts      # List only LTS versions
+
+  Execute:
+    vp env exec --node lts npm i  # Execute 'npm i' with latest LTS
+    vp env exec node -v           # Shim mode (version auto-resolved)
+
+Related Commands:
+  vp install -g <package>       # Install a package globally
+  vp uninstall -g <package>     # Uninstall a package globally
+  vp update -g [package]        # Update global packages
+  vp list -g [package]          # List global packages
 
 
 > vp upgrade -h # show upgrade help message

--- a/packages/cli/snap-tests-global/command-env-install-no-arg-fail/snap.txt
+++ b/packages/cli/snap-tests-global/command-env-install-no-arg-fail/snap.txt
@@ -1,4 +1,6 @@
 [1]> vp env install # No version config - should error
+VITE+ - The Unified Toolchain for the Web
+
 No Node.js version found in current project.
 Specify a version: vp env install <VERSION>
 Or pin one:       vp env pin <VERSION>

--- a/packages/cli/snap-tests-global/command-env-install-no-arg/snap.txt
+++ b/packages/cli/snap-tests-global/command-env-install-no-arg/snap.txt
@@ -1,3 +1,5 @@
 > vp env install # Install version from .node-version (22.x)
+VITE+ - The Unified Toolchain for the Web
+
 Installing Node.js v<semver>...
 Installed Node.js v<semver>

--- a/packages/cli/snap-tests-global/command-env-which/snap.txt
+++ b/packages/cli/snap-tests-global/command-env-which/snap.txt
@@ -2,16 +2,22 @@
 v20.18.0
 
 > vp env which node # Core tool - shows resolved Node.js binary path
+VITE+ - The Unified Toolchain for the Web
+
 <vite-plus-home>/js_runtime/node/<semver>/bin/node
   Version:    <semver>
   Source:     <cwd>/.node-version
 
 > vp env which npm # Core tool - shows resolved npm binary path
+VITE+ - The Unified Toolchain for the Web
+
 <vite-plus-home>/js_runtime/node/<semver>/bin/npm
   Version:    <semver>
   Source:     <cwd>/.node-version
 
 > vp env which npx # Core tool - shows resolved npx binary path
+VITE+ - The Unified Toolchain for the Web
+
 <vite-plus-home>/js_runtime/node/<semver>/bin/npx
   Version:    <semver>
   Source:     <cwd>/.node-version
@@ -30,6 +36,8 @@ added 41 packages in <variable>ms
   Binaries: cowsay, cowthink
 
 > vp env which cowsay # Global package - shows binary path with metadata
+VITE+ - The Unified Toolchain for the Web
+
 <vite-plus-home>/packages/cowsay/lib/node_modules/cowsay/./cli.js
   Package:    cowsay@<semver>
   Binaries:   cowsay, cowthink
@@ -41,6 +49,8 @@ added 41 packages in <variable>ms
   Uninstalled cowsay
 
 [1]> vp env which unknown-tool # Unknown tool - error message
+VITE+ - The Unified Toolchain for the Web
+
 error: tool 'unknown-tool' not found
 Not a core tool (node, npm, npx) or installed global package.
 Run 'vp list -g' to see installed packages.

--- a/packages/cli/snap-tests-global/command-pack-exe-error/snap.txt
+++ b/packages/cli/snap-tests-global/command-pack-exe-error/snap.txt
@@ -3,6 +3,4 @@ VITE+ - The Unified Toolchain for the Web
 
 ℹ entry: src/index.ts
 ℹ target: node22.22.0
-
- ERROR  Error: Node.js version v<semver> does not support `exe` option. Please upgrade to Node.js <semver> or later.
-
+error: Node.js version v<semver> does not support `exe` option. Please upgrade to Node.js <semver> or later.

--- a/packages/cli/snap-tests-global/command-remove-pnpm10/snap.txt
+++ b/packages/cli/snap-tests-global/command-remove-pnpm10/snap.txt
@@ -104,10 +104,8 @@ Done in <variable>ms using pnpm v<semver>
 Failed to uninstall testnpm2: Configuration error: Package testnpm2 is not installed
 
 [2]> vp rm --stream foo && should show tips to use pass through arguments when options are not supported
-error: unexpected argument '--stream' found
+VITE+ - The Unified Toolchain for the Web
 
-  tip: to pass '--stream' as a value, use '-- --stream'
+error: Unexpected argument '--stream'
 
-Usage: vp remove [OPTIONS] <PACKAGES>... [-- <PASS_THROUGH_ARGS>...]
-
-For more information, try '--help'.
+Use `-- --stream` to pass the argument as a value

--- a/packages/cli/snap-tests-global/delegate-respects-default-node-version/snap.txt
+++ b/packages/cli/snap-tests-global/delegate-respects-default-node-version/snap.txt
@@ -1,4 +1,6 @@
 > vp env default 22.12.0 # Set global default to 22.12.0
+VITE+ - The Unified Toolchain for the Web
+
 ✓ Default Node.js version set to <semver>
 
 > vp run check-node # Should also use 22.12.0
@@ -16,6 +18,8 @@ VITE+ - The Unified Toolchain for the Web
 v<semver>
 
 > vp env which node # Should show 22.12.0 from 'default' source
+VITE+ - The Unified Toolchain for the Web
+
 <vite-plus-home>/js_runtime/node/<semver>/bin/node
   Version:    <semver>
   Source:     <vite-plus-home>/config.json

--- a/packages/cli/snap-tests-global/fallback-all-invalid-to-user-default/snap.txt
+++ b/packages/cli/snap-tests-global/fallback-all-invalid-to-user-default/snap.txt
@@ -1,4 +1,6 @@
 > vp env default 22.12.0 # Set user default
+VITE+ - The Unified Toolchain for the Web
+
 ✓ Default Node.js version set to <semver>
 
 > vp exec node -e "console.log(process.version)" # Should use default 22.12.0, not LTS

--- a/packages/cli/snap-tests-global/fallback-invalid-engines-to-dev-engines/snap.txt
+++ b/packages/cli/snap-tests-global/fallback-invalid-engines-to-dev-engines/snap.txt
@@ -6,6 +6,8 @@ warning: invalid version 'invalid' in engines.node, ignoring
 v<semver>
 
 > vp env which node # Should show devEngines.runtime source
+VITE+ - The Unified Toolchain for the Web
+
 warning: invalid version 'invalid' in engines.node, ignoring
 <vite-plus-home>/js_runtime/node/<semver>/bin/node
   Version:    <semver>

--- a/packages/cli/snap-tests-global/migration-check/snap.txt
+++ b/packages/cli/snap-tests-global/migration-check/snap.txt
@@ -9,13 +9,12 @@ Arguments:
   PATH  Target directory to migrate (default: current directory)
 
 Options:
-  --agent NAME       Write agent instructions file into the project (e.g. chatgpt, claude, opencode).
-  --no-agent         Skip writing agent instructions file
-  --editor NAME      Write editor config files into the project.
-  --no-editor        Skip writing editor config files
-  --no-interactive   Run in non-interactive mode (skip prompts and use defaults)
-  --non-interactive  Alias for --no-interactive
-  -h, --help         Show this help message
+  --agent NAME      Write agent instructions file into the project (e.g. chatgpt, claude, opencode).
+  --no-agent        Skip writing agent instructions file
+  --editor NAME     Write editor config files into the project.
+  --no-editor       Skip writing editor config files
+  --no-interactive  Run in non-interactive mode (skip prompts and use defaults)
+  -h, --help        Show this help message
 
 Examples:
   # Migrate current package

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-json/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-json/snap.txt
@@ -9,13 +9,12 @@ Arguments:
   PATH  Target directory to migrate (default: current directory)
 
 Options:
-  --agent NAME       Write agent instructions file into the project (e.g. chatgpt, claude, opencode).
-  --no-agent         Skip writing agent instructions file
-  --editor NAME      Write editor config files into the project.
-  --no-editor        Skip writing editor config files
-  --no-interactive   Run in non-interactive mode (skip prompts and use defaults)
-  --non-interactive  Alias for --no-interactive
-  -h, --help         Show this help message
+  --agent NAME      Write agent instructions file into the project (e.g. chatgpt, claude, opencode).
+  --no-agent        Skip writing agent instructions file
+  --editor NAME     Write editor config files into the project.
+  --no-editor       Skip writing editor config files
+  --no-interactive  Run in non-interactive mode (skip prompts and use defaults)
+  -h, --help        Show this help message
 
 Examples:
   # Migrate current package

--- a/packages/cli/snap-tests/command-pack-external/snap.txt
+++ b/packages/cli/snap-tests/command-pack-external/snap.txt
@@ -7,9 +7,7 @@
 
 > vp pack --external node:path src/index.ts # should bundle with legacy external flag
 ℹ entry: src/index.ts
-
- WARN  `external` is deprecated. Use `deps.neverBundle` instead.
-
+warn: `external` is deprecated. Use `deps.neverBundle` instead.
 ℹ Build start
 ℹ Cleaning 1 files
 ℹ dist/index.mjs  <variable> kB │ gzip: <variable> kB

--- a/packages/cli/snap-tests/command-pack-no-input/snap.txt
+++ b/packages/cli/snap-tests/command-pack-no-input/snap.txt
@@ -1,4 +1,2 @@
 [1]> vp pack # should not mention tsdown in error
-
- ERROR  Error: undefined No input files, try "vp pack <your-file>" or create src/index.ts
-
+error: No input files, try "vp pack <your-file>" or create src/index.ts

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -63,7 +63,6 @@ const helpMessage = renderCliDoc({
           label: '--no-interactive',
           description: 'Run in non-interactive mode (skip prompts and use defaults)',
         },
-        { label: '--non-interactive', description: 'Alias for --no-interactive' },
         { label: '-h, --help', description: 'Show this help message' },
       ],
     },
@@ -96,17 +95,14 @@ function parseArgs() {
   const parsed = mri<{
     help?: boolean;
     interactive?: boolean;
-    nonInteractive?: boolean;
-    'non-interactive'?: boolean;
     agent?: string | false;
     editor?: string | false;
   }>(args, {
     alias: { h: 'help' },
-    boolean: ['help', 'interactive', 'non-interactive', 'nonInteractive'],
+    boolean: ['help', 'interactive'],
     default: { interactive: defaultInteractive() },
   });
-  const nonInteractive = parsed['non-interactive'] ?? parsed.nonInteractive;
-  const interactive = nonInteractive ? false : parsed.interactive;
+  const interactive = parsed.interactive;
 
   let projectPath = parsed._[0];
   if (projectPath) {

--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -397,27 +397,111 @@ async function bundleTsdown() {
 async function brandTsdown() {
   const tsdownDistDir = join(projectDir, 'dist/tsdown');
   const buildFiles = await glob(toPosixPath(join(tsdownDistDir, 'build-*.js')), { absolute: true });
+  const mainFiles = await glob(toPosixPath(join(tsdownDistDir, 'main-*.js')), { absolute: true });
   if (buildFiles.length === 0) {
     throw new Error('brandTsdown: no build chunk found in dist/tsdown/');
+  }
+  if (mainFiles.length === 0) {
+    throw new Error('brandTsdown: no main chunk found in dist/tsdown/');
   }
 
   const search = '"tsdown <your-file>"';
   const replacement = '"vp pack <your-file>"';
+  const buildErrorPatches = [
+    {
+      search:
+        'else throw new Error(`${nameLabel} No input files, try "vp pack <your-file>" or create src/index.ts`);',
+      replacement:
+        'else throw new Error(`${nameLabel ? `${nameLabel} ` : ""}No input files, try "vp pack <your-file>" or create src/index.ts`);',
+    },
+    {
+      search:
+        'if (entries.length === 0) throw new Error(`${nameLabel} Cannot find entry: ${JSON.stringify(entry)}`);',
+      replacement:
+        'if (entries.length === 0) throw new Error(`${nameLabel ? `${nameLabel} ` : ""}Cannot find entry: ${JSON.stringify(entry)}`);',
+    },
+  ];
   let patched = false;
+  let buildErrorsPatched = false;
 
   for (const buildFile of buildFiles) {
     let content = await readFile(buildFile, 'utf-8');
+    let changed = false;
     if (!content.includes(search)) {
-      continue;
+      // Keep going to apply other safety patches below.
+    } else {
+      content = content.replace(search, replacement);
+      console.log(`Branded tsdown → vp pack in ${buildFile}`);
+      patched = true;
+      changed = true;
     }
-    content = content.replace(search, replacement);
-    await writeFile(buildFile, content, 'utf-8');
-    console.log(`Branded tsdown → vp pack in ${buildFile}`);
-    patched = true;
+
+    for (const { search, replacement } of buildErrorPatches) {
+      if (content.includes(search)) {
+        content = content.replaceAll(search, replacement);
+        buildErrorsPatched = true;
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      await writeFile(buildFile, content, 'utf-8');
+    }
   }
 
   if (!patched) {
     throw new Error(`brandTsdown: pattern ${search} not found in any build chunk`);
+  }
+  if (!buildErrorsPatched) {
+    throw new Error('brandTsdown: build error message patterns not found in any build chunk');
+  }
+
+  const loggerPatches = [
+    {
+      search: 'output("warn", `\\n${bgYellow` WARN `} ${message}\\n`);',
+      replacement: 'output("warn", `${bold(yellow`warn:`)} ${message}`);',
+    },
+    {
+      search: 'output("warn", `${bgYellow` WARN `} ${message}\\n`);',
+      replacement: 'output("warn", `${bold(yellow`warn:`)} ${message}`);',
+    },
+    {
+      search: 'output("error", `\\n${bgRed` ERROR `} ${format(msgs)}\\n`);',
+      replacement:
+        'output("error", `${bold(red`error:`)} ${format(msgs).replace(/^([A-Za-z]*Error):\\s*/, "")}`);',
+    },
+    {
+      search: 'output("error", `${bgRed` ERROR `} ${format(msgs)}\\n`);',
+      replacement:
+        'output("error", `${bold(red`error:`)} ${format(msgs).replace(/^([A-Za-z]*Error):\\s*/, "")}`);',
+    },
+    {
+      search: 'output("error", `${bold(red`error:`)} ${format(msgs)}`);',
+      replacement:
+        'output("error", `${bold(red`error:`)} ${format(msgs).replace(/^([A-Za-z]*Error):\\s*/, "")}`);',
+    },
+  ];
+  let loggerPatched = false;
+
+  for (const mainFile of mainFiles) {
+    let content = await readFile(mainFile, 'utf-8');
+    let changed = false;
+    for (const { search, replacement } of loggerPatches) {
+      if (content.includes(search)) {
+        content = content.replaceAll(search, replacement);
+        changed = true;
+      }
+    }
+    if (!changed) {
+      continue;
+    }
+    await writeFile(mainFile, content, 'utf-8');
+    console.log(`Branded tsdown logger prefixes in ${mainFile}`);
+    loggerPatched = true;
+  }
+
+  if (!loggerPatched) {
+    throw new Error('brandTsdown: logger prefix patterns not found in any main chunk');
   }
 }
 

--- a/packages/test/build.ts
+++ b/packages/test/build.ts
@@ -538,11 +538,11 @@ async function brandVitest() {
       'printBanner() {\n',
     );
 
-    // Use a magenta badge for both DEV and RUN.
+    // Use a blue badge for both DEV and RUN.
     patchString(
       'banner color',
       /const color = this\.ctx\.config\.watch \? "blue" : "cyan";\n\t\tconst mode = this\.ctx\.config\.watch \? "DEV" : "RUN";/,
-      'const mode = this.ctx.config.watch ? "DEV" : "RUN";\n\t\tconst label = c.bold(c.inverse(c.magenta(` ${mode} `)));',
+      'const mode = this.ctx.config.watch ? "DEV" : "RUN";\n\t\tconst label = c.bold(c.inverse(c.blue(` ${mode} `)));',
     );
 
     // Remove the version from the banner line and render a high-contrast label.

--- a/packages/tools/src/brand-rolldown-vite.ts
+++ b/packages/tools/src/brand-rolldown-vite.ts
@@ -7,7 +7,7 @@
  *
  * Changes applied:
  * 1. constants.ts: Add VITE_PLUS_VERSION constant
- * 2. cli.ts: Import VITE_PLUS_VERSION, change CLI name/version, and make banner magenta
+ * 2. cli.ts: Import VITE_PLUS_VERSION, change CLI name/version, and make banner blue
  * 3. build.ts: Remove startup build banner and change error prefix
  * 4. logger.ts: Change default prefix from '[vite]' to '[vite+]'
  * 5. plugins/reporter.ts: Suppress redundant "vite v<version>" native reporter line
@@ -107,7 +107,7 @@ export function brandRolldownVite(rootDir: string = process.cwd()) {
     replaceInFile(
       cliFile,
       "colors.green(\n            `${colors.bold('VITE+')} v${VITE_PLUS_VERSION}`,\n          )",
-      "colors.magenta(\n            `${colors.bold('VITE+')} v${VITE_PLUS_VERSION}`,\n          )",
+      "colors.blue(\n            `${colors.bold('VITE+')} v${VITE_PLUS_VERSION}`,\n          )",
     ),
   ];
   logPatch(

--- a/rfcs/env-command.md
+++ b/rfcs/env-command.md
@@ -1275,7 +1275,7 @@ The shim mode controls how shims resolve tools:
 $ vp env on
 ✓ Shim mode set to managed.
 
-Shims will now always use vite-plus managed Node.js.
+Shims will now always use the Vite+ managed Node.js.
 Run 'vp env off' to prefer system Node.js instead.
 
 # Enable system-first mode (prefer system Node.js)


### PR DESCRIPTION
This PR makes a number of changes to CLI printing:
* Switches from magenta to blue as discussed.
* Fades from blue via magenta to the foreground color in the header.
* Fixes `vp pack` rendering to align it with other error messages.
* Fixes printing of `vp --unknown` and `vp run --unknown`.
* Changes typos like `vp fnt` from `Did you mean <xyz>` to `Do you want to run `vp fmt`? (y/N)`, and when typing `y` it immediately runs the command. Yay for usability.

Screenshots:

<img width="895" height="754" alt="CleanShot 2026-03-04 at 14 42 17@2x" src="https://github.com/user-attachments/assets/d0cf204f-f22d-4100-9da0-53e108ecff12" />
<img width="895" height="754" alt="CleanShot 2026-03-04 at 14 42 26@2x" src="https://github.com/user-attachments/assets/7729aed4-949c-4aab-8e11-d81bdc1cd250" />
<img width="895" height="754" alt="CleanShot 2026-03-04 at 15 22 49@2x" src="https://github.com/user-attachments/assets/152f91f8-4a41-42f6-9732-c3f0e074e458" />
<img width="897" height="754" alt="CleanShot 2026-03-04 at 14 39 34@2x" src="https://github.com/user-attachments/assets/bfa3c42b-ca3f-4c86-9982-e4a1772d753c" />
