### PR TITLE
fix: Tighten `vp create` behavior related to agent file handling.

### DIFF
--- a/packages/cli/src/create/bin.ts
+++ b/packages/cli/src/create/bin.ts
@@ -13,7 +13,7 @@ import {
 } from '../migration/migrator.js';
 import { DependencyType, type WorkspaceInfo } from '../types/index.js';
 import {
-  detectExistingAgentTargetPath,
+  detectExistingAgentTargetPaths,
   selectAgentTargetPaths,
   writeAgentInstructions,
 } from '../utils/agent.js';
@@ -493,11 +493,14 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
   // Prompt for package manager or use default
   const packageManager =
     workspaceInfoOptional.packageManager ?? (await selectPackageManager(options.interactive));
+  const shouldSilencePackageManagerInstallLog =
+    isMonorepo && workspaceInfoOptional.packageManager !== undefined;
   // ensure the package manager is installed by vite-plus
   const downloadResult = await downloadPackageManager(
     packageManager,
     workspaceInfoOptional.packageManagerVersion,
     options.interactive,
+    shouldSilencePackageManagerInstallLog,
   );
   const workspaceInfo: WorkspaceInfo = {
     ...workspaceInfoOptional,
@@ -505,13 +508,13 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
     downloadPackageManager: downloadResult,
   };
 
-  const existingAgentTargetPath =
+  const existingAgentTargetPaths =
     options.agent !== undefined || !options.interactive
       ? undefined
-      : detectExistingAgentTargetPath(workspaceInfoOptional.rootDir);
+      : detectExistingAgentTargetPaths(workspaceInfoOptional.rootDir);
   selectedAgentTargetPaths =
