### PR TITLE
feat: Overwrite `vp fmt --init` and `vp lint --init`.

### DIFF
--- a/crates/vite_global_cli/src/cli.rs
+++ b/crates/vite_global_cli/src/cli.rs
@@ -1450,6 +1450,29 @@ fn determine_save_dependency_type(
     }
 }
 
+fn has_flag_before_terminator(args: &[String], flag: &str) -> bool {
+    for arg in args {
+        if arg == "--" {
+            break;
+        }
+        if arg == flag || arg.starts_with(&format!("{flag}=")) {
+            return true;
+        }
+    }
+    false
+}
+
+fn should_force_global_delegate(command: &str, args: &[String]) -> bool {
+    match command {
+        "lint" => has_flag_before_terminator(args, "--init"),
+        "fmt" => {
+            has_flag_before_terminator(args, "--init")
+                || has_flag_before_terminator(args, "--migrate")
+        }
+        _ => false,
+    }
+}
+
 /// Run the CLI command.
 pub async fn run_command(cwd: AbsolutePathBuf, args: Args) -> Result<ExitStatus, Error> {
     run_command_with_options(cwd, args, RenderOptions::default()).await
@@ -1859,7 +1882,11 @@ pub async fn run_command_with_options(
                 return Ok(ExitStatus::default());
             }
             print_runtime_header(render_options.show_header);
-            commands::delegate::execute(cwd, "lint", &args).await
+            if should_force_global_delegate("lint", &args) {
+                commands::delegate::execute_global(cwd, "lint", &args).await
+            } else {
+                commands::delegate::execute(cwd, "lint", &args).await
+            }
         }
 
         Commands::Fmt { args } => {
@@ -1867,7 +1894,11 @@ pub async fn run_command_with_options(
                 return Ok(ExitStatus::default());
             }
             print_runtime_header(render_options.show_header);
-            commands::delegate::execute(cwd, "fmt", &args).await
+            if should_force_global_delegate("fmt", &args) {
+                commands::delegate::execute_global(cwd, "fmt", &args).await
+            } else {
+                commands::delegate::execute(cwd, "fmt", &args).await
+            }
         }
 
         Commands::Check { args } => {
@@ -2000,4 +2031,41 @@ pub fn try_parse_args_from_with_options(
     let cmd = apply_custom_help(Args::command(), render_options);
     let matches = cmd.try_get_matches_from(args)?;
     Args::from_arg_matches(&matches).map_err(|e| e.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{has_flag_before_terminator, should_force_global_delegate};
+
+    #[test]
+    fn detects_flag_before_option_terminator() {
+        assert!(has_flag_before_terminator(
+            &["--init".to_string(), "src/index.ts".to_string()],
+            "--init"
+        ));
+    }
+
+    #[test]
+    fn ignores_flag_after_option_terminator() {
+        assert!(!has_flag_before_terminator(
+            &["src/index.ts".to_string(), "--".to_string(), "--init".to_string(),],
+            "--init"
+        ));
+    }
+
+    #[test]
+    fn lint_init_forces_global_delegate() {
+        assert!(should_force_global_delegate("lint", &["--init".to_string()]));
+    }
+
+    #[test]
+    fn fmt_migrate_forces_global_delegate() {
+        assert!(should_force_global_delegate("fmt", &["--migrate=prettier".to_string()]));
+    }
+
+    #[test]
+    fn non_init_does_not_force_global_delegate() {
+        assert!(!should_force_global_delegate("lint", &["src/index.ts".to_string()]));
+        assert!(!should_force_global_delegate("fmt", &["--check".to_string()]));
+    }
 }

--- a/crates/vite_global_cli/src/commands/delegate.rs
+++ b/crates/vite_global_cli/src/commands/delegate.rs
@@ -18,6 +18,18 @@ pub async fn execute(
     executor.delegate_to_local_cli(&cwd, &full_args).await
 }
 
+/// Execute a command by delegating to the global `vite-plus` CLI.
+pub async fn execute_global(
+    cwd: AbsolutePathBuf,
+    command: &str,
+    args: &[String],
+) -> Result<ExitStatus, Error> {
+    let mut executor = JsExecutor::new(None);
+    let mut full_args = vec![command.to_string()];
+    full_args.extend(args.iter().cloned());
+    executor.delegate_to_global_cli(&cwd, &full_args).await
+}
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/crates/vite_global_cli/src/js_executor.rs
+++ b/crates/vite_global_cli/src/js_executor.rs
@@ -221,6 +221,28 @@ impl JsExecutor {
         self.run_js_entry(project_path, &node_binary, &bin_prefix, args).await
     }
 
+    /// Delegate to the global vite-plus CLI entrypoint directly.
+    ///
+    /// Unlike [`delegate_to_local_cli`], this bypasses project-local resolution and always runs
+    /// the global installation's `dist/bin.js`.
+    pub async fn delegate_to_global_cli(
+        &mut self,
+        project_path: &AbsolutePath,
+        args: &[String],
+    ) -> Result<ExitStatus, Error> {
+        let runtime = self.ensure_cli_runtime().await?;
+        let node_binary = runtime.get_binary_path();
+        let bin_prefix = runtime.get_bin_prefix();
+        let scripts_dir = self.get_scripts_dir()?;
+        let entry_point = scripts_dir.join("bin.js");
+
+        let mut cmd = Self::create_js_command(&node_binary, &bin_prefix);
+        cmd.arg(entry_point.as_path()).args(args).current_dir(project_path.as_path());
+
+        let status = cmd.status().await?;
+        Ok(status)
+    }
+
     /// Delegate to local or global vite-plus CLI using the CLI's own runtime.
     ///
     /// Like [`delegate_to_local_cli`], but uses the CLI's bundled runtime

--- a/packages/cli/binding/src/cli.rs
+++ b/packages/cli/binding/src/cli.rs
@@ -928,7 +928,21 @@ async fn execute_direct_subcommand(
 
             status
         }
-        other => resolve_and_execute(&mut resolver, other, &envs, cwd, &cwd_arc).await?,
+        other => {
+            if should_suppress_subcommand_stdout(&other) {
+                resolve_and_execute_with_stdout_filter(
+                    &mut resolver,
+                    other,
+                    &envs,
+                    cwd,
+                    &cwd_arc,
+                    |_| Cow::Borrowed(""),
+                )
+                .await?
+            } else {
+                resolve_and_execute(&mut resolver, other, &envs, cwd, &cwd_arc).await?
+            }
+        }
     };
 
     resolver.cleanup_temp_files().await;
@@ -1051,6 +1065,29 @@ fn is_vitest_watch_flag(arg: &str) -> bool {
 
 fn is_vitest_test_subcommand(arg: &str) -> bool {
     matches!(arg, "run" | "watch" | "dev" | "related" | "bench" | "init" | "list")
+}
+
+fn has_flag_before_terminator(args: &[String], flag: &str) -> bool {
+    for arg in args {
+        if arg == "--" {
+            break;
+        }
+        if arg == flag || arg.starts_with(&format!("{flag}=")) {
+            return true;
+        }
+    }
+    false
+}
+
+fn should_suppress_subcommand_stdout(subcommand: &SynthesizableSubcommand) -> bool {
+    match subcommand {
+        SynthesizableSubcommand::Lint { args } => has_flag_before_terminator(args, "--init"),
+        SynthesizableSubcommand::Fmt { args } => {
+            has_flag_before_terminator(args, "--init")
+                || has_flag_before_terminator(args, "--migrate")
+        }
+        _ => false,
+    }
 }
 
 fn should_prepend_vitest_run(args: &[String]) -> bool {
@@ -1197,7 +1234,8 @@ mod tests {
     use vite_task::config::UserRunConfig;
 
     use super::{
-        CLIArgs, extract_unknown_argument, has_pass_as_value_suggestion, should_prepend_vitest_run,
+        CLIArgs, SynthesizableSubcommand, extract_unknown_argument, has_pass_as_value_suggestion,
+        should_prepend_vitest_run, should_suppress_subcommand_stdout,
     };
 
     #[test]
@@ -1285,5 +1323,24 @@ mod tests {
             "--watch".to_string(),
             "src/foo.test.ts".to_string(),
         ]));
+    }
+
+    #[test]
+    fn lint_init_suppresses_stdout() {
+        let subcommand = SynthesizableSubcommand::Lint { args: vec!["--init".to_string()] };
+        assert!(should_suppress_subcommand_stdout(&subcommand));
+    }
+
+    #[test]
+    fn fmt_migrate_suppresses_stdout() {
+        let subcommand =
+            SynthesizableSubcommand::Fmt { args: vec!["--migrate=prettier".to_string()] };
+        assert!(should_suppress_subcommand_stdout(&subcommand));
+    }
+
+    #[test]
+    fn normal_lint_does_not_suppress_stdout() {
+        let subcommand = SynthesizableSubcommand::Lint { args: vec!["src/index.ts".to_string()] };
+        assert!(!should_suppress_subcommand_stdout(&subcommand));
     }
 }

