### PR TITLE
fix(dlx): fall back to npx when no package.json is found

### DIFF
--- a/crates/vite_global_cli/src/commands/dlx.rs
+++ b/crates/vite_global_cli/src/commands/dlx.rs
@@ -1,9 +1,13 @@
-use std::process::ExitStatus;
+use std::{collections::HashMap, process::ExitStatus};
 
-use vite_install::commands::dlx::DlxCommandOptions;
+use vite_command::run_command;
+use vite_install::{
+    commands::dlx::{DlxCommandOptions, build_npx_args},
+    package_manager::PackageManager,
+};
 use vite_path::AbsolutePathBuf;
 
-use super::{build_package_manager, prepend_js_runtime_to_path_env};
+use super::prepend_js_runtime_to_path_env;
 use crate::error::Error;
 
 /// Dlx command for executing packages without installing them as dependencies.
@@ -14,6 +18,8 @@ use crate::error::Error;
 /// - npm: npm exec
 /// - yarn@2+: yarn dlx
 /// - yarn@1: falls back to npx
+///
+/// When no package.json is found, falls back to npx directly.
 pub struct DlxCommand {
     cwd: AbsolutePathBuf,
 }
@@ -40,8 +46,6 @@ impl DlxCommand {
         let package_spec = &args[0];
         let command_args: Vec<String> = args[1..].to_vec();
 
-        let package_manager = build_package_manager(&self.cwd).await?;
-
         let dlx_command_options = DlxCommandOptions {
             packages: &packages,
             package_spec,
@@ -50,7 +54,18 @@ impl DlxCommand {
             silent,
         };
 
-        Ok(package_manager.run_dlx_command(&dlx_command_options, &self.cwd).await?)
+        match PackageManager::builder(&self.cwd).build_with_default().await {
+            Ok(pm) => Ok(pm.run_dlx_command(&dlx_command_options, &self.cwd).await?),
+            Err(vite_error::Error::WorkspaceError(vite_workspace::Error::PackageJsonNotFound(
+                _,
+            ))) => {
+                // No package.json found — fall back to npx directly
+                let args = build_npx_args(&dlx_command_options);
+                let envs = HashMap::new();
+                Ok(run_command("npx", &args, &envs, &self.cwd).await?)
+            }
+            Err(e) => Err(e.into()),
+        }
     }
 }
 

--- a/crates/vite_install/src/commands/dlx.rs
+++ b/crates/vite_install/src/commands/dlx.rs
@@ -184,35 +184,44 @@ impl PackageManager {
     ) -> ResolveCommandResult {
         output::note("yarn@1 does not have dlx command, falling back to npx");
 
-        let mut args = Vec::new();
-
-        // Add package flags
-        for pkg in options.packages {
-            args.push("--package".into());
-            args.push(pkg.clone());
-        }
-
-        // Always add --yes to auto-confirm prompts (align with pnpm behavior)
-        args.push("--yes".into());
-
-        // Add quiet flag for silent mode
-        if options.silent {
-            args.push("--quiet".into());
-        }
-
-        if options.shell_mode {
-            args.push("-c".into());
-            args.push(build_shell_command(options.package_spec, options.args));
-        } else {
-            // Add package spec
-            args.push(options.package_spec.into());
-
-            // Add command arguments
-            args.extend(options.args.iter().cloned());
-        }
-
+        let args = build_npx_args(options);
         ResolveCommandResult { bin_path: "npx".into(), args, envs }
     }
+}
+
+/// Build npx command-line arguments from dlx options.
+///
+/// Used both by the yarn@1 fallback (in `resolve_npx_fallback`) and by the
+/// no-package.json fallback in `vite_global_cli`.
+pub fn build_npx_args(options: &DlxCommandOptions<'_>) -> Vec<String> {
+    let mut args = Vec::new();
+
+    // Add package flags
+    for pkg in options.packages {
+        args.push("--package".into());
+        args.push(pkg.clone());
+    }
+
+    // Always add --yes to auto-confirm prompts (align with pnpm behavior)
+    args.push("--yes".into());
+
+    // Add quiet flag for silent mode
+    if options.silent {
+        args.push("--quiet".into());
+    }
+
+    if options.shell_mode {
+        args.push("-c".into());
+        args.push(build_shell_command(options.package_spec, options.args));
+    } else {
+        // Add package spec
+        args.push(options.package_spec.into());
+
+        // Add command arguments
+        args.extend(options.args.iter().cloned());
+    }
+
+    args
 }
 
 fn build_shell_command(package_spec: &str, args: &[String]) -> String {

--- a/packages/cli/snap-tests-global/command-dlx-no-package-json/snap.txt
+++ b/packages/cli/snap-tests-global/command-dlx-no-package-json/snap.txt
@@ -1,0 +1,9 @@
+> vp dlx -s cowsay hello # should work without package.json
+ _______
+< hello >
+ -------
+        \   ^__^
+         \  (oo)\_______
+            (__)\       )\/\
+                ||----w |
+                ||     ||