-    existingAgentTargetPath !== undefined
-      ? [existingAgentTargetPath]
+    existingAgentTargetPaths !== undefined
+      ? existingAgentTargetPaths
       : await selectAgentTargetPaths({
           interactive: options.interactive,
           agent: options.agent,
@@ -628,8 +631,9 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
 
   prompts.log.success(`Project directory: ${accent(projectDir)}`);
   const fullPath = path.join(workspaceInfo.rootDir, projectDir);
+  const agentInstructionsRoot = isMonorepo ? workspaceInfo.rootDir : fullPath;
   await writeAgentInstructions({
-    projectRoot: fullPath,
+    projectRoot: agentInstructionsRoot,
     targetPaths: selectedAgentTargetPaths,
     interactive: options.interactive,
   });

--- a/packages/cli/src/utils/__tests__/agent.spec.ts
+++ b/packages/cli/src/utils/__tests__/agent.spec.ts
@@ -6,6 +6,7 @@ import * as prompts from '@voidzero-dev/vite-plus-prompts';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  detectExistingAgentTargetPaths,
   detectExistingAgentTargetPath,
   replaceMarkedAgentInstructionsSection,
   resolveAgentTargetPaths,
@@ -259,6 +260,14 @@ describe('resolveAgentTargetPaths', () => {
 });
 
 describe('detectExistingAgentTargetPath', () => {
+  it('detects all existing regular agent files', async () => {
+    const dir = await createProjectDir();
+    await mockFs.writeFile(path.join(dir, 'AGENTS.md'), '# Agents');
+    await mockFs.writeFile(path.join(dir, 'CLAUDE.md'), '# Claude');
+
+    expect(detectExistingAgentTargetPaths(dir)).toEqual(['AGENTS.md', 'CLAUDE.md']);
+  });
+
   it('detects existing regular agent files', async () => {
     const dir = await createProjectDir();
     await mockFs.writeFile(path.join(dir, 'CLAUDE.md'), '# Claude');
@@ -339,5 +348,30 @@ describe('writeAgentInstructions symlink behavior', () => {
     expect(mockFs.isSymlink(existingClaude)).toBe(false);
     expect(await mockFs.readText(existingClaude)).toBe('existing claude instructions');
     expect(mockFs.existsSync(path.join(dir, 'AGENTS.md'))).toBe(true);
+  });
+
+  it('silently updates marker blocks without prompting in interactive mode', async () => {
+    const dir = await createProjectDir();
+    const targetPath = path.join(dir, 'AGENTS.md');
+    const existing = [
+      '# Local',
+      '<!--VITE PLUS START-->',
+      'old block',
+      '<!--VITE PLUS END-->',
+    ].join('\n');
+    await mockFs.writeFile(targetPath, existing);
+
+    const selectSpy = vi.spyOn(prompts, 'select');
+    const successSpy = vi.spyOn(prompts.log, 'success');
+
+    await writeAgentInstructions({
+      projectRoot: dir,
+      targetPaths: ['AGENTS.md'],
+      interactive: true,
+    });
+
+    expect(selectSpy).not.toHaveBeenCalled();
+    expect(await mockFs.readText(targetPath)).toContain('template block');
+    expect(successSpy).not.toHaveBeenCalledWith('Updated agent instructions in AGENTS.md');
   });
 });

--- a/packages/cli/src/utils/agent.ts
+++ b/packages/cli/src/utils/agent.ts
@@ -245,14 +245,24 @@ export async function selectAgentTargetPath({
   return targetPaths?.[0];
 }
 
-export function detectExistingAgentTargetPath(projectRoot: string) {
+export function detectExistingAgentTargetPaths(projectRoot: string) {
+  const detectedPaths: string[] = [];
+  const seenTargetPaths = new Set<string>();
   for (const option of AGENTS) {
+    if (seenTargetPaths.has(option.targetPath)) {
+      continue;
+    }
+    seenTargetPaths.add(option.targetPath);
     const targetPath = path.join(projectRoot, option.targetPath);
     if (fs.existsSync(targetPath) && !fs.lstatSync(targetPath).isSymbolicLink()) {
-      return option.targetPath;
+      detectedPaths.push(option.targetPath);
     }
   }
-  return undefined;
+  return detectedPaths.length > 0 ? detectedPaths : undefined;
+}
+
+export function detectExistingAgentTargetPath(projectRoot: string) {
+  return detectExistingAgentTargetPaths(projectRoot)?.[0];
 }
 
 export function resolveAgentTargetPaths(agent?: string | string[]) {
@@ -357,6 +367,19 @@ export async function writeAgentInstructions({
         continue;
       }
 
+      const existingContent = await fsPromises.readFile(destinationPath, 'utf-8');
+      const updatedContent = replaceMarkedAgentInstructionsSection(
+        existingContent,
+        incomingContent,
+      );
+      if (updatedContent !== undefined) {
+        if (updatedContent !== existingContent) {
+          await fsPromises.writeFile(destinationPath, updatedContent);
+        }
+        seenRealPaths.add(destinationRealPath);
+        continue;
+      }
+
       if (interactive) {
         const action = await prompts.select({
           message: `Agent instructions already exist at ${targetPathToWrite}.`,
@@ -376,18 +399,6 @@ export async function writeAgentInstructions({
         });
         if (prompts.isCancel(action) || action === 'skip') {
           prompts.log.info(`Skipped writing ${targetPathToWrite}`);
-          seenRealPaths.add(destinationRealPath);
-          continue;
-        }
-
-        const existingContent = await fsPromises.readFile(destinationPath, 'utf-8');
-        const updatedContent = replaceMarkedAgentInstructionsSection(
-          existingContent,
-          incomingContent,
-        );
-        if (updatedContent !== undefined) {
-          await fsPromises.writeFile(destinationPath, updatedContent);
-          prompts.log.success(`Updated agent instructions in ${targetPathToWrite}`);
           seenRealPaths.add(destinationRealPath);
           continue;
         }

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -39,8 +39,9 @@ export async function downloadPackageManager(
   packageManager: PackageManager,
   version: string,
   interactive?: boolean,
+  silent = false,
 ) {
-  const spinner = getSpinner(interactive);
+  const spinner = silent ? getSilentSpinner() : getSpinner(interactive);
   spinner.start(`${packageManager}@${version} installing...`);
   const downloadResult = await downloadPackageManagerBinding({
     name: packageManager,
@@ -168,5 +169,13 @@ export function getSpinner(interactive?: boolean) {
         prompts.log.info(msg);
       }
     },
+  };
+}
+
+function getSilentSpinner() {
+  return {
+    start: () => {},
+    stop: () => {},
+    message: () => {},
   };
 }


### PR DESCRIPTION
When you use `vp create` in a monorepo, it will propose to write `AGENTS.md`. This PR changes it so it only asks if there are no agent files present, or silently updates them if they are, and writes them at the monorepo root instead of the package.