### PR TITLE
feat: Allow selecting multiple agents + replace agent instructions instead of appending.

### DIFF
--- a/crates/vite_global_cli/src/command_picker.rs
+++ b/crates/vite_global_cli/src/command_picker.rs
@@ -25,6 +25,13 @@ pub struct PickedCommand {
     pub append_help: bool,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TopLevelCommandPick {
+    Skipped,
+    Selected(PickedCommand),
+    Cancelled,
+}
+
 #[derive(Clone, Copy)]
 struct CommandEntry {
     label: &'static str,
@@ -113,12 +120,15 @@ const CI_ENV_VARS: &[&str] = &[
     "TF_BUILD",
 ];
 
-pub fn pick_top_level_command_if_interactive() -> io::Result<Option<PickedCommand>> {
+pub fn pick_top_level_command_if_interactive() -> io::Result<TopLevelCommandPick> {
     if !should_enable_picker() {
-        return Ok(None);
+        return Ok(TopLevelCommandPick::Skipped);
     }
 
-    run_picker()
+    Ok(match run_picker()? {
+        Some(selection) => TopLevelCommandPick::Selected(selection),
+        None => TopLevelCommandPick::Cancelled,
+    })
 }
 
 fn should_enable_picker() -> bool {

--- a/crates/vite_global_cli/src/main.rs
+++ b/crates/vite_global_cli/src/main.rs
@@ -249,13 +249,16 @@ async fn main() -> ExitCode {
 
     if args.len() == 1 {
         match command_picker::pick_top_level_command_if_interactive() {
-            Ok(Some(selection)) => {
+            Ok(command_picker::TopLevelCommandPick::Selected(selection)) => {
                 args.push(selection.command.to_string());
                 if selection.append_help {
                     args.push("--help".to_string());
                 }
             }
-            Ok(None) => {}
+            Ok(command_picker::TopLevelCommandPick::Cancelled) => {
+                return ExitCode::SUCCESS;
+            }
+            Ok(command_picker::TopLevelCommandPick::Skipped) => {}
             Err(err) => {
                 tracing::debug!("Failed to run top-level command picker: {err}");
             }

--- a/packages/cli/src/create/bin.ts
+++ b/packages/cli/src/create/bin.ts
@@ -13,7 +13,7 @@ import {
 import { DependencyType, type WorkspaceInfo } from '../types/index.js';
 import {
   detectExistingAgentTargetPath,
-  selectAgentTargetPath,
+  selectAgentTargetPaths,
   writeAgentInstructions,
 } from '../utils/agent.js';
 import { detectExistingEditor, selectEditor, writeEditorConfigs } from '../utils/editor.js';
@@ -161,7 +161,7 @@ export interface Options {
   interactive: boolean;
   list: boolean;
   help: boolean;
-  agent?: string;
+  agent?: string | string[] | false;
   editor?: string;
 }
 
@@ -181,7 +181,7 @@ function parseArgs() {
     interactive?: boolean;
     list?: boolean;
     help?: boolean;
-    agent?: string;
+    agent?: string | string[] | false;
     editor?: string;
   }>(viteArgs, {
     alias: { h: 'help' },
@@ -282,7 +282,7 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
   // Interactive mode: prompt for template if not provided
   let selectedTemplateName = templateName as string;
   let selectedTemplateArgs = [...templateArgs];
-  let selectedAgentTargetPath: string | undefined;
+  let selectedAgentTargetPaths: string[] | undefined;
   let selectedEditor: Awaited<ReturnType<typeof selectEditor>>;
   let selectedParentDir: string | undefined;
 
@@ -495,16 +495,17 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
   };
 
   const existingAgentTargetPath =
-    options.agent || !options.interactive
+    options.agent !== undefined || !options.interactive
       ? undefined
       : detectExistingAgentTargetPath(workspaceInfoOptional.rootDir);
-  selectedAgentTargetPath =
-    existingAgentTargetPath ??
-    (await selectAgentTargetPath({
-      interactive: options.interactive,
-      agent: options.agent,
-      onCancel: () => cancelAndExit(),
-    }));
+  selectedAgentTargetPaths =
+    existingAgentTargetPath !== undefined
+      ? [existingAgentTargetPath]
+      : await selectAgentTargetPaths({
+          interactive: options.interactive,
+          agent: options.agent,
+          onCancel: () => cancelAndExit(),
+        });
 
   const existingEditor =
     options.editor || !options.interactive
@@ -556,7 +557,7 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
     const fullPath = path.join(workspaceInfo.rootDir, projectDir);
     await writeAgentInstructions({
       projectRoot: fullPath,
-      targetPath: selectedAgentTargetPath,
+      targetPaths: selectedAgentTargetPaths,
       interactive: options.interactive,
     });
     await writeEditorConfigs({
@@ -614,7 +615,7 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
   const fullPath = path.join(workspaceInfo.rootDir, projectDir);
   await writeAgentInstructions({
     projectRoot: fullPath,
-    targetPath: selectedAgentTargetPath,
+    targetPaths: selectedAgentTargetPaths,
     interactive: options.interactive,
   });
   await writeEditorConfigs({

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -8,7 +8,7 @@ import semver from 'semver';
 
 import { vitePlusHeader } from '../../binding/index.js';
 import { PackageManager, type WorkspaceInfo } from '../types/index.js';
-import { selectAgentTargetPath, writeAgentInstructions } from '../utils/agent.js';
+import { selectAgentTargetPaths, writeAgentInstructions } from '../utils/agent.js';
 import { selectEditor, writeEditorConfigs } from '../utils/editor.js';
 import { renderCliDoc } from '../utils/help.js';
 import { hasVitePlusDependency, readNearestPackageJson } from '../utils/package.js';
@@ -85,7 +85,7 @@ const helpMessage = renderCliDoc({
 export interface MigrationOptions {
   interactive: boolean;
   help?: boolean;
-  agent?: string | false;
+  agent?: string | string[] | false;
   editor?: string | false;
 }
 
@@ -95,7 +95,7 @@ function parseArgs() {
   const parsed = mri<{
     help?: boolean;
     interactive?: boolean;
-    agent?: string | false;
+    agent?: string | string[] | false;
     editor?: string | false;
   }>(args, {
     alias: { h: 'help' },
@@ -218,7 +218,7 @@ async function main() {
     rewriteStandaloneProject(workspaceInfo.rootDir, workspaceInfo);
   }
 
-  const selectedAgentTargetPath = await selectAgentTargetPath({
+  const selectedAgentTargetPaths = await selectAgentTargetPaths({
     interactive: options.interactive,
     agent: options.agent,
     onCancel: () => cancelAndExit(),
@@ -226,7 +226,7 @@ async function main() {
 
   await writeAgentInstructions({
     projectRoot: workspaceInfo.rootDir,
-    targetPath: selectedAgentTargetPath,
+    targetPaths: selectedAgentTargetPaths,
     interactive: options.interactive,
   });
 

--- a/packages/cli/src/utils/__tests__/agent.spec.ts
+++ b/packages/cli/src/utils/__tests__/agent.spec.ts
@@ -1,0 +1,343 @@
+import fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
+import path from 'node:path';
+
+import * as prompts from '@voidzero-dev/vite-plus-prompts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  detectExistingAgentTargetPath,
+  replaceMarkedAgentInstructionsSection,
+  resolveAgentTargetPaths,
+  writeAgentInstructions,
+} from '../agent.js';
+import { pkgRoot } from '../path.js';
+
+type MockNode =
+  | { kind: 'dir' }
+  | { kind: 'file'; content: string }
+  | { kind: 'symlink'; target: string };
+
+class InMemoryFs {
+  private readonly nodes = new Map<string, MockNode>();
+
+  constructor() {
+    this.ensureDirectory(path.parse(process.cwd()).root);
+  }
+
+  existsSync(filePath: fs.PathLike): boolean {
+    return this.nodes.has(this.normalize(filePath));
+  }
+
+  lstatSync(filePath: fs.PathLike): fs.Stats {
+    const node = this.getNode(filePath);
+    return {
+      isSymbolicLink: () => node.kind === 'symlink',
+    } as fs.Stats;
+  }
+
+  async lstat(filePath: fs.PathLike): Promise<fs.Stats> {
+    return this.lstatSync(filePath);
+  }
+
+  async mkdir(dirPath: fs.PathLike, options: { recursive: true }): Promise<void> {
+    if (!options.recursive) {
+      throw new Error('Only recursive mkdir is supported in tests');
+    }
+    this.ensureDirectory(this.normalize(dirPath));
+  }
+
+  async readFile(filePath: fs.PathLike): Promise<string> {
+    const resolvedPath = this.resolvePath(filePath);
+    const node = this.nodes.get(resolvedPath);
+    if (!node || node.kind !== 'file') {
+      throw new Error(`ENOENT: no such file "${String(filePath)}"`);
+    }
+    return node.content;
+  }
+
+  async writeFile(filePath: fs.PathLike, content: string): Promise<void> {
+    const resolvedPath = this.resolvePathForWrite(filePath);
+    this.ensureDirectory(path.dirname(resolvedPath));
+    this.nodes.set(resolvedPath, { kind: 'file', content });
+  }
+
+  async appendFile(filePath: fs.PathLike, content: string): Promise<void> {
+    const resolvedPath = this.resolvePathForWrite(filePath);
+    this.ensureDirectory(path.dirname(resolvedPath));
+    const existing = this.nodes.get(resolvedPath);
+    if (!existing) {
+      this.nodes.set(resolvedPath, { kind: 'file', content });
+      return;
+    }
+    if (existing.kind !== 'file') {
+      throw new Error(`EISDIR: cannot append to non-file "${String(filePath)}"`);
+    }
+    existing.content += content;
+  }
+
+  async realpath(filePath: fs.PathLike): Promise<string> {
+    return this.resolvePath(filePath);
+  }
+
+  async symlink(target: string, filePath: fs.PathLike): Promise<void> {
+    const normalizedPath = this.normalize(filePath);
+    this.ensureDirectory(path.dirname(normalizedPath));
+    this.nodes.set(normalizedPath, { kind: 'symlink', target });
+  }
+
+  async readlink(filePath: fs.PathLike): Promise<string> {
+    const node = this.getNode(filePath);
+    if (node.kind !== 'symlink') {
+      throw new Error(`EINVAL: not a symlink "${String(filePath)}"`);
+    }
+    return node.target;
+  }
+
+  async unlink(filePath: fs.PathLike): Promise<void> {
+    const normalizedPath = this.normalize(filePath);
+    if (!this.nodes.has(normalizedPath)) {
+      throw new Error(`ENOENT: no such file "${String(filePath)}"`);
+    }
+    this.nodes.delete(normalizedPath);
+  }
+
+  isSymlink(filePath: string): boolean {
+    return this.lstatSync(filePath).isSymbolicLink();
+  }
+
+  readlinkSync(filePath: string): string {
+    const node = this.getNode(filePath);
+    if (node.kind !== 'symlink') {
+      throw new Error(`EINVAL: not a symlink "${filePath}"`);
+    }
+    return node.target;
+  }
+
+  async readText(filePath: string): Promise<string> {
+    return this.readFile(filePath);
+  }
+
+  private normalize(filePath: fs.PathLike): string {
+    return path.resolve(String(filePath));
+  }
+
+  private getNode(filePath: fs.PathLike): MockNode {
+    const normalizedPath = this.normalize(filePath);
+    const node = this.nodes.get(normalizedPath);
+    if (!node) {
+      throw new Error(`ENOENT: no such file "${String(filePath)}"`);
+    }
+    return node;
+  }
+
+  private ensureDirectory(dirPath: string): void {
+    const normalizedPath = path.resolve(dirPath);
+    const root = path.parse(normalizedPath).root;
+    let current = root;
+    this.nodes.set(root, { kind: 'dir' });
+
+    const segments = path.relative(root, normalizedPath).split(path.sep).filter(Boolean);
+    for (const segment of segments) {
+      current = path.join(current, segment);
+      const node = this.nodes.get(current);
+      if (!node) {
+        this.nodes.set(current, { kind: 'dir' });
+        continue;
+      }
+      if (node.kind !== 'dir') {
+        throw new Error(`ENOTDIR: "${current}" is not a directory`);
+      }
+    }
+  }
+
+  private resolvePath(filePath: fs.PathLike): string {
+    let current = this.normalize(filePath);
+    const visited = new Set<string>();
+
+    while (true) {
+      const node = this.nodes.get(current);
+      if (!node) {
+        throw new Error(`ENOENT: no such file "${String(filePath)}"`);
+      }
+      if (node.kind !== 'symlink') {
+        return current;
+      }
+      if (visited.has(current)) {
+        throw new Error(`ELOOP: too many symlink levels "${String(filePath)}"`);
+      }
+      visited.add(current);
+      current = path.resolve(path.dirname(current), node.target);
+    }
+  }
+
+  private resolvePathForWrite(filePath: fs.PathLike): string {
+    const normalizedPath = this.normalize(filePath);
+    const node = this.nodes.get(normalizedPath);
+    if (node?.kind === 'symlink') {
+      return path.resolve(path.dirname(normalizedPath), node.target);
+    }
+    return normalizedPath;
+  }
+}
+
+const AGENT_TEMPLATE = ['<!--VITE PLUS START-->', 'template block', '<!--VITE PLUS END-->'].join(
+  '\n',
+);
+
+let mockFs: InMemoryFs;
+let projectIndex = 0;
+
+beforeEach(async () => {
+  vi.spyOn(prompts.log, 'message').mockImplementation(() => {});
+
+  mockFs = new InMemoryFs();
+  projectIndex = 0;
+
+  vi.spyOn(fs, 'existsSync').mockImplementation((filePath) => mockFs.existsSync(filePath));
+  vi.spyOn(fs, 'lstatSync').mockImplementation((filePath) => mockFs.lstatSync(filePath));
+
+  vi.spyOn(fsPromises, 'appendFile').mockImplementation(async (filePath, data) =>
+    mockFs.appendFile(filePath as fs.PathLike, String(data)),
+  );
+  vi.spyOn(fsPromises, 'lstat').mockImplementation(async (filePath) => mockFs.lstat(filePath));
+  vi.spyOn(fsPromises, 'mkdir').mockImplementation(async (filePath, options) => {
+    await mockFs.mkdir(filePath, options as { recursive: true });
+    return undefined;
+  });
+  vi.spyOn(fsPromises, 'readFile').mockImplementation(async (filePath) =>
+    mockFs.readFile(filePath as fs.PathLike),
+  );
+  vi.spyOn(fsPromises, 'readlink').mockImplementation(async (filePath) =>
+    mockFs.readlink(filePath),
+  );
+  vi.spyOn(fsPromises, 'realpath').mockImplementation(async (filePath) =>
+    mockFs.realpath(filePath),
+  );
+  vi.spyOn(fsPromises, 'symlink').mockImplementation(async (target, filePath) => {
+    await mockFs.symlink(String(target), filePath);
+  });
+  vi.spyOn(fsPromises, 'unlink').mockImplementation(async (filePath) => {
+    await mockFs.unlink(filePath);
+  });
+  vi.spyOn(fsPromises, 'writeFile').mockImplementation(async (filePath, data) => {
+    await mockFs.writeFile(filePath as fs.PathLike, String(data as string));
+  });
+
+  await mockFs.writeFile(path.join(pkgRoot, 'AGENTS.md'), AGENT_TEMPLATE);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+async function createProjectDir() {
+  const dir = path.join(pkgRoot, '__virtual__', `project-${projectIndex++}`);
+  await mockFs.mkdir(dir, { recursive: true });
+  return dir;
+}
+
+describe('resolveAgentTargetPaths', () => {
+  it('resolves comma-separated agent names and deduplicates target paths', () => {
+    expect(resolveAgentTargetPaths('claude,amp,opencode,chatgpt')).toEqual([
+      'CLAUDE.md',
+      'AGENTS.md',
+    ]);
+  });
+
+  it('resolves repeated --agent values and trims whitespace', () => {
+    expect(resolveAgentTargetPaths([' claude ', ' amp, opencode ', 'codex'])).toEqual([
+      'CLAUDE.md',
+      'AGENTS.md',
+    ]);
+  });
+
+  it('falls back to AGENTS.md when no valid agents are provided', () => {
+    expect(resolveAgentTargetPaths()).toEqual(['AGENTS.md']);
+    expect(resolveAgentTargetPaths(' , , ')).toEqual(['AGENTS.md']);
+  });
+});
+
+describe('detectExistingAgentTargetPath', () => {
+  it('detects existing regular agent files', async () => {
+    const dir = await createProjectDir();
+    await mockFs.writeFile(path.join(dir, 'CLAUDE.md'), '# Claude');
+
+    expect(detectExistingAgentTargetPath(dir)).toBe('CLAUDE.md');
+  });
+
+  it('ignores symlinked agent files', async () => {
+    const dir = await createProjectDir();
+    await mockFs.symlink('AGENTS.md', path.join(dir, 'CLAUDE.md'));
+
+    expect(detectExistingAgentTargetPath(dir)).toBeUndefined();
+  });
+});
+
+describe('replaceMarkedAgentInstructionsSection', () => {
+  it('replaces the marker block when markers are present in both files', () => {
+    const existing = [
+      '# Local instructions',
+      '<!--VITE PLUS START-->',
+      'old block',
+      '<!--VITE PLUS END-->',
+      '# Footer',
+    ].join('\n');
+    const incoming = ['<!--VITE PLUS START-->', 'new block', '<!--VITE PLUS END-->'].join('\n');
+
+    expect(replaceMarkedAgentInstructionsSection(existing, incoming)).toBe(
+      [
+        '# Local instructions',
+        '<!--VITE PLUS START-->',
+        'new block',
+        '<!--VITE PLUS END-->',
+        '# Footer',
+      ].join('\n'),
+    );
+  });
+
+  it('returns undefined when markers are missing in existing content', () => {
+    expect(
+      replaceMarkedAgentInstructionsSection(
+        'no markers here',
+        '<!--VITE PLUS START-->\nnew\n<!--VITE PLUS END-->',
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe('writeAgentInstructions symlink behavior', () => {
+  it('links non-standard agent files to AGENTS.md when AGENTS.md is selected', async () => {
+    const dir = await createProjectDir();
+
+    await writeAgentInstructions({
+      projectRoot: dir,
+      targetPaths: ['AGENTS.md', 'CLAUDE.md', '.github/copilot-instructions.md'],
+      interactive: false,
+    });
+
+    expect(mockFs.isSymlink(path.join(dir, 'AGENTS.md'))).toBe(false);
+    expect(mockFs.isSymlink(path.join(dir, 'CLAUDE.md'))).toBe(true);
+    expect(mockFs.readlinkSync(path.join(dir, 'CLAUDE.md'))).toBe('AGENTS.md');
+    expect(mockFs.isSymlink(path.join(dir, '.github/copilot-instructions.md'))).toBe(true);
+    expect(mockFs.readlinkSync(path.join(dir, '.github/copilot-instructions.md'))).toBe(
+      path.join('..', 'AGENTS.md'),
+    );
+  });
+
+  it('does not replace existing non-symlink files with symlinks', async () => {
+    const dir = await createProjectDir();
+    const existingClaude = path.join(dir, 'CLAUDE.md');
+    await mockFs.writeFile(existingClaude, 'existing claude instructions');
+
+    await writeAgentInstructions({
+      projectRoot: dir,
+      targetPaths: ['AGENTS.md', 'CLAUDE.md'],
+      interactive: false,
+    });
+
+    expect(mockFs.isSymlink(existingClaude)).toBe(false);
+    expect(await mockFs.readText(existingClaude)).toBe('existing claude instructions');
+    expect(mockFs.existsSync(path.join(dir, 'AGENTS.md'))).toBe(true);
+  });
+});

--- a/packages/cli/src/utils/agent.ts
+++ b/packages/cli/src/utils/agent.ts
@@ -187,13 +187,18 @@ export const AGENTS = [
   { id: 'other', label: 'Other', targetPath: 'AGENTS.md' },
 ] as const;
 
-export async function selectAgentTargetPath({
+type AgentSelection = string | string[] | false;
+const AGENT_STANDARD_PATH = 'AGENTS.md';
+const AGENT_INSTRUCTIONS_START_MARKER = '<!--VITE PLUS START-->';
+const AGENT_INSTRUCTIONS_END_MARKER = '<!--VITE PLUS END-->';
+
+export async function selectAgentTargetPaths({
   interactive,
   agent,
   onCancel,
 }: {
   interactive: boolean;
-  agent?: string | false;
+  agent?: AgentSelection;
   onCancel: () => void;
 }) {
   // Skip entirely if --no-agent is passed
@@ -202,51 +207,87 @@ export async function selectAgentTargetPath({
   }
 
   if (interactive && !agent) {
-    const selectedAgent = await prompts.select({
-      message: 'Which agent are you using?',
-      options: [
-        {
-          label: 'None',
-          value: null,
-          hint: 'Skip writing agent instructions',
-        },
-        ...AGENTS.map((option) => ({
-          label: option.label,
-          value: option.id,
-          hint: option.targetPath,
-        })),
-      ],
-      initialValue: 'chatgpt-codex',
+    const selectedAgents = await prompts.multiselect({
+      message: 'Which agents are you using?',
+      options: AGENTS.map((option) => ({
+        label: option.label,
+        value: option.id,
+        hint: option.targetPath,
+      })),
+      initialValues: ['chatgpt-codex'],
+      required: false,
     });
 
-    if (prompts.isCancel(selectedAgent)) {
+    if (prompts.isCancel(selectedAgents)) {
       onCancel();
       return undefined;
     }
 
-    if (selectedAgent === null) {
+    if (selectedAgents.length === 0) {
       return undefined;
     }
-    return resolveAgentTargetPath(selectedAgent);
+    return resolveAgentTargetPaths(selectedAgents);
   }
 
-  return resolveAgentTargetPath(agent ?? 'other');
+  return resolveAgentTargetPaths(agent ?? 'other');
+}
+
+export async function selectAgentTargetPath({
+  interactive,
+  agent,
+  onCancel,
+}: {
+  interactive: boolean;
+  agent?: AgentSelection;
+  onCancel: () => void;
+}) {
+  const targetPaths = await selectAgentTargetPaths({ interactive, agent, onCancel });
+  return targetPaths?.[0];
 }
 
 export function detectExistingAgentTargetPath(projectRoot: string) {
   for (const option of AGENTS) {
     const targetPath = path.join(projectRoot, option.targetPath);
-    if (fs.existsSync(targetPath)) {
+    if (fs.existsSync(targetPath) && !fs.lstatSync(targetPath).isSymbolicLink()) {
       return option.targetPath;
     }
   }
   return undefined;
 }
 
-export function resolveAgentTargetPath(agent?: string) {
-  if (!agent) {
-    return 'AGENTS.md';
+export function resolveAgentTargetPaths(agent?: string | string[]) {
+  const agentNames = parseAgentNames(agent);
+  const resolvedAgentNames = agentNames.length > 0 ? agentNames : ['other'];
+  const dedupedTargetPaths: string[] = [];
+  const seenTargetPaths = new Set<string>();
+  for (const name of resolvedAgentNames) {
+    const targetPath = resolveSingleAgentTargetPath(name);
+    if (seenTargetPaths.has(targetPath)) {
+      continue;
+    }
+    seenTargetPaths.add(targetPath);
+    dedupedTargetPaths.push(targetPath);
   }
+  return dedupedTargetPaths;
+}
+
+export function resolveAgentTargetPath(agent?: string) {
+  return resolveAgentTargetPaths(agent)[0] ?? 'AGENTS.md';
+}
+
+function parseAgentNames(agent?: string | string[]) {
+  if (!agent) {
+    return [];
+  }
+  const values = Array.isArray(agent) ? agent : [agent];
+  return values
+    .filter((value): value is string => typeof value === 'string')
+    .flatMap((value) => value.split(','))
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+}
+
+function resolveSingleAgentTargetPath(agent: string) {
   const normalized = normalizeAgentName(agent);
   const alias = AGENT_ALIASES[normalized];
   const resolved = alias ? normalizeAgentName(alias) : normalized;
@@ -254,19 +295,22 @@ export function resolveAgentTargetPath(agent?: string) {
     (option) =>
       normalizeAgentName(option.id) === resolved || normalizeAgentName(option.label) === resolved,
   );
-  return match?.targetPath ?? 'AGENTS.md';
+  return match?.targetPath ?? AGENTS[AGENTS.length - 1].targetPath;
 }
 
 export async function writeAgentInstructions({
   projectRoot,
   targetPath,
+  targetPaths,
   interactive,
 }: {
   projectRoot: string;
-  targetPath: string | undefined;
+  targetPath?: string;
+  targetPaths?: string[];
   interactive: boolean;
 }) {
-  if (!targetPath) {
+  const paths = [...(targetPaths ?? []), ...(targetPath ? [targetPath] : [])];
+  if (paths.length === 0) {
     return;
   }
 
@@ -276,47 +320,94 @@ export async function writeAgentInstructions({
     return;
   }
 
-  const destinationPath = path.join(projectRoot, targetPath);
-  await fsPromises.mkdir(path.dirname(destinationPath), { recursive: true });
-  if (fs.existsSync(destinationPath)) {
-    if (interactive) {
-      const action = await prompts.select({
-        message: `Agent instructions already exist at ${targetPath}.`,
-        options: [
-          {
-            label: 'Append',
-            value: 'append',
-            hint: 'Add template content to the end',
-          },
-          {
-            label: 'Skip',
-            value: 'skip',
-            hint: 'Leave existing file unchanged',
-          },
-        ],
-        initialValue: 'skip',
-      });
-      if (prompts.isCancel(action) || action === 'skip') {
-        prompts.log.info(`Skipped writing ${targetPath}`);
-        return;
-      }
+  const seenDestinationPaths = new Set<string>();
+  const seenRealPaths = new Set<string>();
+  const incomingContent = await fsPromises.readFile(sourcePath, 'utf-8');
+  const shouldLinkToAgents = paths.includes(AGENT_STANDARD_PATH);
+  const orderedPaths = shouldLinkToAgents
+    ? [AGENT_STANDARD_PATH, ...paths.filter((p) => p !== AGENT_STANDARD_PATH)]
+    : paths;
 
-      const [existingContent, incomingContent] = await Promise.all([
-        fsPromises.readFile(destinationPath, 'utf-8'),
-        fsPromises.readFile(sourcePath, 'utf-8'),
-      ]);
-      const separator = existingContent.endsWith('\n') ? '' : '\n';
-      await fsPromises.appendFile(destinationPath, `${separator}\n${incomingContent}`);
-      prompts.log.success(`Appended agent instructions to ${targetPath}`);
-      return;
+  for (const targetPathToWrite of orderedPaths) {
+    const destinationPath = path.join(projectRoot, targetPathToWrite);
+    const destinationKey = path.resolve(destinationPath);
+    if (seenDestinationPaths.has(destinationKey)) {
+      continue;
+    }
+    seenDestinationPaths.add(destinationKey);
+
+    await fsPromises.mkdir(path.dirname(destinationPath), { recursive: true });
+
+    if (shouldLinkToAgents && targetPathToWrite !== AGENT_STANDARD_PATH) {
+      const linked = await tryLinkTargetToAgents(projectRoot, targetPathToWrite);
+      if (linked) {
+        continue;
+      }
     }
 
-    prompts.log.info(`Skipped writing ${targetPath} (already exists)`);
-    return;
-  }
+    if (fs.existsSync(destinationPath)) {
+      if (fs.lstatSync(destinationPath).isSymbolicLink()) {
+        prompts.log.info(`Skipped writing ${targetPathToWrite} (symlink)`);
+        continue;
+      }
 
-  await fsPromises.copyFile(sourcePath, destinationPath);
-  prompts.log.success(`Wrote agent instructions to ${targetPath}`);
+      const destinationRealPath = await fsPromises.realpath(destinationPath);
+      if (seenRealPaths.has(destinationRealPath)) {
+        prompts.log.info(`Skipped writing ${targetPathToWrite} (duplicate target)`);
+        continue;
+      }
+
+      if (interactive) {
+        const action = await prompts.select({
+          message: `Agent instructions already exist at ${targetPathToWrite}.`,
+          options: [
+            {
+              label: 'Append',
+              value: 'append',
+              hint: 'Add template content to the end',
+            },
+            {
+              label: 'Skip',
+              value: 'skip',
+              hint: 'Leave existing file unchanged',
+            },
+          ],
+          initialValue: 'skip',
+        });
+        if (prompts.isCancel(action) || action === 'skip') {
+          prompts.log.info(`Skipped writing ${targetPathToWrite}`);
+          seenRealPaths.add(destinationRealPath);
+          continue;
+        }
+
+        const existingContent = await fsPromises.readFile(destinationPath, 'utf-8');
+        const updatedContent = replaceMarkedAgentInstructionsSection(
+          existingContent,
+          incomingContent,
+        );
+        if (updatedContent !== undefined) {
+          await fsPromises.writeFile(destinationPath, updatedContent);
+          prompts.log.success(`Updated agent instructions in ${targetPathToWrite}`);
+          seenRealPaths.add(destinationRealPath);
+          continue;
+        }
+
+        const separator = existingContent.endsWith('\n') ? '' : '\n';
+        await fsPromises.appendFile(destinationPath, `${separator}\n${incomingContent}`);
+        prompts.log.success(`Appended agent instructions to ${targetPathToWrite}`);
+        seenRealPaths.add(destinationRealPath);
+        continue;
+      }
+
+      prompts.log.info(`Skipped writing ${targetPathToWrite} (already exists)`);
+      seenRealPaths.add(destinationRealPath);
+      continue;
+    }
+
+    await fsPromises.writeFile(destinationPath, incomingContent);
+    prompts.log.success(`Wrote agent instructions to ${targetPathToWrite}`);
+    seenRealPaths.add(await fsPromises.realpath(destinationPath));
+  }
 }
 
 function normalizeAgentName(value: string) {
@@ -324,4 +415,77 @@ function normalizeAgentName(value: string) {
     .trim()
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '');
+}
+
+export function replaceMarkedAgentInstructionsSection(existing: string, incoming: string) {
+  const existingRange = getMarkedRange(
+    existing,
+    AGENT_INSTRUCTIONS_START_MARKER,
+    AGENT_INSTRUCTIONS_END_MARKER,
+  );
+  if (!existingRange) {
+    return undefined;
+  }
+
+  const incomingRange = getMarkedRange(
+    incoming,
+    AGENT_INSTRUCTIONS_START_MARKER,
+    AGENT_INSTRUCTIONS_END_MARKER,
+  );
+  if (!incomingRange) {
+    return undefined;
+  }
+
+  return `${existing.slice(0, existingRange.start)}${incoming.slice(
+    incomingRange.start,
+    incomingRange.end,
+  )}${existing.slice(existingRange.end)}`;
+}
+
+async function tryLinkTargetToAgents(projectRoot: string, targetPath: string) {
+  const destinationPath = path.join(projectRoot, targetPath);
+  const agentsPath = path.join(projectRoot, AGENT_STANDARD_PATH);
+  const symlinkTarget = path.relative(path.dirname(destinationPath), agentsPath);
+  const existing = await getExistingPathKind(destinationPath);
+
+  if (existing === 'file') {
+    return false;
+  }
+
+  if (existing === 'symlink') {
+    const currentLink = await fsPromises.readlink(destinationPath);
+    const resolvedCurrentLink = path.resolve(path.dirname(destinationPath), currentLink);
+    if (resolvedCurrentLink === agentsPath) {
+      prompts.log.info(`Skipped linking ${targetPath} (already linked to ${AGENT_STANDARD_PATH})`);
+      return true;
+    }
+    await fsPromises.unlink(destinationPath);
+  }
+
+  await fsPromises.symlink(symlinkTarget, destinationPath);
+  prompts.log.success(`Linked ${targetPath} to ${AGENT_STANDARD_PATH}`);
+  return true;
+}
+
+async function getExistingPathKind(filePath: string) {
+  if (!fs.existsSync(filePath)) {
+    return 'missing' as const;
+  }
+  const stat = await fsPromises.lstat(filePath);
+  return stat.isSymbolicLink() ? ('symlink' as const) : ('file' as const);
+}
+
+function getMarkedRange(content: string, startMarker: string, endMarker: string) {
+  const start = content.indexOf(startMarker);
+  if (start === -1) {
+    return undefined;
+  }
+  const endMarkerIndex = content.indexOf(endMarker, start + startMarker.length);
+  if (endMarkerIndex === -1) {
+    return undefined;
+  }
+  return {
+    start,
+    end: endMarkerIndex + endMarker.length,
+  };
 }


### PR DESCRIPTION
See title of the PR. Just getting the `--agent` story to work better.

Also fixed a bug where ESC in the interactive `vp` was printing the help text. Now it prints nothing.