### PR TITLE
chore: Improve `vp create` output.

### DIFF
--- a/packages/cli/snap-tests-global/command-create-help/snap.txt
+++ b/packages/cli/snap-tests-global/command-create-help/snap.txt
@@ -18,6 +18,7 @@ Options:
   --editor NAME     Write editor config files for the specified editor.
   --hooks           Set up pre-commit hooks (default in non-interactive mode)
   --no-hooks        Skip pre-commit hooks setup
+  --verbose         Show detailed scaffolding output
   --no-interactive  Run in non-interactive mode
   --list            List all available templates
   -h, --help        Show this help message
@@ -69,6 +70,7 @@ Options:
   --editor NAME     Write editor config files for the specified editor.
   --hooks           Set up pre-commit hooks (default in non-interactive mode)
   --no-hooks        Skip pre-commit hooks setup
+  --verbose         Show detailed scaffolding output
   --no-interactive  Run in non-interactive mode
   --list            List all available templates
   -h, --help        Show this help message
@@ -120,6 +122,7 @@ Options:
   --editor NAME     Write editor config files for the specified editor.
   --hooks           Set up pre-commit hooks (default in non-interactive mode)
   --no-hooks        Skip pre-commit hooks setup
+  --verbose         Show detailed scaffolding output
   --no-interactive  Run in non-interactive mode
   --list            List all available templates
   -h, --help        Show this help message

--- a/packages/cli/snap-tests-global/new-check/snap.txt
+++ b/packages/cli/snap-tests-global/new-check/snap.txt
@@ -18,6 +18,7 @@ Options:
   --editor NAME     Write editor config files for the specified editor.
   --hooks           Set up pre-commit hooks (default in non-interactive mode)
   --no-hooks        Skip pre-commit hooks setup
+  --verbose         Show detailed scaffolding output
   --no-interactive  Run in non-interactive mode
   --list            List all available templates
   -h, --help        Show this help message