--- a/packages/cli/snap-tests-global/command-upgrade-check/snap.txt
+++ b/packages/cli/snap-tests-global/command-upgrade-check/snap.txt
@@ -1,5 +1,5 @@
 > vp upgrade --check # check for updates without installing
 info: checking for updates...
-info: found vite-plus@<semver>
+info: found vite-plus@<semver> (current: <semver>)
 Update available: <semver> → <semver>
 Run `vp upgrade` to update.

--- a/packages/cli/snap-tests/command-init-inline-config-existing/package.json
+++ b/packages/cli/snap-tests/command-init-inline-config-existing/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "command-init-inline-config-existing",
+  "version": "0.0.0",
+  "private": true
+}

--- a/packages/cli/snap-tests/command-init-inline-config-existing/snap.txt
+++ b/packages/cli/snap-tests/command-init-inline-config-existing/snap.txt
@@ -1,0 +1,11 @@
+> vp lint --init
+Skipped initialization: 'lint' already exists in 'vite.config.ts'.
+
+> cat .oxlintrc.json && exit 1 || true # check .oxlintrc.json is not created
+cat: .oxlintrc.json: No such file or directory
+
+> vp fmt --init
+Skipped initialization: 'fmt' already exists in 'vite.config.ts'.
+
+> cat .oxfmtrc.json && exit 1 || true # check .oxfmtrc.json is not created
+cat: .oxfmtrc.json: No such file or directory

