### PR TITLE
fix: Fix tooling version when `vite-plus` is not found + reorder migrate prompts.

### DIFF
--- a/packages/cli/snap-tests/cli-helper-message/snap.txt
+++ b/packages/cli/snap-tests/cli-helper-message/snap.txt
@@ -30,14 +30,5 @@ VITE+ - The Unified Toolchain for the Web
 vp v<semver>
 
 Local vite-plus:
-  vite-plus  v<semver>
-
-Tools:
-  vite             v<semver>
-  rolldown         v<semver>
-  vitest           v<semver>
-  oxfmt            v<semver>
-  oxlint           v<semver>
-  oxlint-tsgolint  v<semver>
-  tsdown           v<semver>
+  vite-plus  Not found
 

--- a/packages/cli/snap-tests/command-version/snap.txt
+++ b/packages/cli/snap-tests/command-version/snap.txt
@@ -4,14 +4,5 @@ VITE+ - The Unified Toolchain for the Web
 vp v<semver>
 
 Local vite-plus:
-  vite-plus  v<semver>
-
-Tools:
-  vite             v<semver>
-  rolldown         v<semver>
-  vitest           v<semver>
-  oxfmt            v<semver>
-  oxlint           v<semver>
-  oxlint-tsgolint  v<semver>
-  tsdown           v<semver>
+  vite-plus  Not found
 

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -175,6 +175,20 @@ async function main() {
   const packageManager =
     workspaceInfoOptional.packageManager ?? (await selectPackageManager(options.interactive));
 
+  let shouldSetupHooks = await promptGitHooks(options);
+
+  const selectedAgentTargetPaths = await selectAgentTargetPaths({
+    interactive: options.interactive,
+    agent: options.agent,
+    onCancel: () => cancelAndExit(),
+  });
+
+  const selectedEditor = await selectEditor({
+    interactive: options.interactive,
+    editor: options.editor,
+    onCancel: () => cancelAndExit(),
+  });
+
   // ensure the package manager is installed by vite-plus
   const downloadResult = await downloadPackageManager(
     packageManager,
@@ -223,8 +237,6 @@ async function main() {
     cancelAndExit('Vite+ cannot automatically migrate this project yet.', 1);
   }
 
-  let shouldSetupHooks = await promptGitHooks(options);
-
   if (shouldSetupHooks) {
     const reason = preflightGitHooksSetup(workspaceInfo.rootDir);
     if (reason) {
@@ -248,22 +260,10 @@ async function main() {
     installGitHooks(workspaceInfo.rootDir);
   }
 
-  const selectedAgentTargetPaths = await selectAgentTargetPaths({
-    interactive: options.interactive,
-    agent: options.agent,
-    onCancel: () => cancelAndExit(),
-  });
-
   await writeAgentInstructions({
     projectRoot: workspaceInfo.rootDir,
     targetPaths: selectedAgentTargetPaths,
     interactive: options.interactive,
-  });
-
-  const selectedEditor = await selectEditor({
-    interactive: options.interactive,
-    editor: options.editor,
-    onCancel: () => cancelAndExit(),
   });
 
   await writeEditorConfigs({

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -5,14 +5,16 @@ import path from 'node:path';
 import { vitePlusHeader } from '../binding/index.js';
 import { VITE_PLUS_NAME } from './utils/constants.js';
 import { renderCliDoc } from './utils/help.js';
-import { detectPackageMetadata } from './utils/package.js';
+import { detectPackageMetadata, hasVitePlusDependency } from './utils/package.js';
 import { accent, log } from './utils/terminal.js';
 
 const require = createRequire(import.meta.url);
 
 interface PackageJson {
-  version: string;
+  version?: string;
   bundledVersions?: Record<string, string>;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
 }
 
 interface LocalPackageMetadata {
@@ -38,7 +40,27 @@ function getCliVersion(): string | null {
 }
 
 function getLocalMetadata(cwd: string): LocalPackageMetadata | null {
+  if (!isVitePlusDeclaredInAncestors(cwd)) {
+    return null;
+  }
   return detectPackageMetadata(cwd, VITE_PLUS_NAME) ?? null;
+}
+
+function isVitePlusDeclaredInAncestors(cwd: string): boolean {
+  let currentDir = path.resolve(cwd);
+  while (true) {
+    const packageJsonPath = path.join(currentDir, 'package.json');
+    const pkg = readPackageJsonFromPath(packageJsonPath);
+    if (pkg && hasVitePlusDependency(pkg)) {
+      return true;
+    }
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      break;
+    }
+    currentDir = parentDir;
+  }
+  return false;
 }
 
 function readPackageJsonFromPath(packageJsonPath: string): PackageJson | null {
@@ -158,18 +180,20 @@ export async function printVersion(cwd: string) {
     },
   ];
 
-  const resolvedTools = tools.map((tool) => ({
-    tool,
-    version: localMetadata ? resolveToolVersion(tool, localMetadata.path) : null,
-  }));
+  if (localMetadata) {
+    const resolvedTools = tools.map((tool) => ({
+      tool,
+      version: resolveToolVersion(tool, localMetadata.path),
+    }));
 
-  sections.push({
-    title: 'Tools',
-    rows: resolvedTools.map(({ tool, version }) => ({
-      label: accent(tool.displayName),
-      description: version ? `v${version}` : 'Not found',
-    })),
-  });
+    sections.push({
+      title: 'Tools',
+      rows: resolvedTools.map(({ tool, version }) => ({
+        label: accent(tool.displayName),
+        description: version ? `v${version}` : 'Not found',
+      })),
+    });
+  }
 
   log(renderCliDoc({ sections }));
 }


### PR DESCRIPTION
This PR makes two changes in one (sorry):

* Fixes `vp --version` to not show the tools section when the local version of `vite-plus` is not found.
* Reorders the migration prompts so it asks the user everything before executing the migration.