--- a/packages/cli/snap-tests-global/command-dlx-no-package-json/steps.json
+++ b/packages/cli/snap-tests-global/command-dlx-no-package-json/steps.json
@@ -1,0 +1,3 @@
+{
+  "commands": ["vp dlx -s cowsay hello # should work without package.json"]
+}

--- a/packages/cli/snap-tests-global/command-vpx-no-package-json/snap.txt
+++ b/packages/cli/snap-tests-global/command-vpx-no-package-json/snap.txt
@@ -1,0 +1,9 @@
+> vpx -s cowsay hello # should work without package.json
+ _______
+< hello >
+ -------
+        \   ^__^
+         \  (oo)\_______
+            (__)\       )\/\
+                ||----w |
+                ||     ||

--- a/packages/cli/snap-tests-global/command-vpx-no-package-json/steps.json
+++ b/packages/cli/snap-tests-global/command-vpx-no-package-json/steps.json
@@ -1,0 +1,3 @@
+{
+  "commands": ["vpx -s cowsay hello # should work without package.json"]
+}

--- a/rfcs/dlx-command.md
+++ b/rfcs/dlx-command.md
@@ -540,7 +540,18 @@ impl DlxCommand {
 - Automation provides consistent UX
 - Handles scoped packages correctly
 
-### 6. Auto-confirm Prompts for npm/npx
+### 6. Fallback to npx Without package.json
+
+**Decision**: When no `package.json` is found anywhere up the directory tree, fall back to `npx` directly instead of erroring.
+
+**Rationale**:
+
+- `npx` doesn't require a `package.json` — `vp dlx` shouldn't either
+- Users may run `vp dlx` or `vpx` from directories outside any project (e.g., `/tmp`, home directory)
+- Without a `package.json`, there is no package manager to detect, so `npx` is the universal fallback
+- `prepend_js_runtime_to_path_env()` already handles the no-package.json case (uses CLI runtime), so `npx` is on PATH
+
+### 7. Auto-confirm Prompts for npm/npx
 
 **Decision**: Always add `--yes` flag for npm and npx (yarn@1 fallback).
 
@@ -566,6 +577,22 @@ Usage: vp dlx [OPTIONS] <package[@version]> [args...]
 Examples:
   vp dlx create-vue my-app
   vp dlx typescript tsc --version
+```
+
+### No package.json
+
+```bash
+$ cd /tmp
+$ vp dlx cowsay hello
+# No package.json found — falls back to npx directly
+ _______
+< hello >
+ -------
+        \   ^__^
+         \  (oo)\_______
+            (__)\       )\/\
+                ||----w |
+                ||     ||
 ```
 
 ### Package Not Found

--- a/rfcs/vpx-command.md
+++ b/rfcs/vpx-command.md
@@ -398,6 +398,24 @@ Running: pnpm dlx some-tool --version
 some-tool v1.2.3
 ```
 
+### No package.json
+
+```bash
+$ cd /tmp
+$ vpx cowsay hello
+# No package.json — vpx delegates to vp dlx, which falls back to npx
+ _______
+< hello >
+ -------
+        \   ^__^
+         \  (oo)\_______
+            (__)\       )\/\
+                ||----w |
+                ||     ||
+```
+
+`vpx` works in directories without a `package.json` because `vp dlx` falls back to `npx` when no package manager can be detected.
+
 ### Remote Package Not Found
 
 ```bash


### PR DESCRIPTION
`vp dlx` and `vpx` failed with "No package.json found" when run
outside a project directory. Now when no package.json exists,
DlxCommand falls back to npx directly instead of erroring, matching
npx's behavior of working anywhere.

Extracts a shared `build_npx_args` in `vite_install::commands::dlx`,
reused by both the yarn@1 fallback and the no-package.json fallback.