--- a/packages/cli/snap-tests/command-init-inline-config-existing/steps.json
+++ b/packages/cli/snap-tests/command-init-inline-config-existing/steps.json
@@ -1,0 +1,11 @@
+{
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": [
+    "vp lint --init",
+    "cat .oxlintrc.json && exit 1 || true # check .oxlintrc.json is not created",
+    "vp fmt --init",
+    "cat .oxfmtrc.json && exit 1 || true # check .oxfmtrc.json is not created"
+  ]
+}

--- a/packages/cli/snap-tests/command-init-inline-config-existing/vite.config.ts
+++ b/packages/cli/snap-tests/command-init-inline-config-existing/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite-plus';
+
+export default defineConfig({
+  lint: {
+    rules: {},
+  },
+  fmt: {
+    ignorePatterns: [],
+  },
+});

--- a/packages/cli/snap-tests/command-init-inline-config/package.json
+++ b/packages/cli/snap-tests/command-init-inline-config/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "command-init-inline-config",
+  "version": "0.0.0",
+  "private": true
+}

--- a/packages/cli/snap-tests/command-init-inline-config/snap.txt
+++ b/packages/cli/snap-tests/command-init-inline-config/snap.txt
@@ -1,0 +1,28 @@
+> vp lint --init
+Added 'lint' to 'vite.config.ts'.
+
+> cat vite.config.ts
+import { defineConfig } from "vite-plus";
+
+export default defineConfig({
+  lint: {},
+});
+
+> cat .oxlintrc.json && exit 1 || true # check .oxlintrc.json is removed
+cat: .oxlintrc.json: No such file or directory
+
+> rm vite.config.ts
+> vp fmt --init
+Added 'fmt' to 'vite.config.ts'.
+
+> cat vite.config.ts
+import { defineConfig } from "vite-plus";
+
+export default defineConfig({
+  fmt: {
+    ignorePatterns: [],
+  },
+});
+
+> cat .oxfmtrc.json && exit 1 || true # check .oxfmtrc.json is removed
+cat: .oxfmtrc.json: No such file or directory

