### PR TITLE
ci: optimize Windows CI speed by skipping redundant NAPI rebuild and disabling Defender

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,12 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/clone
 
+      # Disable Windows Defender real-time scanning to speed up I/O-heavy builds (~30-50% faster)
+      - name: Disable Windows Defender
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
+
       - uses: oxc-project/setup-rust@d286d43bc1f606abbd98096666ff8be68c8d5f57 # v1.0.0
         with:
           save-cache: ${{ github.ref_name == 'main' }}
@@ -186,6 +192,12 @@ jobs:
       - name: Configure Git for access to vite-task
         run: git config --global url."https://x-access-token:${{ secrets.VITE_TASK_TOKEN }}@github.com/".insteadOf "ssh://git@github.com/"
 
+      # Disable Windows Defender real-time scanning to speed up I/O-heavy builds (~30-50% faster)
+      - name: Disable Windows Defender
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
+
       - run: |
           brew install rustup
           rustup install stable
@@ -210,9 +222,10 @@ jobs:
         with:
           target: ${{ matrix.os == 'ubuntu-latest' && 'x86_64-unknown-linux-gnu' ||  matrix.os == 'windows-latest' && 'x86_64-pc-windows-msvc' || 'aarch64-apple-darwin' }}
 
+      # Skip native rebuild — NAPI bindings are already built and cached by build-upstream
       - name: Build CLI
         run: |
-          pnpm build
+          pnpm -F vite-plus-cli build-ts
           pnpm bootstrap-cli:ci
           if [[ "$RUNNER_OS" == "Windows" ]]; then
             echo "$USERPROFILE\.vite-plus\bin" >> $GITHUB_PATH


### PR DESCRIPTION
## Summary

Optimizes the Windows CI build time by addressing two key bottlenecks identified in #715.

### Changes

1. **Skip redundant NAPI rebuild in Build CLI step**
    - Changed `pnpm build` → `pnpm -F vite-plus-cli build-ts` in the CLI E2E `Build CLI` step
    - The `build-upstream` action already builds and caches NAPI bindings — no need to recompile
    - **Expected savings: ~3 min on Windows, ~1 min on Ubuntu**
2. **Disable Windows Defender real-time scanning**
    - Added early step to disable Defender in both `test` and `cli-e2e-test` jobs
    - Reduces NTFS I/O overhead for cargo/pnpm operations
    - **Expected savings: ~30-50% on I/O-heavy steps**

### Before vs After (expected)

| Step | Windows (before) | Windows (after) |
| --- | --- | --- |
| Build CLI | ~5m 12s | ~30s (TS only) |
| setup-rust | ~1m 5s | ~40s |
| setup-node | ~1m 44s | ~1m |

Before 

![image.png](https://app.graphite.com/user-attachments/assets/a52ad50c-2e4e-463d-9d3c-74b041b6858b.png)

After

![image.png](https://app.graphite.com/user-attachments/assets/817757e5-8a34-4cbe-bdad-1af3c77cce21.png)



### Verification

The CI run on this PR will validate:

- CLI E2E tests still pass on all platforms (the NAPI bindings from build-upstream are correctly reused)
- Windows Defender disable does not cause permission issues

Closes #715