### PR TITLE
fix: Run Oxfmt after creating a new project.

### DIFF
--- a/packages/cli/snap-tests-global/new-vite-monorepo/snap.txt
+++ b/packages/cli/snap-tests-global/new-vite-monorepo/snap.txt
@@ -19,11 +19,11 @@ vite.config.ts
     "ready": "vp fmt && vp lint --type-aware && vp run test -r && vp run build -r",
     "dev": "vp run website#dev"
   },
-  "engines": {
-    "node": ">=22.12.0"
-  },
   "devDependencies": {
     "vite-plus": "catalog:"
+  },
+  "engines": {
+    "node": ">=22.12.0"
   },
   "packageManager": "pnpm@<semver>"
 }
@@ -37,21 +37,21 @@ packages:
 catalogMode: prefer
 
 catalog:
-  '@types/node': ^24
+  "@types/node": ^24
   typescript: ^5
   vite: npm:@voidzero-dev/vite-plus-core@latest
   vitest: npm:@voidzero-dev/vite-plus-test@latest
   vite-plus: latest
 overrides:
-  vite: 'catalog:'
-  vitest: 'catalog:'
+  vite: "catalog:"
+  vitest: "catalog:"
 peerDependencyRules:
   allowAny:
     - vite
     - vitest
   allowedVersions:
-    vite: '*'
-    vitest: '*'
+    vite: "*"
+    vitest: "*"
 
 > test -d vite-plus-monorepo/.git && echo 'Git initialized' || echo 'No git' # check git init
 Git initialized
@@ -128,11 +128,11 @@ vite.config.ts
     "ready": "vp fmt && vp lint --type-aware && vp run test -r && vp run build -r",
     "dev": "vp run website#dev"
   },
-  "engines": {
-    "node": ">=22.12.0"
-  },
   "devDependencies": {
     "vite-plus": "catalog:"
+  },
+  "engines": {
+    "node": ">=22.12.0"
   },
   "packageManager": "pnpm@<semver>"
 }

--- a/packages/cli/src/create/bin.ts
+++ b/packages/cli/src/create/bin.ts
@@ -22,6 +22,7 @@ import { displayRelative } from '../utils/path.js';
 import {
   defaultInteractive,
   downloadPackageManager,
+  runViteFmt,
   runViteInstall,
   selectPackageManager,
 } from '../utils/prompts.js';
@@ -567,6 +568,7 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
     workspaceInfo.rootDir = fullPath;
     rewriteMonorepo(workspaceInfo);
     await runViteInstall(fullPath, options.interactive);
+    await runViteFmt(fullPath, options.interactive);
     prompts.outro(`✔ Created ${accent(projectDir)}!`);
     log(styleText('bold', 'Next steps:'));
     log(`  ${accent(`cd ${projectDir}`)}`);
@@ -685,9 +687,11 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
 
     updateWorkspaceConfig(projectDir, workspaceInfo);
     await runViteInstall(workspaceInfo.rootDir, options.interactive);
+    await runViteFmt(workspaceInfo.rootDir, options.interactive, [projectDir]);
   } else {
     rewriteStandaloneProject(fullPath, workspaceInfo);
     await runViteInstall(fullPath, options.interactive);
+    await runViteFmt(fullPath, options.interactive);
   }
 
   prompts.outro(`✔ Created ${accent(projectDir)}!`);

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -1,6 +1,7 @@
 import * as prompts from '@voidzero-dev/vite-plus-prompts';
 
 import { downloadPackageManager as downloadPackageManagerBinding } from '../../binding/index.js';
+import { fmt as resolveFmt } from '../resolve-fmt.js';
 import { PackageManager } from '../types/index.js';
 import { runCommandSilently } from './command.js';
 import { accent } from './terminal.js';
@@ -70,6 +71,32 @@ export async function runViteInstall(cwd: string, interactive?: boolean, extraAr
     prompts.log.info(stdout.toString());
     prompts.log.error(stderr.toString());
     prompts.log.info(`You may need to run "vp install" manually in ${cwd}`);
+  }
+}
+
+export async function runViteFmt(cwd: string, interactive?: boolean, paths?: string[]) {
+  const spinner = getSpinner(interactive);
+  spinner.start(`Formatting code...`);
+
+  const { binPath, envs } = await resolveFmt();
+  const { exitCode, stderr, stdout } = await runCommandSilently({
+    command: binPath,
+    args: ['--write', ...(paths ?? [])],
+    cwd,
+    envs: {
+      ...process.env,
+      ...envs,
+    },
+  });
+
+  if (exitCode === 0) {
+    spinner.stop(`Code formatted`);
+  } else {
+    spinner.stop(`Format failed`);
+    prompts.log.info(stdout.toString());
+    prompts.log.error(stderr.toString());
+    const relativePaths = (paths ?? []).length > 0 ? ` ${(paths ?? []).join(' ')}` : '';
+    prompts.log.info(`You may need to run "vp fmt --write${relativePaths}" manually in ${cwd}`);
   }
 }
 


### PR DESCRIPTION
When creating a new project with any template we should run Oxfmt to format the project. This is especially useful when using third-party templates.