### PR TITLE
fix(core): remove Vite build size limit

### DIFF
--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -209,7 +209,7 @@ async function buildVite() {
             typeof plugin === 'object' &&
             plugin !== null &&
             'name' in plugin &&
-            plugin.name === 'rollup-plugin-license'
+            (plugin.name === 'rollup-plugin-license' || plugin.name === 'bundle-limit')
           );
         }),
       ];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized build-script change; risk is limited to potentially allowing larger bundles to be produced without failing CI.
> 
> **Overview**
> Stops the `packages/core` Vite bundling pipeline from including the `bundle-limit` plugin by filtering it out alongside `rollup-plugin-license`, effectively removing build-time bundle size enforcement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91d11997fd9b5077c37bed0678276f3cba2129a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->