### PR TITLE
fix(migrate): support re-migration of husky/lint-staged when vite-plus already installed

### DIFF
--- a/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-hookspath/.husky/pre-commit
+++ b/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-hookspath/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-hookspath/package.json
+++ b/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-hookspath/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "migration-already-vite-plus-with-husky-hookspath",
+  "scripts": {
+    "prepare": "husky"
+  },
+  "devDependencies": {
+    "husky": "^9.1.7",
+    "lint-staged": "^16.2.7",
+    "vite": "^7.0.0",
+    "vite-plus": "latest"
+  },
+  "lint-staged": {
+    "*": "vp check --fix"
+  }
+}

--- a/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-hookspath/snap.txt
+++ b/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-hookspath/snap.txt
@@ -1,0 +1,31 @@
+> git init
+> git config core.hooksPath .husky/_
+> vp migrate --no-interactive # should override husky's core.hooksPath and migrate hooks
+VITE+ - The Unified Toolchain for the Web
+
+
+✔ Created vite.config.ts in vite.config.ts
+
+✔ Merged staged config into vite.config.ts
+
+✔ Git hooks configured
+✔ Migration completed!
+
+
+> cat package.json # husky/lint-staged should be removed, prepare should be vp config
+{
+  "name": "migration-already-vite-plus-with-husky-hookspath",
+  "scripts": {
+    "prepare": "vp config"
+  },
+  "devDependencies": {
+    "vite": "^7.0.0",
+    "vite-plus": "latest"
+  }
+}
+
+> cat .vite-hooks/pre-commit # pre-commit hook should be rewritten
+vp staged
+
+> git config --local core.hooksPath # should be .vite-hooks/_
+.vite-hooks/_

--- a/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-hookspath/steps.json
+++ b/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-hookspath/steps.json
@@ -1,0 +1,10 @@
+{
+  "commands": [
+    { "command": "git init", "ignoreOutput": true },
+    { "command": "git config core.hooksPath .husky/_", "ignoreOutput": true },
+    "vp migrate --no-interactive # should override husky's core.hooksPath and migrate hooks",
+    "cat package.json # husky/lint-staged should be removed, prepare should be vp config",
+    "cat .vite-hooks/pre-commit # pre-commit hook should be rewritten",
+    "git config --local core.hooksPath # should be .vite-hooks/_"
+  ]
+}

--- a/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-lint-staged/.husky/pre-commit
+++ b/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-lint-staged/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-lint-staged/package.json
+++ b/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-lint-staged/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "migration-already-vite-plus-with-husky-lint-staged",
+  "scripts": {
+    "prepare": "husky"
+  },
+  "devDependencies": {
+    "husky": "^9.1.7",
+    "lint-staged": "^16.2.7",
+    "vite": "^7.0.0",
+    "vite-plus": "latest"
+  },
+  "lint-staged": {
+    "*": "vp check --fix"
+  }
+}

--- a/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-lint-staged/snap.txt
@@ -1,0 +1,30 @@
+> git init
+> vp migrate --no-interactive # should still migrate husky/lint-staged even though vite-plus exists
+VITE+ - The Unified Toolchain for the Web
+
+
+✔ Created vite.config.ts in vite.config.ts
+
+✔ Merged staged config into vite.config.ts
+
+✔ Git hooks configured
+✔ Migration completed!
+
+
+> cat package.json # husky/lint-staged should be removed, prepare should be vp config
+{
+  "name": "migration-already-vite-plus-with-husky-lint-staged",
+  "scripts": {
+    "prepare": "vp config"
+  },
+  "devDependencies": {
+    "vite": "^7.0.0",
+    "vite-plus": "latest"
+  }
+}
+
+> cat .vite-hooks/pre-commit # pre-commit hook should be rewritten
+vp staged
+
+> test -d .husky && echo '.husky directory exists' || echo 'No .husky directory' # .husky should be removed
+No .husky directory

