### PR TITLE
feat: Customize the design of prompts in Vite+.

### DIFF
--- a/packages/cli/snap-tests-global/migration-agent-claude/snap.txt
+++ b/packages/cli/snap-tests-global/migration-agent-claude/snap.txt
@@ -1,15 +1,15 @@
 > vp migrate --agent claude --no-interactive # migration with --agent claude should write CLAUDE.md
-┌  VITE+ - The Unified Toolchain for the Web
-│
-●  Using default package manager: pnpm
-│
-●  pnpm@latest installing...
-│
-●  pnpm@<semver> installed
-│
-◆  Wrote agent instructions to CLAUDE.md
-│
-└  ✔ Migration completed!
+VITE+ - The Unified Toolchain for the Web
+
+
+Using default package manager: pnpm
+
+pnpm@latest installing...
+
+pnpm@<semver> installed
+
+Wrote agent instructions to CLAUDE.md
+✔ Migration completed!
 
 
 > cat CLAUDE.md | head -3 # verify CLAUDE.md was created

--- a/packages/cli/snap-tests-global/migration-already-vite-plus/snap.txt
+++ b/packages/cli/snap-tests-global/migration-already-vite-plus/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive # should detect existing vite-plus and exit
-┌  VITE+ - The Unified Toolchain for the Web
-│
-└  This project is already using Vite+! Happy coding!
+VITE+ - The Unified Toolchain for the Web
+
+This project is already using Vite+! Happy coding!
 

--- a/packages/cli/snap-tests-global/migration-auto-create-vite-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-auto-create-vite-config/snap.txt
@@ -1,21 +1,21 @@
 > vp migrate --no-interactive # migration should auto create vite.config.ts and remove oxlintrc and oxfmtrc
-┌  VITE+ - The Unified Toolchain for the Web
-│
-●  Using default package manager: pnpm
-│
-●  pnpm@latest installing...
-│
-●  pnpm@<semver> installed
-│
-◆  ✔ Created vite.config.ts in vite.config.ts
-│
-◆  ✔ Merged .oxlintrc.json into vite.config.ts
-│
-◆  ✔ Merged .oxfmtrc.json into vite.config.ts
-│
-◆  Wrote agent instructions to AGENTS.md
-│
-└  ✔ Migration completed!
+VITE+ - The Unified Toolchain for the Web
+
+
+Using default package manager: pnpm
+
+pnpm@latest installing...
+
+pnpm@<semver> installed
+
+✔ Created vite.config.ts in vite.config.ts
+
+✔ Merged .oxlintrc.json into vite.config.ts
+
+✔ Merged .oxfmtrc.json into vite.config.ts
+
+Wrote agent instructions to AGENTS.md
+✔ Migration completed!
 
 
 > cat vite.config.ts # check vite.config.ts

--- a/packages/cli/snap-tests-global/migration-from-tsdown-json-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-from-tsdown-json-config/snap.txt
@@ -1,17 +1,17 @@
 > vp migrate --no-interactive # migration should rewrite imports to vite-plus
-┌  VITE+ - The Unified Toolchain for the Web
-│
-●  Using default package manager: pnpm
-│
-●  pnpm@latest installing...
-│
-●  pnpm@<semver> installed
-│
-◆  ✔ Merged tsdown.config.json into vite.config.ts
-│
-◆  Wrote agent instructions to AGENTS.md
-│
-└  ✔ Migration completed!
+VITE+ - The Unified Toolchain for the Web
+
+
+Using default package manager: pnpm
+
+pnpm@latest installing...
+
+pnpm@<semver> installed
+
+✔ Merged tsdown.config.json into vite.config.ts
+
+Wrote agent instructions to AGENTS.md
+✔ Migration completed!
 
 
 > cat tsdown.config.json && exit 1 || true # check tsdown.config.json should be removed
