### PR TITLE
fix: add docs/pnpm-workspace.yaml to isolate docs from root workspace

### DIFF
--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - .

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,4 @@
 [build]
-# Use rfcs/ as base to avoid Netlify detecting the root pnpm workspace
-# (rolldown-vite patches don't exist on Netlify, causing pnpm install to fail).
-# The ignore command watches docs/ so builds still trigger on docs changes.
-base = "rfcs/"
-ignore = "git diff --quiet $CACHED_COMMIT_REF HEAD -- ../docs/"
-command = "cd ../docs && npm i --force && npm run build"
-publish = "../docs/.vitepress/dist"
+base = "docs/"
+command = "pnpm build"
+publish = ".vitepress/dist"


### PR DESCRIPTION
Add a pnpm-workspace.yaml in docs/ so pnpm won't traverse up to the
root workspace (which fails on missing rolldown-vite patches). This
allows using base=docs/ directly in netlify.toml, so Netlify watches
docs/ for changes and builds trigger correctly.