--- a/packages/cli/src/create/bin.ts
+++ b/packages/cli/src/create/bin.ts
@@ -21,6 +21,7 @@ import { detectExistingEditor, selectEditor, writeEditorConfigs } from '../utils
 import { renderCliDoc } from '../utils/help.js';
 import { displayRelative } from '../utils/path.js';
 import {
+  type CommandRunSummary,
   defaultInteractive,
   downloadPackageManager,
   promptGitHooks,
@@ -45,7 +46,7 @@ import {
 } from './templates/index.js';
 import { InitialMonorepoAppDir } from './templates/monorepo.js';
 import { BuiltinTemplate, TemplateType } from './templates/types.js';
-import { formatDisplayTargetDir, formatTargetDir } from './utils.js';
+import { formatTargetDir } from './utils.js';
 
 const helpMessage = renderCliDoc({
   usage: 'vp create [TEMPLATE] [OPTIONS] [-- TEMPLATE_OPTIONS]',
@@ -83,6 +84,7 @@ const helpMessage = renderCliDoc({
           description: 'Set up pre-commit hooks (default in non-interactive mode)',
         },
         { label: '--no-hooks', description: 'Skip pre-commit hooks setup' },
+        { label: '--verbose', description: 'Show detailed scaffolding output' },
         { label: '--no-interactive', description: 'Run in non-interactive mode' },
         { label: '--list', description: 'List all available templates' },
         { label: '-h, --help', description: 'Show this help message' },
@@ -169,6 +171,7 @@ export interface Options {
   interactive: boolean;
   list: boolean;
   help: boolean;
+  verbose: boolean;
   agent?: string | string[] | false;
   editor?: string;
   hooks?: boolean;
@@ -190,12 +193,13 @@ function parseArgs() {
     interactive?: boolean;
     list?: boolean;
     help?: boolean;
+    verbose?: boolean;
     agent?: string | string[] | false;
     editor?: string;
     hooks?: boolean;
   }>(viteArgs, {
     alias: { h: 'help' },
-    boolean: ['help', 'list', 'all', 'interactive', 'hooks'],
+    boolean: ['help', 'list', 'all', 'interactive', 'hooks', 'verbose'],
     string: ['directory', 'agent', 'editor'],
     default: { interactive: defaultInteractive() },
   });
@@ -209,6 +213,7 @@ function parseArgs() {
       interactive: parsed.interactive,
       list: parsed.list || false,
       help: parsed.help || false,
+      verbose: parsed.verbose || false,
       agent: parsed.agent,
       editor: parsed.editor,
       hooks: parsed.hooks,
@@ -217,8 +222,121 @@ function parseArgs() {
   };
 }
 
+function describeScaffold(templateName: string, templateArgs: string[]) {
+  if (templateName === BuiltinTemplate.monorepo) {
+    return 'Vite+ monorepo';
+  }
+  if (templateName === BuiltinTemplate.generator) {
+    return 'generator scaffold';
+  }
+  if (templateName === BuiltinTemplate.library) {
+    return 'TypeScript library';
+  }
+
+  const selectedTemplate = getTemplateOption(templateArgs);
+  if (selectedTemplate) {
+    return formatTemplateName(selectedTemplate);
+  }
+
+  if (templateName === BuiltinTemplate.application) {
+    return 'Vite application';
+  }
+
+  return undefined;
+}
+
+function getTemplateOption(args: string[]) {
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (arg === '--template' || arg === '-t') {
+      return args[index + 1];
+    }
+    if (arg.startsWith('--template=')) {
+      return arg.slice('--template='.length);
+    }
+  }
+  return undefined;
+}
+
+function formatTemplateName(templateName: string) {
+  const templateAliases: Record<string, string> = {
+    lit: 'Lit',
+    preact: 'Preact',
+    react: 'React',
+    'react-router': 'React Router',
+    solid: 'Solid',
+    svelte: 'Svelte',
+    vanilla: 'Vanilla',
+    vue: 'Vue',
+  };
+  const isTypeScript = templateName.endsWith('-ts');
+  const baseName = isTypeScript ? templateName.slice(0, -3) : templateName;
+  const frameworkName =
+    templateAliases[baseName] ??
+    baseName
+      .split(/[-_]/)
+      .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+      .join(' ');
+
+  return `${frameworkName} + ${isTypeScript ? 'TypeScript' : 'JavaScript'}`;
+}
+
+function formatDuration(durationMs: number) {
+  if (durationMs < 1000) {
+    return `${Math.max(1, durationMs)}ms`;
+  }
+  const durationSeconds = durationMs / 1000;
+  if (durationSeconds < 10) {
+    return `${durationSeconds.toFixed(1)}s`;
+  }
+  return `${Math.round(durationSeconds)}s`;
+}
+
+function getNextCommand(projectDir: string, command: string) {
+  if (!projectDir || projectDir === '.') {
+    return command;
+  }
+  return `cd ${projectDir} && ${command}`;
+}
+
+function showCreateSummary(options: {
+  description?: string;
+  installSummary?: CommandRunSummary;
+  nextCommand: string;
+  packageManager: string;
+  packageManagerVersion: string;
+  projectDir: string;
+}) {
+  const {
+    description,
+    installSummary,
+    nextCommand,
+    packageManager,
+    packageManagerVersion,
+    projectDir,
+  } = options;
+
+  log(
+    `${styleText('magenta', '◇')} Scaffolded ${accent(projectDir)}${
+      description ? ` with ${description}` : ''
+    }`,
+  );
+  log(
+    `${styleText('gray', '•')} Node ${process.versions.node}  ${packageManager} ${packageManagerVersion}`,
+  );
+  if (installSummary?.status === 'installed') {
+    log(
+      `${styleText('green', '✓')} Dependencies installed in ${formatDuration(
+        installSummary.durationMs,
+      )}`,
+    );
+  }
+  log(`${styleText('blue', '→')} Next: ${accent(nextCommand)}`);
+}
+
 async function main() {
   const { templateName, options, templateArgs } = parseArgs();
+  const compactOutput = !options.verbose;
 
   // #region Handle help flag
   if (options.help) {
@@ -253,7 +371,9 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
   // #endregion
 
   // #region Prepare Stage
-  prompts.intro(vitePlusHeader());
+  if (options.interactive) {
+    prompts.intro(vitePlusHeader());
+  }
 
   // check --directory option is valid
   let targetDir = '';
@@ -296,6 +416,7 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
   let selectedAgentTargetPaths: string[] | undefined;
   let selectedEditor: Awaited<ReturnType<typeof selectEditor>>;
   let selectedParentDir: string | undefined;
+  let shouldSetupHooks = false;
 
   if (!selectedTemplateName) {
     const templates: { label: string; value: string; hint: string }[] = [];
@@ -391,7 +512,7 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
     cancelAndExit('Cannot create a monorepo inside an existing monorepo', 1);
   }
 
-  if (isInSubdirectory) {
+  if (isInSubdirectory && !compactOutput) {
     prompts.log.info(`Detected monorepo root at ${accent(workspaceInfoOptional.rootDir)}`);
   }
 
@@ -460,7 +581,7 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
     selectedParentDir = parentDir;
   }
   if (isMonorepo && !options.interactive && !targetDir) {
-    if (isInSubdirectory) {
+    if (isInSubdirectory && !compactOutput) {
       prompts.log.info(`Use ${accent('--directory')} to specify a different target location.`);
     }
     const inferredParentDir =
@@ -492,9 +613,10 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
 
   // Prompt for package manager or use default
   const packageManager =
-    workspaceInfoOptional.packageManager ?? (await selectPackageManager(options.interactive));
+    workspaceInfoOptional.packageManager ??
+    (await selectPackageManager(options.interactive, compactOutput));
   const shouldSilencePackageManagerInstallLog =
-    isMonorepo && workspaceInfoOptional.packageManager !== undefined;
+    compactOutput || (isMonorepo && workspaceInfoOptional.packageManager !== undefined);
   // ensure the package manager is installed by vite-plus
   const downloadResult = await downloadPackageManager(
     packageManager,
@@ -533,6 +655,8 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
       onCancel: () => cancelAndExit(),
     }));
 
+  shouldSetupHooks = await promptGitHooks(options);
+
   // Discover template
   const templateInfo = discoverTemplate(
     selectedTemplateName,
@@ -560,6 +684,7 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
       workspaceInfo,
       { ...templateInfo, packageName, targetDir },
       options.interactive,
+      { silent: compactOutput },
     );
     const { projectDir } = result;
     if (result.exitCode !== 0 || !projectDir) {
@@ -572,24 +697,31 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
       projectRoot: fullPath,
       targetPaths: selectedAgentTargetPaths,
       interactive: options.interactive,
+      silent: compactOutput,
     });
     await writeEditorConfigs({
       projectRoot: fullPath,
       editorId: selectedEditor,
       interactive: options.interactive,
+      silent: compactOutput,
     });
     workspaceInfo.rootDir = fullPath;
-    rewriteMonorepo(workspaceInfo);
-    const shouldSetupHooks = await promptGitHooks(options);
+    rewriteMonorepo(workspaceInfo, undefined, compactOutput);
     if (shouldSetupHooks) {
-      installGitHooks(fullPath);
+      installGitHooks(fullPath, compactOutput);
     }
-    await runViteInstall(fullPath, options.interactive);
-    await runViteFmt(fullPath, options.interactive);
-    prompts.outro(`✔ Created ${accent(projectDir)}!`);
-    log(styleText('bold', 'Next steps:'));
-    log(`  ${accent(`cd ${projectDir}`)}`);
-    log(`  ${accent(`vp dev ${InitialMonorepoAppDir}`)}`);
+    const installSummary = await runViteInstall(fullPath, options.interactive, undefined, {
+      silent: compactOutput,
+    });
+    await runViteFmt(fullPath, options.interactive, undefined, { silent: compactOutput });
+    showCreateSummary({
+      description: describeScaffold(selectedTemplateName, selectedTemplateArgs),
+      installSummary,
+      nextCommand: getNextCommand(projectDir, `vp dev ${InitialMonorepoAppDir}`),
+      packageManager: workspaceInfo.packageManager,
+      packageManagerVersion: workspaceInfo.downloadPackageManager.version,
+      projectDir,
+    });
     return;
   }
   // #endregion
@@ -611,14 +743,17 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
         : selected.targetDir;
     }
     await checkProjectDirExists(targetDir, options.interactive);
-    prompts.log.info(`Target directory: ${accent(formatDisplayTargetDir(targetDir))}`);
-    result = await executeBuiltinTemplate(workspaceInfo, {
-      ...templateInfo,
-      packageName,
-      targetDir,
-    });
+    result = await executeBuiltinTemplate(
+      workspaceInfo,
+      {
+        ...templateInfo,
+        packageName,
+        targetDir,
+      },
+      { silent: compactOutput },
+    );
   } else {
-    result = await executeRemoteTemplate(workspaceInfo, templateInfo);
+    result = await executeRemoteTemplate(workspaceInfo, templateInfo, { silent: compactOutput });
   }
 
   if (result.exitCode !== 0) {
@@ -629,23 +764,27 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
     process.exit(0);
   }
 
-  prompts.log.success(`Project directory: ${accent(projectDir)}`);
   const fullPath = path.join(workspaceInfo.rootDir, projectDir);
   const agentInstructionsRoot = isMonorepo ? workspaceInfo.rootDir : fullPath;
   await writeAgentInstructions({
     projectRoot: agentInstructionsRoot,
     targetPaths: selectedAgentTargetPaths,
     interactive: options.interactive,
+    silent: compactOutput,
   });
   await writeEditorConfigs({
     projectRoot: fullPath,
     editorId: selectedEditor,
     interactive: options.interactive,
+    silent: compactOutput,
   });
 
+  let installSummary: CommandRunSummary | undefined;
   if (isMonorepo) {
-    prompts.log.step('Monorepo integration...');
-    rewriteMonorepoProject(fullPath, workspaceInfo.packageManager);
+    if (!compactOutput) {
+      prompts.log.step('Monorepo integration...');
+    }
+    rewriteMonorepoProject(fullPath, workspaceInfo.packageManager, undefined, compactOutput);
 
     if (workspaceInfo.packages.length > 0) {
       if (options.interactive) {
@@ -704,33 +843,32 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
     }
 
     updateWorkspaceConfig(projectDir, workspaceInfo);
-    await runViteInstall(workspaceInfo.rootDir, options.interactive);
-    await runViteFmt(workspaceInfo.rootDir, options.interactive, [projectDir]);
+    installSummary = await runViteInstall(workspaceInfo.rootDir, options.interactive, undefined, {
+      silent: compactOutput,
+    });
+    await runViteFmt(workspaceInfo.rootDir, options.interactive, [projectDir], {
+      silent: compactOutput,
+    });
   } else {
-    rewriteStandaloneProject(fullPath, workspaceInfo);
-    const shouldSetupHooks = await promptGitHooks(options);
+    rewriteStandaloneProject(fullPath, workspaceInfo, undefined, compactOutput);
     if (shouldSetupHooks) {
-      installGitHooks(fullPath);
+      installGitHooks(fullPath, compactOutput);
     }
-    await runViteInstall(fullPath, options.interactive);
-    await runViteFmt(fullPath, options.interactive);
+    installSummary = await runViteInstall(fullPath, options.interactive, undefined, {
+      silent: compactOutput,
+    });
+    await runViteFmt(fullPath, options.interactive, undefined, { silent: compactOutput });
   }
 
-  prompts.outro(`✔ Created ${accent(projectDir)}!`);
-
-  showNextSteps(projectDir, isMonorepo);
+  showCreateSummary({
+    description: describeScaffold(selectedTemplateName, selectedTemplateArgs),
+    installSummary,
+    nextCommand: isMonorepo ? `vp dev ${projectDir}` : getNextCommand(projectDir, 'vp dev'),
+    packageManager: workspaceInfo.packageManager,
+    packageManagerVersion: workspaceInfo.downloadPackageManager.version,
+    projectDir,
+  });
   // #endregion
-}
-
-function showNextSteps(projectDir: string, isMonorepo: boolean) {
-  log(styleText('bold', 'Next steps:'));
-  if (isMonorepo) {
-    log(`  ${accent(`vp dev ${projectDir}`)}`);
-  } else {
-    log(`  ${accent(`cd ${projectDir}`)}`);
-    log(`  ${accent('vp dev')}`);
-  }
-  log('');
 }
 
 async function showAvailableTemplates() {

--- a/packages/cli/src/create/command.ts
+++ b/packages/cli/src/create/command.ts
@@ -94,6 +94,35 @@ export interface RunCommandResult extends ExecutionResult {
   stderr: Buffer;
 }
 
+export async function runCommandSilently(options: RunCommandOptions): Promise<RunCommandResult> {
+  const child = spawn(options.command, options.args, {
+    stdio: 'pipe',
+    cwd: options.cwd,
+    env: options.envs,
+  });
+  const promise = new Promise<RunCommandResult>((resolve, reject) => {
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    child.stdout?.on('data', (data) => {
+      stdout.push(data);
+    });
+    child.stderr?.on('data', (data) => {
+      stderr.push(data);
+    });
+    child.on('close', (code) => {
+      resolve({
+        exitCode: code ?? 0,
+        stdout: Buffer.concat(stdout),
+        stderr: Buffer.concat(stderr),
+      });
+    });
+    child.on('error', (err) => {
+      reject(err);
+    });
+  });
+  return await promise;
+}
+
 export async function runCommand(options: RunCommandOptions): Promise<ExecutionResult> {
   const child = spawn(options.command, options.args, {
     stdio: 'inherit',

--- a/packages/cli/src/create/templates/builtin.ts
+++ b/packages/cli/src/create/templates/builtin.ts
@@ -11,12 +11,13 @@ import { BuiltinTemplate, type BuiltinTemplateInfo } from './types.js';
 export async function executeBuiltinTemplate(
   workspaceInfo: WorkspaceInfo,
   templateInfo: BuiltinTemplateInfo,
+  options?: { silent?: boolean },
 ): Promise<ExecutionResult> {
   assert(templateInfo.targetDir, 'targetDir is required');
   assert(templateInfo.packageName, 'packageName is required');
 
   if (templateInfo.command === BuiltinTemplate.generator) {
-    return await executeGeneratorScaffold(workspaceInfo, templateInfo);
+    return await executeGeneratorScaffold(workspaceInfo, templateInfo, options);
   }
 
   if (templateInfo.command === BuiltinTemplate.application) {
@@ -42,6 +43,7 @@ export async function executeBuiltinTemplate(
     workspaceInfo.rootDir,
     templateInfo,
     false,
+    options?.silent ?? false,
   );
   const fullPath = path.join(workspaceInfo.rootDir, templateInfo.targetDir);
   // set package name in the project directory

--- a/packages/cli/src/create/templates/generator.ts
+++ b/packages/cli/src/create/templates/generator.ts
@@ -14,8 +14,11 @@ import type { BuiltinTemplateInfo } from './types.js';
 export async function executeGeneratorScaffold(
   workspaceInfo: WorkspaceInfo,
   templateInfo: BuiltinTemplateInfo,
+  options?: { silent?: boolean },
 ): Promise<ExecutionResult> {
-  prompts.log.step('Creating generator scaffold...');
+  if (!options?.silent) {
+    prompts.log.step('Creating generator scaffold...');
+  }
   let description: string | undefined;
   if (templateInfo.interactive) {
     const defaultDescription = 'Generate new components for our monorepo';
@@ -43,6 +46,8 @@ export async function executeGeneratorScaffold(
     return pkg;
   });
 
-  prompts.log.success('Generator scaffold created');
+  if (!options?.silent) {
+    prompts.log.success('Generator scaffold created');
+  }
   return { exitCode: 0, projectDir: templateInfo.targetDir };
 }

--- a/packages/cli/src/create/templates/monorepo.ts
+++ b/packages/cli/src/create/templates/monorepo.ts
@@ -22,6 +22,7 @@ export async function executeMonorepoTemplate(
   workspaceInfo: WorkspaceInfo,
   templateInfo: BuiltinTemplateInfo,
   interactive: boolean,
+  options?: { silent?: boolean },
 ): Promise<ExecutionResult> {
   assert(templateInfo.packageName, 'packageName is required');
   assert(templateInfo.targetDir, 'targetDir is required');
@@ -43,11 +44,15 @@ export async function executeMonorepoTemplate(
       initGit = selected;
     }
   } else {
-    prompts.log.info(`Initializing git repository (default: yes)`);
+    if (!options?.silent) {
+      prompts.log.info(`Initializing git repository (default: yes)`);
+    }
   }
 
-  prompts.log.info(`Target directory: ${formatDisplayTargetDir(templateInfo.targetDir)}`);
-  prompts.log.step('Creating Vite+ monorepo...');
+  if (!options?.silent) {
+    prompts.log.info(`Target directory: ${formatDisplayTargetDir(templateInfo.targetDir)}`);
+    prompts.log.step('Creating Vite+ monorepo...');
+  }
 
   // Copy template files
   const templateDir = path.join(templatesDir, 'monorepo');
@@ -100,7 +105,9 @@ export async function executeMonorepoTemplate(
     }
   }
 
-  prompts.log.success('Monorepo template created');
+  if (!options?.silent) {
+    prompts.log.success('Monorepo template created');
+  }
 
   if (initGit) {
     const gitResult = spawn.sync('git', ['init'], {
@@ -109,7 +116,9 @@ export async function executeMonorepoTemplate(
     });
 
     if (gitResult.status === 0) {
-      prompts.log.success('Git repository initialized');
+      if (!options?.silent) {
+        prompts.log.success('Git repository initialized');
+      }
     } else {
       prompts.log.warn('Failed to initialize git repository');
       if (gitResult.stderr) {
@@ -119,14 +128,22 @@ export async function executeMonorepoTemplate(
   }
 
   // Automatically create a default application in apps/website
-  prompts.log.step('Creating default application in apps/website...');
+  if (!options?.silent) {
+    prompts.log.step('Creating default application in apps/website...');
+  }
 
   const appTemplateInfo = discoverTemplate(
     'create-vite@latest',
     [InitialMonorepoAppDir, '--template', 'vanilla-ts', '--no-interactive'],
     workspaceInfo,
   );
-  const appResult = await runRemoteTemplateCommand(workspaceInfo, fullPath, appTemplateInfo);
+  const appResult = await runRemoteTemplateCommand(
+    workspaceInfo,
+    fullPath,
+    appTemplateInfo,
+    false,
+    options?.silent ?? false,
+  );
 
   if (appResult.exitCode !== 0) {
     prompts.log.error(`Failed to create default application: ${appResult.exitCode}`);
@@ -139,10 +156,17 @@ export async function executeMonorepoTemplate(
   const appProjectPath = path.join(fullPath, InitialMonorepoAppDir);
   setPackageName(appProjectPath, appPackageName);
   // Perform auto-migration on the created app
-  rewriteMonorepoProject(appProjectPath, workspaceInfo.packageManager);
+  rewriteMonorepoProject(
+    appProjectPath,
+    workspaceInfo.packageManager,
+    undefined,
+    options?.silent ?? false,
+  );
 
   // Automatically create a default library in packages/utils
-  prompts.log.step('Creating default library in packages/utils...');
+  if (!options?.silent) {
+    prompts.log.step('Creating default library in packages/utils...');
+  }
   const libraryDir = 'packages/utils';
   const libraryTemplateInfo = discoverTemplate(
     'create-tsdown@latest',
@@ -153,6 +177,8 @@ export async function executeMonorepoTemplate(
     workspaceInfo,
     fullPath,
     libraryTemplateInfo,
+    false,
+    options?.silent ?? false,
   );
   if (libraryResult.exitCode !== 0) {
     prompts.log.error(`Failed to create default library, exit code: ${libraryResult.exitCode}`);
@@ -165,7 +191,12 @@ export async function executeMonorepoTemplate(
   const libraryProjectPath = path.join(fullPath, libraryDir);
   setPackageName(libraryProjectPath, libraryPackageName);
   // Perform auto-migration on the created library
-  rewriteMonorepoProject(libraryProjectPath, workspaceInfo.packageManager);
+  rewriteMonorepoProject(
+    libraryProjectPath,
+    workspaceInfo.packageManager,
+    undefined,
+    options?.silent ?? false,
+  );
 
   return { exitCode: 0, projectDir: templateInfo.targetDir };
 }

--- a/packages/cli/src/create/templates/remote.ts
+++ b/packages/cli/src/create/templates/remote.ts
@@ -7,6 +7,7 @@ import {
   formatDlxCommand,
   runCommand,
   runCommandAndDetectProjectDir,
+  runCommandSilently,
 } from '../command.js';
 import type { TemplateInfo } from './types.js';
 
@@ -15,8 +16,12 @@ const { gray, yellow } = colors;
 export async function executeRemoteTemplate(
   workspaceInfo: WorkspaceInfo,
   templateInfo: TemplateInfo,
+  options?: { silent?: boolean },
 ): Promise<ExecutionResult> {
-  prompts.log.step('Generating project…');
+  const silent = options?.silent ?? false;
+  if (!silent) {
+    prompts.log.step('Generating project…');
+  }
 
   let isGitHubTemplate = templateInfo.command === 'degit';
   let result: ExecutionResult;
@@ -25,7 +30,9 @@ export async function executeRemoteTemplate(
     const command = templateInfo.command;
     const args = templateInfo.args;
     const envs = templateInfo.envs;
-    prompts.log.info(`Running: ${gray(`${command} ${args.join(' ')}`)}`);
+    if (!silent) {
+      prompts.log.info(`Running: ${gray(`${command} ${args.join(' ')}`)}`);
+    }
     result = await runCommandAndDetectProjectDir(
       { command, args, cwd: workspaceInfo.rootDir, envs },
       templateInfo.parentDir,
@@ -38,6 +45,7 @@ export async function executeRemoteTemplate(
       workspaceInfo.rootDir,
       templateInfo,
       true,
+      silent,
     );
   }
 
@@ -62,18 +70,24 @@ export async function runRemoteTemplateCommand(
   cwd: string,
   templateInfo: TemplateInfo,
   detectCreatedProjectDir?: boolean,
+  silent = false,
 ): Promise<ExecutionResult> {
   autoFixRemoteTemplateCommand(templateInfo, workspaceInfo);
   const remotePackageName = templateInfo.command;
   const execArgs = [...templateInfo.args];
   const envs = templateInfo.envs;
   const { command, args } = formatDlxCommand(remotePackageName, execArgs, workspaceInfo);
-  prompts.log.info(`Running: ${gray(`${command} ${args.join(' ')}`)}`);
+  if (!silent) {
+    prompts.log.info(`Running: ${gray(`${command} ${args.join(' ')}`)}`);
+  }
   if (detectCreatedProjectDir) {
     return await runCommandAndDetectProjectDir(
       { command, args, cwd, envs },
       templateInfo.parentDir,
     );
+  }
+  if (silent) {
+    return await runCommandSilently({ command, args, cwd, envs });
   }
   return await runCommand({ command, args, cwd, envs });
 }

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -331,6 +331,7 @@ export function rewriteStandaloneProject(
   projectPath: string,
   workspaceInfo: WorkspaceInfo,
   skipStagedMigration?: boolean,
+  silent = false,
 ): void {
   const packageJsonPath = path.join(projectPath, 'package.json');
   if (!fs.existsSync(packageJsonPath)) {
@@ -394,7 +395,7 @@ export function rewriteStandaloneProject(
 
   // Merge extracted staged config into vite.config.ts, then remove lint-staged from package.json
   if (extractedStagedConfig) {
-    if (mergeStagedConfigToViteConfig(projectPath, extractedStagedConfig)) {
+    if (mergeStagedConfigToViteConfig(projectPath, extractedStagedConfig, silent)) {
       removeLintStagedFromPackageJson(packageJsonPath);
     }
   }
@@ -402,10 +403,10 @@ export function rewriteStandaloneProject(
   if (!skipStagedMigration) {
     rewriteLintStagedConfigFile(projectPath);
   }
-  mergeViteConfigFiles(projectPath);
-  mergeTsdownConfigFile(projectPath);
+  mergeViteConfigFiles(projectPath, silent);
+  mergeTsdownConfigFile(projectPath, silent);
   // rewrite imports in all TypeScript/JavaScript files
-  rewriteAllImports(projectPath);
+  rewriteAllImports(projectPath, silent);
   // set package manager
   setPackageManager(projectPath, workspaceInfo.downloadPackageManager);
 }
@@ -414,7 +415,11 @@ export function rewriteStandaloneProject(
  * Rewrite monorepo to add vite-plus dependencies
  * @param workspaceInfo - The workspace info
  */
-export function rewriteMonorepo(workspaceInfo: WorkspaceInfo, skipStagedMigration?: boolean): void {
+export function rewriteMonorepo(
+  workspaceInfo: WorkspaceInfo,
+  skipStagedMigration?: boolean,
+  silent = false,
+): void {
   // rewrite root workspace
   if (workspaceInfo.packageManager === PackageManager.pnpm) {
     rewritePnpmWorkspaceYaml(workspaceInfo.rootDir);
@@ -433,16 +438,17 @@ export function rewriteMonorepo(workspaceInfo: WorkspaceInfo, skipStagedMigratio
       path.join(workspaceInfo.rootDir, pkg.path),
       workspaceInfo.packageManager,
       skipStagedMigration,
+      silent,
     );
   }
 
   if (!skipStagedMigration) {
     rewriteLintStagedConfigFile(workspaceInfo.rootDir);
   }
-  mergeViteConfigFiles(workspaceInfo.rootDir);
-  mergeTsdownConfigFile(workspaceInfo.rootDir);
+  mergeViteConfigFiles(workspaceInfo.rootDir, silent);
+  mergeTsdownConfigFile(workspaceInfo.rootDir, silent);
   // rewrite imports in all TypeScript/JavaScript files
-  rewriteAllImports(workspaceInfo.rootDir);
+  rewriteAllImports(workspaceInfo.rootDir, silent);
   // set package manager
   setPackageManager(workspaceInfo.rootDir, workspaceInfo.downloadPackageManager);
 }
@@ -455,9 +461,10 @@ export function rewriteMonorepoProject(
   projectPath: string,
   packageManager: PackageManager,
   skipStagedMigration?: boolean,
+  silent = false,
 ): void {
-  mergeViteConfigFiles(projectPath);
-  mergeTsdownConfigFile(projectPath);
+  mergeViteConfigFiles(projectPath, silent);
+  mergeTsdownConfigFile(projectPath, silent);
 
   const packageJsonPath = path.join(projectPath, 'package.json');
   if (!fs.existsSync(packageJsonPath)) {
@@ -477,7 +484,7 @@ export function rewriteMonorepoProject(
 
   // Merge extracted staged config into vite.config.ts, then remove lint-staged from package.json
   if (extractedStagedConfig) {
-    if (mergeStagedConfigToViteConfig(projectPath, extractedStagedConfig)) {
+    if (mergeStagedConfigToViteConfig(projectPath, extractedStagedConfig, silent)) {
       removeLintStagedFromPackageJson(packageJsonPath);
     }
   }
@@ -853,7 +860,7 @@ function rewriteLintStagedConfigFile(projectPath: string): void {
  * Ensure vite.config.ts exists, create it if not
  * @returns The vite config filename
  */
-function ensureViteConfig(projectPath: string, configs: ConfigFiles): string {
+function ensureViteConfig(projectPath: string, configs: ConfigFiles, silent = false): string {
   if (!configs.viteConfig) {
     configs.viteConfig = 'vite.config.ts';
     const viteConfigPath = path.join(projectPath, 'vite.config.ts');
@@ -864,7 +871,9 @@ function ensureViteConfig(projectPath: string, configs: ConfigFiles): string {
 export default defineConfig({});
 `,
     );
-    prompts.log.success(`✔ Created vite.config.ts in ${displayRelative(viteConfigPath)}`);
+    if (!silent) {
+      prompts.log.success(`✔ Created vite.config.ts in ${displayRelative(viteConfigPath)}`);
+    }
   }
   return configs.viteConfig;
 }
@@ -874,12 +883,12 @@ export default defineConfig({});
  * - For JSON files: merge content directly into `pack` field and delete the JSON file
  * - For TS/JS files: import the config file
  */
-function mergeTsdownConfigFile(projectPath: string): void {
+function mergeTsdownConfigFile(projectPath: string, silent = false): void {
   const configs = detectConfigs(projectPath);
   if (!configs.tsdownConfig) {
     return;
   }
-  const viteConfig = ensureViteConfig(projectPath, configs);
+  const viteConfig = ensureViteConfig(projectPath, configs, silent);
 
   const fullViteConfigPath = path.join(projectPath, viteConfig);
   const fullTsdownConfigPath = path.join(projectPath, configs.tsdownConfig);
@@ -895,32 +904,36 @@ function mergeTsdownConfigFile(projectPath: string): void {
   const result = mergeTsdownConfig(fullViteConfigPath, tsdownRelativePath);
   if (result.updated) {
     fs.writeFileSync(fullViteConfigPath, result.content);
-    prompts.log.success(
-      `✔ Added import for ${displayRelative(fullTsdownConfigPath)} in ${displayRelative(fullViteConfigPath)}`,
-    );
+    if (!silent) {
+      prompts.log.success(
+        `✔ Added import for ${displayRelative(fullTsdownConfigPath)} in ${displayRelative(fullViteConfigPath)}`,
+      );
+    }
   }
   // Show documentation link for manual merging since we only added the import
-  prompts.log.info(
-    `Please manually merge ${displayRelative(fullTsdownConfigPath)} into ${displayRelative(fullViteConfigPath)}, see https://viteplus.dev/migration/#tsdown`,
-  );
+  if (!silent) {
+    prompts.log.info(
+      `Please manually merge ${displayRelative(fullTsdownConfigPath)} into ${displayRelative(fullViteConfigPath)}, see https://viteplus.dev/migration/#tsdown`,
+    );
+  }
 }
 
 /**
  * Merge oxlint and oxfmt config into vite.config.ts
  */
-export function mergeViteConfigFiles(projectPath: string): void {
+export function mergeViteConfigFiles(projectPath: string, silent = false): void {
   const configs = detectConfigs(projectPath);
   if (!configs.oxfmtConfig && !configs.oxlintConfig) {
     return;
   }
-  const viteConfig = ensureViteConfig(projectPath, configs);
+  const viteConfig = ensureViteConfig(projectPath, configs, silent);
   if (configs.oxlintConfig) {
     // merge oxlint config into vite.config.ts
-    mergeAndRemoveJsonConfig(projectPath, viteConfig, configs.oxlintConfig, 'lint');
+    mergeAndRemoveJsonConfig(projectPath, viteConfig, configs.oxlintConfig, 'lint', silent);
   }
   if (configs.oxfmtConfig) {
     // merge oxfmt config into vite.config.ts
-    mergeAndRemoveJsonConfig(projectPath, viteConfig, configs.oxfmtConfig, 'fmt');
+    mergeAndRemoveJsonConfig(projectPath, viteConfig, configs.oxfmtConfig, 'fmt', silent);
   }
 }
 
@@ -929,6 +942,7 @@ function mergeAndRemoveJsonConfig(
   viteConfigPath: string,
   jsonConfigPath: string,
   configKey: string,
+  silent = false,
 ): void {
   const fullViteConfigPath = path.join(projectPath, viteConfigPath);
   const fullJsonConfigPath = path.join(projectPath, jsonConfigPath);
@@ -936,9 +950,11 @@ function mergeAndRemoveJsonConfig(
   if (result.updated) {
     fs.writeFileSync(fullViteConfigPath, result.content);
     fs.unlinkSync(fullJsonConfigPath);
-    prompts.log.success(
-      `✔ Merged ${displayRelative(fullJsonConfigPath)} into ${displayRelative(fullViteConfigPath)}`,
-    );
+    if (!silent) {
+      prompts.log.success(
+        `✔ Merged ${displayRelative(fullJsonConfigPath)} into ${displayRelative(fullViteConfigPath)}`,
+      );
+    }
   } else {
     prompts.log.warn(
       `✘ Failed to merge ${displayRelative(fullJsonConfigPath)} into ${displayRelative(fullViteConfigPath)}`,
@@ -956,6 +972,7 @@ function mergeAndRemoveJsonConfig(
 function mergeStagedConfigToViteConfig(
   projectPath: string,
   stagedConfig: Record<string, string | string[]>,
+  silent = false,
 ): boolean {
   const configs = detectConfigs(projectPath);
   const viteConfig = ensureViteConfig(projectPath, configs);
@@ -974,7 +991,9 @@ function mergeStagedConfigToViteConfig(
 
   if (result.updated) {
     fs.writeFileSync(fullViteConfigPath, result.content);
-    prompts.log.success(`✔ Merged staged config into ${displayRelative(fullViteConfigPath)}`);
+    if (!silent) {
+      prompts.log.success(`✔ Merged staged config into ${displayRelative(fullViteConfigPath)}`);
+    }
     return true;
   } else {
     prompts.log.warn(`✘ Failed to merge staged config into ${displayRelative(fullViteConfigPath)}`);
@@ -1003,12 +1022,12 @@ function hasStagedConfigInViteConfig(projectPath: string): boolean {
  * This rewrites vite/vitest imports to @voidzero-dev/vite-plus
  * @param projectPath - The root directory to search for files
  */
-function rewriteAllImports(projectPath: string): void {
+function rewriteAllImports(projectPath: string, silent = false): void {
   const result = rewriteImportsInDirectory(projectPath);
   const modified = result.modifiedFiles.length;
   const errors = result.errors.length;
 
-  if (modified > 0) {
+  if (!silent && modified > 0) {
     prompts.log.success(`Rewrote imports in ${modified === 1 ? 'one file' : `${modified} files`}`);
     prompts.log.info(result.modifiedFiles.map((file) => `  ${displayRelative(file)}`).join('\n'));
   }
@@ -1090,9 +1109,9 @@ function collapseHuskyInstall(script: string): string {
  * High-level helper: detect old hooks dir, set up git hooks, and rewrite
  * the prepare script.  Returns true if hooks were successfully installed.
  */
-export function installGitHooks(projectPath: string): boolean {
+export function installGitHooks(projectPath: string, silent = false): boolean {
   const oldHooksDir = getOldHooksDir(projectPath);
-  if (setupGitHooks(projectPath, oldHooksDir)) {
+  if (setupGitHooks(projectPath, oldHooksDir, silent)) {
     rewritePrepareScript(projectPath);
     return true;
   }
@@ -1159,7 +1178,7 @@ export function preflightGitHooksSetup(projectPath: string): string | null {
  * Skips if another hook tool is detected (warns user).
  * Returns true if hooks were successfully set up, false if skipped.
  */
-export function setupGitHooks(projectPath: string, oldHooksDir?: string): boolean {
+export function setupGitHooks(projectPath: string, oldHooksDir?: string, silent = false): boolean {
   const reason = preflightGitHooksSetup(projectPath);
   if (reason) {
     prompts.log.warn(`⚠ ${reason}`);
@@ -1214,7 +1233,7 @@ export function setupGitHooks(projectPath: string, oldHooksDir?: string): boolea
     const finalConfig: Record<string, string | string[]> = updated
       ? JSON.parse(updated)
       : stagedConfig;
-    stagedMerged = mergeStagedConfigToViteConfig(projectPath, finalConfig);
+    stagedMerged = mergeStagedConfigToViteConfig(projectPath, finalConfig, silent);
   }
 
   // Only remove lint-staged key from package.json after staged config is
@@ -1294,7 +1313,9 @@ export function setupGitHooks(projectPath: string, oldHooksDir?: string): boolea
       return false;
     }
     removeReplacedHookPackages(packageJsonPath);
-    prompts.log.success('✔ Git hooks configured');
+    if (!silent) {
+      prompts.log.success('✔ Git hooks configured');
+    }
     return true;
   }
   prompts.log.warn('Failed to install git hooks');

--- a/packages/cli/src/utils/agent.ts
+++ b/packages/cli/src/utils/agent.ts
@@ -395,12 +395,14 @@ export async function writeAgentInstructions({
   targetPaths,
   interactive,
   conflictDecisions,
+  silent = false,
 }: {
   projectRoot: string;
   targetPath?: string;
   targetPaths?: string[];
   interactive: boolean;
   conflictDecisions?: Map<string, 'append' | 'skip'>;
+  silent?: boolean;
 }) {
   const paths = [...(targetPaths ?? []), ...(targetPath ? [targetPath] : [])];
   if (paths.length === 0) {
@@ -409,7 +411,9 @@ export async function writeAgentInstructions({
 
   const sourcePath = path.join(pkgRoot, 'AGENTS.md');
   if (!fs.existsSync(sourcePath)) {
-    prompts.log.warn('Agent instructions template not found; skipping.');
+    if (!silent) {
+      prompts.log.warn('Agent instructions template not found; skipping.');
+    }
     return;
   }
 
@@ -432,7 +436,7 @@ export async function writeAgentInstructions({
     await fsPromises.mkdir(path.dirname(destinationPath), { recursive: true });
 
     if (shouldLinkToAgents && targetPathToWrite !== AGENT_STANDARD_PATH) {
-      const linked = await tryLinkTargetToAgents(projectRoot, targetPathToWrite);
+      const linked = await tryLinkTargetToAgents(projectRoot, targetPathToWrite, silent);
       if (linked) {
         continue;
       }
@@ -440,13 +444,17 @@ export async function writeAgentInstructions({
 
     if (fs.existsSync(destinationPath)) {
       if (fs.lstatSync(destinationPath).isSymbolicLink()) {
-        prompts.log.info(`Skipped writing ${targetPathToWrite} (symlink)`);
+        if (!silent) {
+          prompts.log.info(`Skipped writing ${targetPathToWrite} (symlink)`);
+        }
         continue;
       }
 
       const destinationRealPath = await fsPromises.realpath(destinationPath);
       if (seenRealPaths.has(destinationRealPath)) {
-        prompts.log.info(`Skipped writing ${targetPathToWrite} (duplicate target)`);
+        if (!silent) {
+          prompts.log.info(`Skipped writing ${targetPathToWrite} (duplicate target)`);
+        }
         continue;
       }
 
@@ -496,17 +504,22 @@ export async function writeAgentInstructions({
           targetPathToWrite,
           existingContent,
           incomingContent,
+          silent,
         );
       } else {
         const suffix = !preResolved && !interactive ? ' (already exists)' : '';
-        prompts.log.info(`Skipped writing ${targetPathToWrite}${suffix}`);
+        if (!silent) {
+          prompts.log.info(`Skipped writing ${targetPathToWrite}${suffix}`);
+        }
       }
       seenRealPaths.add(destinationRealPath);
       continue;
     }
 
     await fsPromises.writeFile(destinationPath, incomingContent);
-    prompts.log.success(`Wrote agent instructions to ${targetPathToWrite}`);
+    if (!silent) {
+      prompts.log.success(`Wrote agent instructions to ${targetPathToWrite}`);
+    }
     seenRealPaths.add(await fsPromises.realpath(destinationPath));
   }
 }
@@ -516,10 +529,13 @@ async function appendAgentContent(
   targetPath: string,
   existingContent: string,
   incomingContent: string,
+  silent = false,
 ) {
   const separator = existingContent.endsWith('\n') ? '' : '\n';
   await fsPromises.appendFile(destinationPath, `${separator}\n${incomingContent}`);
-  prompts.log.success(`Appended agent instructions to ${targetPath}`);
+  if (!silent) {
+    prompts.log.success(`Appended agent instructions to ${targetPath}`);
+  }
 }
 
 function normalizeAgentName(value: string) {
@@ -554,7 +570,7 @@ export function replaceMarkedAgentInstructionsSection(existing: string, incoming
   )}${existing.slice(existingRange.end)}`;
 }
 
-async function tryLinkTargetToAgents(projectRoot: string, targetPath: string) {
+async function tryLinkTargetToAgents(projectRoot: string, targetPath: string, silent = false) {
   const destinationPath = path.join(projectRoot, targetPath);
   const agentsPath = path.join(projectRoot, AGENT_STANDARD_PATH);
   const symlinkTarget = path.relative(path.dirname(destinationPath), agentsPath);
@@ -568,14 +584,20 @@ async function tryLinkTargetToAgents(projectRoot: string, targetPath: string) {
     const currentLink = await fsPromises.readlink(destinationPath);
     const resolvedCurrentLink = path.resolve(path.dirname(destinationPath), currentLink);
     if (resolvedCurrentLink === agentsPath) {
-      prompts.log.info(`Skipped linking ${targetPath} (already linked to ${AGENT_STANDARD_PATH})`);
+      if (!silent) {
+        prompts.log.info(
+          `Skipped linking ${targetPath} (already linked to ${AGENT_STANDARD_PATH})`,
+        );
+      }
       return true;
     }
     await fsPromises.unlink(destinationPath);
   }
 
   await fsPromises.symlink(symlinkTarget, destinationPath);
-  prompts.log.success(`Linked ${targetPath} to ${AGENT_STANDARD_PATH}`);
+  if (!silent) {
+    prompts.log.success(`Linked ${targetPath} to ${AGENT_STANDARD_PATH}`);
+  }
   return true;
 }
 

--- a/packages/cli/src/utils/editor.ts
+++ b/packages/cli/src/utils/editor.ts
@@ -144,11 +144,13 @@ export async function writeEditorConfigs({
   editorId,
   interactive,
   conflictDecisions,
+  silent = false,
 }: {
   projectRoot: string;
   editorId: EditorId | undefined;
   interactive: boolean;
   conflictDecisions?: Map<string, 'merge' | 'skip'>;
+  silent?: boolean;
 }) {
   if (!editorId) {
     return;
@@ -197,15 +199,19 @@ export async function writeEditorConfigs({
       }
 
       if (conflictAction === 'merge') {
-        mergeAndWriteEditorConfig(filePath, incoming, fileName, displayPath);
+        mergeAndWriteEditorConfig(filePath, incoming, fileName, displayPath, silent);
       } else {
-        prompts.log.info(`Skipped writing ${displayPath}`);
+        if (!silent) {
+          prompts.log.info(`Skipped writing ${displayPath}`);
+        }
       }
       continue;
     }
 
     writeJsonFile(filePath, incoming);
-    prompts.log.success(`Wrote editor config to ${editorConfig.targetDir}/${fileName}`);
+    if (!silent) {
+      prompts.log.success(`Wrote editor config to ${editorConfig.targetDir}/${fileName}`);
+    }
   }
 }
 
@@ -214,11 +220,14 @@ function mergeAndWriteEditorConfig(
   incoming: Record<string, unknown>,
   fileName: string,
   displayPath: string,
+  silent = false,
 ) {
   const existing = readJsonFile(filePath);
   const merged = mergeEditorConfigs(existing, incoming, fileName);
   writeJsonFile(filePath, merged);
-  prompts.log.success(`Merged editor config into ${displayPath}`);
+  if (!silent) {
+    prompts.log.success(`Merged editor config into ${displayPath}`);
+  }
 }
 
 function mergeEditorConfigs(

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -6,12 +6,18 @@ import { PackageManager } from '../types/index.js';
 import { runCommandSilently } from './command.js';
 import { accent } from './terminal.js';
 
+export interface CommandRunSummary {
+  durationMs: number;
+  exitCode?: number;
+  status: 'installed' | 'formatted' | 'failed' | 'skipped';
+}
+
 export function cancelAndExit(message = 'Operation cancelled', exitCode = 0): never {
   prompts.cancel(message);
   process.exit(exitCode);
 }
 
-export async function selectPackageManager(interactive?: boolean) {
+export async function selectPackageManager(interactive?: boolean, silent = false) {
   if (interactive) {
     const selected = await prompts.select({
       message: 'Which package manager would you like to use?',
@@ -30,7 +36,9 @@ export async function selectPackageManager(interactive?: boolean) {
     return selected;
   } else {
     // --no-interactive: use pnpm as default
-    prompts.log.info(`Using default package manager: ${accent(PackageManager.pnpm)}`);
+    if (!silent) {
+      prompts.log.info(`Using default package manager: ${accent(PackageManager.pnpm)}`);
+    }
     return PackageManager.pnpm;
   }
 }
@@ -51,12 +59,19 @@ export async function downloadPackageManager(
   return downloadResult;
 }
 
-export async function runViteInstall(cwd: string, interactive?: boolean, extraArgs?: string[]) {
-  if (process.env.VITE_PLUS_SKIP_INSTALL) {
-    return;
+export async function runViteInstall(
+  cwd: string,
+  interactive?: boolean,
+  extraArgs?: string[],
+  options?: { silent?: boolean },
+) {
+  // install dependencies on non-CI environment
+  if (process.env.VITE_PLUS_SKIP_INSTALL || process.env.CI) {
+    return { durationMs: 0, status: 'skipped' } satisfies CommandRunSummary;
   }
 
-  const spinner = getSpinner(interactive);
+  const spinner = options?.silent ? getSilentSpinner() : getSpinner(interactive);
+  const startTime = Date.now();
   spinner.start(`Installing dependencies...`);
   const { exitCode, stderr, stdout } = await runCommandSilently({
     command: process.env.VITE_PLUS_CLI_BIN ?? 'vp',
@@ -66,16 +81,32 @@ export async function runViteInstall(cwd: string, interactive?: boolean, extraAr
   });
   if (exitCode === 0) {
     spinner.stop(`Dependencies installed`);
+    return {
+      durationMs: Date.now() - startTime,
+      exitCode,
+      status: 'installed',
+    } satisfies CommandRunSummary;
   } else {
     spinner.stop(`Install failed`);
     prompts.log.info(stdout.toString());
     prompts.log.error(stderr.toString());
     prompts.log.info(`You may need to run "vp install" manually in ${cwd}`);
+    return {
+      durationMs: Date.now() - startTime,
+      exitCode,
+      status: 'failed',
+    } satisfies CommandRunSummary;
   }
 }
 
-export async function runViteFmt(cwd: string, interactive?: boolean, paths?: string[]) {
-  const spinner = getSpinner(interactive);
+export async function runViteFmt(
+  cwd: string,
+  interactive?: boolean,
+  paths?: string[],
+  options?: { silent?: boolean },
+) {
+  const spinner = options?.silent ? getSilentSpinner() : getSpinner(interactive);
+  const startTime = Date.now();
   spinner.start(`Formatting code...`);
 
   const { binPath, envs } = await resolveFmt();
@@ -91,12 +122,22 @@ export async function runViteFmt(cwd: string, interactive?: boolean, paths?: str
 
   if (exitCode === 0) {
     spinner.stop(`Code formatted`);
+    return {
+      durationMs: Date.now() - startTime,
+      exitCode,
+      status: 'formatted',
+    } satisfies CommandRunSummary;
   } else {
     spinner.stop(`Format failed`);
     prompts.log.info(stdout.toString());
     prompts.log.error(stderr.toString());
     const relativePaths = (paths ?? []).length > 0 ? ` ${(paths ?? []).join(' ')}` : '';
     prompts.log.info(`You may need to run "vp fmt --write${relativePaths}" manually in ${cwd}`);
+    return {
+      durationMs: Date.now() - startTime,
+      exitCode,
+      status: 'failed',
+    } satisfies CommandRunSummary;
   }
 }
 

--- a/packages/prompts/src/__tests__/__snapshots__/render.spec.ts.snap
+++ b/packages/prompts/src/__tests__/__snapshots__/render.spec.ts.snap
@@ -64,3 +64,17 @@ exports[`prompt renderers > renders select with pointer markers and aligned mult
 
 "
 `;
+
+exports[`prompt renderers > renders submitted prompts without extra blank lines 1`] = `
+"◇ Choose multiple
+  Beta
+
+---
+◇ Proceed?
+  Yes
+
+---
+◇ Project name
+  acme-web
+"
+`;

--- a/packages/prompts/src/__tests__/render.spec.ts
+++ b/packages/prompts/src/__tests__/render.spec.ts
@@ -11,6 +11,8 @@ const captured: {
   autocomplete?: PromptConfig;
   confirm?: PromptConfig;
   selectKey?: PromptConfig;
+  text?: PromptConfig;
+  password?: PromptConfig;
 } = {};
 
 class SelectPrompt<_Value> {
@@ -73,6 +75,26 @@ class SelectKeyPrompt<_Value> {
   }
 }
 
+class TextPrompt {
+  constructor(config: PromptConfig) {
+    captured.text = config;
+  }
+
+  prompt() {
+    return Promise.resolve(Symbol('cancel'));
+  }
+}
+
+class PasswordPrompt {
+  constructor(config: PromptConfig) {
+    captured.password = config;
+  }
+
+  prompt() {
+    return Promise.resolve(Symbol('cancel'));
+  }
+}
+
 vi.mock('@clack/core', () => {
   return {
     settings: { withGuide: true },
@@ -95,6 +117,8 @@ vi.mock('@clack/core', () => {
     AutocompletePrompt,
     ConfirmPrompt,
     SelectKeyPrompt,
+    TextPrompt,
+    PasswordPrompt,
   };
 });
 
@@ -116,6 +140,8 @@ beforeEach(() => {
   captured.autocomplete = undefined;
   captured.confirm = undefined;
   captured.selectKey = undefined;
+  captured.text = undefined;
+  captured.password = undefined;
 });
 
 describe('prompt renderers', () => {
@@ -269,5 +295,41 @@ describe('prompt renderers', () => {
     });
 
     expect(`${confirmOutput}\n---\n${selectKeyOutput}`).toMatchSnapshot();
+  });
+
+  it('renders submitted prompts without extra blank lines', async () => {
+    const [{ multiselect }, { confirm }, { text }] = await Promise.all([
+      import('../multi-select.js'),
+      import('../confirm.js'),
+      import('../text.js'),
+    ]);
+
+    const multiOptions = [
+      { value: 'alpha', label: 'Alpha' },
+      { value: 'beta', label: 'Beta' },
+    ];
+    void multiselect({
+      message: 'Choose multiple',
+      options: multiOptions,
+    });
+    const multiselectOutput = renderWith(captured.multiSelect, {
+      state: 'submit',
+      options: multiOptions,
+      value: ['beta'],
+    });
+
+    void confirm({ message: 'Proceed?' });
+    const confirmOutput = renderWith(captured.confirm, {
+      state: 'submit',
+      value: true,
+    });
+
+    void text({ message: 'Project name' });
+    const textOutput = renderWith(captured.text, {
+      state: 'submit',
+      value: 'acme-web',
+    });
+
+    expect(`${multiselectOutput}\n---\n${confirmOutput}\n---\n${textOutput}`).toMatchSnapshot();
   });
 });

--- a/packages/prompts/src/confirm.ts
+++ b/packages/prompts/src/confirm.ts
@@ -36,13 +36,13 @@ export const confirm = (opts: ConfirmOptions) => {
       switch (this.state) {
         case 'submit': {
           const submitPrefix = hasGuide ? `${color.gray(S_BAR)} ` : nestedPrefix;
-          return `${title}${submitPrefix}${color.dim(value)}\n\n`;
+          return `${title}${submitPrefix}${color.dim(value)}\n`;
         }
         case 'cancel': {
           const cancelPrefix = hasGuide ? `${color.gray(S_BAR)} ` : nestedPrefix;
           return `${title}${cancelPrefix}${color.strikethrough(
             color.dim(value),
-          )}${hasGuide ? `\n${color.gray(S_BAR)}` : ''}\n\n`;
+          )}${hasGuide ? `\n${color.gray(S_BAR)}` : ''}\n`;
         }
         default: {
           const defaultPrefix = hasGuide ? `${color.blue(S_BAR)} ` : nestedPrefix;

--- a/packages/prompts/src/multi-select.ts
+++ b/packages/prompts/src/multi-select.ts
@@ -183,7 +183,7 @@ export const multiselect = <Value>(opts: MultiSelectOptions<Value>) => {
               .join(color.dim(', ')) || color.dim('none');
           const submitPrefix = hasGuide ? `${color.gray(S_BAR)} ` : nestedPrefix;
           const wrappedSubmitText = wrapTextWithPrefix(opts.output, submitText, submitPrefix);
-          return `${title}${wrappedSubmitText}\n\n`;
+          return `${title}${wrappedSubmitText}\n`;
         }
         case 'cancel': {
           const label = this.options
@@ -191,13 +191,13 @@ export const multiselect = <Value>(opts: MultiSelectOptions<Value>) => {
             .map((option) => opt(option, 'cancelled'))
             .join(color.dim(', '));
           if (label.trim() === '') {
-            return hasGuide ? `${title}${color.gray(S_BAR)}\n\n` : `${title.trimEnd()}\n\n`;
+            return hasGuide ? `${title}${color.gray(S_BAR)}\n` : `${title.trimEnd()}\n`;
           }
           const cancelPrefix = hasGuide ? `${color.gray(S_BAR)} ` : nestedPrefix;
           const wrappedLabel = wrapTextWithPrefix(opts.output, label, cancelPrefix);
           return hasGuide
-            ? `${title}${wrappedLabel}\n${color.gray(S_BAR)}\n\n`
-            : `${title}${wrappedLabel}\n\n`;
+            ? `${title}${wrappedLabel}\n${color.gray(S_BAR)}\n`
+            : `${title}${wrappedLabel}\n`;
         }
         case 'error': {
           const prefix = hasGuide ? `${color.yellow(S_BAR)} ` : nestedPrefix;

--- a/packages/prompts/src/password.ts
+++ b/packages/prompts/src/password.ts
@@ -36,14 +36,14 @@ export const password = (opts: PasswordOptions) => {
         case 'submit': {
           const submitPrefix = hasGuide ? `${color.gray(S_BAR)} ` : nestedPrefix;
           const maskedText = masked ? color.dim(masked) : '';
-          return `${title}${submitPrefix}${maskedText}\n\n`;
+          return `${title}${submitPrefix}${maskedText}\n`;
         }
         case 'cancel': {
           const cancelPrefix = hasGuide ? `${color.gray(S_BAR)} ` : nestedPrefix;
           const maskedText = masked ? color.strikethrough(color.dim(masked)) : '';
           return `${title}${cancelPrefix}${maskedText}${
             masked && hasGuide ? `\n${color.gray(S_BAR)}` : ''
-          }\n\n`;
+          }\n`;
         }
         default: {
           const defaultPrefix = hasGuide ? `${color.blue(S_BAR)} ` : nestedPrefix;

--- a/packages/prompts/src/select-key.ts
+++ b/packages/prompts/src/select-key.ts
@@ -79,7 +79,7 @@ export const selectKey = <Value extends string>(opts: SelectKeyOptions<Value>) =
             opt(selectedOption, 'selected'),
             submitPrefix,
           );
-          return `${title}${wrapped}\n\n`;
+          return `${title}${wrapped}\n`;
         }
         case 'cancel': {
           const cancelPrefix = hasGuide ? `${color.gray(S_BAR)} ` : nestedPrefix;
@@ -88,7 +88,7 @@ export const selectKey = <Value extends string>(opts: SelectKeyOptions<Value>) =
             opt(this.options[0], 'cancelled'),
             cancelPrefix,
           );
-          return `${title}${wrapped}${hasGuide ? `\n${color.gray(S_BAR)}` : ''}\n\n`;
+          return `${title}${wrapped}${hasGuide ? `\n${color.gray(S_BAR)}` : ''}\n`;
         }
         default: {
           const defaultPrefix = hasGuide ? `${color.blue(S_BAR)} ` : nestedPrefix;

--- a/packages/prompts/src/text.ts
+++ b/packages/prompts/src/text.ts
@@ -40,12 +40,12 @@ export const text = (opts: TextOptions) => {
         case 'submit': {
           const valueText = value ? color.dim(value) : '';
           const submitPrefix = hasGuide ? `${color.gray(S_BAR)} ` : nestedPrefix;
-          return `${title}${submitPrefix}${valueText}\n\n`;
+          return `${title}${submitPrefix}${valueText}\n`;
         }
         case 'cancel': {
           const valueText = value ? color.strikethrough(color.dim(value)) : '';
           const cancelPrefix = hasGuide ? `${color.gray(S_BAR)} ` : nestedPrefix;
-          return `${title}${cancelPrefix}${valueText}${value.trim() ? `\n${cancelPrefix}` : ''}\n\n`;
+          return `${title}${cancelPrefix}${valueText}${value.trim() ? `\n${cancelPrefix}` : ''}\n`;
         }
         default: {
           const defaultPrefix = hasGuide ? `${color.blue(S_BAR)} ` : nestedPrefix;


### PR DESCRIPTION
We are printing way too much stuff that nobody needs to see in `vp create`. This PR moves the pre-commit hook question to before it runs any commands, suppresses all the output, fixes inconsistent newline rendering, and prints a clean summary that matches the output from our website about the `vp create` command.

Example:
<img width="880" height="736" alt="CleanShot 2026-03-09 at 15 23 42@2x" src="https://github.com/user-attachments/assets/5e7d878a-a2f7-4c77-b1da-207025b16976" />

I will do a pass on `vp migrate` later as well.