--- a/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-lint-staged/steps.json
+++ b/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-lint-staged/steps.json
@@ -1,0 +1,9 @@
+{
+  "commands": [
+    { "command": "git init", "ignoreOutput": true },
+    "vp migrate --no-interactive # should still migrate husky/lint-staged even though vite-plus exists",
+    "cat package.json # husky/lint-staged should be removed, prepare should be vp config",
+    "cat .vite-hooks/pre-commit # pre-commit hook should be rewritten",
+    "test -d .husky && echo '.husky directory exists' || echo 'No .husky directory' # .husky should be removed"
+  ]
+}

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -145,12 +145,27 @@ async function main() {
   prompts.intro(vitePlusHeader());
 
   const workspaceInfoOptional = await detectWorkspace(projectPath);
-  if (
-    hasVitePlusDependency(
-      readNearestPackageJson<PackageDependencies>(workspaceInfoOptional.rootDir),
-    )
-  ) {
-    prompts.outro(`This project is already using Vite+! ${accent(`Happy coding!`)}`);
+  const rootPkg = readNearestPackageJson<PackageDependencies>(workspaceInfoOptional.rootDir);
+  if (hasVitePlusDependency(rootPkg)) {
+    const hasHooksToMigrate =
+      rootPkg?.devDependencies?.husky ||
+      rootPkg?.dependencies?.husky ||
+      rootPkg?.devDependencies?.['lint-staged'] ||
+      rootPkg?.dependencies?.['lint-staged'];
+
+    if (!hasHooksToMigrate) {
+      prompts.outro(`This project is already using Vite+! ${accent(`Happy coding!`)}`);
+      return;
+    }
+
+    // Project has vite-plus but still needs husky/lint-staged migration
+    // installGitHooks → setupGitHooks already performs preflightGitHooksSetup internally
+    const shouldSetupHooks = await promptGitHooks(options);
+    if (shouldSetupHooks && installGitHooks(workspaceInfoOptional.rootDir)) {
+      prompts.outro(green('✔ Migration completed!'));
+    } else {
+      prompts.outro(`This project is already using Vite+! ${accent(`Happy coding!`)}`);
+    }
     return;
   }
 

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -974,7 +974,16 @@ export function setupGitHooks(projectPath: string, oldHooksDir?: string): boolea
   let stagedMerged = hasStagedConfigInViteConfig(projectPath);
   const hasStandaloneConfig = hasStandaloneLintStagedConfig(projectPath);
   if (!stagedMerged && !hasStandaloneConfig) {
-    stagedMerged = mergeStagedConfigToViteConfig(projectPath, { '*': 'vp check --fix' });
+    // Use lint-staged config from package.json if available, otherwise use default
+    const pkgData = readJsonFile<{ 'lint-staged'?: Record<string, string | string[]> }>(
+      packageJsonPath,
+    );
+    const stagedConfig = pkgData?.['lint-staged'] ?? { '*': 'vp check --fix' };
+    const updated = rewriteScripts(JSON.stringify(stagedConfig), readRulesYaml());
+    const finalConfig: Record<string, string | string[]> = updated
+      ? JSON.parse(updated)
+      : stagedConfig;
+    stagedMerged = mergeStagedConfigToViteConfig(projectPath, finalConfig);
   }
 
   // Only remove lint-staged key from package.json after staged config is
@@ -999,6 +1008,8 @@ export function setupGitHooks(projectPath: string, oldHooksDir?: string): boolea
         fs.copyFileSync(src, dest);
         fs.chmodSync(dest, 0o755);
       }
+      // Remove old .husky/ directory after copying hooks to .vite-hooks/
+      fs.rmSync(oldDir, { recursive: true, force: true });
     }
   }
 
@@ -1013,6 +1024,22 @@ export function setupGitHooks(projectPath: string, oldHooksDir?: string): boolea
   if (!gitRoot) {
     removeReplacedHookPackages(packageJsonPath);
     return true;
+  }
+
+  // Clear husky's core.hooksPath so vp config can set the new one.
+  // Only clear if it matches the old husky directory — preserve genuinely custom paths.
+  if (oldHooksDir) {
+    const checkResult = spawn.sync('git', ['config', '--local', 'core.hooksPath'], {
+      cwd: projectPath,
+      stdio: 'pipe',
+    });
+    const existingPath = checkResult.status === 0 ? checkResult.stdout?.toString().trim() : '';
+    if (existingPath === `${oldHooksDir}/_` || existingPath === oldHooksDir) {
+      spawn.sync('git', ['config', '--local', '--unset', 'core.hooksPath'], {
+        cwd: projectPath,
+        stdio: 'pipe',
+      });
+    }
   }
 
   const vpBin = process.env.VITE_PLUS_CLI_BIN ?? 'vp';

--- a/rfcs/migration-command.md
+++ b/rfcs/migration-command.md
@@ -38,6 +38,11 @@ When transitioning to Vite+, projects typically use standalone tools like vite, 
 - ✅ **Configuration files**:
   - .oxlintrc → vite.config.ts (lint section)
   - .oxfmtrc → vite.config.ts (format section)
+- ✅ **Git hooks**: husky + lint-staged → `vp config` + `vp staged`
+  - Rewrites `prepare: "husky"` → `prepare: "vp config"`
+  - Migrates lint-staged config into `staged` in vite.config.ts
+  - Replaces `.husky/pre-commit` with `.vite-hooks/pre-commit` using `vp staged`
+  - Removes `husky` and `lint-staged` from devDependencies
 
 **What this command does NOT migrate**:
 
@@ -48,6 +53,10 @@ When transitioning to Vite+, projects typically use standalone tools like vite, 
 - ❌ Build tool changes (webpack/rollup → vite)
 
 These are **consolidation migrations**, not **feature migrations**.
+
+### Re-migration
+
+When a project already has `vite-plus` in its dependencies but still retains `husky` and/or `lint-staged`, `vp migrate` detects the remaining hooks to migrate and runs only the git hooks migration (skipping the full dependency/config migration). This handles the scenario where a project was partially migrated or adopted `vite-plus` manually without migrating its git hooks setup.
 
 ## Command Usage
 


### PR DESCRIPTION
When a project already has vite-plus but still retains husky and
lint-staged, `vp migrate` now detects the remaining hooks and runs
a targeted hooks-only migration instead of exiting early.

Also fixes two related issues:
- Clear husky's core.hooksPath before running `vp config` so the new
  .vite-hooks/_ path can be set (previously skipped with warning)
- Remove old .husky/ directory after copying hooks to .vite-hooks/
- Use actual lint-staged config from package.json in setupGitHooks
  instead of hardcoded default