--- a/packages/cli/snap-tests/command-init-inline-config/steps.json
+++ b/packages/cli/snap-tests/command-init-inline-config/steps.json
@@ -1,0 +1,14 @@
+{
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": [
+    "vp lint --init",
+    "cat vite.config.ts",
+    "cat .oxlintrc.json && exit 1 || true # check .oxlintrc.json is removed",
+    "rm vite.config.ts",
+    "vp fmt --init",
+    "cat vite.config.ts",
+    "cat .oxfmtrc.json && exit 1 || true # check .oxfmtrc.json is removed"
+  ]
+}

--- a/packages/cli/src/__tests__/init-config.spec.ts
+++ b/packages/cli/src/__tests__/init-config.spec.ts
@@ -1,0 +1,209 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { vi } from 'vitest';
+
+import { applyToolInitConfigToViteConfig, inspectInitCommand } from '../init-config.js';
+
+const tempDirs: string[] = [];
+
+function createTempDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vp-init-config-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0, tempDirs.length)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  vi.clearAllMocks();
+});
+
+describe('applyToolInitConfigToViteConfig', () => {
+  it('returns false for non-init command invocations', async () => {
+    const projectPath = createTempDir();
+    await expect(
+      applyToolInitConfigToViteConfig('lint', ['src/index.ts'], projectPath),
+    ).resolves.toEqual({ handled: false });
+  });
+
+  it('creates vite.config.ts and writes lint: {} for vp lint --init', async () => {
+    const projectPath = createTempDir();
+    fs.writeFileSync(
+      path.join(projectPath, '.oxlintrc.json'),
+      JSON.stringify(
+        {
+          rules: {
+            eqeqeq: 'warn',
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const result = await applyToolInitConfigToViteConfig('lint', ['--init'], projectPath);
+    expect(result.handled).toBe(true);
+    expect(result.action).toBe('added');
+
+    const viteConfigPath = path.join(projectPath, 'vite.config.ts');
+    expect(fs.existsSync(viteConfigPath)).toBe(true);
+    const content = fs.readFileSync(viteConfigPath, 'utf8');
+    expect(content).toContain('import { defineConfig } from');
+    expect(content).toContain('vite-plus');
+    expect(content).toContain('lint: {}');
+    expect(fs.existsSync(path.join(projectPath, '.oxlintrc.json'))).toBe(false);
+  });
+
+  it('ignores generated lint init defaults and still writes lint: {}', async () => {
+    const projectPath = createTempDir();
+    fs.writeFileSync(
+      path.join(projectPath, '.oxlintrc.json'),
+      JSON.stringify(
+        {
+          plugins: null,
+          categories: {},
+          rules: {},
+          settings: {
+            'jsx-a11y': {
+              polymorphicPropName: null,
+              components: {},
+              attributes: {},
+            },
+            next: {
+              rootDir: [],
+            },
+            react: {
+              formComponents: [],
+              linkComponents: [],
+              version: null,
+              componentWrapperFunctions: [],
+            },
+            jsdoc: {
+              ignorePrivate: false,
+              ignoreInternal: false,
+              ignoreReplacesDocs: true,
+              overrideReplacesDocs: true,
+              augmentsExtendsReplacesDocs: false,
+              implementsReplacesDocs: false,
+              exemptDestructuredRootsFromChecks: false,
+              tagNamePreference: {},
+            },
+            vitest: {
+              typecheck: false,
+            },
+          },
+          env: {
+            builtin: true,
+          },
+          globals: {},
+          ignorePatterns: [],
+        },
+        null,
+        2,
+      ),
+    );
+
+    const result = await applyToolInitConfigToViteConfig('lint', ['--init'], projectPath);
+    expect(result.handled).toBe(true);
+    expect(result.action).toBe('added');
+
+    const content = fs.readFileSync(path.join(projectPath, 'vite.config.ts'), 'utf8');
+    expect(content).toContain('lint: {}');
+    expect(content).not.toContain('jsx-a11y');
+    expect(content).not.toContain('ignorePatterns');
+  });
+
+  it('inlines fmt migrate output into existing vite config', async () => {
+    const projectPath = createTempDir();
+    const viteConfigPath = path.join(projectPath, 'vite.config.ts');
+    fs.writeFileSync(
+      viteConfigPath,
+      `import { defineConfig } from 'vite-plus';
+
+export default defineConfig({
+  plugins: [],
+});
+`,
+    );
+    fs.writeFileSync(path.join(projectPath, '.oxfmtrc.json'), '{\n  "semi": true\n}\n');
+
+    const result = await applyToolInitConfigToViteConfig(
+      'fmt',
+      ['--migrate=prettier'],
+      projectPath,
+    );
+    expect(result.handled).toBe(true);
+    expect(result.action).toBe('added');
+
+    const content = fs.readFileSync(viteConfigPath, 'utf8');
+    expect(content).toContain('fmt:');
+    expect(content).toContain('semi');
+    expect(fs.existsSync(path.join(projectPath, '.oxfmtrc.json'))).toBe(false);
+  });
+
+  it('uses explicit --config path when provided', async () => {
+    const projectPath = createTempDir();
+    const customConfigPath = path.join(projectPath, 'custom-oxfmt.json');
+    fs.writeFileSync(customConfigPath, '{\n  "tabWidth": 4\n}\n');
+
+    const result = await applyToolInitConfigToViteConfig(
+      'fmt',
+      ['--init', '--config', 'custom-oxfmt.json'],
+      projectPath,
+    );
+    expect(result.handled).toBe(true);
+    expect(result.action).toBe('added');
+
+    const content = fs.readFileSync(path.join(projectPath, 'vite.config.ts'), 'utf8');
+    expect(content).toContain('fmt:');
+    expect(content).toContain('tabWidth');
+    expect(fs.existsSync(customConfigPath)).toBe(false);
+  });
+
+  it('removes generated file when key already exists', async () => {
+    const projectPath = createTempDir();
+    const viteConfigPath = path.join(projectPath, 'vite.config.ts');
+    const existing = `import { defineConfig } from 'vite-plus';
+
+export default defineConfig({
+  lint: {
+    rules: {},
+  },
+});
+`;
+    fs.writeFileSync(viteConfigPath, existing);
+    fs.writeFileSync(
+      path.join(projectPath, '.oxlintrc.json'),
+      '{\n  "rules": { "no-console": "warn" }\n}\n',
+    );
+
+    const result = await applyToolInitConfigToViteConfig('lint', ['--init'], projectPath);
+    expect(result.handled).toBe(true);
+    expect(result.action).toBe('skipped-existing');
+    expect(fs.readFileSync(viteConfigPath, 'utf8')).toBe(existing);
+    expect(fs.existsSync(path.join(projectPath, '.oxlintrc.json'))).toBe(false);
+  });
+
+  it('detects existing init key before running native init', () => {
+    const projectPath = createTempDir();
+    const viteConfigPath = path.join(projectPath, 'vite.config.ts');
+    fs.writeFileSync(
+      viteConfigPath,
+      `import { defineConfig } from 'vite-plus';
+
+export default defineConfig({
+  fmt: {},
+});
+`,
+    );
+    const inspection = inspectInitCommand('fmt', ['--init'], projectPath);
+    expect(inspection.handled).toBe(true);
+    expect(inspection.configKey).toBe('fmt');
+    expect(inspection.hasExistingConfigKey).toBe(true);
+    expect(inspection.existingViteConfigPath).toBe(viteConfigPath);
+  });
+});

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -10,7 +10,10 @@
  * If no local installation is found, this global dist/bin.js is used as fallback.
  */
 
+import path from 'node:path';
+
 import { run } from '../binding/index.js';
+import { applyToolInitConfigToViteConfig, inspectInitCommand } from './init-config.js';
 import { doc } from './resolve-doc.js';
 import { fmt } from './resolve-fmt.js';
 import { lint } from './resolve-lint.js';
@@ -18,6 +21,7 @@ import { pack } from './resolve-pack.js';
 import { test } from './resolve-test.js';
 import { resolveUniversalViteConfig } from './resolve-vite-config.js';
 import { vite } from './resolve-vite.js';
+import { accent, log } from './utils/terminal.js';
 
 // Parse command line arguments
 let args = process.argv.slice(2);
@@ -52,21 +56,64 @@ if (command === 'create') {
   await import('./global/staged.js');
 } else {
   // All other commands — delegate to Rust core via NAPI binding
-  run({
-    lint,
-    pack,
-    fmt,
-    vite,
-    test,
-    doc,
-    resolveUniversalViteConfig,
-    args: process.argv.slice(2),
-  })
-    .then((exitCode) => {
-      process.exit(exitCode);
-    })
-    .catch((err) => {
-      console.error('[Vite+] run error:', err);
-      process.exit(1);
+  try {
+    const initInspection = inspectInitCommand(command, args.slice(1));
+    if (
+      initInspection.handled &&
+      initInspection.configKey &&
+      initInspection.hasExistingConfigKey &&
+      initInspection.existingViteConfigPath
+    ) {
+      log(
+        `Skipped initialization: '${accent(initInspection.configKey)}' already exists in '${accent(path.basename(initInspection.existingViteConfigPath))}'.`,
+      );
+      process.exit(0);
+    }
+
+    const exitCode = await run({
+      lint,
+      pack,
+      fmt,
+      vite,
+      test,
+      doc,
+      resolveUniversalViteConfig,
+      args: process.argv.slice(2),
     });
+
+    let finalExitCode = exitCode;
+    if (exitCode === 0) {
+      try {
+        const result = await applyToolInitConfigToViteConfig(command, args.slice(1));
+        if (
+          result.handled &&
+          result.action === 'added' &&
+          result.configKey &&
+          result.viteConfigPath
+        ) {
+          log(
+            `Added '${accent(result.configKey)}' to '${accent(path.basename(result.viteConfigPath))}'.`,
+          );
+        }
+        if (
+          result.handled &&
+          result.action === 'skipped-existing' &&
+          result.configKey &&
+          result.viteConfigPath
+        ) {
+          log(
+            `Skipped initialization: '${accent(result.configKey)}' already exists in '${accent(path.basename(result.viteConfigPath))}'.`,
+          );
+        }
+      } catch (err) {
+        console.error('[Vite+] Failed to initialize config in vite.config.ts:', err);
+        finalExitCode = 1;
+      }
+    }
+
+    process.exit(finalExitCode);
+  } catch (err) {
+    console.error('[Vite+] run error:', err);
+    process.exit(1);
+  }
 }

--- a/packages/cli/src/init-config.ts
+++ b/packages/cli/src/init-config.ts
@@ -1,0 +1,278 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { mergeJsonConfig } from '../binding/index.js';
+import { fmt as resolveFmt } from './resolve-fmt.js';
+import { runCommandSilently } from './utils/command.js';
+import { VITE_PLUS_NAME } from './utils/constants.js';
+
+interface InitCommandSpec {
+  configKey: 'lint' | 'fmt';
+  triggerFlags: string[];
+  defaultConfigFiles: string[];
+}
+
+const INIT_COMMAND_SPECS: Record<string, InitCommandSpec> = {
+  lint: {
+    configKey: 'lint',
+    triggerFlags: ['--init'],
+    defaultConfigFiles: ['.oxlintrc.json'],
+  },
+  fmt: {
+    configKey: 'fmt',
+    triggerFlags: ['--init', '--migrate'],
+    defaultConfigFiles: ['.oxfmtrc.json', '.oxfmtrc.jsonc'],
+  },
+};
+
+const VITE_CONFIG_FILES = [
+  'vite.config.ts',
+  'vite.config.mts',
+  'vite.config.cts',
+  'vite.config.js',
+  'vite.config.mjs',
+  'vite.config.cjs',
+] as const;
+
+export interface InitCommandInspection {
+  handled: boolean;
+  configKey?: 'lint' | 'fmt';
+  existingViteConfigPath?: string;
+  hasExistingConfigKey?: boolean;
+}
+
+export interface ApplyToolInitResult {
+  handled: boolean;
+  action?: 'added' | 'skipped-existing' | 'no-generated-config';
+  configKey?: 'lint' | 'fmt';
+  viteConfigPath?: string;
+}
+
+function optionTerminatorIndex(args: string[]): number {
+  const index = args.indexOf('--');
+  return index === -1 ? args.length : index;
+}
+
+function hasTriggerFlag(args: string[], triggerFlags: string[]): boolean {
+  const limit = optionTerminatorIndex(args);
+  for (let i = 0; i < limit; i++) {
+    const arg = args[i];
+    if (triggerFlags.some((flag) => arg === flag || arg.startsWith(`${flag}=`))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function extractConfigPathArg(args: string[]): string | null {
+  const limit = optionTerminatorIndex(args);
+  for (let i = 0; i < limit; i++) {
+    const arg = args[i];
+    if (arg === '-c' || arg === '--config') {
+      const value = args[i + 1];
+      return value ? value : null;
+    }
+    if (arg.startsWith('--config=')) {
+      return arg.slice('--config='.length);
+    }
+    if (arg.startsWith('-c=')) {
+      return arg.slice('-c='.length);
+    }
+  }
+  return null;
+}
+
+function resolveGeneratedConfigPath(
+  projectPath: string,
+  args: string[],
+  defaultConfigFiles: readonly string[],
+): string | null {
+  const configArg = extractConfigPathArg(args);
+  if (configArg) {
+    const resolved = path.isAbsolute(configArg) ? configArg : path.join(projectPath, configArg);
+    if (fs.existsSync(resolved)) {
+      return resolved;
+    }
+  }
+
+  for (const filename of defaultConfigFiles) {
+    const fullPath = path.join(projectPath, filename);
+    if (fs.existsSync(fullPath)) {
+      return fullPath;
+    }
+  }
+
+  return null;
+}
+
+function findViteConfigPath(projectPath: string): string | null {
+  for (const filename of VITE_CONFIG_FILES) {
+    const fullPath = path.join(projectPath, filename);
+    if (fs.existsSync(fullPath)) {
+      return fullPath;
+    }
+  }
+  return null;
+}
+
+function ensureViteConfigPath(projectPath: string): string {
+  const existing = findViteConfigPath(projectPath);
+  if (existing) {
+    return existing;
+  }
+  const viteConfigPath = path.join(projectPath, 'vite.config.ts');
+  fs.writeFileSync(
+    viteConfigPath,
+    `import { defineConfig } from '${VITE_PLUS_NAME}';
+
+export default defineConfig({});
+`,
+  );
+  return viteConfigPath;
+}
+
+function hasConfigKey(viteConfigPath: string, configKey: string): boolean {
+  const viteConfig = fs.readFileSync(viteConfigPath, 'utf8');
+  return new RegExp(`\\b${configKey}\\s*:`).test(viteConfig);
+}
+
+async function vpFmt(cwd: string, filePath: string): Promise<void> {
+  const { binPath, envs } = await resolveFmt();
+  const result = await runCommandSilently({
+    command: binPath,
+    args: ['--write', filePath],
+    cwd,
+    envs: {
+      ...process.env,
+      ...envs,
+    },
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `Failed to format ${filePath} with vp fmt:\n${result.stdout.toString()}${result.stderr.toString()}`,
+    );
+  }
+}
+
+function resolveInitSpec(command: string | undefined, args: string[]): InitCommandSpec | null {
+  if (!command) {
+    return null;
+  }
+  const spec = INIT_COMMAND_SPECS[command];
+  if (!spec || !hasTriggerFlag(args, spec.triggerFlags)) {
+    return null;
+  }
+  return spec;
+}
+
+export function inspectInitCommand(
+  command: string | undefined,
+  args: string[],
+  projectPath = process.cwd(),
+): InitCommandInspection {
+  const spec = resolveInitSpec(command, args);
+  if (!spec) {
+    return { handled: false };
+  }
+
+  const viteConfigPath = findViteConfigPath(projectPath);
+  if (!viteConfigPath) {
+    return {
+      handled: true,
+      configKey: spec.configKey,
+      hasExistingConfigKey: false,
+    };
+  }
+
+  return {
+    handled: true,
+    configKey: spec.configKey,
+    existingViteConfigPath: viteConfigPath,
+    hasExistingConfigKey: hasConfigKey(viteConfigPath, spec.configKey),
+  };
+}
+
+/**
+ * Merge generated tool config from `vp lint/fmt --init` (and fmt --migrate)
+ * into the project's vite config, then remove the generated standalone file.
+ *
+ * Returns true when the command was an init/migrate command (handled), false otherwise.
+ */
+export async function applyToolInitConfigToViteConfig(
+  command: string | undefined,
+  args: string[],
+  projectPath = process.cwd(),
+): Promise<ApplyToolInitResult> {
+  const inspection = inspectInitCommand(command, args, projectPath);
+  if (!inspection.handled || !inspection.configKey) {
+    return { handled: false };
+  }
+  const spec = INIT_COMMAND_SPECS[command as keyof typeof INIT_COMMAND_SPECS];
+  const viteConfigPath = ensureViteConfigPath(projectPath);
+  const generatedConfigPath = resolveGeneratedConfigPath(
+    projectPath,
+    args,
+    spec.defaultConfigFiles,
+  );
+
+  if (hasConfigKey(viteConfigPath, spec.configKey)) {
+    if (generatedConfigPath) {
+      fs.rmSync(generatedConfigPath, { force: true });
+    }
+    return {
+      handled: true,
+      action: 'skipped-existing',
+      configKey: spec.configKey,
+      viteConfigPath,
+    };
+  }
+
+  if (spec.configKey === 'lint' && hasTriggerFlag(args, ['--init'])) {
+    const lintInitConfigPath = path.join(projectPath, '.vite-plus-lint-init.oxlintrc.json');
+    fs.writeFileSync(lintInitConfigPath, '{}');
+    const mergeResult = mergeJsonConfig(viteConfigPath, lintInitConfigPath, spec.configKey);
+
+    if (!mergeResult.updated) {
+      throw new Error(`Failed to initialize lint config in ${path.basename(viteConfigPath)}`);
+    }
+
+    fs.writeFileSync(viteConfigPath, mergeResult.content);
+    fs.rmSync(lintInitConfigPath, { force: true });
+    if (generatedConfigPath) {
+      fs.rmSync(generatedConfigPath, { force: true });
+    }
+    await vpFmt(projectPath, path.relative(projectPath, viteConfigPath));
+    return {
+      handled: true,
+      action: 'added',
+      configKey: spec.configKey,
+      viteConfigPath,
+    };
+  }
+
+  if (!generatedConfigPath) {
+    return {
+      handled: true,
+      action: 'no-generated-config',
+      configKey: inspection.configKey,
+      viteConfigPath,
+    };
+  }
+
+  const mergeResult = mergeJsonConfig(viteConfigPath, generatedConfigPath, spec.configKey);
+  if (!mergeResult.updated) {
+    throw new Error(
+      `Failed to merge ${path.basename(generatedConfigPath)} into ${path.basename(viteConfigPath)}`,
+    );
+  }
+
+  fs.writeFileSync(viteConfigPath, mergeResult.content);
+  fs.rmSync(generatedConfigPath, { force: true });
+  await vpFmt(projectPath, path.relative(projectPath, viteConfigPath));
+  return {
+    handled: true,
+    action: 'added',
+    configKey: spec.configKey,
+    viteConfigPath,
+  };
+}


### PR DESCRIPTION
Intercept `vp fmt --init` or `vp lint --init` to write config into `vite.config.ts` instead of creating `.oxlintrc.json` and `.oxfmtrc.json` files.

Output of the commands (first two are when the keys exist, third and fourth are after I removed them):
<img width="906" height="749" alt="CleanShot 2026-03-06 at 15 34 23@2x" src="https://github.com/user-attachments/assets/a8c279e9-650c-4b56-a2cf-678c5cdd3705" />
