### PR TITLE
fix: trigger Netlify docs builds on docs/ changes

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -8,8 +8,8 @@ import { defineConfig, type HeadConfig } from 'vitepress';
 export default extendConfig(
   defineConfig({
     title: 'Vite+',
-    titleTemplate: ':title | The Unified Toolchain for the Web (Alpha)',
-    description: 'The Unified Toolchain for the Web (Alpha)',
+    titleTemplate: ':title | The Unified Toolchain for the Web',
+    description: 'The Unified Toolchain for the Web',
     cleanUrls: true,
     head: [
       ['link', { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' }],

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,6 @@
 # (rolldown-vite patches don't exist on Netlify, causing pnpm install to fail).
 # The ignore command watches docs/ so builds still trigger on docs changes.
 base = "rfcs/"
-ignore = "[ -z \"$CACHED_COMMIT_REF\" ] && exit 1; git diff --quiet $CACHED_COMMIT_REF HEAD -- docs/ netlify.toml"
+ignore = "git diff --quiet $CACHED_COMMIT_REF HEAD -- ../docs/"
 command = "cd ../docs && npm i --force && npm run build"
 publish = "../docs/.vitepress/dist"


### PR DESCRIPTION
## Summary

- Add `ignore` command to `netlify.toml` that watches `docs/` for changes, fixing builds being skipped ("No changes detected in base directory")
- Keep `base = "rfcs/"` to avoid Netlify's auto pnpm install failing on missing `rolldown-vite` patches
- Handle empty `$CACHED_COMMIT_REF` (no previous successful build) by always proceeding

## Context

Netlify's change detection watches the `base` directory. With `base = "rfcs/"`, changes to `docs/` were invisible, causing builds to be skipped. We can't use `base = "docs/"` because Netlify detects the root pnpm workspace and fails installing dependencies (missing `rolldown-vite/patches/`). The `ignore` command provides custom change detection that watches `docs/` from the `rfcs/` base.

## Test plan

- [x] Push triggers Netlify build (ignore command exits 1 on docs/ changes)
- [x] Verify docs site deploys successfully