### PR TITLE
ci: add Windows Defender disable to e2e-test.yml

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -83,6 +83,12 @@ jobs:
       - name: Configure Git for access to vite-task
         run: git config --global url."https://x-access-token:${{ secrets.VITE_TASK_TOKEN }}@github.com/".insteadOf "ssh://git@github.com/"
 
+      # Disable Windows Defender real-time scanning to speed up I/O-heavy builds (~30-50% faster)
+      - name: Disable Windows Defender
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
+
       - uses: oxc-project/setup-rust@d286d43bc1f606abbd98096666ff8be68c8d5f57 # v1.0.0
         with:
           save-cache: ${{ github.ref_name == 'main' }}
@@ -257,6 +263,12 @@ jobs:
       - uses: ./.github/actions/clone
         with:
           ecosystem-ci-project: ${{ matrix.project.name }}
+
+      # Disable Windows Defender real-time scanning to speed up I/O-heavy operations
+      - name: Disable Windows Defender
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
 
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:


### PR DESCRIPTION
## Summary

Add Windows Defender real-time scanning disable to `e2e-test.yml` Windows jobs, which previously had **no Windows I/O optimization**.

### Changes

#### e2e-test.yml — Add Defender disable (new)
- **Build job** (`windows-latest`): Added `Set-MpPreference -DisableRealtimeMonitoring $true`
- **E2E test jobs** (`windows-latest`): Added Defender disable for `vp install`, test execution, etc.

#### ci.yml — No change
Test and CLI E2E jobs already had Defender disable from PR #716.

### Expected Impact

| Job | Before | After (expected) |
|-----|--------|------------------|
| E2E Build (Windows) | ~4m18s | ~3-4min |
| E2E tests (Windows) | baseline | ~20-30% faster I/O |

### Notes

Dev Drive (`setup-dev-drive`) was also tested in this PR but **reverted** — it caused cargo target directory cache invalidation due to workspace path changes, resulting in full rebuilds. See [comparison comment](https://github.com/voidzero-dev/vite-plus/pull/723#issuecomment-4018681165) for details. The simpler Defender-disable approach is sufficient.