@@ -57,9 +57,9 @@ export default defineConfig({
 }
 
 > vp migrate --no-interactive # run migration again to check if it is idempotent
-┌  VITE+ - The Unified Toolchain for the Web
-│
-└  This project is already using Vite+! Happy coding!
+VITE+ - The Unified Toolchain for the Web
+
+This project is already using Vite+! Happy coding!
 
 
 > cat vite.config.ts # check vite.config.ts

--- a/packages/cli/snap-tests-global/migration-from-tsdown/snap.txt
+++ b/packages/cli/snap-tests-global/migration-from-tsdown/snap.txt
@@ -1,25 +1,25 @@
 > vp migrate --no-interactive # migration should rewrite imports to vite-plus
-┌  VITE+ - The Unified Toolchain for the Web
-│
-●  Using default package manager: pnpm
-│
-●  pnpm@latest installing...
-│
-●  pnpm@<semver> installed
-│
-◆  ✔ Created vite.config.ts in vite.config.ts
-│
-◆  ✔ Added import for tsdown.config.ts in vite.config.ts
-│
-●  Please manually merge tsdown.config.ts into vite.config.ts, see https://viteplus.dev/migration/#tsdown
-│
-◆  Rewrote imports in one file
-│
-●    tsdown.config.ts
-│
-◆  Wrote agent instructions to AGENTS.md
-│
-└  ✔ Migration completed!
+VITE+ - The Unified Toolchain for the Web
+
+
+Using default package manager: pnpm
+
+pnpm@latest installing...
+
+pnpm@<semver> installed
+
+✔ Created vite.config.ts in vite.config.ts
+
+✔ Added import for tsdown.config.ts in vite.config.ts
+
+Please manually merge tsdown.config.ts into vite.config.ts, see https://viteplus.dev/migration/#tsdown
+
+Rewrote imports in one file
+
+  tsdown.config.ts
+
+Wrote agent instructions to AGENTS.md
+✔ Migration completed!
 
 
 > cat tsdown.config.ts # check tsdown.config.ts
@@ -64,9 +64,9 @@ export default defineConfig({
 }
 
 > vp migrate --no-interactive # run migration again to check if it is idempotent
-┌  VITE+ - The Unified Toolchain for the Web
-│
-└  This project is already using Vite+! Happy coding!
+VITE+ - The Unified Toolchain for the Web
+
+This project is already using Vite+! Happy coding!
 
 
 > cat tsdown.config.ts # check tsdown.config.ts

--- a/packages/cli/snap-tests-global/migration-from-vitest-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-from-vitest-config/snap.txt
@@ -1,19 +1,19 @@
 > vp migrate --no-interactive # migration should rewrite imports to vite-plus
-┌  VITE+ - The Unified Toolchain for the Web
-│
-●  Using default package manager: pnpm
-│
-●  pnpm@latest installing...
-│
-●  pnpm@<semver> installed
-│
-◆  Rewrote imports in one file
-│
-●    vitest.config.ts
-│
-◆  Wrote agent instructions to AGENTS.md
-│
-└  ✔ Migration completed!
+VITE+ - The Unified Toolchain for the Web
+
+
+Using default package manager: pnpm
+
+pnpm@latest installing...
+
+pnpm@<semver> installed
+
+Rewrote imports in one file
+
+  vitest.config.ts
+
+Wrote agent instructions to AGENTS.md
+✔ Migration completed!
 
 
 > cat vitest.config.ts # check vitest.config.ts

--- a/packages/cli/snap-tests-global/migration-from-vitest-files/snap.txt
+++ b/packages/cli/snap-tests-global/migration-from-vitest-files/snap.txt
@@ -1,19 +1,19 @@
 > vp migrate --no-interactive # migration should rewrite imports to vite-plus
-┌  VITE+ - The Unified Toolchain for the Web
-│
-●  Using default package manager: pnpm
-│
-●  pnpm@latest installing...
-│
-●  pnpm@<semver> installed
-│
-◆  Rewrote imports in one file
-│
-●    test/hello.ts
-│
-◆  Wrote agent instructions to AGENTS.md
-│
-└  ✔ Migration completed!
+VITE+ - The Unified Toolchain for the Web
+
+
+Using default package manager: pnpm
+
+pnpm@latest installing...
+
+pnpm@<semver> installed
+
+Rewrote imports in one file
+
+  test/hello.ts
+
+Wrote agent instructions to AGENTS.md
+✔ Migration completed!
 
 
 > cat package.json # check package.json

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-json/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-json/snap.txt
@@ -28,19 +28,19 @@ Examples:
 
 
 > vp migrate --no-interactive # migration work with lintstagedrc.json
-┌  VITE+ - The Unified Toolchain for the Web
-│
-●  Using default package manager: pnpm
-│
-●  pnpm@latest installing...
-│
-●  pnpm@<semver> installed
-│
-◆  ✔ Rewrote lint-staged config in .lintstagedrc.json
-│
-◆  Wrote agent instructions to AGENTS.md
-│
-└  ✔ Migration completed!
+VITE+ - The Unified Toolchain for the Web
+
+
+Using default package manager: pnpm
+
+pnpm@latest installing...
+
+pnpm@<semver> installed
+
+✔ Rewrote lint-staged config in .lintstagedrc.json
+
+Wrote agent instructions to AGENTS.md
+✔ Migration completed!
 
 
 > cat .lintstagedrc.json # check lintstagedrc.json

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-not-support/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-not-support/snap.txt
@@ -1,23 +1,23 @@
 > vp migrate --no-interactive # migration should not support non-json format lintstagedrc
-┌  VITE+ - The Unified Toolchain for the Web
-│
-●  Using default package manager: pnpm
-│
-●  pnpm@latest installing...
-│
-●  pnpm@<semver> installed
-│
-▲  ✘ .lintstagedrc is not JSON format file, auto migration is not supported
-│
-▲  ✘ .lintstagedrc.yaml is not supported by auto migration
-│
-▲  ✘ lint-staged.config.mjs is not supported by auto migration
-│
-▲  Please migrate the lint-staged config manually, see https://viteplus.dev/migration/#lint-staged for more details
-│
-◆  Wrote agent instructions to AGENTS.md
-│
-└  ✔ Migration completed!
+VITE+ - The Unified Toolchain for the Web
+
+
+Using default package manager: pnpm
+
+pnpm@latest installing...
+
+pnpm@<semver> installed
+
+✘ .lintstagedrc is not JSON format file, auto migration is not supported
+
+✘ .lintstagedrc.yaml is not supported by auto migration
+
+✘ lint-staged.config.mjs is not supported by auto migration
+
+Please migrate the lint-staged config manually, see https://viteplus.dev/migration/#lint-staged for more details
+
+Wrote agent instructions to AGENTS.md
+✔ Migration completed!
 
 
 > cat .lintstagedrc # check .lintstagedrc is not updated

--- a/packages/cli/snap-tests-global/migration-merge-vite-config-js/snap.txt
+++ b/packages/cli/snap-tests-global/migration-merge-vite-config-js/snap.txt
@@ -1,17 +1,17 @@
 > vp migrate --no-interactive # migration should merge vite.config.js and remove oxlintrc
-┌  VITE+ - The Unified Toolchain for the Web
-│
-●  Using default package manager: pnpm
-│
-●  pnpm@latest installing...
-│
-●  pnpm@<semver> installed
-│
-◆  ✔ Merged .oxlintrc.json into vite.config.js
-│
-◆  Wrote agent instructions to AGENTS.md
-│
-└  ✔ Migration completed!
+VITE+ - The Unified Toolchain for the Web
+
+
+Using default package manager: pnpm
+
+pnpm@latest installing...
+
+pnpm@<semver> installed
+
+✔ Merged .oxlintrc.json into vite.config.js
+
+Wrote agent instructions to AGENTS.md
+✔ Migration completed!
 
 
 > cat vite.config.js # check vite.config.js

--- a/packages/cli/snap-tests-global/migration-merge-vite-config-ts/snap.txt
+++ b/packages/cli/snap-tests-global/migration-merge-vite-config-ts/snap.txt
@@ -1,23 +1,23 @@
 > vp migrate --no-interactive # migration should merge vite.config.ts and remove oxlintrc and oxfmtrc
-┌  VITE+ - The Unified Toolchain for the Web
-│
-●  Using default package manager: pnpm
-│
-●  pnpm@latest installing...
-│
-●  pnpm@<semver> installed
-│
-◆  ✔ Merged .oxlintrc.json into vite.config.ts
-│
-◆  ✔ Merged .oxfmtrc.json into vite.config.ts
-│
-◆  Rewrote imports in one file
-│
-●    vite.config.ts
-│
-◆  Wrote agent instructions to AGENTS.md
-│
-└  ✔ Migration completed!
+VITE+ - The Unified Toolchain for the Web
+
+
+Using default package manager: pnpm
+
+pnpm@latest installing...
+
+pnpm@<semver> installed
+
+✔ Merged .oxlintrc.json into vite.config.ts
+
+✔ Merged .oxfmtrc.json into vite.config.ts
+
+Rewrote imports in one file
+
+  vite.config.ts
+
+Wrote agent instructions to AGENTS.md
+✔ Migration completed!
 
 
 > cat vite.config.ts # check vite.config.ts

--- a/packages/cli/snap-tests-global/migration-monorepo-pnpm-overrides-dependency-selector/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-pnpm-overrides-dependency-selector/snap.txt
@@ -1,17 +1,17 @@
 > vp migrate --no-interactive # migration should merge pnpm overrides with dependency selector
-┌  VITE+ - The Unified Toolchain for the Web
-│
-●  pnpm@<semver> installing...
-│
-●  pnpm@<semver> installed
-│
-◆  Rewrote imports in one file
-│
-●    vite.config.ts
-│
-◆  Wrote agent instructions to AGENTS.md
-│
-└  ✔ Migration completed!
+VITE+ - The Unified Toolchain for the Web
+
+
+pnpm@<semver> installing...
+
+pnpm@<semver> installed
+
+Rewrote imports in one file
+
+  vite.config.ts
+
+Wrote agent instructions to AGENTS.md
+✔ Migration completed!
 
 
 > cat vite.config.ts # check vite.config.ts

--- a/packages/cli/snap-tests-global/migration-monorepo-pnpm/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-pnpm/snap.txt
@@ -1,25 +1,25 @@
 > vp migrate --no-interactive # migration should merge vite.config.ts and remove oxlintrc and oxfmtrc
-┌  VITE+ - The Unified Toolchain for the Web
-│
-●  pnpm@<semver> installing...
-│
-●  pnpm@<semver> installed
-│
-◆  ✔ Merged .oxlintrc.json into vite.config.ts
-│
-◆  ✔ Merged .oxfmtrc.json into vite.config.ts
-│
-◆  ✔ Created vite.config.ts in packages/only-oxlint/vite.config.ts
-│
-◆  ✔ Merged packages/only-oxlint/.oxlintrc.json into packages/only-oxlint/vite.config.ts
-│
-◆  Rewrote imports in one file
-│
-●    vite.config.ts
-│
-◆  Wrote agent instructions to AGENTS.md
-│
-└  ✔ Migration completed!
+VITE+ - The Unified Toolchain for the Web
+
+
+pnpm@<semver> installing...
+
+pnpm@<semver> installed
+
+✔ Merged .oxlintrc.json into vite.config.ts
+
+✔ Merged .oxfmtrc.json into vite.config.ts
+
+✔ Created vite.config.ts in packages/only-oxlint/vite.config.ts
+
+✔ Merged packages/only-oxlint/.oxlintrc.json into packages/only-oxlint/vite.config.ts
+
+Rewrote imports in one file
+
+  vite.config.ts
+
+Wrote agent instructions to AGENTS.md
+✔ Migration completed!
 
 
 > cat vite.config.ts # check vite.config.ts

--- a/packages/cli/snap-tests-global/migration-monorepo-skip-vite-peer-dependency/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-skip-vite-peer-dependency/snap.txt
@@ -1,17 +1,17 @@
 > vp migrate --no-interactive # migration should check each package's peerDependencies
-┌  VITE+ - The Unified Toolchain for the Web
-│
-●  pnpm@latest installing...
-│
-●  pnpm@<semver> installed
-│
-◆  Rewrote imports in one file
-│
-●    packages/vite-plugin/src/index.ts
-│
-◆  Wrote agent instructions to AGENTS.md
-│
-└  ✔ Migration completed!
+VITE+ - The Unified Toolchain for the Web
+
+
+pnpm@latest installing...
+
+pnpm@<semver> installed
+
+Rewrote imports in one file
+
+  packages/vite-plugin/src/index.ts
+
+Wrote agent instructions to AGENTS.md
+✔ Migration completed!
 
 
 > cat packages/vite-plugin/src/index.ts # vite-plugin has vite in peerDeps: vite NOT rewritten, vitest rewritten

--- a/packages/cli/snap-tests-global/migration-monorepo-yarn4/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-yarn4/snap.txt
@@ -1,19 +1,19 @@
 > vp migrate --no-interactive # migration should merge vite.config.ts and remove oxlintrc
-┌  VITE+ - The Unified Toolchain for the Web
-│
-●  yarn@<semver> installing...
-│
-●  yarn@<semver> installed
-│
-◆  ✔ Merged .oxlintrc.json into vite.config.ts
-│
-◆  Rewrote imports in one file
-│
-●    vite.config.ts
-│
-◆  Wrote agent instructions to AGENTS.md
-│
-└  ✔ Migration completed!
+VITE+ - The Unified Toolchain for the Web
+
+
+yarn@<semver> installing...
+
+yarn@<semver> installed
+
+✔ Merged .oxlintrc.json into vite.config.ts
+
+Rewrote imports in one file
+
+  vite.config.ts
+
+Wrote agent instructions to AGENTS.md
+✔ Migration completed!
 
 
 > cat vite.config.ts # check vite.config.ts

--- a/packages/cli/snap-tests-global/migration-no-agent/snap.txt
+++ b/packages/cli/snap-tests-global/migration-no-agent/snap.txt
@@ -1,13 +1,13 @@
 > vp migrate --no-agent --no-interactive # migration with --no-agent should skip agent instructions
-┌  VITE+ - The Unified Toolchain for the Web
-│
-●  Using default package manager: pnpm
-│
-●  pnpm@latest installing...
-│
-●  pnpm@<semver> installed
-│
-└  ✔ Migration completed!
+VITE+ - The Unified Toolchain for the Web
+
+
+Using default package manager: pnpm
+
+pnpm@latest installing...
+
+pnpm@<semver> installed
+✔ Migration completed!
 
 
 > ls -la | grep -E '(AGENTS|CLAUDE)' || echo 'No agent file created' # verify no agent file was created

--- a/packages/cli/snap-tests-global/migration-not-supported-npm8.2/snap.txt
+++ b/packages/cli/snap-tests-global/migration-not-supported-npm8.2/snap.txt
@@ -1,12 +1,13 @@
 [1]> vp migrate --no-interactive # migration should fail because npm version is not supported
-┌  VITE+ - The Unified Toolchain for the Web
-│
-●  npm@<semver> installing...
-│
-●  npm@<semver> installed
-│
-■  ✘ npm@<semver> is not supported by auto migration, please upgrade npm to >=8.3.0 first
-└  Vite+ cannot automatically migrate this project yet.
+VITE+ - The Unified Toolchain for the Web
+
+
+npm@<semver> installing...
+
+npm@<semver> installed
+
+✘ npm@<semver> is not supported by auto migration, please upgrade npm to >=8.3.0 first
+Vite+ cannot automatically migrate this project yet.
 
 
 > cat package.json # check package.json is not updated

--- a/packages/cli/snap-tests-global/migration-not-supported-pnpm9.4/snap.txt
+++ b/packages/cli/snap-tests-global/migration-not-supported-pnpm9.4/snap.txt
@@ -1,12 +1,13 @@
 [1]> vp migrate --no-interactive # migration should fail because pnpm version is not supported
-┌  VITE+ - The Unified Toolchain for the Web
-│
-●  pnpm@<semver> installing...
-│
-●  pnpm@<semver> installed
-│
-■  ✘ pnpm@<semver> is not supported by auto migration, please upgrade pnpm to >=9.5.0 first
-└  Vite+ cannot automatically migrate this project yet.
+VITE+ - The Unified Toolchain for the Web
+
+
+pnpm@<semver> installing...
+
+pnpm@<semver> installed
+
+✘ pnpm@<semver> is not supported by auto migration, please upgrade pnpm to >=9.5.0 first
+Vite+ cannot automatically migrate this project yet.
 
 
 > cat package.json # check package.json is not updated

--- a/packages/cli/snap-tests-global/migration-not-supported-vite6/snap.txt
+++ b/packages/cli/snap-tests-global/migration-not-supported-vite6/snap.txt
@@ -1,15 +1,16 @@
 > vp install # install dependencies first
 [1]> vp migrate --no-interactive # migration should fail because vite version is not supported
-┌  VITE+ - The Unified Toolchain for the Web
-│
-●  pnpm@<semver> installing...
-│
-●  pnpm@<semver> installed
-│
-■  ✘ vite@<semver> in package.json is not supported by auto migration
-│
-●  Please upgrade vite to version >=7.0.0 first
-└  Vite+ cannot automatically migrate this project yet.
+VITE+ - The Unified Toolchain for the Web
+
+
+pnpm@<semver> installing...
+
+pnpm@<semver> installed
+
+✘ vite@<semver> in package.json is not supported by auto migration
+
+Please upgrade vite to version >=7.0.0 first
+Vite+ cannot automatically migrate this project yet.
 
 
 > cat package.json # check package.json is not updated

--- a/packages/cli/snap-tests-global/migration-not-supported-vitest3/snap.txt
+++ b/packages/cli/snap-tests-global/migration-not-supported-vitest3/snap.txt
@@ -1,15 +1,16 @@
 > vp install # install dependencies first
 [1]> vp migrate --no-interactive # migration should fail because vitest version is not supported
-┌  VITE+ - The Unified Toolchain for the Web
-│
-●  pnpm@<semver> installing...
-│
-●  pnpm@<semver> installed
-│
-■  ✘ vitest@<semver> in package.json is not supported by auto migration
-│
-●  Please upgrade vitest to version >=4.0.0 first
-└  Vite+ cannot automatically migrate this project yet.
+VITE+ - The Unified Toolchain for the Web
+
+
+pnpm@<semver> installing...
+
+pnpm@<semver> installed
+
+✘ vitest@<semver> in package.json is not supported by auto migration
+
+Please upgrade vitest to version >=4.0.0 first
+Vite+ cannot automatically migrate this project yet.
 
 
 > cat package.json # check package.json is not updated

--- a/packages/cli/snap-tests-global/migration-rewrite-declare-module/snap.txt
+++ b/packages/cli/snap-tests-global/migration-rewrite-declare-module/snap.txt
@@ -1,19 +1,19 @@
 > vp migrate --no-interactive # migration should rewrite imports to vite-plus
-┌  VITE+ - The Unified Toolchain for the Web
-│
-●  Using default package manager: pnpm
-│
-●  pnpm@latest installing...
-│
-●  pnpm@<semver> installed
-│
-◆  Rewrote imports in one file
-│
-●    src/index.ts
-│
-◆  Wrote agent instructions to AGENTS.md
-│
-└  ✔ Migration completed!
+VITE+ - The Unified Toolchain for the Web
+
+
+Using default package manager: pnpm
+
+pnpm@latest installing...
+
+pnpm@<semver> installed
+
+Rewrote imports in one file
+
+  src/index.ts
+
+Wrote agent instructions to AGENTS.md
+✔ Migration completed!
 
 
 > cat src/index.ts # check src/index.ts

--- a/packages/cli/snap-tests-global/migration-rewrite-reference-types/snap.txt
+++ b/packages/cli/snap-tests-global/migration-rewrite-reference-types/snap.txt
@@ -1,19 +1,19 @@
 > vp migrate --no-interactive # migration rewrites reference types
-┌  VITE+ - The Unified Toolchain for the Web
-│
-●  Using default package manager: pnpm
-│
-●  pnpm@latest installing...
-│
-●  pnpm@<semver> installed
-│
-◆  Rewrote imports in one file
-│
-●    src/env.d.ts
-│
-◆  Wrote agent instructions to AGENTS.md
-│
-└  ✔ Migration completed!
+VITE+ - The Unified Toolchain for the Web
+
+
+Using default package manager: pnpm
+
+pnpm@latest installing...
+
+pnpm@<semver> installed
+
+Rewrote imports in one file
+
+  src/env.d.ts
+
+Wrote agent instructions to AGENTS.md
+✔ Migration completed!
 
 
 > cat src/env.d.ts # check reference types rewritten

--- a/packages/cli/snap-tests-global/migration-skip-vite-dependency/snap.txt
+++ b/packages/cli/snap-tests-global/migration-skip-vite-dependency/snap.txt
@@ -1,19 +1,19 @@
 > vp migrate --no-interactive # migration should skip rewriting vite imports when vite is in dependencies
-┌  VITE+ - The Unified Toolchain for the Web
-│
-●  Using default package manager: pnpm
-│
-●  pnpm@latest installing...
-│
-●  pnpm@<semver> installed
-│
-◆  Rewrote imports in one file
-│
-●    src/index.ts
-│
-◆  Wrote agent instructions to AGENTS.md
-│
-└  ✔ Migration completed!
+VITE+ - The Unified Toolchain for the Web
+
+
+Using default package manager: pnpm
+
+pnpm@latest installing...
+
+pnpm@<semver> installed
+
+Rewrote imports in one file
+
+  src/index.ts
+
+Wrote agent instructions to AGENTS.md
+✔ Migration completed!
 
 
 > cat src/index.ts # vite imports should NOT be rewritten, vitest imports SHOULD be rewritten

--- a/packages/cli/snap-tests-global/migration-skip-vite-peer-dependency/snap.txt
+++ b/packages/cli/snap-tests-global/migration-skip-vite-peer-dependency/snap.txt
@@ -1,19 +1,19 @@
 > vp migrate --no-interactive # migration should skip rewriting vite imports when vite is in peerDependencies
-┌  VITE+ - The Unified Toolchain for the Web
-│
-●  Using default package manager: pnpm
-│
-●  pnpm@latest installing...
-│
-●  pnpm@<semver> installed
-│
-◆  Rewrote imports in one file
-│
-●    src/index.ts
-│
-◆  Wrote agent instructions to AGENTS.md
-│
-└  ✔ Migration completed!
+VITE+ - The Unified Toolchain for the Web
+
+
+Using default package manager: pnpm
+
+pnpm@latest installing...
+
+pnpm@<semver> installed
+
+Rewrote imports in one file
+
+  src/index.ts
+
+Wrote agent instructions to AGENTS.md
+✔ Migration completed!
 
 
 > cat src/index.ts # vite imports should NOT be rewritten, vitest imports SHOULD be rewritten

--- a/packages/cli/snap-tests-global/migration-standalone-npm/snap.txt
+++ b/packages/cli/snap-tests-global/migration-standalone-npm/snap.txt
@@ -1,21 +1,21 @@
 > vp migrate --no-interactive # migration should work with npm, add overrides, and update lockfile
-┌  VITE+ - The Unified Toolchain for the Web
-│
-●  npm@<semver> installing...
-│
-●  npm@<semver> installed
-│
-●  Installing dependencies...
-│
-●  Dependencies installed
-│
-◆  Wrote agent instructions to AGENTS.md
-│
-●  Installing dependencies...
-│
-●  Dependencies installed
-│
-└  ✔ Migration completed!
+VITE+ - The Unified Toolchain for the Web
+
+
+npm@<semver> installing...
+
+npm@<semver> installed
+
+Installing dependencies...
+
+Dependencies installed
+
+Wrote agent instructions to AGENTS.md
+
+Installing dependencies...
+
+Dependencies installed
+✔ Migration completed!
 
 
 > cat package.json # check package.json has overrides field (not pnpm.overrides)

--- a/packages/cli/snap-tests-global/migration-subpath/snap.txt
+++ b/packages/cli/snap-tests-global/migration-subpath/snap.txt
@@ -1,15 +1,15 @@
 > vp migrate foo --no-interactive # migration work with subpath
-┌  VITE+ - The Unified Toolchain for the Web
-│
-●  Using default package manager: pnpm
-│
-●  pnpm@latest installing...
-│
-●  pnpm@<semver> installed
-│
-◆  Wrote agent instructions to AGENTS.md
-│
-└  ✔ Migration completed!
+VITE+ - The Unified Toolchain for the Web
+
+
+Using default package manager: pnpm
+
+pnpm@latest installing...
+
+pnpm@<semver> installed
+
+Wrote agent instructions to AGENTS.md
+✔ Migration completed!
 
 
 > cat foo/package.json # check package.json

--- a/packages/cli/snap-tests-global/migration-vite-version/snap.txt
+++ b/packages/cli/snap-tests-global/migration-vite-version/snap.txt
@@ -1,15 +1,15 @@
 > vp migrate --no-interactive # migration should rewrite vite --version to vp --version
-┌  VITE+ - The Unified Toolchain for the Web
-│
-●  Using default package manager: pnpm
-│
-●  pnpm@latest installing...
-│
-●  pnpm@<semver> installed
-│
-◆  Wrote agent instructions to AGENTS.md
-│
-└  ✔ Migration completed!
+VITE+ - The Unified Toolchain for the Web
+
+
+Using default package manager: pnpm
+
+pnpm@latest installing...
+
+pnpm@<semver> installed
+
+Wrote agent instructions to AGENTS.md
+✔ Migration completed!
 
 
 > cat package.json # check package.json

--- a/packages/cli/src/create/bin.ts
+++ b/packages/cli/src/create/bin.ts
@@ -42,7 +42,7 @@ import {
 } from './templates/index.js';
 import { InitialMonorepoAppDir } from './templates/monorepo.js';
 import { BuiltinTemplate, TemplateType } from './templates/types.js';
-import { formatTargetDir } from './utils.js';
+import { formatDisplayTargetDir, formatTargetDir } from './utils.js';
 
 const helpMessage = renderCliDoc({
   usage: 'vp create [TEMPLATE] [OPTIONS] [-- TEMPLATE_OPTIONS]',
@@ -307,7 +307,7 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
       });
     }
     const template = await prompts.select({
-      message: 'Which template would you like to use?',
+      message: '',
       options: [
         ...templates,
         {
@@ -541,7 +541,6 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
 
   // #region Handle monorepo template
   if (templateInfo.command === BuiltinTemplate.monorepo) {
-    prompts.log.info(`Target directory: ${accent(targetDir)}`);
     await checkProjectDirExists(path.join(workspaceInfo.rootDir, targetDir), options.interactive);
     const result = await executeMonorepoTemplate(
       workspaceInfo,
@@ -593,7 +592,7 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
         : selected.targetDir;
     }
     await checkProjectDirExists(targetDir, options.interactive);
-    prompts.log.info(`Target directory: ${accent(targetDir)}`);
+    prompts.log.info(`Target directory: ${accent(formatDisplayTargetDir(targetDir))}`);
     result = await executeBuiltinTemplate(workspaceInfo, {
       ...templateInfo,
       packageName,

--- a/packages/cli/src/create/templates/monorepo.ts
+++ b/packages/cli/src/create/templates/monorepo.ts
@@ -11,7 +11,7 @@ import { editJsonFile } from '../../utils/json.js';
 import { templatesDir } from '../../utils/path.js';
 import type { ExecutionResult } from '../command.js';
 import { discoverTemplate } from '../discovery.js';
-import { copyDir, setPackageName } from '../utils.js';
+import { copyDir, formatDisplayTargetDir, setPackageName } from '../utils.js';
 import { runRemoteTemplateCommand } from './remote.js';
 import { type BuiltinTemplateInfo } from './types.js';
 
@@ -23,12 +23,31 @@ export async function executeMonorepoTemplate(
   templateInfo: BuiltinTemplateInfo,
   interactive: boolean,
 ): Promise<ExecutionResult> {
-  prompts.log.step('Creating Vite+ monorepo...');
   assert(templateInfo.packageName, 'packageName is required');
   assert(templateInfo.targetDir, 'targetDir is required');
 
   workspaceInfo.monorepoScope = getScopeFromPackageName(templateInfo.packageName);
   const fullPath = path.join(workspaceInfo.rootDir, templateInfo.targetDir);
+
+  // Ask user to init git repository before creation starts.
+  let initGit = true; // Default to yes
+  if (interactive) {
+    const selected = await prompts.confirm({
+      message: `Initialize git repository:`,
+      initialValue: true,
+    });
+    if (prompts.isCancel(selected)) {
+      prompts.log.info('Operation cancelled. Skipping git initialization');
+      initGit = false;
+    } else {
+      initGit = selected;
+    }
+  } else {
+    prompts.log.info(`Initializing git repository (default: yes)`);
+  }
+
+  prompts.log.info(`Target directory: ${formatDisplayTargetDir(templateInfo.targetDir)}`);
+  prompts.log.step('Creating Vite+ monorepo...');
 
   // Copy template files
   const templateDir = path.join(templatesDir, 'monorepo');
@@ -82,23 +101,6 @@ export async function executeMonorepoTemplate(
   }
 
   prompts.log.success('Monorepo template created');
-
-  // Ask user to init git repository or auto-init if --no-interactive
-  let initGit = true; // Default to yes
-  if (interactive) {
-    const selected = await prompts.confirm({
-      message: `Initialize git repository:`,
-      initialValue: true,
-    });
-    if (prompts.isCancel(selected)) {
-      prompts.log.info('Operation cancelled. Skipping git initialization');
-      initGit = false;
-    } else {
-      initGit = selected;
-    }
-  } else {
-    prompts.log.info(`Initializing git repository (default: yes)`);
-  }
 
   if (initGit) {
     const gitResult = spawn.sync('git', ['init'], {

--- a/packages/cli/src/create/utils.ts
+++ b/packages/cli/src/create/utils.ts
@@ -104,3 +104,19 @@ export function setPackageName(projectDir: string, packageName: string) {
     return pkg;
   });
 }
+
+export function formatDisplayTargetDir(targetDir: string) {
+  const normalized = targetDir.split(path.sep).join('/');
+  if (normalized === '' || normalized === '.') {
+    return './';
+  }
+  if (
+    normalized.startsWith('./') ||
+    normalized.startsWith('../') ||
+    normalized.startsWith('/') ||
+    normalized.startsWith('~')
+  ) {
+    return normalized;
+  }
+  return `./${normalized}`;
+}

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -150,7 +150,7 @@ async function main() {
         '- Inspect workspace and package manager',
         `- Run ${accent('vp install')} to prepare dependencies`,
         '- Rewrite configs and dependencies for Vite+',
-      ].join('\n'),
+      ].join('\n') + '\n',
     );
     const approved = await prompts.confirm({
       message: 'Migrate this project to Vite+?',

--- a/packages/cli/src/utils/editor.ts
+++ b/packages/cli/src/utils/editor.ts
@@ -51,20 +51,22 @@ export async function selectEditor({
   }
 
   if (interactive && !editor) {
+    const editorOptions = EDITORS.map((option) => ({
+      label: option.label,
+      value: option.id,
+      hint: option.targetDir,
+    }));
+    const noneOption = {
+      label: 'None',
+      value: null,
+      hint: 'Skip writing editor configs',
+    };
     const selectedEditor = await prompts.select({
       message: 'Which editor are you using?',
-      options: [
-        {
-          label: 'None',
-          value: null,
-          hint: 'Skip writing editor configs',
-        },
-        ...EDITORS.map((option) => ({
-          label: option.label,
-          value: option.id,
-          hint: option.targetDir,
-        })),
-      ],
+      options:
+        editorOptions.length > 0
+          ? [editorOptions[0], noneOption, ...editorOptions.slice(1)]
+          : [noneOption],
       initialValue: 'vscode',
     });
 

--- a/packages/prompts/src/__tests__/__snapshots__/render.spec.ts.snap
+++ b/packages/prompts/src/__tests__/__snapshots__/render.spec.ts.snap
@@ -1,0 +1,66 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`prompt renderers > renders autocomplete multiselect with pointer markers plus checkboxes 1`] = `
+"› Search and select
+  Search: type to filter
+    ◻ Alpha
+      Second line
+  › ◼ Beta
+  ↑/↓ to navigate • Space/Tab: select • Enter: confirm • Type: to search"
+`;
+
+exports[`prompt renderers > renders autocomplete with pointer markers and focused hint 1`] = `
+"› Search options
+  Search: type to filter
+  › Alpha (recommended)
+    Second line
+    Beta
+  ↑/↓ to select • Enter: confirm • Type: to search
+"
+`;
+
+exports[`prompt renderers > renders confirm and select-key in pointer style 1`] = `
+"› Proceed?
+  › Yes /   No
+
+
+---
+› Pick shortcut
+  ›  a  Add item
+     r  Remove item
+
+"
+`;
+
+exports[`prompt renderers > renders grouped multiselect with marker, tree branch, and checkbox alignment 1`] = `
+"› Grouped choices
+
+  ◻ Fruits
+    │ ◻ Apple (fresh)
+      Green
+  › └ ◼ Banana
+
+  ◻ Tools
+    └ ◻ Hammer
+
+"
+`;
+
+exports[`prompt renderers > renders multiselect with cursor marker plus checkbox state 1`] = `
+"› Choose multiple
+    ◻ Alpha
+      Second line
+  › ◼ Beta
+    ◻ Gamma
+
+"
+`;
+
+exports[`prompt renderers > renders select with pointer markers and aligned multiline labels 1`] = `
+"› Choose an option
+  › Alpha: recommended
+    Second line
+    Beta
+
+"
+`;

--- a/packages/prompts/src/__tests__/render.spec.ts
+++ b/packages/prompts/src/__tests__/render.spec.ts
@@ -1,0 +1,273 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type PromptConfig = {
+  render: (this: Record<string, unknown>) => string;
+};
+
+const captured: {
+  select?: PromptConfig;
+  multiSelect?: PromptConfig;
+  groupMultiSelect?: PromptConfig;
+  autocomplete?: PromptConfig;
+  confirm?: PromptConfig;
+  selectKey?: PromptConfig;
+} = {};
+
+class SelectPrompt<_Value> {
+  constructor(config: PromptConfig) {
+    captured.select = config;
+  }
+
+  prompt() {
+    return Promise.resolve(Symbol('cancel'));
+  }
+}
+
+class MultiSelectPrompt<_Value> {
+  constructor(config: PromptConfig) {
+    captured.multiSelect = config;
+  }
+
+  prompt() {
+    return Promise.resolve(Symbol('cancel'));
+  }
+}
+
+class GroupMultiSelectPrompt<_Value> {
+  constructor(config: PromptConfig) {
+    captured.groupMultiSelect = config;
+  }
+
+  prompt() {
+    return Promise.resolve(Symbol('cancel'));
+  }
+}
+
+class AutocompletePrompt<_Value> {
+  constructor(config: PromptConfig) {
+    captured.autocomplete = config;
+  }
+
+  prompt() {
+    return Promise.resolve(Symbol('cancel'));
+  }
+}
+
+class ConfirmPrompt {
+  constructor(config: PromptConfig) {
+    captured.confirm = config;
+  }
+
+  prompt() {
+    return Promise.resolve(Symbol('cancel'));
+  }
+}
+
+class SelectKeyPrompt<_Value> {
+  constructor(config: PromptConfig) {
+    captured.selectKey = config;
+  }
+
+  prompt() {
+    return Promise.resolve(Symbol('cancel'));
+  }
+}
+
+vi.mock('@clack/core', () => {
+  return {
+    settings: { withGuide: true },
+    wrapTextWithPrefix: (
+      _output: unknown,
+      text: string,
+      firstPrefix: string,
+      nextPrefix = firstPrefix,
+    ) => {
+      return text
+        .split('\n')
+        .map((line, index) => `${index === 0 ? firstPrefix : nextPrefix}${line}`)
+        .join('\n');
+    },
+    getColumns: () => 80,
+    getRows: () => 24,
+    SelectPrompt,
+    MultiSelectPrompt,
+    GroupMultiSelectPrompt,
+    AutocompletePrompt,
+    ConfirmPrompt,
+    SelectKeyPrompt,
+  };
+});
+
+// oxlint-disable-next-line no-control-regex
+const stripAnsi = (value: string): string => value.replaceAll(/\x1b\[[0-9;]*m/gu, '');
+const normalize = (value: string): string => stripAnsi(value).replaceAll('\r\n', '\n');
+
+const renderWith = (config: PromptConfig | undefined, ctx: Record<string, unknown>): string => {
+  if (config === undefined) {
+    throw new Error('Prompt config was not captured');
+  }
+  return normalize(config.render.call(ctx));
+};
+
+beforeEach(() => {
+  captured.select = undefined;
+  captured.multiSelect = undefined;
+  captured.groupMultiSelect = undefined;
+  captured.autocomplete = undefined;
+  captured.confirm = undefined;
+  captured.selectKey = undefined;
+});
+
+describe('prompt renderers', () => {
+  it('renders select with pointer markers and aligned multiline labels', async () => {
+    const { select } = await import('../select.js');
+    const options = [
+      { value: 'alpha', label: 'Alpha\nSecond line', hint: 'recommended' },
+      { value: 'beta', label: 'Beta' },
+    ];
+    void select({
+      message: 'Choose an option',
+      options,
+    });
+    expect(
+      renderWith(captured.select, {
+        state: 'active',
+        options,
+        cursor: 0,
+      }),
+    ).toMatchSnapshot();
+  });
+
+  it('renders multiselect with cursor marker plus checkbox state', async () => {
+    const { multiselect } = await import('../multi-select.js');
+    const options = [
+      { value: 'alpha', label: 'Alpha\nSecond line', hint: 'recommended' },
+      { value: 'beta', label: 'Beta' },
+      { value: 'gamma', label: 'Gamma' },
+    ];
+    void multiselect({
+      message: 'Choose multiple',
+      options,
+    });
+    expect(
+      renderWith(captured.multiSelect, {
+        state: 'active',
+        options,
+        cursor: 1,
+        value: ['beta'],
+      }),
+    ).toMatchSnapshot();
+  });
+
+  it('renders grouped multiselect with marker, tree branch, and checkbox alignment', async () => {
+    const { groupMultiselect } = await import('../group-multi-select.js');
+    void groupMultiselect({
+      message: 'Grouped choices',
+      options: {
+        Fruits: [
+          { value: 'apple', label: 'Apple\nGreen', hint: 'fresh' },
+          { value: 'banana', label: 'Banana' },
+        ],
+        Tools: [{ value: 'hammer', label: 'Hammer' }],
+      },
+      selectableGroups: true,
+      groupSpacing: 1,
+    });
+    const renderedOptions = [
+      { value: 'Fruits', label: 'Fruits', group: true },
+      { value: 'apple', label: 'Apple\nGreen', hint: 'fresh', group: 'Fruits' },
+      { value: 'banana', label: 'Banana', group: 'Fruits' },
+      { value: 'Tools', label: 'Tools', group: true },
+      { value: 'hammer', label: 'Hammer', group: 'Tools' },
+    ];
+    expect(
+      renderWith(captured.groupMultiSelect, {
+        state: 'active',
+        options: renderedOptions,
+        cursor: 2,
+        value: ['banana'],
+        isGroupSelected: () => false,
+      }),
+    ).toMatchSnapshot();
+  });
+
+  it('renders autocomplete with pointer markers and focused hint', async () => {
+    const { autocomplete } = await import('../autocomplete.js');
+    const options = [
+      { value: 'alpha', label: 'Alpha\nSecond line', hint: 'recommended' },
+      { value: 'beta', label: 'Beta' },
+    ];
+    void autocomplete({
+      message: 'Search options',
+      options,
+      placeholder: 'type to filter',
+    });
+    expect(
+      renderWith(captured.autocomplete, {
+        state: 'active',
+        options,
+        filteredOptions: options,
+        selectedValues: [],
+        focusedValue: 'alpha',
+        userInput: '',
+        userInputWithCursor: '|',
+        cursor: 0,
+        isNavigating: true,
+      }),
+    ).toMatchSnapshot();
+  });
+
+  it('renders autocomplete multiselect with pointer markers plus checkboxes', async () => {
+    const { autocompleteMultiselect } = await import('../autocomplete.js');
+    const options = [
+      { value: 'alpha', label: 'Alpha\nSecond line', hint: 'recommended' },
+      { value: 'beta', label: 'Beta' },
+    ];
+    void autocompleteMultiselect({
+      message: 'Search and select',
+      options,
+      placeholder: 'type to filter',
+    });
+    expect(
+      renderWith(captured.autocomplete, {
+        state: 'active',
+        options,
+        filteredOptions: options,
+        selectedValues: ['beta'],
+        focusedValue: 'beta',
+        userInput: '',
+        userInputWithCursor: '|',
+        cursor: 1,
+        isNavigating: true,
+      }),
+    ).toMatchSnapshot();
+  });
+
+  it('renders confirm and select-key in pointer style', async () => {
+    const [{ confirm }, { selectKey }] = await Promise.all([
+      import('../confirm.js'),
+      import('../select-key.js'),
+    ]);
+    void confirm({ message: 'Proceed?' });
+    const confirmOutput = renderWith(captured.confirm, {
+      state: 'active',
+      value: true,
+    });
+
+    const keyOptions = [
+      { value: 'a', label: 'Add item' },
+      { value: 'r', label: 'Remove item' },
+    ];
+    void selectKey({
+      message: 'Pick shortcut',
+      options: keyOptions,
+    });
+    const selectKeyOutput = renderWith(captured.selectKey, {
+      state: 'active',
+      options: keyOptions,
+      cursor: 0,
+    });
+
+    expect(`${confirmOutput}\n---\n${selectKeyOutput}`).toMatchSnapshot();
+  });
+});

--- a/packages/prompts/src/autocomplete.ts
+++ b/packages/prompts/src/autocomplete.ts
@@ -1,4 +1,4 @@
-import { AutocompletePrompt, settings } from '@clack/core';
+import { AutocompletePrompt } from '@clack/core';
 import color from 'picocolors';
 
 import {
@@ -7,8 +7,8 @@ import {
   S_BAR_END,
   S_CHECKBOX_INACTIVE,
   S_CHECKBOX_SELECTED,
-  S_RADIO_ACTIVE,
-  S_RADIO_INACTIVE,
+  S_POINTER_ACTIVE,
+  S_POINTER_INACTIVE,
   symbol,
 } from './common.js';
 import { limitOptions } from './limit-options.js';
@@ -41,6 +41,43 @@ function getSelectedOptions<T>(values: T[], options: Option<T>[]): Option<T>[] {
 
   return results;
 }
+
+const withMarker = (
+  marker: string,
+  label: string,
+  format: (text: string) => string,
+  firstLineSuffix = '',
+) => {
+  const lines = label.split('\n');
+  if (lines.length === 1) {
+    return `${marker} ${format(lines[0])}${firstLineSuffix}`;
+  }
+  const [firstLine, ...rest] = lines;
+  return [
+    `${marker} ${format(firstLine)}${firstLineSuffix}`,
+    ...rest.map((line) => `${S_POINTER_INACTIVE} ${format(line)}`),
+  ].join('\n');
+};
+
+const withMarkerAndIndicator = (
+  marker: string,
+  indicator: string,
+  indicatorWidth: number,
+  label: string,
+  format: (text: string) => string,
+  firstLineSuffix = '',
+) => {
+  const lines = label.split('\n');
+  const continuationPrefix = `${S_POINTER_INACTIVE} ${' '.repeat(indicatorWidth)} `;
+  if (lines.length === 1) {
+    return `${marker} ${indicator} ${format(lines[0])}${firstLineSuffix}`;
+  }
+  const [firstLine, ...rest] = lines;
+  return [
+    `${marker} ${indicator} ${format(firstLine)}${firstLineSuffix}`,
+    ...rest.map((line) => `${continuationPrefix}${format(line)}`),
+  ].join('\n');
+};
 
 interface AutocompleteSharedOptions<Value> extends CommonOptions {
   /**
@@ -96,11 +133,12 @@ export const autocomplete = <Value>(opts: AutocompleteOptions<Value>) => {
     output: opts.output,
     validate: opts.validate,
     render() {
-      const hasGuide = opts.withGuide ?? settings.withGuide;
+      const hasGuide = opts.withGuide ?? false;
+      const nestedPrefix = '  ';
       // Title and message display
       const headings = hasGuide
-        ? [color.gray(S_BAR), `${symbol(this.state)}  ${opts.message}`]
-        : [`${symbol(this.state)}  ${opts.message}`];
+        ? [color.gray(S_BAR), `${symbol(this.state)} ${opts.message}`]
+        : [`${symbol(this.state)} ${opts.message}`];
       const userInput = this.userInput;
       const options = this.options;
       const placeholder = opts.placeholder;
@@ -111,21 +149,20 @@ export const autocomplete = <Value>(opts: AutocompleteOptions<Value>) => {
         case 'submit': {
           // Show selected value
           const selected = getSelectedOptions(this.selectedValues, options);
-          const label =
-            selected.length > 0 ? `  ${color.dim(selected.map(getLabel).join(', '))}` : '';
-          const submitPrefix = hasGuide ? color.gray(S_BAR) : '';
-          return `${headings.join('\n')}\n${submitPrefix}${label}`;
+          const label = selected.length > 0 ? color.dim(selected.map(getLabel).join(', ')) : '';
+          const submitPrefix = hasGuide ? `${color.gray(S_BAR)} ` : nestedPrefix;
+          return `${headings.join('\n')}\n${submitPrefix}${label}\n\n`;
         }
 
         case 'cancel': {
-          const userInputText = userInput ? `  ${color.strikethrough(color.dim(userInput))}` : '';
-          const cancelPrefix = hasGuide ? color.gray(S_BAR) : '';
-          return `${headings.join('\n')}\n${cancelPrefix}${userInputText}`;
+          const userInputText = userInput ? color.strikethrough(color.dim(userInput)) : '';
+          const cancelPrefix = hasGuide ? `${color.gray(S_BAR)} ` : nestedPrefix;
+          return `${headings.join('\n')}\n${cancelPrefix}${userInputText}\n\n`;
         }
 
         default: {
           const barColor = this.state === 'error' ? color.yellow : color.blue;
-          const guidePrefix = hasGuide ? `${barColor(S_BAR)}  ` : '';
+          const guidePrefix = hasGuide ? `${barColor(S_BAR)} ` : nestedPrefix;
           const guidePrefixEnd = hasGuide ? barColor(S_BAR_END) : '';
           // Display cursor position - show plain text in navigation mode
           let searchText = '';
@@ -178,18 +215,23 @@ export const autocomplete = <Value>(opts: AutocompleteOptions<Value>) => {
               : limitOptions({
                   cursor: this.cursor,
                   options: this.filteredOptions,
-                  columnPadding: hasGuide ? 3 : 0, // for `|  ` when guide is shown
+                  columnPadding: hasGuide ? 2 : 2,
                   rowPadding: headings.length + footers.length,
                   style: (option, active) => {
                     const label = getLabel(option);
                     const hint =
                       option.hint && option.value === this.focusedValue
-                        ? color.dim(` (${option.hint})`)
+                        ? color.gray(` (${option.hint})`)
                         : '';
 
                     return active
-                      ? `${color.green(S_RADIO_ACTIVE)} ${label}${hint}`
-                      : `${color.dim(S_RADIO_INACTIVE)} ${color.dim(label)}${hint}`;
+                      ? withMarker(
+                          color.blue(S_POINTER_ACTIVE),
+                          label,
+                          (text) => color.blue(color.bold(text)),
+                          hint,
+                        )
+                      : withMarker(color.dim(S_POINTER_INACTIVE), label, color.dim, hint);
                   },
                   maxItems: opts.maxItems,
                   output: opts.output,
@@ -236,14 +278,19 @@ export const autocompleteMultiselect = <Value>(opts: AutocompleteMultiSelectOpti
     const label = option.label ?? String(option.value ?? '');
     const hint =
       option.hint && focusedValue !== undefined && option.value === focusedValue
-        ? color.dim(` (${option.hint})`)
+        ? color.gray(` (${option.hint})`)
         : '';
-    const checkbox = isSelected ? color.green(S_CHECKBOX_SELECTED) : color.dim(S_CHECKBOX_INACTIVE);
-
-    if (active) {
-      return `${checkbox} ${label}${hint}`;
-    }
-    return `${checkbox} ${color.dim(label)}`;
+    const checkboxRaw = isSelected ? S_CHECKBOX_SELECTED : S_CHECKBOX_INACTIVE;
+    const checkbox = isSelected ? color.blue(checkboxRaw) : color.dim(checkboxRaw);
+    const marker = active ? color.blue(S_POINTER_ACTIVE) : color.dim(S_POINTER_INACTIVE);
+    return withMarkerAndIndicator(
+      marker,
+      checkbox,
+      checkboxRaw.length,
+      label,
+      active ? (text) => color.blue(color.bold(text)) : color.dim,
+      hint,
+    );
   };
 
   // Create text prompt which we'll use as foundation
@@ -266,8 +313,10 @@ export const autocompleteMultiselect = <Value>(opts: AutocompleteMultiSelectOpti
     input: opts.input,
     output: opts.output,
     render() {
+      const hasGuide = opts.withGuide ?? false;
+      const nestedPrefix = '  ';
       // Title and symbol
-      const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${opts.message}\n`;
+      const title = `${hasGuide ? `${color.gray(S_BAR)}\n` : ''}${symbol(this.state)} ${opts.message}\n`;
 
       // Selection counter
       const userInput = this.userInput;
@@ -292,13 +341,19 @@ export const autocompleteMultiselect = <Value>(opts: AutocompleteMultiSelectOpti
       // Render prompt state
       switch (this.state) {
         case 'submit': {
-          return `${title}${color.gray(S_BAR)}  ${color.dim(`${this.selectedValues.length} items selected`)}`;
+          const submitPrefix = hasGuide ? `${color.gray(S_BAR)} ` : '';
+          const finalPrefix = hasGuide ? submitPrefix : nestedPrefix;
+          return `${title}${finalPrefix}${color.dim(`${this.selectedValues.length} items selected`)}\n\n`;
         }
         case 'cancel': {
-          return `${title}${color.gray(S_BAR)}  ${color.strikethrough(color.dim(userInput))}`;
+          const cancelPrefix = hasGuide ? `${color.gray(S_BAR)} ` : '';
+          const finalPrefix = hasGuide ? cancelPrefix : nestedPrefix;
+          return `${title}${finalPrefix}${color.strikethrough(color.dim(userInput))}\n\n`;
         }
         default: {
           const barColor = this.state === 'error' ? color.yellow : color.blue;
+          const prefix = hasGuide ? `${barColor(S_BAR)} ` : nestedPrefix;
+          const footerEnd = hasGuide ? [barColor(S_BAR_END)] : [];
           // Instructions
           const instructions = [
             `${color.dim('↑/↓')} to navigate`,
@@ -310,23 +365,20 @@ export const autocompleteMultiselect = <Value>(opts: AutocompleteMultiSelectOpti
           // No results message
           const noResults =
             this.filteredOptions.length === 0 && userInput
-              ? [`${barColor(S_BAR)}  ${color.yellow('No matches found')}`]
+              ? [`${prefix}${color.yellow('No matches found')}`]
               : [];
 
           const errorMessage =
-            this.state === 'error' ? [`${barColor(S_BAR)}  ${color.yellow(this.error)}`] : [];
+            this.state === 'error' ? [`${prefix}${color.yellow(this.error)}`] : [];
 
           // Calculate header and footer line counts for rowPadding
           const headerLines = [
-            ...`${title}${barColor(S_BAR)}`.split('\n'),
-            `${barColor(S_BAR)}  ${color.dim('Search:')} ${searchText}${matches}`,
+            ...title.trimEnd().split('\n'),
+            `${prefix}${color.dim('Search:')} ${searchText}${matches}`,
             ...noResults,
             ...errorMessage,
           ];
-          const footerLines = [
-            `${barColor(S_BAR)}  ${instructions.join(' • ')}`,
-            barColor(S_BAR_END),
-          ];
+          const footerLines = [`${prefix}${instructions.join(' • ')}`, ...footerEnd];
 
           // Get limited options for display
           const displayOptions = limitOptions({
@@ -342,7 +394,7 @@ export const autocompleteMultiselect = <Value>(opts: AutocompleteMultiSelectOpti
           // Build the prompt display
           return [
             ...headerLines,
-            ...displayOptions.map((option) => `${barColor(S_BAR)}  ${option}`),
+            ...displayOptions.map((option) => `${prefix}${option}`),
             ...footerLines,
           ].join('\n');
         }

--- a/packages/prompts/src/box.ts
+++ b/packages/prompts/src/box.ts
@@ -1,6 +1,6 @@
 import type { Writable } from 'node:stream';
 
-import { getColumns, settings } from '@clack/core';
+import { getColumns } from '@clack/core';
 import stringWidth from 'fast-string-width';
 import { wrapAnsi } from 'fast-wrap-ansi';
 
@@ -69,7 +69,7 @@ export const box = (message = '', title = '', opts?: BoxOptions) => {
   const titlePadding = opts?.titlePadding ?? 1;
   const contentPadding = opts?.contentPadding ?? 2;
   const width = opts?.width === undefined || opts.width === 'auto' ? 1 : Math.min(1, opts.width);
-  const hasGuide = opts?.withGuide ?? settings.withGuide;
+  const hasGuide = opts?.withGuide ?? false;
   const linePrefix = !hasGuide ? '' : `${S_BAR} `;
   const formatBorder = opts?.formatBorder ?? defaultFormatBorder;
   const symbols = (opts?.rounded ? roundedSymbols : squareSymbols).map(formatBorder);

--- a/packages/prompts/src/common.ts
+++ b/packages/prompts/src/common.ts
@@ -10,7 +10,9 @@ export const isTTY = (output: Writable): boolean => {
   return (output as Writable & { isTTY?: boolean }).isTTY === true;
 };
 export const unicodeOr = (c: string, fallback: string) => (unicode ? c : fallback);
-export const S_STEP_ACTIVE = unicodeOr('◆', '*');
+export const S_POINTER_ACTIVE = unicodeOr('›', '>');
+export const S_POINTER_INACTIVE = ' ';
+export const S_STEP_ACTIVE = S_POINTER_ACTIVE;
 export const S_STEP_CANCEL = unicodeOr('■', 'x');
 export const S_STEP_ERROR = unicodeOr('▲', 'x');
 export const S_STEP_SUBMIT = unicodeOr('◇', 'o');
@@ -21,8 +23,8 @@ export const S_BAR_END = unicodeOr('└', '—');
 export const S_BAR_START_RIGHT = unicodeOr('┐', 'T');
 export const S_BAR_END_RIGHT = unicodeOr('┘', '—');
 
-export const S_RADIO_ACTIVE = unicodeOr('●', '>');
-export const S_RADIO_INACTIVE = unicodeOr('○', ' ');
+export const S_RADIO_ACTIVE = S_POINTER_ACTIVE;
+export const S_RADIO_INACTIVE = S_POINTER_INACTIVE;
 export const S_CHECKBOX_ACTIVE = unicodeOr('◻', '[•]');
 export const S_CHECKBOX_SELECTED = unicodeOr('◼', '[+]');
 export const S_CHECKBOX_INACTIVE = unicodeOr('◻', '[ ]');
@@ -40,6 +42,8 @@ export const S_SUCCESS = unicodeOr('◆', '*');
 export const S_WARN = unicodeOr('▲', '!');
 export const S_ERROR = unicodeOr('■', 'x');
 
+export const completeColor = (value: string) => color.gray(value);
+
 export const symbol = (state: State) => {
   switch (state) {
     case 'initial':
@@ -50,7 +54,7 @@ export const symbol = (state: State) => {
     case 'error':
       return color.yellow(S_STEP_ERROR);
     case 'submit':
-      return color.green(S_STEP_SUBMIT);
+      return completeColor(S_STEP_SUBMIT);
   }
 };
 
@@ -64,7 +68,7 @@ export const symbolBar = (state: State) => {
     case 'error':
       return color.yellow(S_BAR);
     case 'submit':
-      return color.green(S_BAR);
+      return completeColor(S_BAR);
   }
 };
 

--- a/packages/prompts/src/confirm.ts
+++ b/packages/prompts/src/confirm.ts
@@ -1,12 +1,12 @@
-import { ConfirmPrompt, settings } from '@clack/core';
+import { ConfirmPrompt } from '@clack/core';
 import color from 'picocolors';
 
 import {
   type CommonOptions,
   S_BAR,
   S_BAR_END,
-  S_RADIO_ACTIVE,
-  S_RADIO_INACTIVE,
+  S_POINTER_ACTIVE,
+  S_POINTER_INACTIVE,
   symbol,
 } from './common.js';
 
@@ -28,32 +28,39 @@ export const confirm = (opts: ConfirmOptions) => {
     output: opts.output,
     initialValue: opts.initialValue ?? true,
     render() {
-      const hasGuide = opts.withGuide ?? settings.withGuide;
-      const title = `${hasGuide ? `${color.gray(S_BAR)}\n` : ''}${symbol(this.state)}  ${opts.message}\n`;
+      const hasGuide = opts.withGuide ?? false;
+      const nestedPrefix = '  ';
+      const title = `${hasGuide ? `${color.gray(S_BAR)}\n` : ''}${symbol(this.state)} ${opts.message}\n`;
       const value = this.value ? active : inactive;
 
       switch (this.state) {
         case 'submit': {
-          const submitPrefix = hasGuide ? `${color.gray(S_BAR)}  ` : '';
-          return `${title}${submitPrefix}${color.dim(value)}`;
+          const submitPrefix = hasGuide ? `${color.gray(S_BAR)} ` : nestedPrefix;
+          return `${title}${submitPrefix}${color.dim(value)}\n\n`;
         }
         case 'cancel': {
-          const cancelPrefix = hasGuide ? `${color.gray(S_BAR)}  ` : '';
+          const cancelPrefix = hasGuide ? `${color.gray(S_BAR)} ` : nestedPrefix;
           return `${title}${cancelPrefix}${color.strikethrough(
             color.dim(value),
-          )}${hasGuide ? `\n${color.gray(S_BAR)}` : ''}`;
+          )}${hasGuide ? `\n${color.gray(S_BAR)}` : ''}\n\n`;
         }
         default: {
-          const defaultPrefix = hasGuide ? `${color.blue(S_BAR)}  ` : '';
+          const defaultPrefix = hasGuide ? `${color.blue(S_BAR)} ` : nestedPrefix;
           const defaultPrefixEnd = hasGuide ? color.blue(S_BAR_END) : '';
           return `${title}${defaultPrefix}${
             this.value
-              ? `${color.green(S_RADIO_ACTIVE)} ${active}`
-              : `${color.dim(S_RADIO_INACTIVE)} ${color.dim(active)}`
-          }${opts.vertical ? (hasGuide ? `\n${color.blue(S_BAR)}  ` : '\n') : ` ${color.dim('/')} `}${
+              ? `${color.blue(S_POINTER_ACTIVE)} ${color.bold(active)}`
+              : `${color.dim(S_POINTER_INACTIVE)} ${color.dim(active)}`
+          }${
+            opts.vertical
+              ? hasGuide
+                ? `\n${color.blue(S_BAR)} `
+                : `\n${nestedPrefix}`
+              : ` ${color.dim('/')} `
+          }${
             !this.value
-              ? `${color.green(S_RADIO_ACTIVE)} ${inactive}`
-              : `${color.dim(S_RADIO_INACTIVE)} ${color.dim(inactive)}`
+              ? `${color.blue(S_POINTER_ACTIVE)} ${color.bold(inactive)}`
+              : `${color.dim(S_POINTER_INACTIVE)} ${color.dim(inactive)}`
           }\n${defaultPrefixEnd}\n`;
         }
       }

--- a/packages/prompts/src/group-multi-select.ts
+++ b/packages/prompts/src/group-multi-select.ts
@@ -8,6 +8,8 @@ import {
   S_CHECKBOX_ACTIVE,
   S_CHECKBOX_INACTIVE,
   S_CHECKBOX_SELECTED,
+  S_POINTER_ACTIVE,
+  S_POINTER_INACTIVE,
   symbol,
 } from './common.js';
 import type { Option } from './select.js';
@@ -23,6 +25,29 @@ export interface GroupMultiSelectOptions<Value> extends CommonOptions {
 }
 export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) => {
   const { selectableGroups = true, groupSpacing = 0 } = opts;
+  const hasGuide = opts.withGuide ?? false;
+  const nestedPrefix = '  ';
+  const withMarkerAndPrefix = (
+    marker: string,
+    prefix: string,
+    prefixWidth: number,
+    label: string,
+    format: (text: string) => string,
+    firstLineSuffix = '',
+    spacingPrefix = '',
+  ) => {
+    const lines = label.split('\n');
+    const continuationPrefix = `${S_POINTER_INACTIVE} ${' '.repeat(prefixWidth)}`;
+    if (lines.length === 1) {
+      return `${spacingPrefix}${marker} ${prefix}${format(lines[0])}${firstLineSuffix}`;
+    }
+    const [firstLine, ...rest] = lines;
+    return [
+      `${spacingPrefix}${marker} ${prefix}${format(firstLine)}${firstLineSuffix}`,
+      ...rest.map((line) => `${continuationPrefix}${format(line)}`),
+    ].join('\n');
+  };
+
   const opt = (
     option: Option<Value> & { group: string | boolean },
     state:
@@ -37,46 +62,65 @@ export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) =>
     options: (Option<Value> & { group: string | boolean })[] = [],
   ) => {
     const label = option.label ?? String(option.value);
+    const hint = option.hint ? ` ${color.gray(`(${option.hint})`)}` : '';
     const isItem = typeof option.group === 'string';
     const next = isItem && (options[options.indexOf(option) + 1] ?? { group: true });
     const isLast = isItem && next && next.group === true;
-    const prefix = isItem ? (selectableGroups ? `${isLast ? S_BAR_END : S_BAR} ` : '  ') : '';
+    const branchPrefixRaw = isItem
+      ? selectableGroups
+        ? `${isLast ? S_BAR_END : S_BAR} `
+        : '  '
+      : '';
     let spacingPrefix = '';
     if (groupSpacing > 0 && !isItem) {
-      const spacingPrefixText = `\n${color.blue(S_BAR)}`;
-      spacingPrefix = `${spacingPrefixText.repeat(groupSpacing - 1)}${spacingPrefixText}  `;
+      const spacingPrefixText = hasGuide ? `\n${color.blue(S_BAR)}` : '\n';
+      const spacingSuffix = hasGuide ? ' ' : '';
+      spacingPrefix = `${spacingPrefixText.repeat(groupSpacing - 1)}${spacingPrefixText}${spacingSuffix}`;
     }
 
-    if (state === 'active') {
-      return `${spacingPrefix}${color.dim(prefix)}${color.blue(S_CHECKBOX_ACTIVE)} ${label}${
-        option.hint ? ` ${color.dim(`(${option.hint})`)}` : ''
-      }`;
-    }
-    if (state === 'group-active') {
-      return `${spacingPrefix}${prefix}${color.blue(S_CHECKBOX_ACTIVE)} ${color.dim(label)}`;
-    }
-    if (state === 'group-active-selected') {
-      return `${spacingPrefix}${prefix}${color.green(S_CHECKBOX_SELECTED)} ${color.dim(label)}`;
-    }
-    if (state === 'selected') {
-      const selectedCheckbox = isItem || selectableGroups ? color.green(S_CHECKBOX_SELECTED) : '';
-      return `${spacingPrefix}${color.dim(prefix)}${selectedCheckbox} ${color.dim(label)}${
-        option.hint ? ` ${color.dim(`(${option.hint})`)}` : ''
-      }`;
-    }
     if (state === 'cancelled') {
       return color.strikethrough(color.dim(label));
-    }
-    if (state === 'active-selected') {
-      return `${spacingPrefix}${color.dim(prefix)}${color.green(S_CHECKBOX_SELECTED)} ${label}${
-        option.hint ? ` ${color.dim(`(${option.hint})`)}` : ''
-      }`;
     }
     if (state === 'submitted') {
       return color.dim(label);
     }
-    const unselectedCheckbox = isItem || selectableGroups ? color.dim(S_CHECKBOX_INACTIVE) : '';
-    return `${spacingPrefix}${color.dim(prefix)}${unselectedCheckbox} ${color.dim(label)}`;
+
+    const marker =
+      state === 'active' || state === 'active-selected'
+        ? color.blue(S_POINTER_ACTIVE)
+        : color.dim(S_POINTER_INACTIVE);
+    const branchPrefix = color.dim(branchPrefixRaw);
+    const hasCheckbox = isItem || selectableGroups;
+    const checkboxRaw = hasCheckbox
+      ? state === 'active' || state === 'group-active'
+        ? S_CHECKBOX_ACTIVE
+        : state === 'selected' || state === 'active-selected' || state === 'group-active-selected'
+          ? S_CHECKBOX_SELECTED
+          : S_CHECKBOX_INACTIVE
+      : '';
+    const checkbox = hasCheckbox
+      ? checkboxRaw === S_CHECKBOX_SELECTED
+        ? color.blue(checkboxRaw)
+        : checkboxRaw === S_CHECKBOX_ACTIVE
+          ? color.blue(checkboxRaw)
+          : color.dim(checkboxRaw)
+      : '';
+    const format =
+      state === 'active' || state === 'active-selected'
+        ? (text: string) => color.blue(color.bold(text))
+        : color.dim;
+    const styledPrefix = `${branchPrefix}${hasCheckbox ? `${checkbox} ` : ''}`;
+    const prefixWidth = branchPrefixRaw.length + (hasCheckbox ? checkboxRaw.length + 1 : 0);
+
+    return withMarkerAndPrefix(
+      marker,
+      styledPrefix,
+      prefixWidth,
+      label,
+      format,
+      hint,
+      spacingPrefix,
+    );
   };
   const required = opts.required ?? true;
 
@@ -101,7 +145,7 @@ export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) =>
       }
     },
     render() {
-      const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${opts.message}\n`;
+      const title = `${hasGuide ? `${color.gray(S_BAR)}\n` : ''}${symbol(this.state)} ${opts.message}\n`;
       const value = this.value ?? [];
 
       switch (this.state) {
@@ -109,27 +153,35 @@ export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) =>
           const selectedOptions = this.options
             .filter(({ value: optionValue }) => value.includes(optionValue))
             .map((option) => opt(option, 'submitted'));
+          const submitPrefix = hasGuide ? `${color.gray(S_BAR)} ` : nestedPrefix;
           const optionsText =
-            selectedOptions.length === 0 ? '' : `  ${selectedOptions.join(color.dim(', '))}`;
-          return `${title}${color.gray(S_BAR)}${optionsText}`;
+            selectedOptions.length === 0 ? '' : selectedOptions.join(color.dim(', '));
+          return `${title}${submitPrefix}${optionsText}\n\n`;
         }
         case 'cancel': {
           const label = this.options
             .filter(({ value: optionValue }) => value.includes(optionValue))
             .map((option) => opt(option, 'cancelled'))
             .join(color.dim(', '));
-          return `${title}${color.gray(S_BAR)}  ${
-            label.trim() ? `${label}\n${color.gray(S_BAR)}` : ''
-          }`;
+          if (!label.trim()) {
+            return hasGuide ? `${title}${color.gray(S_BAR)}\n\n` : `${title.trimEnd()}\n\n`;
+          }
+          const cancelPrefix = hasGuide ? `${color.gray(S_BAR)} ` : nestedPrefix;
+          return hasGuide
+            ? `${title}${cancelPrefix}${label}\n${color.gray(S_BAR)}\n\n`
+            : `${title}${cancelPrefix}${label}\n\n`;
         }
         case 'error': {
-          const footer = this.error
-            .split('\n')
-            .map((ln, i) =>
-              i === 0 ? `${color.yellow(S_BAR_END)}  ${color.yellow(ln)}` : `   ${ln}`,
-            )
-            .join('\n');
-          return `${title}${color.yellow(S_BAR)}  ${this.options
+          const prefix = hasGuide ? `${color.yellow(S_BAR)} ` : nestedPrefix;
+          const footer = hasGuide
+            ? this.error
+                .split('\n')
+                .map((ln, i) =>
+                  i === 0 ? `${color.yellow(S_BAR_END)} ${color.yellow(ln)}` : `  ${ln}`,
+                )
+                .join('\n')
+            : `${nestedPrefix}${color.yellow(this.error)}`;
+          return `${title}${prefix}${this.options
             .map((option, i, options) => {
               const selected =
                 value.includes(option.value) ||
@@ -150,7 +202,7 @@ export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) =>
               }
               return opt(option, active ? 'active' : 'inactive', options);
             })
-            .join(`\n${color.yellow(S_BAR)}  `)}\n${footer}\n`;
+            .join(`\n${prefix}`)}\n${footer}\n`;
         }
         default: {
           const optionsText = this.options
@@ -180,9 +232,11 @@ export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) =>
               const prefix = i !== 0 && !optionText.startsWith('\n') ? '  ' : '';
               return `${prefix}${optionText}`;
             })
-            .join(`\n${color.blue(S_BAR)}`);
-          const optionsPrefix = optionsText.startsWith('\n') ? '' : '  ';
-          return `${title}${color.blue(S_BAR)}${optionsPrefix}${optionsText}\n${color.blue(S_BAR_END)}\n`;
+            .join(hasGuide ? `\n${color.blue(S_BAR)}` : '\n');
+          const optionsPrefix = optionsText.startsWith('\n') ? '' : nestedPrefix;
+          const defaultPrefix = hasGuide ? color.blue(S_BAR) : '';
+          const defaultSuffix = hasGuide ? color.blue(S_BAR_END) : '';
+          return `${title}${defaultPrefix}${optionsPrefix}${optionsText}\n${defaultSuffix}\n`;
         }
       }
     },

--- a/packages/prompts/src/log.ts
+++ b/packages/prompts/src/log.ts
@@ -1,4 +1,3 @@
-import { settings } from '@clack/core';
 import color from 'picocolors';
 
 import {
@@ -9,6 +8,7 @@ import {
   S_STEP_SUBMIT,
   S_SUCCESS,
   S_WARN,
+  completeColor,
 } from './common.js';
 
 export interface LogMessageOptions extends CommonOptions {
@@ -29,7 +29,7 @@ export const log = {
     }: LogMessageOptions = {},
   ) => {
     const parts: string[] = [];
-    const hasGuide = withGuide ?? settings.withGuide;
+    const hasGuide = withGuide ?? false;
     const spacingString = !hasGuide ? '' : secondarySymbol;
     const prefix = !hasGuide ? '' : `${symbol}  `;
     const secondaryPrefix = !hasGuide ? '' : `${secondarySymbol}  `;
@@ -60,10 +60,10 @@ export const log = {
     log.message(message, { ...opts, symbol: color.blue(S_INFO) });
   },
   success: (message: string, opts?: LogMessageOptions) => {
-    log.message(message, { ...opts, symbol: color.green(S_SUCCESS) });
+    log.message(message, { ...opts, symbol: completeColor(S_SUCCESS) });
   },
   step: (message: string, opts?: LogMessageOptions) => {
-    log.message(message, { ...opts, symbol: color.green(S_STEP_SUBMIT) });
+    log.message(message, { ...opts, symbol: completeColor(S_STEP_SUBMIT) });
   },
   warn: (message: string, opts?: LogMessageOptions) => {
     log.message(message, { ...opts, symbol: color.yellow(S_WARN) });

--- a/packages/prompts/src/messages.ts
+++ b/packages/prompts/src/messages.ts
@@ -2,19 +2,19 @@ import type { Writable } from 'node:stream';
 
 import color from 'picocolors';
 
-import { type CommonOptions, S_BAR, S_BAR_END, S_BAR_START } from './common.js';
+import { type CommonOptions } from './common.js';
 
 export const cancel = (message = '', opts?: CommonOptions) => {
   const output: Writable = opts?.output ?? process.stdout;
-  output.write(`${color.gray(S_BAR_END)}  ${color.red(message)}\n\n`);
+  output.write(`${color.red(message)}\n\n`);
 };
 
 export const intro = (title = '', opts?: CommonOptions) => {
   const output: Writable = opts?.output ?? process.stdout;
-  output.write(`${color.gray(S_BAR_START)}  ${title}\n`);
+  output.write(`${title}\n\n`);
 };
 
 export const outro = (message = '', opts?: CommonOptions) => {
   const output: Writable = opts?.output ?? process.stdout;
-  output.write(`${color.gray(S_BAR)}\n${color.gray(S_BAR_END)}  ${message}\n\n`);
+  output.write(`${message}\n\n`);
 };

--- a/packages/prompts/src/multi-select.ts
+++ b/packages/prompts/src/multi-select.ts
@@ -8,6 +8,8 @@ import {
   S_CHECKBOX_ACTIVE,
   S_CHECKBOX_INACTIVE,
   S_CHECKBOX_SELECTED,
+  S_POINTER_ACTIVE,
+  S_POINTER_INACTIVE,
   symbol,
   symbolBar,
 } from './common.js';
@@ -29,6 +31,26 @@ const computeLabel = (label: string, format: (text: string) => string) => {
     .join('\n');
 };
 
+const withMarkerAndCheckbox = (
+  marker: string,
+  checkbox: string,
+  checkboxWidth: number,
+  label: string,
+  format: (text: string) => string,
+  firstLineSuffix = '',
+) => {
+  const lines = label.split('\n');
+  const continuationPrefix = `${S_POINTER_INACTIVE} ${' '.repeat(checkboxWidth)} `;
+  if (lines.length === 1) {
+    return `${marker} ${checkbox} ${format(lines[0])}${firstLineSuffix}`;
+  }
+  const [firstLine, ...rest] = lines;
+  return [
+    `${marker} ${checkbox} ${format(firstLine)}${firstLineSuffix}`,
+    ...rest.map((line) => `${continuationPrefix}${format(line)}`),
+  ].join('\n');
+};
+
 export const multiselect = <Value>(opts: MultiSelectOptions<Value>) => {
   const opt = (
     option: Option<Value>,
@@ -42,33 +64,60 @@ export const multiselect = <Value>(opts: MultiSelectOptions<Value>) => {
       | 'disabled',
   ) => {
     const label = option.label ?? String(option.value);
+    const hint = option.hint ? ` ${color.gray(`(${option.hint})`)}` : '';
     if (state === 'disabled') {
-      return `${color.gray(S_CHECKBOX_INACTIVE)} ${computeLabel(label, (str) => color.strikethrough(color.gray(str)))}${
-        option.hint ? ` ${color.dim(`(${option.hint ?? 'disabled'})`)}` : ''
-      }`;
+      return withMarkerAndCheckbox(
+        color.gray(S_POINTER_INACTIVE),
+        color.gray(S_CHECKBOX_INACTIVE),
+        S_CHECKBOX_INACTIVE.length,
+        label,
+        (str) => color.strikethrough(color.gray(str)),
+        option.hint ? ` ${color.dim(`(${option.hint ?? 'disabled'})`)}` : '',
+      );
     }
     if (state === 'active') {
-      return `${color.blue(S_CHECKBOX_ACTIVE)} ${label}${
-        option.hint ? ` ${color.dim(`(${option.hint})`)}` : ''
-      }`;
+      return withMarkerAndCheckbox(
+        color.blue(S_POINTER_ACTIVE),
+        color.blue(S_CHECKBOX_ACTIVE),
+        S_CHECKBOX_ACTIVE.length,
+        label,
+        (text) => color.blue(color.bold(text)),
+        hint,
+      );
     }
     if (state === 'selected') {
-      return `${color.green(S_CHECKBOX_SELECTED)} ${computeLabel(label, color.dim)}${
-        option.hint ? ` ${color.dim(`(${option.hint})`)}` : ''
-      }`;
+      return withMarkerAndCheckbox(
+        color.dim(S_POINTER_INACTIVE),
+        color.blue(S_CHECKBOX_SELECTED),
+        S_CHECKBOX_SELECTED.length,
+        label,
+        color.dim,
+        hint,
+      );
     }
     if (state === 'cancelled') {
       return computeLabel(label, (text) => color.strikethrough(color.dim(text)));
     }
     if (state === 'active-selected') {
-      return `${color.green(S_CHECKBOX_SELECTED)} ${label}${
-        option.hint ? ` ${color.dim(`(${option.hint})`)}` : ''
-      }`;
+      return withMarkerAndCheckbox(
+        color.blue(S_POINTER_ACTIVE),
+        color.blue(S_CHECKBOX_SELECTED),
+        S_CHECKBOX_SELECTED.length,
+        label,
+        (text) => color.blue(color.bold(text)),
+        hint,
+      );
     }
     if (state === 'submitted') {
       return computeLabel(label, color.dim);
     }
-    return `${color.dim(S_CHECKBOX_INACTIVE)} ${computeLabel(label, color.dim)}`;
+    return withMarkerAndCheckbox(
+      color.dim(S_POINTER_INACTIVE),
+      color.dim(S_CHECKBOX_INACTIVE),
+      S_CHECKBOX_INACTIVE.length,
+      label,
+      color.dim,
+    );
   };
   const required = opts.required ?? true;
 
@@ -92,13 +141,23 @@ export const multiselect = <Value>(opts: MultiSelectOptions<Value>) => {
       }
     },
     render() {
-      const wrappedMessage = wrapTextWithPrefix(
-        opts.output,
-        opts.message,
-        `${symbolBar(this.state)}  `,
-        `${symbol(this.state)}  `,
-      );
-      const title = `${color.gray(S_BAR)}\n${wrappedMessage}\n`;
+      const hasGuide = opts.withGuide ?? false;
+      const nestedPrefix = '  ';
+      const formatMessageLines = (message: string) => {
+        const lines = message.split('\n');
+        return lines
+          .map((line, index) => `${index === 0 ? `${symbol(this.state)} ` : nestedPrefix}${line}`)
+          .join('\n');
+      };
+      const wrappedMessage = hasGuide
+        ? wrapTextWithPrefix(
+            opts.output,
+            opts.message,
+            `${symbolBar(this.state)} `,
+            `${symbol(this.state)} `,
+          )
+        : formatMessageLines(opts.message);
+      const title = `${hasGuide ? `${color.gray(S_BAR)}\n` : ''}${wrappedMessage}\n`;
       const value = this.value ?? [];
 
       const styleOption = (option: Option<Value>, active: boolean) => {
@@ -122,12 +181,9 @@ export const multiselect = <Value>(opts: MultiSelectOptions<Value>) => {
               .filter(({ value: optionValue }) => value.includes(optionValue))
               .map((option) => opt(option, 'submitted'))
               .join(color.dim(', ')) || color.dim('none');
-          const wrappedSubmitText = wrapTextWithPrefix(
-            opts.output,
-            submitText,
-            `${color.gray(S_BAR)}  `,
-          );
-          return `${title}${wrappedSubmitText}`;
+          const submitPrefix = hasGuide ? `${color.gray(S_BAR)} ` : nestedPrefix;
+          const wrappedSubmitText = wrapTextWithPrefix(opts.output, submitText, submitPrefix);
+          return `${title}${wrappedSubmitText}\n\n`;
         }
         case 'cancel': {
           const label = this.options
@@ -135,19 +191,24 @@ export const multiselect = <Value>(opts: MultiSelectOptions<Value>) => {
             .map((option) => opt(option, 'cancelled'))
             .join(color.dim(', '));
           if (label.trim() === '') {
-            return `${title}${color.gray(S_BAR)}`;
+            return hasGuide ? `${title}${color.gray(S_BAR)}\n\n` : `${title.trimEnd()}\n\n`;
           }
-          const wrappedLabel = wrapTextWithPrefix(opts.output, label, `${color.gray(S_BAR)}  `);
-          return `${title}${wrappedLabel}\n${color.gray(S_BAR)}`;
+          const cancelPrefix = hasGuide ? `${color.gray(S_BAR)} ` : nestedPrefix;
+          const wrappedLabel = wrapTextWithPrefix(opts.output, label, cancelPrefix);
+          return hasGuide
+            ? `${title}${wrappedLabel}\n${color.gray(S_BAR)}\n\n`
+            : `${title}${wrappedLabel}\n\n`;
         }
         case 'error': {
-          const prefix = `${color.yellow(S_BAR)}  `;
-          const footer = this.error
-            .split('\n')
-            .map((ln, i) =>
-              i === 0 ? `${color.yellow(S_BAR_END)}  ${color.yellow(ln)}` : `   ${ln}`,
-            )
-            .join('\n');
+          const prefix = hasGuide ? `${color.yellow(S_BAR)} ` : nestedPrefix;
+          const footer = hasGuide
+            ? this.error
+                .split('\n')
+                .map((ln, i) =>
+                  i === 0 ? `${color.yellow(S_BAR_END)} ${color.yellow(ln)}` : `  ${ln}`,
+                )
+                .join('\n')
+            : `${nestedPrefix}${color.yellow(this.error)}`;
           // Calculate rowPadding: title lines + footer lines (error message + trailing newline)
           const titleLineCount = title.split('\n').length;
           const footerLineCount = footer.split('\n').length + 1; // footer + trailing newline
@@ -162,10 +223,10 @@ export const multiselect = <Value>(opts: MultiSelectOptions<Value>) => {
           }).join(`\n${prefix}`)}\n${footer}\n`;
         }
         default: {
-          const prefix = `${color.blue(S_BAR)}  `;
+          const prefix = hasGuide ? `${color.blue(S_BAR)} ` : nestedPrefix;
           // Calculate rowPadding: title lines + footer lines (S_BAR_END + trailing newline)
           const titleLineCount = title.split('\n').length;
-          const footerLineCount = 2; // S_BAR_END + trailing newline
+          const footerLineCount = hasGuide ? 2 : 1; // S_BAR_END + trailing newline
           return `${title}${prefix}${limitOptions({
             output: opts.output,
             options: this.options,
@@ -174,7 +235,7 @@ export const multiselect = <Value>(opts: MultiSelectOptions<Value>) => {
             columnPadding: prefix.length,
             rowPadding: titleLineCount + footerLineCount,
             style: styleOption,
-          }).join(`\n${prefix}`)}\n${color.blue(S_BAR_END)}\n`;
+          }).join(`\n${prefix}`)}\n${hasGuide ? color.blue(S_BAR_END) : ''}\n`;
         }
       }
     },

--- a/packages/prompts/src/note.ts
+++ b/packages/prompts/src/note.ts
@@ -1,13 +1,14 @@
 import process from 'node:process';
 import type { Writable } from 'node:stream';
 
-import { getColumns, settings } from '@clack/core';
+import { getColumns } from '@clack/core';
 import stringWidth from 'fast-string-width';
 import { type Options as WrapAnsiOptions, wrapAnsi } from 'fast-wrap-ansi';
 import color from 'picocolors';
 
 import {
   type CommonOptions,
+  completeColor,
   S_BAR,
   S_BAR_H,
   S_CONNECT_LEFT,
@@ -38,7 +39,7 @@ const wrapWithFormat = (message: string, width: number, format: FormatFn): strin
 
 export const note = (message = '', title = '', opts?: NoteOptions) => {
   const output: Writable = opts?.output ?? process.stdout;
-  const hasGuide = opts?.withGuide ?? settings.withGuide;
+  const hasGuide = opts?.withGuide ?? false;
   const format = opts?.format ?? defaultNoteFormatter;
   const wrapMsg = wrapWithFormat(message, getColumns(output) - 6, format);
   const lines = ['', ...wrapMsg.split('\n').map(format), ''];
@@ -51,15 +52,14 @@ export const note = (message = '', title = '', opts?: NoteOptions) => {
       }, 0),
       titleLen,
     ) + 2;
+  const lineSymbol = hasGuide ? color.gray(S_BAR) : ' ';
   const msg = lines
-    .map(
-      (ln) => `${color.gray(S_BAR)}  ${ln}${' '.repeat(len - stringWidth(ln))}${color.gray(S_BAR)}`,
-    )
+    .map((ln) => `${lineSymbol}  ${ln}${' '.repeat(len - stringWidth(ln))}${lineSymbol}`)
     .join('\n');
   const leadingBorder = hasGuide ? `${color.gray(S_BAR)}\n` : '';
   const bottomLeft = hasGuide ? S_CONNECT_LEFT : S_CORNER_BOTTOM_LEFT;
   output.write(
-    `${leadingBorder}${color.green(S_STEP_SUBMIT)}  ${color.reset(title)} ${color.gray(
+    `${leadingBorder}${completeColor(S_STEP_SUBMIT)}  ${color.reset(title)} ${color.gray(
       S_BAR_H.repeat(Math.max(len - titleLen - 1, 1)) + S_CORNER_TOP_RIGHT,
     )}\n${msg}\n${color.gray(bottomLeft + S_BAR_H.repeat(len + 2) + S_CORNER_BOTTOM_RIGHT)}\n`,
   );

--- a/packages/prompts/src/password.ts
+++ b/packages/prompts/src/password.ts
@@ -1,4 +1,4 @@
-import { PasswordPrompt, settings } from '@clack/core';
+import { PasswordPrompt } from '@clack/core';
 import color from 'picocolors';
 
 import { type CommonOptions, S_BAR, S_BAR_END, S_PASSWORD_MASK, symbol } from './common.js';
@@ -17,15 +17,16 @@ export const password = (opts: PasswordOptions) => {
     input: opts.input,
     output: opts.output,
     render() {
-      const hasGuide = opts.withGuide ?? settings.withGuide;
-      const title = `${hasGuide ? `${color.gray(S_BAR)}\n` : ''}${symbol(this.state)}  ${opts.message}\n`;
+      const hasGuide = opts.withGuide ?? false;
+      const nestedPrefix = '  ';
+      const title = `${hasGuide ? `${color.gray(S_BAR)}\n` : ''}${symbol(this.state)} ${opts.message}\n`;
       const userInput = this.userInputWithCursor;
       const masked = this.masked;
 
       switch (this.state) {
         case 'error': {
-          const errorPrefix = hasGuide ? `${color.yellow(S_BAR)}  ` : '';
-          const errorPrefixEnd = hasGuide ? `${color.yellow(S_BAR_END)}  ` : '';
+          const errorPrefix = hasGuide ? `${color.yellow(S_BAR)} ` : nestedPrefix;
+          const errorPrefixEnd = hasGuide ? `${color.yellow(S_BAR_END)} ` : '';
           const maskedText = masked ?? '';
           if (opts.clearOnError) {
             this.clear();
@@ -33,19 +34,19 @@ export const password = (opts: PasswordOptions) => {
           return `${title.trim()}\n${errorPrefix}${maskedText}\n${errorPrefixEnd}${color.yellow(this.error)}\n`;
         }
         case 'submit': {
-          const submitPrefix = hasGuide ? `${color.gray(S_BAR)}  ` : '';
+          const submitPrefix = hasGuide ? `${color.gray(S_BAR)} ` : nestedPrefix;
           const maskedText = masked ? color.dim(masked) : '';
-          return `${title}${submitPrefix}${maskedText}`;
+          return `${title}${submitPrefix}${maskedText}\n\n`;
         }
         case 'cancel': {
-          const cancelPrefix = hasGuide ? `${color.gray(S_BAR)}  ` : '';
+          const cancelPrefix = hasGuide ? `${color.gray(S_BAR)} ` : nestedPrefix;
           const maskedText = masked ? color.strikethrough(color.dim(masked)) : '';
           return `${title}${cancelPrefix}${maskedText}${
             masked && hasGuide ? `\n${color.gray(S_BAR)}` : ''
-          }`;
+          }\n\n`;
         }
         default: {
-          const defaultPrefix = hasGuide ? `${color.blue(S_BAR)}  ` : '';
+          const defaultPrefix = hasGuide ? `${color.blue(S_BAR)} ` : nestedPrefix;
           const defaultPrefixEnd = hasGuide ? color.blue(S_BAR_END) : '';
           return `${title}${defaultPrefix}${userInput}\n${defaultPrefixEnd}\n`;
         }

--- a/packages/prompts/src/progress-bar.ts
+++ b/packages/prompts/src/progress-bar.ts
@@ -1,7 +1,7 @@
 import type { State } from '@clack/core';
 import color from 'picocolors';
 
-import { unicodeOr } from './common.js';
+import { completeColor, unicodeOr } from './common.js';
 import { type SpinnerOptions, type SpinnerResult, spinner } from './spinner.js';
 
 const S_PROGRESS_CHAR: Record<NonNullable<ProgressOptions['style']>, string> = {
@@ -42,7 +42,7 @@ export function progress({
       case 'cancel':
         return color.red;
       case 'submit':
-        return color.green;
+        return completeColor;
       default:
         return color.magenta;
     }

--- a/packages/prompts/src/select-key.ts
+++ b/packages/prompts/src/select-key.ts
@@ -1,7 +1,14 @@
-import { SelectKeyPrompt, settings, wrapTextWithPrefix } from '@clack/core';
+import { SelectKeyPrompt, wrapTextWithPrefix } from '@clack/core';
 import color from 'picocolors';
 
-import { type CommonOptions, S_BAR, S_BAR_END, symbol } from './common.js';
+import {
+  type CommonOptions,
+  S_BAR,
+  S_BAR_END,
+  S_POINTER_ACTIVE,
+  S_POINTER_INACTIVE,
+  symbol,
+} from './common.js';
 import type { Option } from './select.js';
 
 export interface SelectKeyOptions<Value extends string> extends CommonOptions {
@@ -12,6 +19,17 @@ export interface SelectKeyOptions<Value extends string> extends CommonOptions {
 }
 
 export const selectKey = <Value extends string>(opts: SelectKeyOptions<Value>) => {
+  const withMarker = (marker: string, value: string) => {
+    const lines = value.split('\n');
+    if (lines.length === 1) {
+      return `${marker} ${lines[0]}`;
+    }
+    const [firstLine, ...rest] = lines;
+    return [`${marker} ${firstLine}`, ...rest.map((line) => `${S_POINTER_INACTIVE} ${line}`)].join(
+      '\n',
+    );
+  };
+
   const opt = (
     option: Option<Value>,
     state: 'inactive' | 'active' | 'selected' | 'cancelled' = 'inactive',
@@ -24,13 +42,19 @@ export const selectKey = <Value extends string>(opts: SelectKeyOptions<Value>) =
       return color.strikethrough(color.dim(label));
     }
     if (state === 'active') {
-      return `${color.bgBlue(color.white(` ${option.value} `))} ${label}${
-        option.hint ? ` ${color.dim(`(${option.hint})`)}` : ''
-      }`;
+      return withMarker(
+        color.blue(S_POINTER_ACTIVE),
+        `${color.bgBlue(color.white(` ${option.value} `))} ${color.bold(label)}${
+          option.hint ? ` ${color.dim(`(${option.hint})`)}` : ''
+        }`,
+      );
     }
-    return `${color.gray(color.bgWhite(color.inverse(` ${option.value} `)))} ${label}${
-      option.hint ? ` ${color.dim(`(${option.hint})`)}` : ''
-    }`;
+    return withMarker(
+      color.dim(S_POINTER_INACTIVE),
+      `${color.gray(color.bgWhite(color.inverse(` ${option.value} `)))} ${color.dim(label)}${
+        option.hint ? ` ${color.dim(`(${option.hint})`)}` : ''
+      }`,
+    );
   };
 
   return new SelectKeyPrompt({
@@ -41,12 +65,13 @@ export const selectKey = <Value extends string>(opts: SelectKeyOptions<Value>) =
     initialValue: opts.initialValue,
     caseSensitive: opts.caseSensitive,
     render() {
-      const hasGuide = opts.withGuide ?? settings.withGuide;
-      const title = `${hasGuide ? `${color.gray(S_BAR)}\n` : ''}${symbol(this.state)}  ${opts.message}\n`;
+      const hasGuide = opts.withGuide ?? false;
+      const nestedPrefix = '  ';
+      const title = `${hasGuide ? `${color.gray(S_BAR)}\n` : ''}${symbol(this.state)} ${opts.message}\n`;
 
       switch (this.state) {
         case 'submit': {
-          const submitPrefix = hasGuide ? `${color.gray(S_BAR)}  ` : '';
+          const submitPrefix = hasGuide ? `${color.gray(S_BAR)} ` : nestedPrefix;
           const selectedOption =
             this.options.find((opt) => opt.value === this.value) ?? opts.options[0];
           const wrapped = wrapTextWithPrefix(
@@ -54,19 +79,19 @@ export const selectKey = <Value extends string>(opts: SelectKeyOptions<Value>) =
             opt(selectedOption, 'selected'),
             submitPrefix,
           );
-          return `${title}${wrapped}`;
+          return `${title}${wrapped}\n\n`;
         }
         case 'cancel': {
-          const cancelPrefix = hasGuide ? `${color.gray(S_BAR)}  ` : '';
+          const cancelPrefix = hasGuide ? `${color.gray(S_BAR)} ` : nestedPrefix;
           const wrapped = wrapTextWithPrefix(
             opts.output,
             opt(this.options[0], 'cancelled'),
             cancelPrefix,
           );
-          return `${title}${wrapped}${hasGuide ? `\n${color.gray(S_BAR)}` : ''}`;
+          return `${title}${wrapped}${hasGuide ? `\n${color.gray(S_BAR)}` : ''}\n\n`;
         }
         default: {
-          const defaultPrefix = hasGuide ? `${color.blue(S_BAR)}  ` : '';
+          const defaultPrefix = hasGuide ? `${color.blue(S_BAR)} ` : nestedPrefix;
           const defaultPrefixEnd = hasGuide ? color.blue(S_BAR_END) : '';
           const wrapped = this.options
             .map((option, i) =>

--- a/packages/prompts/src/select.ts
+++ b/packages/prompts/src/select.ts
@@ -1,12 +1,12 @@
-import { SelectPrompt, settings, wrapTextWithPrefix } from '@clack/core';
+import { SelectPrompt, wrapTextWithPrefix } from '@clack/core';
 import color from 'picocolors';
 
 import {
   type CommonOptions,
   S_BAR,
   S_BAR_END,
-  S_RADIO_ACTIVE,
-  S_RADIO_INACTIVE,
+  S_POINTER_ACTIVE,
+  S_POINTER_INACTIVE,
   symbol,
   symbolBar,
 } from './common.js';
@@ -83,27 +83,51 @@ const computeLabel = (label: string, format: (text: string) => string) => {
     .join('\n');
 };
 
+const withMarker = (
+  marker: string,
+  label: string,
+  format: (text: string) => string,
+  firstLineSuffix = '',
+) => {
+  const lines = label.split('\n');
+  if (lines.length === 1) {
+    return `${marker} ${format(lines[0])}${firstLineSuffix}`;
+  }
+  const [firstLine, ...rest] = lines;
+  return [
+    `${marker} ${format(firstLine)}${firstLineSuffix}`,
+    ...rest.map((line) => `${S_POINTER_INACTIVE} ${format(line)}`),
+  ].join('\n');
+};
+
 export const select = <Value>(opts: SelectOptions<Value>) => {
   const opt = (
     option: Option<Value>,
     state: 'inactive' | 'active' | 'selected' | 'cancelled' | 'disabled',
   ) => {
     const label = option.label ?? String(option.value);
+    const hint = option.hint ? `: ${color.gray(option.hint)}` : '';
     switch (state) {
       case 'disabled':
-        return `${color.gray(S_RADIO_INACTIVE)} ${computeLabel(label, color.gray)}${
-          option.hint ? ` ${color.dim(`(${option.hint ?? 'disabled'})`)}` : ''
-        }`;
+        return withMarker(
+          color.gray(S_POINTER_INACTIVE),
+          label,
+          (text) => color.strikethrough(color.gray(text)),
+          option.hint ? `: ${color.gray(option.hint ?? 'disabled')}` : '',
+        );
       case 'selected':
         return computeLabel(label, color.dim);
       case 'active':
-        return `${color.green(S_RADIO_ACTIVE)} ${label}${
-          option.hint ? ` ${color.dim(`(${option.hint})`)}` : ''
-        }`;
+        return withMarker(
+          color.blue(S_POINTER_ACTIVE),
+          label,
+          (text) => color.blue(color.bold(text)),
+          hint,
+        );
       case 'cancelled':
         return computeLabel(label, (str) => color.strikethrough(color.dim(str)));
       default:
-        return `${color.dim(S_RADIO_INACTIVE)} ${computeLabel(label, color.dim)}`;
+        return withMarker(color.dim(S_POINTER_INACTIVE), label, (text) => text, hint);
     }
   };
 
@@ -114,41 +138,53 @@ export const select = <Value>(opts: SelectOptions<Value>) => {
     output: opts.output,
     initialValue: opts.initialValue,
     render() {
-      const hasGuide = opts.withGuide ?? settings.withGuide;
-      const titlePrefix = `${symbol(this.state)}  `;
-      const titlePrefixBar = `${symbolBar(this.state)}  `;
-      const messageLines = wrapTextWithPrefix(
-        opts.output,
-        opts.message,
-        titlePrefixBar,
-        titlePrefix,
-      );
-      const title = `${hasGuide ? `${color.gray(S_BAR)}\n` : ''}${messageLines}\n`;
+      const hasGuide = opts.withGuide ?? false;
+      const nestedPrefix = '  ';
+      const formatMessageLines = (message: string) => {
+        const lines = message.split('\n');
+        return lines
+          .map((line, index) => `${index === 0 ? `${symbol(this.state)} ` : nestedPrefix}${line}`)
+          .join('\n');
+      };
+      const hasMessage = opts.message.trim().length > 0;
+      const messageLines = !hasMessage
+        ? ''
+        : hasGuide
+          ? wrapTextWithPrefix(
+              opts.output,
+              opts.message,
+              `${symbolBar(this.state)} `,
+              `${symbol(this.state)} `,
+            )
+          : formatMessageLines(opts.message);
+      const title = hasMessage
+        ? `${hasGuide ? `${color.gray(S_BAR)}\n` : ''}${messageLines}\n`
+        : '';
 
       switch (this.state) {
         case 'submit': {
-          const submitPrefix = hasGuide ? `${color.gray(S_BAR)}  ` : '';
+          const submitPrefix = hasGuide ? `${color.gray(S_BAR)} ` : nestedPrefix;
           const wrappedLines = wrapTextWithPrefix(
             opts.output,
             opt(this.options[this.cursor], 'selected'),
             submitPrefix,
           );
-          return `${title}${wrappedLines}`;
+          return `${title}${wrappedLines}\n`;
         }
         case 'cancel': {
-          const cancelPrefix = hasGuide ? `${color.gray(S_BAR)}  ` : '';
+          const cancelPrefix = hasGuide ? `${color.gray(S_BAR)} ` : nestedPrefix;
           const wrappedLines = wrapTextWithPrefix(
             opts.output,
             opt(this.options[this.cursor], 'cancelled'),
             cancelPrefix,
           );
-          return `${title}${wrappedLines}${hasGuide ? `\n${color.gray(S_BAR)}` : ''}`;
+          return `${title}${wrappedLines}${hasGuide ? `\n${color.gray(S_BAR)}` : ''}\n`;
         }
         default: {
-          const prefix = hasGuide ? `${color.blue(S_BAR)}  ` : '';
+          const prefix = hasGuide ? `${color.blue(S_BAR)} ` : nestedPrefix;
           const prefixEnd = hasGuide ? color.blue(S_BAR_END) : '';
           // Calculate rowPadding: title lines + footer lines (S_BAR_END + trailing newline)
-          const titleLineCount = title.split('\n').length;
+          const titleLineCount = title ? title.split('\n').length : 0;
           const footerLineCount = hasGuide ? 2 : 1; // S_BAR_END + trailing newline (or just trailing newline)
           return `${title}${prefix}${limitOptions({
             output: opts.output,

--- a/packages/prompts/src/spinner.ts
+++ b/packages/prompts/src/spinner.ts
@@ -5,6 +5,7 @@ import { cursor, erase } from 'sisteransi';
 
 import {
   type CommonOptions,
+  completeColor,
   isCI as isCIFn,
   S_BAR,
   S_STEP_CANCEL,
@@ -132,7 +133,7 @@ export const spinner = ({
     output.write(erase.down());
   };
 
-  const hasGuide = opts.withGuide ?? settings.withGuide;
+  const hasGuide = opts.withGuide ?? false;
 
   const start = (msg = ''): void => {
     isSpinnerActive = true;
@@ -184,16 +185,16 @@ export const spinner = ({
     clearPrevMessage();
     const step =
       code === 0
-        ? color.green(S_STEP_SUBMIT)
+        ? completeColor(S_STEP_SUBMIT)
         : code === 1
           ? color.red(S_STEP_CANCEL)
           : color.red(S_STEP_ERROR);
     _message = msg ?? _message;
     if (!silent) {
       if (indicator === 'timer') {
-        output.write(`${step}  ${_message} ${formatTimer(_origin)}\n`);
+        output.write(`${step} ${_message} ${formatTimer(_origin)}\n\n`);
       } else {
-        output.write(`${step}  ${_message}\n`);
+        output.write(`${step} ${_message}\n\n`);
       }
     }
     clearHooks();
@@ -203,9 +204,6 @@ export const spinner = ({
   const stop = (msg = ''): void => _stop(msg, 0);
   const cancel = (msg = ''): void => _stop(msg, 1);
   const error = (msg = ''): void => _stop(msg, 2);
-  // TODO (43081j): this will leave the initial S_BAR since we purposely
-  // don't erase that in `clearPrevMessage`. In future, we may want to treat
-  // `clear` as a special case and remove the bar too.
   const clear = (): void => _stop('', 0, true);
 
   const message = (msg = ''): void => {

--- a/packages/prompts/src/stream.ts
+++ b/packages/prompts/src/stream.ts
@@ -2,10 +2,10 @@ import { stripVTControlCharacters as strip } from 'node:util';
 
 import color from 'picocolors';
 
-import { S_BAR, S_ERROR, S_INFO, S_STEP_SUBMIT, S_SUCCESS, S_WARN } from './common.js';
+import { S_ERROR, S_INFO, S_STEP_SUBMIT, S_SUCCESS, S_WARN, completeColor } from './common.js';
 import type { LogMessageOptions } from './log.js';
 
-const prefix = `${color.gray(S_BAR)}  `;
+const prefix = '   ';
 
 // TODO (43081j): this currently doesn't support custom `output` writables
 // because we rely on `columns` existing (i.e. `process.stdout.columns).
@@ -15,14 +15,15 @@ const prefix = `${color.gray(S_BAR)}  `;
 export const stream = {
   message: async (
     iterable: Iterable<string> | AsyncIterable<string>,
-    { symbol = color.gray(S_BAR) }: LogMessageOptions = {},
+    { symbol = '' }: LogMessageOptions = {},
   ) => {
-    process.stdout.write(`${color.gray(S_BAR)}\n${symbol}  `);
-    let lineWidth = 3;
+    process.stdout.write(symbol ? `${symbol}  ` : '');
+    const initialWidth = symbol ? 3 : 0;
+    let lineWidth = initialWidth;
     for await (let chunk of iterable) {
       chunk = chunk.replace(/\n/g, `\n${prefix}`);
       if (chunk.includes('\n')) {
-        lineWidth = 3 + strip(chunk.slice(chunk.lastIndexOf('\n'))).length;
+        lineWidth = initialWidth + strip(chunk.slice(chunk.lastIndexOf('\n'))).length;
       }
       const chunkLen = strip(chunk).length;
       if (lineWidth + chunkLen < process.stdout.columns) {
@@ -30,7 +31,7 @@ export const stream = {
         process.stdout.write(chunk);
       } else {
         process.stdout.write(`\n${prefix}${chunk.trimStart()}`);
-        lineWidth = 3 + strip(chunk.trimStart()).length;
+        lineWidth = initialWidth + strip(chunk.trimStart()).length;
       }
     }
     process.stdout.write('\n');
@@ -39,10 +40,10 @@ export const stream = {
     return stream.message(iterable, { symbol: color.blue(S_INFO) });
   },
   success: (iterable: Iterable<string> | AsyncIterable<string>) => {
-    return stream.message(iterable, { symbol: color.green(S_SUCCESS) });
+    return stream.message(iterable, { symbol: completeColor(S_SUCCESS) });
   },
   step: (iterable: Iterable<string> | AsyncIterable<string>) => {
-    return stream.message(iterable, { symbol: color.green(S_STEP_SUBMIT) });
+    return stream.message(iterable, { symbol: completeColor(S_STEP_SUBMIT) });
   },
   warn: (iterable: Iterable<string> | AsyncIterable<string>) => {
     return stream.message(iterable, { symbol: color.yellow(S_WARN) });

--- a/packages/prompts/src/task-log.ts
+++ b/packages/prompts/src/task-log.ts
@@ -6,6 +6,7 @@ import { erase } from 'sisteransi';
 
 import {
   type CommonOptions,
+  completeColor,
   isCI as isCIFn,
   isTTY as isTTYFn,
   S_BAR,
@@ -56,7 +57,7 @@ export const taskLog = (opts: TaskLogOptions) => {
   const isTTY = !isCIFn() && isTTYFn(output);
 
   output.write(`${secondarySymbol}\n`);
-  output.write(`${color.green(S_STEP_SUBMIT)}  ${opts.title}\n`);
+  output.write(`${completeColor(S_STEP_SUBMIT)}  ${opts.title}\n`);
   for (let i = 0; i < spacing; i++) {
     output.write(`${secondarySymbol}\n`);
   }

--- a/packages/prompts/src/text.ts
+++ b/packages/prompts/src/text.ts
@@ -1,4 +1,4 @@
-import { settings, TextPrompt } from '@clack/core';
+import { TextPrompt } from '@clack/core';
 import color from 'picocolors';
 
 import { type CommonOptions, S_BAR, S_BAR_END, symbol } from './common.js';
@@ -21,9 +21,9 @@ export const text = (opts: TextOptions) => {
     signal: opts.signal,
     input: opts.input,
     render() {
-      const hasGuide = opts?.withGuide ?? settings.withGuide;
-      const titlePrefix = `${hasGuide ? `${color.gray(S_BAR)}\n` : ''}${symbol(this.state)}  `;
-      const title = `${titlePrefix}${opts.message}\n`;
+      const hasGuide = opts?.withGuide ?? false;
+      const nestedPrefix = '  ';
+      const title = `${hasGuide ? `${color.gray(S_BAR)}\n` : ''}${symbol(this.state)} ${opts.message}\n`;
       const placeholder = opts.placeholder
         ? color.inverse(opts.placeholder[0]) + color.dim(opts.placeholder.slice(1))
         : color.inverse(color.hidden('_'));
@@ -32,23 +32,23 @@ export const text = (opts: TextOptions) => {
 
       switch (this.state) {
         case 'error': {
-          const errorText = this.error ? `  ${color.yellow(this.error)}` : '';
-          const errorPrefix = hasGuide ? `${color.yellow(S_BAR)}  ` : '';
+          const errorText = this.error ? ` ${color.yellow(this.error)}` : '';
+          const errorPrefix = hasGuide ? `${color.yellow(S_BAR)} ` : nestedPrefix;
           const errorPrefixEnd = hasGuide ? color.yellow(S_BAR_END) : '';
           return `${title.trim()}\n${errorPrefix}${userInput}\n${errorPrefixEnd}${errorText}\n`;
         }
         case 'submit': {
-          const valueText = value ? `  ${color.dim(value)}` : '';
-          const submitPrefix = hasGuide ? color.gray(S_BAR) : '';
-          return `${title}${submitPrefix}${valueText}`;
+          const valueText = value ? color.dim(value) : '';
+          const submitPrefix = hasGuide ? `${color.gray(S_BAR)} ` : nestedPrefix;
+          return `${title}${submitPrefix}${valueText}\n\n`;
         }
         case 'cancel': {
-          const valueText = value ? `  ${color.strikethrough(color.dim(value))}` : '';
-          const cancelPrefix = hasGuide ? color.gray(S_BAR) : '';
-          return `${title}${cancelPrefix}${valueText}${value.trim() ? `\n${cancelPrefix}` : ''}`;
+          const valueText = value ? color.strikethrough(color.dim(value)) : '';
+          const cancelPrefix = hasGuide ? `${color.gray(S_BAR)} ` : nestedPrefix;
+          return `${title}${cancelPrefix}${valueText}${value.trim() ? `\n${cancelPrefix}` : ''}\n\n`;
         }
         default: {
-          const defaultPrefix = hasGuide ? `${color.blue(S_BAR)}  ` : '';
+          const defaultPrefix = hasGuide ? `${color.blue(S_BAR)} ` : nestedPrefix;
           const defaultPrefixEnd = hasGuide ? color.blue(S_BAR_END) : '';
           return `${title}${defaultPrefix}${userInput}\n${defaultPrefixEnd}\n`;
         }


### PR DESCRIPTION
The goal of forking `@clack/prompts` was to customize the rendering in Vite+. Now that we have a new interactive `vp` command, I took that styling and applied it to our prompts system. This makes our CLI look more consistent, and unique from everyone else who is adopting `@clack/prompts`. Here is what a `vp create` flow looks like now:

https://github.com/user-attachments/assets/552c5d7e-699a-432c-8fd8-35fda0c4f6c2

Among the styling changes, I also moved the "VS Code" option up in the editor selection since it is selected by default, and moved the git init question to before running any commands.

The output after answering all the questions can still be improved in a follow-up.

