### PR TITLE
chore: Fix some `vp create` and `vp migrate` issues.

### DIFF
--- a/packages/cli/snap-tests-global/migration-add-git-hooks/snap.txt
+++ b/packages/cli/snap-tests-global/migration-add-git-hooks/snap.txt
@@ -2,22 +2,10 @@
 > vp migrate --no-interactive # migration should add git hooks setup
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-✔ Git hooks configured
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied
+• Git hooks configured
 
 > cat package.json # check package.json has prepare script and lint-staged config
 {

--- a/packages/cli/snap-tests-global/migration-agent-claude/snap.txt
+++ b/packages/cli/snap-tests-global/migration-agent-claude/snap.txt
@@ -1,20 +1,9 @@
 > vp migrate --agent claude --no-interactive # migration with --agent claude should write CLAUDE.md
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-Wrote agent instructions to CLAUDE.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied
 
 > cat CLAUDE.md | head -3 # verify CLAUDE.md was created
 <!--VITE PLUS START-->

--- a/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-hookspath/snap.txt
+++ b/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-hookspath/snap.txt
@@ -3,14 +3,10 @@
 > vp migrate --no-interactive # should override husky's core.hooksPath and migrate hooks
 VITE+ - The Unified Toolchain for the Web
 
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-✔ Git hooks configured
-✔ Migration completed!
-
+◇ Updated .
+• Node <semver>  unknown latest
+• 2 config updates applied
+• Git hooks configured
 
 > cat package.json # husky/lint-staged should be removed, prepare should be vp config
 {

--- a/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-lint-staged/snap.txt
@@ -2,14 +2,10 @@
 > vp migrate --no-interactive # should still migrate husky/lint-staged even though vite-plus exists
 VITE+ - The Unified Toolchain for the Web
 
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-✔ Git hooks configured
-✔ Migration completed!
-
+◇ Updated .
+• Node <semver>  unknown latest
+• 2 config updates applied
+• Git hooks configured
 
 > cat package.json # husky/lint-staged should be removed, prepare should be vp config
 {

--- a/packages/cli/snap-tests-global/migration-auto-create-vite-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-auto-create-vite-config/snap.txt
@@ -1,24 +1,9 @@
 > vp migrate --no-interactive # migration should auto create vite.config.ts and remove oxlintrc and oxfmtrc
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged .oxlintrc.json into vite.config.ts
-
-✔ Merged .oxfmtrc.json into vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 4 config updates applied
 
 > cat vite.config.ts # check vite.config.ts
 import { defineConfig } from 'vite-plus';

--- a/packages/cli/snap-tests-global/migration-baseurl-tsconfig/snap.txt
+++ b/packages/cli/snap-tests-global/migration-baseurl-tsconfig/snap.txt
@@ -1,25 +1,12 @@
 > vp migrate --no-interactive # migration should skip typeAware/typeCheck when tsconfig has baseUrl
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-✔ Created vite.config.ts in vite.config.ts
-
-Skipped typeAware/typeCheck: tsconfig.json contains baseUrl which is not yet supported by the oxlint type checker.
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 3 config updates applied
+! Warnings:
+  - Skipped typeAware/typeCheck: tsconfig.json contains baseUrl which is not yet supported by the oxlint type checker.
   Run `npx @andrewbranch/ts5to6 --fixBaseUrl .` to remove baseUrl from your tsconfig.
-
-✔ Merged .oxlintrc.json into vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
 
 > cat vite.config.ts # check vite.config.ts — should NOT have typeAware or typeCheck
 import { defineConfig } from 'vite-plus';

--- a/packages/cli/snap-tests-global/migration-chained-lint-staged-pre-commit/snap.txt
+++ b/packages/cli/snap-tests-global/migration-chained-lint-staged-pre-commit/snap.txt
@@ -2,22 +2,10 @@
 > vp migrate --no-interactive # migration should preserve chained commands after lint-staged
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-✔ Git hooks configured
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied
+• Git hooks configured
 
 > cat package.json # check prepare rewritten and husky/lint-staged removed
 {

--- a/packages/cli/snap-tests-global/migration-composed-husky-custom-dir/snap.txt
+++ b/packages/cli/snap-tests-global/migration-composed-husky-custom-dir/snap.txt
@@ -2,22 +2,10 @@
 > vp migrate --no-interactive # migration should preserve custom husky dir in composed prepare
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-✔ Git hooks configured
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied
+• Git hooks configured
 
 > cat package.json # prepare should be 'vp config --hooks-dir .config/husky && npm run build'
 {

--- a/packages/cli/snap-tests-global/migration-composed-husky-prepare/snap.txt
+++ b/packages/cli/snap-tests-global/migration-composed-husky-prepare/snap.txt
@@ -2,22 +2,10 @@
 > vp migrate --no-interactive # migration should replace husky in composed prepare script
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-✔ Git hooks configured
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied
+• Git hooks configured
 
 > cat package.json # check prepare becomes 'vp config --hooks-dir .husky && npm run build' without leftover husky
 {

--- a/packages/cli/snap-tests-global/migration-env-prefix-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-env-prefix-lint-staged/snap.txt
@@ -2,22 +2,10 @@
 > vp migrate --no-interactive # migration should replace env-prefixed lint-staged in pre-commit
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-✔ Git hooks configured
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied
+• Git hooks configured
 
 > cat package.json # check husky/lint-staged removed, staged config in vite.config.ts
 {

--- a/packages/cli/snap-tests-global/migration-eslint-legacy/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-legacy/snap.txt
@@ -2,18 +2,7 @@
 VITE+ - The Unified Toolchain for the Web
 
 
-Using default package manager: pnpm
-
 Legacy ESLint configuration detected (.eslintrc). Automatic migration to Oxlint requires ESLint v9+ with flat config format (eslint.config.*). Please upgrade to ESLint v9 first: https://eslint.org/docs/latest/use/migrate-to-9.0.0
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied

--- a/packages/cli/snap-tests-global/migration-eslint-lint-staged-mjs/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-lint-staged-mjs/snap.txt
@@ -2,8 +2,6 @@
 VITE+ - The Unified Toolchain for the Web
 
 
-ESLint configuration detected. Auto-migrating to Oxlint...
-
 Migrating ESLint config to Oxlint...
 
 ESLint config migrated to .oxlintrc.json
@@ -14,13 +12,11 @@ ESLint comments replaced
 
 ✔ Removed eslint.config.mjs
 
-⚠ lint-staged.config.mjs — please update eslint references manually
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged .oxlintrc.json into vite.config.ts
-✔ Migration completed!
-
+lint-staged.config.mjs — please update eslint references manually
+◇ Updated .
+• Node <semver>  unknown latest
+• 2 config updates applied
+• ESLint rules migrated to Oxlint
 
 > cat lint-staged.config.mjs # verify non-JSON lint-staged config is preserved unchanged
 export default {

--- a/packages/cli/snap-tests-global/migration-eslint-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-lint-staged/snap.txt
@@ -1,34 +1,10 @@
 > vp migrate --no-interactive # migration should detect eslint and auto-migrate including lint-staged
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-ESLint configuration detected. Auto-migrating to Oxlint...
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-Migrating ESLint config to Oxlint...
-
-ESLint config migrated to .oxlintrc.json
-
-Replacing ESLint comments with Oxlint equivalents...
-
-ESLint comments replaced
-
-✔ Removed eslint.config.mjs
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-✔ Merged .oxlintrc.json into vite.config.ts
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 4 config updates applied
+• ESLint rules migrated to Oxlint
 
 > cat package.json # check eslint removed, scripts rewritten, lint-staged rewritten
 {

--- a/packages/cli/snap-tests-global/migration-eslint-lintstagedrc/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-lintstagedrc/snap.txt
@@ -1,36 +1,10 @@
 > vp migrate --no-interactive # migration should detect eslint and auto-migrate including lintstagedrc
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-ESLint configuration detected. Auto-migrating to Oxlint...
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-Migrating ESLint config to Oxlint...
-
-ESLint config migrated to .oxlintrc.json
-
-Replacing ESLint comments with Oxlint equivalents...
-
-ESLint comments replaced
-
-✔ Removed eslint.config.mjs
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-✔ Inlined .lintstagedrc.json into "staged" in vite.config.ts
-
-✔ Merged .oxlintrc.json into vite.config.ts
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 5 config updates applied
+• ESLint rules migrated to Oxlint
 
 > cat package.json # check eslint removed and scripts rewritten
 {

--- a/packages/cli/snap-tests-global/migration-eslint-monorepo-package-only/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-monorepo-package-only/snap.txt
@@ -3,18 +3,9 @@ VITE+ - The Unified Toolchain for the Web
 
 
 ESLint detected in workspace packages but no root config found. Package-level ESLint must be migrated manually.
-
-pnpm@<semver> installing...
-
-pnpm@<semver> installed
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied
 
 > cat package.json # check root package.json
 {

--- a/packages/cli/snap-tests-global/migration-eslint-monorepo/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-monorepo/snap.txt
@@ -2,31 +2,13 @@
 VITE+ - The Unified Toolchain for the Web
 
 
-ESLint configuration detected. Auto-migrating to Oxlint...
-
-pnpm@<semver> installing...
-
-pnpm@<semver> installed
-
-Migrating ESLint config to Oxlint...
-
-ESLint config migrated to .oxlintrc.json
-
-Replacing ESLint comments with Oxlint equivalents...
-
-ESLint comments replaced
-
-✔ Removed eslint.config.mjs
-
 ✔ Created vite.config.ts in vite.config.ts
 
 ✔ Merged .oxlintrc.json into vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied
+• ESLint rules migrated to Oxlint
 
 > cat package.json # check root eslint removed and scripts rewritten
 {

--- a/packages/cli/snap-tests-global/migration-eslint-npx-wrapper/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-npx-wrapper/snap.txt
@@ -1,34 +1,10 @@
 > vp migrate --no-interactive # migration should rewrite bare eslint but leave npx wrappers unchanged
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-ESLint configuration detected. Auto-migrating to Oxlint...
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-Migrating ESLint config to Oxlint...
-
-ESLint config migrated to .oxlintrc.json
-
-Replacing ESLint comments with Oxlint equivalents...
-
-ESLint comments replaced
-
-✔ Removed eslint.config.mjs
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged .oxlintrc.json into vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 4 config updates applied
+• ESLint rules migrated to Oxlint
 
 > cat package.json # check eslint removed, bare eslint rewritten, npx/pnpm exec/bunx wrappers unchanged
 {

--- a/packages/cli/snap-tests-global/migration-eslint-rerun-dual-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-rerun-dual-config/snap.txt
@@ -2,8 +2,6 @@
 VITE+ - The Unified Toolchain for the Web
 
 
-ESLint configuration detected. Auto-migrating to Oxlint...
-
 Migrating ESLint config to Oxlint...
 
 ESLint config migrated to .oxlintrc.json
@@ -15,12 +13,10 @@ ESLint comments replaced
 ✔ Removed eslint.config.mjs
 
 ✔ Removed .eslintrc
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged .oxlintrc.json into vite.config.ts
-✔ Migration completed!
-
+◇ Updated .
+• Node <semver>  unknown latest
+• 2 config updates applied
+• ESLint rules migrated to Oxlint
 
 > cat package.json # check eslint removed and scripts rewritten
 {

--- a/packages/cli/snap-tests-global/migration-eslint-rerun-mjs/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-rerun-mjs/snap.txt
@@ -2,8 +2,6 @@
 VITE+ - The Unified Toolchain for the Web
 
 
-ESLint configuration detected. Auto-migrating to Oxlint...
-
 Migrating ESLint config to Oxlint...
 
 ESLint config migrated to .oxlintrc.json
@@ -13,10 +11,10 @@ Replacing ESLint comments with Oxlint equivalents...
 ESLint comments replaced
 
 ✔ Removed eslint.config.mjs
-
-✔ Merged .oxlintrc.json into vite.config.mjs
-✔ Migration completed!
-
+◇ Updated .
+• Node <semver>  unknown latest
+• 1 config update applied
+• ESLint rules migrated to Oxlint
 
 > cat package.json # check eslint removed from devDependencies and scripts rewritten
 {

--- a/packages/cli/snap-tests-global/migration-eslint-rerun/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-rerun/snap.txt
@@ -2,8 +2,6 @@
 VITE+ - The Unified Toolchain for the Web
 
 
-ESLint configuration detected. Auto-migrating to Oxlint...
-
 Migrating ESLint config to Oxlint...
 
 ESLint config migrated to .oxlintrc.json
@@ -13,12 +11,10 @@ Replacing ESLint comments with Oxlint equivalents...
 ESLint comments replaced
 
 ✔ Removed eslint.config.mjs
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged .oxlintrc.json into vite.config.ts
-✔ Migration completed!
-
+◇ Updated .
+• Node <semver>  unknown latest
+• 2 config updates applied
+• ESLint rules migrated to Oxlint
 
 > cat package.json # check eslint removed from devDependencies and scripts rewritten
 {

--- a/packages/cli/snap-tests-global/migration-eslint/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint/snap.txt
@@ -1,34 +1,10 @@
 > vp migrate --no-interactive # migration should detect eslint and auto-migrate
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-ESLint configuration detected. Auto-migrating to Oxlint...
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-Migrating ESLint config to Oxlint...
-
-ESLint config migrated to .oxlintrc.json
-
-Replacing ESLint comments with Oxlint equivalents...
-
-ESLint comments replaced
-
-✔ Removed eslint.config.mjs
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged .oxlintrc.json into vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 4 config updates applied
+• ESLint rules migrated to Oxlint
 
 > cat package.json # check eslint removed and scripts rewritten
 {

--- a/packages/cli/snap-tests-global/migration-existing-husky-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-husky-lint-staged/snap.txt
@@ -2,22 +2,10 @@
 > vp migrate --no-interactive # migration should rewrite husky and lint-staged
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-✔ Git hooks configured
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied
+• Git hooks configured
 
 > cat package.json # check prepare rewritten, lint-staged removed, both removed from devDeps
 {

--- a/packages/cli/snap-tests-global/migration-existing-husky-v8-hooks/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-husky-v8-hooks/snap.txt
@@ -3,17 +3,9 @@
 VITE+ - The Unified Toolchain for the Web
 
 
-Using default package manager: pnpm
-
 ⚠ Detected husky <9.0.0 — please upgrade to husky v9+ first, then re-run migration.
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
 
 > cat package.json # husky/lint-staged should remain in devDeps, prepare should stay as husky
 {

--- a/packages/cli/snap-tests-global/migration-existing-husky-v8-multi-hooks/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-husky-v8-multi-hooks/snap.txt
@@ -3,17 +3,9 @@
 VITE+ - The Unified Toolchain for the Web
 
 
-Using default package manager: pnpm
-
 ⚠ Detected husky <9.0.0 — please upgrade to husky v9+ first, then re-run migration.
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
 
 > cat package.json # husky/lint-staged should remain in devDeps, prepare should stay as husky
 {

--- a/packages/cli/snap-tests-global/migration-existing-husky/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-husky/snap.txt
@@ -2,22 +2,10 @@
 > vp migrate --no-interactive # migration should rewrite husky to vp config
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-✔ Git hooks configured
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied
+• Git hooks configured
 
 > cat package.json # check prepare script rewritten and husky removed from devDeps
 {

--- a/packages/cli/snap-tests-global/migration-existing-lint-staged-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-lint-staged-config/snap.txt
@@ -2,24 +2,10 @@
 > vp migrate --no-interactive # migration should add prepare script, remove lint-staged from devDeps
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-✔ Inlined .lintstagedrc.json into "staged" in vite.config.ts
-
-✔ Git hooks configured
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 3 config updates applied
+• Git hooks configured
 
 > cat package.json # check prepare script added, lint-staged removed from devDeps
 {

--- a/packages/cli/snap-tests-global/migration-existing-pnpm-exec-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-pnpm-exec-lint-staged/snap.txt
@@ -2,22 +2,10 @@
 > vp migrate --no-interactive # migration should strip pnpm exec lint-staged and add vp staged
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-✔ Git hooks configured
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied
+• Git hooks configured
 
 > cat package.json # check prepare rewritten and husky/lint-staged removed
 {

--- a/packages/cli/snap-tests-global/migration-existing-pre-commit/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-pre-commit/snap.txt
@@ -8,22 +8,10 @@ secret-scan
 > vp migrate --no-interactive # migration should preserve existing pre-commit contents
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-✔ Git hooks configured
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied
+• Git hooks configured
 
 > cat .vite-hooks/pre-commit # check pre-commit hook preserves existing commands
 #!/usr/bin/env sh

--- a/packages/cli/snap-tests-global/migration-existing-prepare-script/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-prepare-script/snap.txt
@@ -2,22 +2,10 @@
 > vp migrate --no-interactive # migration should compose vp config with existing prepare script
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-✔ Git hooks configured
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied
+• Git hooks configured
 
 > cat package.json # check prepare script is composed: vp config && npm run build
 {

--- a/packages/cli/snap-tests-global/migration-from-tsdown-json-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-from-tsdown-json-config/snap.txt
@@ -1,20 +1,9 @@
 > vp migrate --no-interactive # migration should rewrite imports to vite-plus
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-✔ Merged tsdown.config.json into vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied
 
 > cat tsdown.config.json && exit 1 || true # check tsdown.config.json should be removed
 cat: tsdown.config.json: No such file or directory

--- a/packages/cli/snap-tests-global/migration-from-tsdown/snap.txt
+++ b/packages/cli/snap-tests-global/migration-from-tsdown/snap.txt
@@ -1,28 +1,11 @@
 > vp migrate --no-interactive # migration should rewrite imports to vite-plus
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Added import for tsdown.config.ts in vite.config.ts
-
-Please manually merge tsdown.config.ts into vite.config.ts, see https://viteplus.dev/migration/#tsdown
-
-Rewrote imports in one file
-
-  tsdown.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 3 config updates applied, 1 file had imports rewritten
+→ Manual follow-up:
+  - Please manually merge tsdown.config.ts into vite.config.ts, see https://viteplus.dev/migration/#tsdown
 
 > cat tsdown.config.ts # check tsdown.config.ts
 import { defineConfig } from 'vite-plus/pack';

--- a/packages/cli/snap-tests-global/migration-from-vitest-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-from-vitest-config/snap.txt
@@ -1,24 +1,9 @@
 > vp migrate --no-interactive # migration should rewrite imports to vite-plus
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-Rewrote imports in one file
-
-  vitest.config.ts
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied, 1 file had imports rewritten
 
 > cat vitest.config.ts # check vitest.config.ts
 import { join } from 'node:path';

--- a/packages/cli/snap-tests-global/migration-from-vitest-files/snap.txt
+++ b/packages/cli/snap-tests-global/migration-from-vitest-files/snap.txt
@@ -1,24 +1,9 @@
 > vp migrate --no-interactive # migration should rewrite imports to vite-plus
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-Rewrote imports in one file
-
-  test/hello.ts
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied, 1 file had imports rewritten
 
 > cat package.json # check package.json
 {

--- a/packages/cli/snap-tests-global/migration-hooks-skip-on-existing-hookspath/snap.txt
+++ b/packages/cli/snap-tests-global/migration-hooks-skip-on-existing-hookspath/snap.txt
@@ -3,22 +3,11 @@
 > vp migrate --no-interactive # should skip hooks because core.hooksPath is already set
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-⚠ Git hooks not configured — core.hooksPath is already set to ".custom-hooks", skipping
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied
+! Warnings:
+  - Git hooks not configured — core.hooksPath is already set to ".custom-hooks", skipping
 
 > cat package.json # prepare should stay 'husky' and husky must remain in devDependencies
 {

--- a/packages/cli/snap-tests-global/migration-husky-env-skip/snap.txt
+++ b/packages/cli/snap-tests-global/migration-husky-env-skip/snap.txt
@@ -2,19 +2,8 @@
 > vp migrate --no-interactive # with HUSKY=0, vp config should skip and warn instead of reporting success
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-⚠ Git hooks not configured — skip install (git hooks disabled)
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied
+! Warnings:
+  - Git hooks not configured — skip install (git hooks disabled)

--- a/packages/cli/snap-tests-global/migration-husky-or-prepare/snap.txt
+++ b/packages/cli/snap-tests-global/migration-husky-or-prepare/snap.txt
@@ -2,22 +2,10 @@
 > vp migrate --no-interactive # migration should preserve || fallback semantics
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-✔ Git hooks configured
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied
+• Git hooks configured
 
 > cat package.json # check prepare script preserves || true fallback
 {

--- a/packages/cli/snap-tests-global/migration-husky-semicolon-prepare/snap.txt
+++ b/packages/cli/snap-tests-global/migration-husky-semicolon-prepare/snap.txt
@@ -2,22 +2,10 @@
 > vp migrate --no-interactive # migration should strip husky from semicolon-composed prepare script
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-✔ Git hooks configured
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied
+• Git hooks configured
 
 > cat package.json # check husky removed from prepare script, not left as broken command
 {

--- a/packages/cli/snap-tests-global/migration-husky-v8-preserves-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-husky-v8-preserves-lint-staged/snap.txt
@@ -3,17 +3,9 @@
 VITE+ - The Unified Toolchain for the Web
 
 
-Using default package manager: pnpm
-
 ⚠ Detected husky <9.0.0 — please upgrade to husky v9+ first, then re-run migration.
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
 
 > cat package.json # lint-staged config should still be in package.json
 {

--- a/packages/cli/snap-tests-global/migration-lint-staged-in-scripts/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lint-staged-in-scripts/snap.txt
@@ -2,22 +2,10 @@
 > vp migrate --no-interactive # migration should rewrite lint-staged commands in scripts
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-✔ Git hooks configured
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied
+• Git hooks configured
 
 > cat package.json # check-staged script should use vp staged, lint-staged removed from devDeps
 {

--- a/packages/cli/snap-tests-global/migration-lint-staged-merge-fail/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lint-staged-merge-fail/snap.txt
@@ -2,26 +2,13 @@
 > vp migrate --no-interactive # should handle merge failure gracefully
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-✘ Failed to merge staged config into vite.config.ts
-
-Please add staged config to vite.config.ts manually, see https://viteplus.dev/config/
-
-✘ Failed to merge staged config into vite.config.ts
-
-Please add staged config to vite.config.ts manually, see https://viteplus.dev/config/
-
-✔ Git hooks configured
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• Git hooks configured
+! Warnings:
+  - Failed to merge staged config into vite.config.ts
+→ Manual follow-up:
+  - Please add staged config to vite.config.ts manually, see https://viteplus.dev/config/
 
 > cat package.json # lint-staged config should be preserved when merge fails
 {

--- a/packages/cli/snap-tests-global/migration-lint-staged-ts-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lint-staged-ts-config/snap.txt
@@ -3,17 +3,9 @@
 VITE+ - The Unified Toolchain for the Web
 
 
-Using default package manager: pnpm
-
 ⚠ Unsupported lint-staged config format — skipping git hooks setup. Please configure git hooks manually.
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
 
 > cat package.json # check lint-staged NOT added to package.json, husky/lint-staged removed from devDependencies
 {

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-json/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-json/snap.txt
@@ -32,22 +32,11 @@ Examples:
 > vp migrate --no-interactive # migration work with lintstagedrc.json
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-⚠ .lintstagedrc.json found but "staged" already exists in vite.config.ts — please merge manually
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied
+! Warnings:
+  - .lintstagedrc.json found but "staged" already exists in vite.config.ts — please merge manually
 
 > cat .lintstagedrc.json # check lintstagedrc.json (should be deleted after inlining)
 {

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-merge-fail/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-merge-fail/snap.txt
@@ -2,22 +2,13 @@
 > vp migrate --no-interactive # should handle merge failure gracefully
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-✘ Failed to merge staged config into vite.config.ts
-
-Please add staged config to vite.config.ts manually, see https://viteplus.dev/config/
-
-✔ Git hooks configured
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• Git hooks configured
+! Warnings:
+  - Failed to merge staged config into vite.config.ts
+→ Manual follow-up:
+  - Please add staged config to vite.config.ts manually, see https://viteplus.dev/config/
 
 > cat package.json # check package.json
 {

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-not-support/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-not-support/snap.txt
@@ -3,17 +3,9 @@
 VITE+ - The Unified Toolchain for the Web
 
 
-Using default package manager: pnpm
-
 ⚠ Unsupported lint-staged config format — skipping git hooks setup. Please configure git hooks manually.
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
 
 > cat .lintstagedrc # check .lintstagedrc is not updated
 '*.js':

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-staged-exists/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-staged-exists/snap.txt
@@ -2,20 +2,11 @@
 > vp migrate --no-interactive # should warn when staged already exists in vite.config.ts
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-⚠ .lintstagedrc.json found but "staged" already exists in vite.config.ts — please merge manually
-
-✔ Git hooks configured
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• Git hooks configured
+! Warnings:
+  - .lintstagedrc.json found but "staged" already exists in vite.config.ts — please merge manually
 
 > cat package.json # check package.json
 {

--- a/packages/cli/snap-tests-global/migration-merge-vite-config-js/snap.txt
+++ b/packages/cli/snap-tests-global/migration-merge-vite-config-js/snap.txt
@@ -1,20 +1,9 @@
 > vp migrate --no-interactive # migration should merge vite.config.js and remove oxlintrc
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-✔ Merged .oxlintrc.json into vite.config.js
-
-✔ Merged staged config into vite.config.js
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied
 
 > cat vite.config.js # check vite.config.js
 import react from '@vitejs/plugin-react';

--- a/packages/cli/snap-tests-global/migration-merge-vite-config-ts/snap.txt
+++ b/packages/cli/snap-tests-global/migration-merge-vite-config-ts/snap.txt
@@ -1,26 +1,9 @@
 > vp migrate --no-interactive # migration should merge vite.config.ts and remove oxlintrc and oxfmtrc
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-✔ Merged .oxlintrc.json into vite.config.ts
-
-✔ Merged .oxfmtrc.json into vite.config.ts
-
-Rewrote imports in one file
-
-  vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 3 config updates applied, 1 file had imports rewritten
 
 > cat vite.config.ts # check vite.config.ts
 import { join } from 'node:path';

--- a/packages/cli/snap-tests-global/migration-monorepo-husky-v8-preserves-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-husky-v8-preserves-lint-staged/snap.txt
@@ -3,14 +3,8 @@ VITE+ - The Unified Toolchain for the Web
 
 
 ⚠ Detected husky <9.0.0 — please upgrade to husky v9+ first, then re-run migration.
-
-pnpm@<semver> installing...
-
-pnpm@<semver> installed
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
 
 > cat package.json # root lint-staged config should still be in package.json
 {

--- a/packages/cli/snap-tests-global/migration-monorepo-pnpm-overrides-dependency-selector/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-pnpm-overrides-dependency-selector/snap.txt
@@ -1,20 +1,9 @@
 > vp migrate --no-interactive # migration should merge pnpm overrides with dependency selector
 VITE+ - The Unified Toolchain for the Web
 
-
-pnpm@<semver> installing...
-
-pnpm@<semver> installed
-
-Rewrote imports in one file
-
-  vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 1 config update applied, 1 file had imports rewritten
 
 > cat vite.config.ts # check vite.config.ts
 import react from '@vitejs/plugin-react';

--- a/packages/cli/snap-tests-global/migration-monorepo-pnpm/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-pnpm/snap.txt
@@ -2,27 +2,12 @@
 VITE+ - The Unified Toolchain for the Web
 
 
-pnpm@<semver> installing...
-
-pnpm@<semver> installed
-
 ✔ Merged .oxlintrc.json into vite.config.ts
 
 ✔ Merged .oxfmtrc.json into vite.config.ts
-
-✔ Created vite.config.ts in packages/only-oxlint/vite.config.ts
-
-✔ Merged packages/only-oxlint/.oxlintrc.json into packages/only-oxlint/vite.config.ts
-
-Rewrote imports in one file
-
-  vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 3 config updates applied, 1 file had imports rewritten
 
 > cat vite.config.ts # check vite.config.ts
 import react from '@vitejs/plugin-react';

--- a/packages/cli/snap-tests-global/migration-monorepo-skip-vite-peer-dependency/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-skip-vite-peer-dependency/snap.txt
@@ -1,22 +1,9 @@
 > vp migrate --no-interactive # migration should check each package's peerDependencies
 VITE+ - The Unified Toolchain for the Web
 
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-Rewrote imports in one file
-
-  packages/vite-plugin/src/index.ts
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied, 1 file had imports rewritten
 
 > cat packages/vite-plugin/src/index.ts # vite-plugin has vite in peerDeps: vite NOT rewritten, vitest rewritten
 import { defineConfig, type Plugin } from 'vite';

--- a/packages/cli/snap-tests-global/migration-monorepo-yarn4/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-yarn4/snap.txt
@@ -2,21 +2,10 @@
 VITE+ - The Unified Toolchain for the Web
 
 
-yarn@<semver> installing...
-
-yarn@<semver> installed
-
 ✔ Merged .oxlintrc.json into vite.config.ts
-
-Rewrote imports in one file
-
-  vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  yarn <semver>
+• 1 config update applied, 1 file had imports rewritten
 
 > cat vite.config.ts # check vite.config.ts
 import react from '@vitejs/plugin-react';

--- a/packages/cli/snap-tests-global/migration-no-agent/snap.txt
+++ b/packages/cli/snap-tests-global/migration-no-agent/snap.txt
@@ -1,18 +1,9 @@
 > vp migrate --no-agent --no-interactive # migration with --no-agent should skip agent instructions
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied
 
 > ls -la | grep -E '(AGENTS|CLAUDE)' || echo 'No agent file created' # verify no agent file was created
 No agent file created

--- a/packages/cli/snap-tests-global/migration-no-git-repo/snap.txt
+++ b/packages/cli/snap-tests-global/migration-no-git-repo/snap.txt
@@ -1,20 +1,9 @@
 > vp migrate --no-interactive # migration should create .vite-hooks/pre-commit even without .git
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied
 
 > cat package.json # check package.json has prepare script and lint-staged config
 {

--- a/packages/cli/snap-tests-global/migration-no-hooks-with-husky/snap.txt
+++ b/packages/cli/snap-tests-global/migration-no-hooks-with-husky/snap.txt
@@ -2,16 +2,8 @@
 > vp migrate --no-hooks --no-interactive # --no-hooks should keep husky/lint-staged and preserve config
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
 
 > cat package.json # prepare script, lint-staged config, check-staged script, and deps should all be preserved
 {

--- a/packages/cli/snap-tests-global/migration-no-hooks/snap.txt
+++ b/packages/cli/snap-tests-global/migration-no-hooks/snap.txt
@@ -2,16 +2,8 @@
 > vp migrate --no-hooks --no-interactive # migration with --no-hooks should skip hooks setup
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
 
 > cat package.json # check package.json has no prepare script and no lint-staged config
 {

--- a/packages/cli/snap-tests-global/migration-not-supported-npm8.2/snap.txt
+++ b/packages/cli/snap-tests-global/migration-not-supported-npm8.2/snap.txt
@@ -2,10 +2,6 @@
 VITE+ - The Unified Toolchain for the Web
 
 
-npm@<semver> installing...
-
-npm@<semver> installed
-
 ✘ npm@<semver> is not supported by auto migration, please upgrade npm to >=8.3.0 first
 Vite+ cannot automatically migrate this project yet.
 

--- a/packages/cli/snap-tests-global/migration-not-supported-pnpm9.4/snap.txt
+++ b/packages/cli/snap-tests-global/migration-not-supported-pnpm9.4/snap.txt
@@ -2,10 +2,6 @@
 VITE+ - The Unified Toolchain for the Web
 
 
-pnpm@<semver> installing...
-
-pnpm@<semver> installed
-
 ✘ pnpm@<semver> is not supported by auto migration, please upgrade pnpm to >=9.5.0 first
 Vite+ cannot automatically migrate this project yet.
 

--- a/packages/cli/snap-tests-global/migration-not-supported-vite6/snap.txt
+++ b/packages/cli/snap-tests-global/migration-not-supported-vite6/snap.txt
@@ -3,10 +3,6 @@
 VITE+ - The Unified Toolchain for the Web
 
 
-pnpm@<semver> installing...
-
-pnpm@<semver> installed
-
 ✘ vite@<semver> in package.json is not supported by auto migration
 
 Please upgrade vite to version >=7.0.0 first

--- a/packages/cli/snap-tests-global/migration-not-supported-vitest3/snap.txt
+++ b/packages/cli/snap-tests-global/migration-not-supported-vitest3/snap.txt
@@ -3,10 +3,6 @@
 VITE+ - The Unified Toolchain for the Web
 
 
-pnpm@<semver> installing...
-
-pnpm@<semver> installed
-
 ✘ vitest@<semver> in package.json is not supported by auto migration
 
 Please upgrade vitest to version >=4.0.0 first

--- a/packages/cli/snap-tests-global/migration-other-hook-tool/snap.txt
+++ b/packages/cli/snap-tests-global/migration-other-hook-tool/snap.txt
@@ -2,17 +2,9 @@
 VITE+ - The Unified Toolchain for the Web
 
 
-Using default package manager: pnpm
-
 ⚠ Detected simple-git-hooks — skipping git hooks setup. Please configure git hooks manually.
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
 
 > cat package.json # lint-staged config, scripts, and simple-git-hooks config should all be preserved
 {

--- a/packages/cli/snap-tests-global/migration-partially-migrated-pre-commit/snap.txt
+++ b/packages/cli/snap-tests-global/migration-partially-migrated-pre-commit/snap.txt
@@ -3,17 +3,9 @@
 VITE+ - The Unified Toolchain for the Web
 
 
-Using default package manager: pnpm
-
 ⚠ Detected husky <9.0.0 — please upgrade to husky v9+ first, then re-run migration.
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
 
 > cat package.json # husky/lint-staged should remain in devDeps, prepare should stay as husky
 {

--- a/packages/cli/snap-tests-global/migration-pre-commit-env-setup/snap.txt
+++ b/packages/cli/snap-tests-global/migration-pre-commit-env-setup/snap.txt
@@ -9,22 +9,10 @@ npm test
 > vp migrate --no-interactive # migration should replace lint-staged in-place
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-✔ Git hooks configured
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied
+• Git hooks configured
 
 > cat .vite-hooks/pre-commit # check vp staged replaced npx lint-staged in-place
 #!/usr/bin/env sh

--- a/packages/cli/snap-tests-global/migration-prettier-eslint-combo/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier-eslint-combo/snap.txt
@@ -2,39 +2,12 @@
 VITE+ - The Unified Toolchain for the Web
 
 
-Using default package manager: pnpm
-
-ESLint configuration detected. Auto-migrating to Oxlint...
-
 Prettier configuration detected. Auto-migrating to Oxfmt...
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-Migrating ESLint config to Oxlint...
-
-ESLint config migrated to .oxlintrc.json
-
-Replacing ESLint comments with Oxlint equivalents...
-
-ESLint comments replaced
-
-✔ Removed eslint.config.mjs
-
-Migrating Prettier config to Oxfmt...
-
-Prettier config migrated to .oxfmtrc.json
-
-✔ Removed .prettierrc.json
-
-✔ Merged .oxlintrc.json into vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 4 config updates applied
+• ESLint rules migrated to Oxlint
+• Prettier migrated to Oxfmt
 
 > cat package.json # check eslint and prettier removed, scripts rewritten
 {

--- a/packages/cli/snap-tests-global/migration-prettier-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier-lint-staged/snap.txt
@@ -2,25 +2,11 @@
 VITE+ - The Unified Toolchain for the Web
 
 
-Using default package manager: pnpm
-
 Prettier configuration detected. Auto-migrating to Oxfmt...
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-Migrating Prettier config to Oxfmt...
-
-Prettier config migrated to .oxfmtrc.json
-
-✔ Removed .prettierrc.json
-
-✔ Merged staged config into vite.config.ts
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied
+• Prettier migrated to Oxfmt
 
 > cat package.json # check prettier removed, scripts rewritten, lint-staged rewritten
 {

--- a/packages/cli/snap-tests-global/migration-prettier-pkg-json/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier-pkg-json/snap.txt
@@ -2,23 +2,11 @@
 VITE+ - The Unified Toolchain for the Web
 
 
-Using default package manager: pnpm
-
 Prettier configuration detected. Auto-migrating to Oxfmt...
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-Migrating Prettier config to Oxfmt...
-
-Prettier config migrated to .oxfmtrc.json
-
-✔ Merged staged config into vite.config.ts
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 1 config update applied
+• Prettier migrated to Oxfmt
 
 > cat package.json # check prettier key removed, scripts rewritten, dep removed
 {

--- a/packages/cli/snap-tests-global/migration-prettier-rerun/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier-rerun/snap.txt
@@ -9,8 +9,9 @@ Migrating Prettier config to Oxfmt...
 Prettier config migrated to .oxfmtrc.json
 
 ✔ Removed .prettierrc.json
-✔ Migration completed!
-
+◇ Updated .
+• Node <semver>  unknown latest
+• Prettier migrated to Oxfmt
 
 > cat package.json # check prettier removed from devDependencies and scripts rewritten
 {

--- a/packages/cli/snap-tests-global/migration-prettier/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier/snap.txt
@@ -2,25 +2,11 @@
 VITE+ - The Unified Toolchain for the Web
 
 
-Using default package manager: pnpm
-
 Prettier configuration detected. Auto-migrating to Oxfmt...
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-Migrating Prettier config to Oxfmt...
-
-Prettier config migrated to .oxfmtrc.json
-
-✔ Removed .prettierrc.json
-
-✔ Merged staged config into vite.config.ts
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied
+• Prettier migrated to Oxfmt
 
 > cat package.json # check prettier removed and scripts rewritten
 {

--- a/packages/cli/snap-tests-global/migration-rewrite-declare-module/snap.txt
+++ b/packages/cli/snap-tests-global/migration-rewrite-declare-module/snap.txt
@@ -1,24 +1,9 @@
 > vp migrate --no-interactive # migration should rewrite imports to vite-plus
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-Rewrote imports in one file
-
-  src/index.ts
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied, 1 file had imports rewritten
 
 > cat src/index.ts # check src/index.ts
 import type { RuntimeEnvConfig } from './runtime.env.config.js';

--- a/packages/cli/snap-tests-global/migration-rewrite-reference-types/snap.txt
+++ b/packages/cli/snap-tests-global/migration-rewrite-reference-types/snap.txt
@@ -1,24 +1,9 @@
 > vp migrate --no-interactive # migration rewrites reference types
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-Rewrote imports in one file
-
-  src/env.d.ts
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied, 1 file had imports rewritten
 
 > cat src/env.d.ts # check reference types rewritten
 /// <reference types="vite-plus" />

--- a/packages/cli/snap-tests-global/migration-skip-vite-dependency/snap.txt
+++ b/packages/cli/snap-tests-global/migration-skip-vite-dependency/snap.txt
@@ -1,24 +1,9 @@
 > vp migrate --no-interactive # migration should skip rewriting vite imports when vite is in dependencies
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-Rewrote imports in one file
-
-  src/index.ts
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied, 1 file had imports rewritten
 
 > cat src/index.ts # vite imports should NOT be rewritten, vitest imports SHOULD be rewritten
 import { defineConfig, type Plugin } from 'vite';

--- a/packages/cli/snap-tests-global/migration-skip-vite-peer-dependency/snap.txt
+++ b/packages/cli/snap-tests-global/migration-skip-vite-peer-dependency/snap.txt
@@ -1,24 +1,9 @@
 > vp migrate --no-interactive # migration should skip rewriting vite imports when vite is in peerDependencies
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-Rewrote imports in one file
-
-  src/index.ts
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied, 1 file had imports rewritten
 
 > cat src/index.ts # vite imports should NOT be rewritten, vitest imports SHOULD be rewritten
 import { defineConfig, type Plugin } from 'vite';

--- a/packages/cli/snap-tests-global/migration-standalone-npm/snap.txt
+++ b/packages/cli/snap-tests-global/migration-standalone-npm/snap.txt
@@ -1,22 +1,9 @@
 > vp migrate --no-interactive --no-hooks # migration should work with npm, add overrides, and update lockfile
 VITE+ - The Unified Toolchain for the Web
 
-
-npm@<semver> installing...
-
-npm@<semver> installed
-
-Installing dependencies...
-
-Dependencies installed
-
-Wrote agent instructions to AGENTS.md
-
-Installing dependencies...
-
-Dependencies installed
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  npm <semver>
+✓ Dependencies installed in <variable>ms
 
 > cat package.json # check package.json has overrides field (not pnpm.overrides)
 {

--- a/packages/cli/snap-tests-global/migration-subpath/snap.txt
+++ b/packages/cli/snap-tests-global/migration-subpath/snap.txt
@@ -3,17 +3,9 @@
 VITE+ - The Unified Toolchain for the Web
 
 
-Using default package manager: pnpm
-
 ⚠ Subdirectory project detected — skipping git hooks setup. Configure hooks at the repository root.
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated foo to Vite+<repeat>
+• Node <semver>  pnpm <semver>
 
 > cat foo/package.json # check package.json
 {

--- a/packages/cli/snap-tests-global/migration-vite-version/snap.txt
+++ b/packages/cli/snap-tests-global/migration-vite-version/snap.txt
@@ -1,20 +1,9 @@
 > vp migrate --no-interactive # migration should rewrite vite --version to vp --version
 VITE+ - The Unified Toolchain for the Web
 
-
-Using default package manager: pnpm
-
-pnpm@latest installing...
-
-pnpm@<semver> installed
-
-✔ Created vite.config.ts in vite.config.ts
-
-✔ Merged staged config into vite.config.ts
-
-Wrote agent instructions to AGENTS.md
-✔ Migration completed!
-
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied
 
 > cat package.json # check package.json
 {

--- a/packages/cli/src/create/__tests__/discovery.spec.ts
+++ b/packages/cli/src/create/__tests__/discovery.spec.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { expandCreateShorthand } from '../discovery.js';
+import {
+  discoverTemplate,
+  expandCreateShorthand,
+  inferGitHubRepoName,
+  parseGitHubUrl,
+} from '../discovery.js';
 
 describe('expandCreateShorthand', () => {
   it('should expand unscoped names to create-* packages', () => {
@@ -57,5 +62,41 @@ describe('expandCreateShorthand', () => {
 
   it('should handle scope-only input gracefully', () => {
     expect(expandCreateShorthand('@scope')).toBe('@scope');
+  });
+});
+
+describe('GitHub template helpers', () => {
+  it('should parse GitHub shorthand URLs', () => {
+    expect(parseGitHubUrl('github:user/repo')).toBe('user/repo');
+  });
+
+  it('should parse GitHub https URLs', () => {
+    expect(parseGitHubUrl('https://github.com/user/repo')).toBe('user/repo');
+    expect(parseGitHubUrl('https://github.com/user/repo.git')).toBe('user/repo');
+  });
+
+  it('should infer the repository name from GitHub templates', () => {
+    expect(inferGitHubRepoName('github:nkzw-tech/fate-template')).toBe('fate-template');
+    expect(inferGitHubRepoName('https://github.com/nkzw-tech/fate-template')).toBe('fate-template');
+  });
+
+  it('should resolve GitHub templates to degit without reusing the original URL as destination', () => {
+    const template = discoverTemplate('https://github.com/nkzw-tech/fate-template', ['my-app'], {
+      rootDir: '/tmp/workspace',
+      isMonorepo: false,
+      monorepoScope: '',
+      workspacePatterns: [],
+      parentDirs: [],
+      packageManager: 'pnpm',
+      packageManagerVersion: 'latest',
+      downloadPackageManager: {
+        binPrefix: '/tmp/bin',
+        version: '10.0.0',
+      } as never,
+      packages: [],
+    });
+
+    expect(template.command).toBe('degit');
+    expect(template.args).toEqual(['nkzw-tech/fate-template', 'my-app']);
   });
 });

--- a/packages/cli/src/create/__tests__/prompts.spec.ts
+++ b/packages/cli/src/create/__tests__/prompts.spec.ts
@@ -1,0 +1,45 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { isTargetDirAvailable, suggestAvailableTargetDir } from '../prompts.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vite-plus-create-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe('target directory helpers', () => {
+  it('reports missing directories as available', () => {
+    const cwd = makeTempDir();
+    expect(isTargetDirAvailable(path.join(cwd, 'new-project'))).toBe(true);
+  });
+
+  it('reports non-empty directories as unavailable', () => {
+    const cwd = makeTempDir();
+    const targetDir = path.join(cwd, 'existing-project');
+    fs.mkdirSync(targetDir, { recursive: true });
+    fs.writeFileSync(path.join(targetDir, 'package.json'), '{}');
+
+    expect(isTargetDirAvailable(targetDir)).toBe(false);
+  });
+
+  it('suggests a different target directory when the default already exists', () => {
+    const cwd = makeTempDir();
+    fs.mkdirSync(path.join(cwd, 'fate-template'), { recursive: true });
+    fs.writeFileSync(path.join(cwd, 'fate-template', 'package.json'), '{}');
+
+    expect(suggestAvailableTargetDir('fate-template', cwd)).not.toBe('fate-template');
+  });
+});

--- a/packages/cli/src/create/bin.ts
+++ b/packages/cli/src/create/bin.ts
@@ -36,8 +36,14 @@ import {
   updateWorkspaceConfig,
 } from '../utils/workspace.js';
 import type { ExecutionResult } from './command.js';
-import { discoverTemplate, inferParentDir } from './discovery.js';
-import { cancelAndExit, checkProjectDirExists, promptPackageNameAndTargetDir } from './prompts.js';
+import { discoverTemplate, inferGitHubRepoName, inferParentDir, isGitHubUrl } from './discovery.js';
+import {
+  cancelAndExit,
+  checkProjectDirExists,
+  promptPackageNameAndTargetDir,
+  promptTargetDir,
+  suggestAvailableTargetDir,
+} from './prompts.js';
 import { getRandomProjectName } from './random-name.js';
 import {
   executeBuiltinTemplate,
@@ -258,6 +264,10 @@ function getTemplateOption(args: string[]) {
   return undefined;
 }
 
+function hasExplicitTargetDir(args: string[]) {
+  return args[0] !== undefined && !args[0].startsWith('-');
+}
+
 function formatTemplateName(templateName: string) {
   const templateAliases: Record<string, string> = {
     lit: 'Lit',
@@ -416,6 +426,7 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
   let selectedAgentTargetPaths: string[] | undefined;
   let selectedEditor: Awaited<ReturnType<typeof selectEditor>>;
   let selectedParentDir: string | undefined;
+  let remoteTargetDir: string | undefined;
   let shouldSetupHooks = false;
 
   if (!selectedTemplateName) {
@@ -590,6 +601,27 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
     selectedParentDir = inferredParentDir;
   }
 
+  if (isGitHubUrl(selectedTemplateName)) {
+    if (hasExplicitTargetDir(selectedTemplateArgs)) {
+      remoteTargetDir = selectedTemplateArgs[0];
+    } else {
+      const inferredTargetDir = inferGitHubRepoName(selectedTemplateName) ?? 'template';
+      const remoteTargetBaseDir = selectedParentDir
+        ? path.join(workspaceInfoOptional.rootDir, selectedParentDir)
+        : workspaceInfoOptional.rootDir;
+      const defaultTargetDir = suggestAvailableTargetDir(inferredTargetDir, remoteTargetBaseDir);
+      if (defaultTargetDir !== inferredTargetDir && options.interactive) {
+        prompts.log.info(
+          `  Target directory "${inferredTargetDir}" already exists. Suggested: ${accent(defaultTargetDir)}`,
+        );
+      }
+      remoteTargetDir = await promptTargetDir(defaultTargetDir, options.interactive, {
+        cwd: remoteTargetBaseDir,
+      });
+      selectedTemplateArgs = [remoteTargetDir, ...selectedTemplateArgs];
+    }
+  }
+
   if (isBuiltinTemplate && !targetDir) {
     if (selectedTemplateName === BuiltinTemplate.monorepo) {
       const selected = await promptPackageNameAndTargetDir(
@@ -657,6 +689,48 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
 
   shouldSetupHooks = await promptGitHooks(options);
 
+  const createProgress =
+    options.interactive && compactOutput ? prompts.spinner({ indicator: 'timer' }) : undefined;
+  let createProgressStarted = false;
+  let createProgressMessage = 'Scaffolding project';
+  const updateCreateProgress = (message: string) => {
+    createProgressMessage = message;
+    if (!createProgress) {
+      return;
+    }
+    if (createProgressStarted) {
+      createProgress.message(message);
+      return;
+    }
+    createProgress.start(message);
+    createProgressStarted = true;
+  };
+  const clearCreateProgress = () => {
+    if (createProgress && createProgressStarted) {
+      createProgress.clear();
+      createProgressStarted = false;
+    }
+  };
+  const failCreateProgress = (message: string) => {
+    if (createProgress && createProgressStarted) {
+      createProgress.error(message);
+      createProgressStarted = false;
+    }
+  };
+  const pauseCreateProgress = () => {
+    if (createProgress && createProgressStarted) {
+      createProgress.pause();
+      createProgressStarted = false;
+    }
+  };
+  const resumeCreateProgress = () => {
+    if (createProgress && !createProgressStarted) {
+      createProgress.resume(createProgressMessage);
+      createProgressStarted = true;
+    }
+  };
+  updateCreateProgress('Scaffolding project');
+
   // Discover template
   const templateInfo = discoverTemplate(
     selectedTemplateName,
@@ -675,10 +749,20 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
     templateInfo.parentDir = undefined;
   }
 
+  if (remoteTargetDir) {
+    const projectDir = templateInfo.parentDir
+      ? path.join(templateInfo.parentDir, remoteTargetDir)
+      : remoteTargetDir;
+    pauseCreateProgress();
+    await checkProjectDirExists(path.join(workspaceInfo.rootDir, projectDir), options.interactive);
+    resumeCreateProgress();
+  }
+
   // #endregion
 
   // #region Handle monorepo template
   if (templateInfo.command === BuiltinTemplate.monorepo) {
+    updateCreateProgress('Creating monorepo');
     await checkProjectDirExists(path.join(workspaceInfo.rootDir, targetDir), options.interactive);
     const result = await executeMonorepoTemplate(
       workspaceInfo,
@@ -688,32 +772,43 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
     );
     const { projectDir } = result;
     if (result.exitCode !== 0 || !projectDir) {
+      failCreateProgress('Scaffolding failed');
       cancelAndExit(`Failed to create monorepo, exit code: ${result.exitCode}`, result.exitCode);
     }
 
     // rewrite monorepo to add vite-plus dependencies
     const fullPath = path.join(workspaceInfo.rootDir, projectDir);
+    updateCreateProgress('Writing agent instructions');
+    pauseCreateProgress();
     await writeAgentInstructions({
       projectRoot: fullPath,
       targetPaths: selectedAgentTargetPaths,
       interactive: options.interactive,
       silent: compactOutput,
     });
+    resumeCreateProgress();
+    updateCreateProgress('Writing editor configs');
+    pauseCreateProgress();
     await writeEditorConfigs({
       projectRoot: fullPath,
       editorId: selectedEditor,
       interactive: options.interactive,
       silent: compactOutput,
     });
+    resumeCreateProgress();
     workspaceInfo.rootDir = fullPath;
+    updateCreateProgress('Integrating monorepo');
     rewriteMonorepo(workspaceInfo, undefined, compactOutput);
     if (shouldSetupHooks) {
       installGitHooks(fullPath, compactOutput);
     }
+    updateCreateProgress('Installing dependencies');
     const installSummary = await runViteInstall(fullPath, options.interactive, undefined, {
       silent: compactOutput,
     });
+    updateCreateProgress('Formatting code');
     await runViteFmt(fullPath, options.interactive, undefined, { silent: compactOutput });
+    clearCreateProgress();
     showCreateSummary({
       description: describeScaffold(selectedTemplateName, selectedTemplateArgs),
       installSummary,
@@ -742,7 +837,10 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
         ? path.join(templateInfo.parentDir, selected.targetDir)
         : selected.targetDir;
     }
+    pauseCreateProgress();
     await checkProjectDirExists(targetDir, options.interactive);
+    resumeCreateProgress();
+    updateCreateProgress('Generating project');
     result = await executeBuiltinTemplate(
       workspaceInfo,
       {
@@ -753,41 +851,52 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
       { silent: compactOutput },
     );
   } else {
+    updateCreateProgress('Generating project');
     result = await executeRemoteTemplate(workspaceInfo, templateInfo, { silent: compactOutput });
   }
 
   if (result.exitCode !== 0) {
+    failCreateProgress('Scaffolding failed');
     process.exit(result.exitCode);
   }
   const projectDir = result.projectDir;
   if (!projectDir) {
+    clearCreateProgress();
     process.exit(0);
   }
 
   const fullPath = path.join(workspaceInfo.rootDir, projectDir);
   const agentInstructionsRoot = isMonorepo ? workspaceInfo.rootDir : fullPath;
+  updateCreateProgress('Writing agent instructions');
+  pauseCreateProgress();
   await writeAgentInstructions({
     projectRoot: agentInstructionsRoot,
     targetPaths: selectedAgentTargetPaths,
     interactive: options.interactive,
     silent: compactOutput,
   });
+  resumeCreateProgress();
+  updateCreateProgress('Writing editor configs');
+  pauseCreateProgress();
   await writeEditorConfigs({
     projectRoot: fullPath,
     editorId: selectedEditor,
     interactive: options.interactive,
     silent: compactOutput,
   });
+  resumeCreateProgress();
 
   let installSummary: CommandRunSummary | undefined;
   if (isMonorepo) {
     if (!compactOutput) {
       prompts.log.step('Monorepo integration...');
     }
+    updateCreateProgress('Integrating into monorepo');
     rewriteMonorepoProject(fullPath, workspaceInfo.packageManager, undefined, compactOutput);
 
     if (workspaceInfo.packages.length > 0) {
       if (options.interactive) {
+        pauseCreateProgress();
         const selectedDepTypeOptions = await prompts.multiselect({
           message: `Add workspace dependencies to ${accent(projectDir)}?`,
           options: [
@@ -839,27 +948,34 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
             );
           }
         }
+        resumeCreateProgress();
       }
     }
 
     updateWorkspaceConfig(projectDir, workspaceInfo);
+    updateCreateProgress('Installing dependencies');
     installSummary = await runViteInstall(workspaceInfo.rootDir, options.interactive, undefined, {
       silent: compactOutput,
     });
+    updateCreateProgress('Formatting code');
     await runViteFmt(workspaceInfo.rootDir, options.interactive, [projectDir], {
       silent: compactOutput,
     });
   } else {
+    updateCreateProgress('Applying Vite+ project setup');
     rewriteStandaloneProject(fullPath, workspaceInfo, undefined, compactOutput);
     if (shouldSetupHooks) {
       installGitHooks(fullPath, compactOutput);
     }
+    updateCreateProgress('Installing dependencies');
     installSummary = await runViteInstall(fullPath, options.interactive, undefined, {
       silent: compactOutput,
     });
+    updateCreateProgress('Formatting code');
     await runViteFmt(fullPath, options.interactive, undefined, { silent: compactOutput });
   }
 
+  clearCreateProgress();
   showCreateSummary({
     description: describeScaffold(selectedTemplateName, selectedTemplateArgs),
     installSummary,

--- a/packages/cli/src/create/discovery.ts
+++ b/packages/cli/src/create/discovery.ts
@@ -30,6 +30,16 @@ export function parseGitHubUrl(url: string): string | null {
   return null;
 }
 
+export function inferGitHubRepoName(templateName: string): string | null {
+  const degitPath = parseGitHubUrl(templateName);
+  if (!degitPath) {
+    return null;
+  }
+
+  const repoName = degitPath.split('/').pop();
+  return repoName || null;
+}
+
 // Discover and identify a template
 export function discoverTemplate(
   templateName: string,
@@ -59,7 +69,7 @@ export function discoverTemplate(
     if (degitPath) {
       return {
         command: 'degit',
-        args: [degitPath, templateName, ...templateArgs],
+        args: [degitPath, ...templateArgs],
         envs,
         type: TemplateType.remote,
         parentDir,

--- a/packages/cli/src/create/prompts.ts
+++ b/packages/cli/src/create/prompts.ts
@@ -5,6 +5,7 @@ import * as prompts from '@voidzero-dev/vite-plus-prompts';
 import validateNpmPackageName from 'validate-npm-package-name';
 
 import { accent } from '../utils/terminal.js';
+import { getRandomProjectName } from './random-name.js';
 import { getProjectDirFromPackageName } from './utils.js';
 
 export async function promptPackageNameAndTargetDir(
@@ -46,8 +47,46 @@ export async function promptPackageNameAndTargetDir(
   return { packageName, targetDir };
 }
 
+export async function promptTargetDir(
+  defaultTargetDir: string,
+  interactive?: boolean,
+  options?: { cwd?: string },
+) {
+  let targetDir: string;
+
+  if (interactive) {
+    const selected = await prompts.text({
+      message: 'Target directory:',
+      placeholder: defaultTargetDir,
+      defaultValue: defaultTargetDir,
+      validate: (value) => validateTargetDir(value ?? defaultTargetDir, options?.cwd).error,
+    });
+    if (prompts.isCancel(selected)) {
+      cancelAndExit();
+    }
+    targetDir = validateTargetDir(selected ?? defaultTargetDir, options?.cwd).directory;
+  } else {
+    targetDir = validateTargetDir(defaultTargetDir, options?.cwd).directory;
+    prompts.log.info(`Using default target directory: ${accent(targetDir)}`);
+  }
+
+  return targetDir;
+}
+
+export function suggestAvailableTargetDir(defaultTargetDir: string, cwd: string) {
+  let suggestedTargetDir = defaultTargetDir;
+  let attempt = 1;
+
+  while (!isTargetDirAvailable(path.join(cwd, suggestedTargetDir))) {
+    suggestedTargetDir = getRandomProjectName({ fallbackName: `${defaultTargetDir}-${attempt}` });
+    attempt++;
+  }
+
+  return suggestedTargetDir;
+}
+
 export async function checkProjectDirExists(projectDirFullPath: string, interactive?: boolean) {
-  if (!fs.existsSync(projectDirFullPath) || isEmpty(projectDirFullPath)) {
+  if (isTargetDirAvailable(projectDirFullPath)) {
     return;
   }
   if (!interactive) {
@@ -105,4 +144,30 @@ function emptyDir(dir: string) {
     }
     fs.rmSync(path.resolve(dir, file), { recursive: true, force: true });
   }
+}
+
+export function isTargetDirAvailable(projectDirFullPath: string) {
+  return !fs.existsSync(projectDirFullPath) || isEmpty(projectDirFullPath);
+}
+
+function validateTargetDir(input?: string, cwd?: string): { directory: string; error?: string } {
+  const value = input?.trim() ?? '';
+  if (!value) {
+    return { directory: '', error: 'Target directory is required' };
+  }
+
+  const targetDir = path.normalize(value);
+  if (!targetDir || targetDir === '.') {
+    return { directory: '', error: 'Target directory is required' };
+  }
+  if (path.isAbsolute(targetDir)) {
+    return { directory: '', error: 'Absolute path is not allowed' };
+  }
+  if (targetDir.includes('..')) {
+    return { directory: '', error: 'Relative path contains ".." which is not allowed' };
+  }
+  if (cwd && !isTargetDirAvailable(path.join(cwd, targetDir))) {
+    return { directory: '', error: `Target directory "${targetDir}" already exists` };
+  }
+  return { directory: targetDir };
 }

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -3,7 +3,6 @@ import { styleText } from 'node:util';
 
 import * as prompts from '@voidzero-dev/vite-plus-prompts';
 import mri from 'mri';
-import colors from 'picocolors';
 import semver from 'semver';
 
 import { vitePlusHeader } from '../../binding/index.js';
@@ -20,13 +19,13 @@ import {
 } from '../utils/agent.js';
 import {
   detectEditorConflicts,
-  EDITORS,
   type EditorId,
   selectEditor,
   writeEditorConfigs,
 } from '../utils/editor.js';
 import { renderCliDoc } from '../utils/help.js';
 import { hasVitePlusDependency, readNearestPackageJson } from '../utils/package.js';
+import { displayRelative } from '../utils/path.js';
 import {
   cancelAndExit,
   defaultInteractive,
@@ -52,8 +51,7 @@ import {
   rewriteMonorepo,
   rewriteStandaloneProject,
 } from './migrator.js';
-
-const { green } = colors;
+import { createMigrationReport, type MigrationReport } from './report.js';
 
 function warnPackageLevelEslint() {
   prompts.log.warn(
@@ -80,7 +78,6 @@ async function confirmEslintMigration(interactive: boolean): Promise<boolean> {
     }
     return !!confirmed;
   }
-  prompts.log.info('ESLint configuration detected. Auto-migrating to Oxlint...');
   return true;
 }
 
@@ -287,22 +284,11 @@ async function collectMigrationPlan(
   options: MigrationOptions,
   packages?: WorkspacePackage[],
 ): Promise<MigrationPlan> {
-  // 1. Confirm migration
-  if (options.interactive) {
-    const approved = await prompts.confirm({
-      message: 'Migrate this project to Vite+?',
-      initialValue: true,
-    });
-    if (prompts.isCancel(approved) || !approved) {
-      cancelAndExit('Migration cancelled');
-    }
-  }
-
-  // 2. Package manager selection
+  // 1. Package manager selection
   const packageManager =
-    detectedPackageManager ?? (await selectPackageManager(options.interactive));
+    detectedPackageManager ?? (await selectPackageManager(options.interactive, true));
 
-  // 3. Git hooks (including preflight check)
+  // 2. Git hooks (including preflight check)
   let shouldSetupHooks = await promptGitHooks(options);
   if (shouldSetupHooks) {
     const reason = preflightGitHooksSetup(rootDir);
@@ -312,14 +298,14 @@ async function collectMigrationPlan(
     }
   }
 
-  // 4. Agent selection
+  // 3. Agent selection
   const selectedAgentTargetPaths = await selectAgentTargetPaths({
     interactive: options.interactive,
     agent: options.agent,
     onCancel: () => cancelAndExit(),
   });
 
-  // 5. Agent conflict detection + prompting
+  // 4. Agent conflict detection + prompting
   const agentConflicts = await detectAgentConflicts({
     projectRoot: rootDir,
     targetPaths: selectedAgentTargetPaths,
@@ -344,14 +330,14 @@ async function collectMigrationPlan(
     }
   }
 
-  // 6. Editor selection
+  // 5. Editor selection
   const selectedEditor = await selectEditor({
     interactive: options.interactive,
     editor: options.editor,
     onCancel: () => cancelAndExit(),
   });
 
-  // 7. Editor conflict detection + prompting
+  // 6. Editor conflict detection + prompting
   const editorConflicts = detectEditorConflicts({
     projectRoot: rootDir,
     editorId: selectedEditor,
@@ -380,7 +366,7 @@ async function collectMigrationPlan(
     }
   }
 
-  // 8. ESLint detection + prompt
+  // 7. ESLint detection + prompt
   const eslintProject = detectEslintProject(rootDir, packages);
   let migrateEslint = false;
   if (eslintProject.hasDependency && !eslintProject.configFile && eslintProject.legacyConfigFile) {
@@ -413,62 +399,140 @@ async function collectMigrationPlan(
     prettierConfigFile: prettierProject.configFile,
   };
 
-  // 10. Display migration plan summary
-  if (options.interactive) {
-    displayMigrationSummary(plan);
-  }
-
   return plan;
 }
 
-function displayMigrationSummary(plan: MigrationPlan) {
-  const lines: string[] = [
-    `- Install ${plan.packageManager} and dependencies`,
-    '- Rewrite configs and dependencies for Vite+',
-  ];
-
-  if (plan.migrateEslint) {
-    lines.push('- Migrate ESLint rules to Oxlint');
+function formatDuration(durationMs: number) {
+  if (durationMs < 1000) {
+    return `${Math.max(1, durationMs)}ms`;
   }
-
-  if (plan.migratePrettier) {
-    lines.push('- Migrate Prettier to Oxfmt');
+  const durationSeconds = durationMs / 1000;
+  if (durationSeconds < 10) {
+    return `${durationSeconds.toFixed(1)}s`;
   }
+  return `${Math.round(durationSeconds)}s`;
+}
 
-  if (plan.shouldSetupHooks) {
-    lines.push('- Set up pre-commit hooks');
+function showMigrationSummary(options: {
+  projectRoot: string;
+  packageManager: string;
+  packageManagerVersion: string;
+  installDurationMs: number;
+  report: MigrationReport;
+  updatedExistingVitePlus?: boolean;
+}) {
+  const {
+    projectRoot,
+    packageManager,
+    packageManagerVersion,
+    installDurationMs,
+    report,
+    updatedExistingVitePlus,
+  } = options;
+  const projectLabel = displayRelative(projectRoot) || '.';
+  const configUpdates =
+    report.createdViteConfigCount +
+    report.mergedConfigCount +
+    report.mergedStagedConfigCount +
+    report.inlinedLintStagedConfigCount +
+    report.removedConfigCount +
+    report.tsdownImportCount;
+
+  log(
+    `${styleText('magenta', '◇')} ${updatedExistingVitePlus ? 'Updated' : 'Migrated'} ${accent(projectLabel)}${
+      updatedExistingVitePlus ? '' : ' to Vite+'
+    }`,
+  );
+  log(
+    `${styleText('gray', '•')} Node ${process.versions.node}  ${packageManager} ${packageManagerVersion}`,
+  );
+  if (installDurationMs > 0) {
+    log(
+      `${styleText('green', '✓')} Dependencies installed in ${formatDuration(installDurationMs)}`,
+    );
   }
-
-  if (plan.selectedAgentTargetPaths && plan.selectedAgentTargetPaths.length > 0) {
-    const parts = plan.selectedAgentTargetPaths.map((tp) => {
-      const action = plan.agentConflictDecisions.get(tp);
-      return action ? `${tp}, ${action}` : tp;
-    });
-    lines.push(`- Write agent instructions (${parts.join('; ')})`);
+  if (configUpdates > 0 || report.rewrittenImportFileCount > 0) {
+    const parts: string[] = [];
+    if (configUpdates > 0) {
+      parts.push(
+        `${configUpdates} ${configUpdates === 1 ? 'config update' : 'config updates'} applied`,
+      );
+    }
+    if (report.rewrittenImportFileCount > 0) {
+      parts.push(
+        `${report.rewrittenImportFileCount} ${
+          report.rewrittenImportFileCount === 1 ? 'file had' : 'files had'
+        } imports rewritten`,
+      );
+    }
+    log(`${styleText('gray', '•')} ${parts.join(', ')}`);
   }
-
-  if (plan.selectedEditor) {
-    const editorConfig = EDITORS.find((e) => e.id === plan.selectedEditor);
-    const targetDir = editorConfig?.targetDir ?? plan.selectedEditor;
-    const decisions = [...plan.editorConflictDecisions.values()];
-    const uniqueActions = [...new Set(decisions)];
-    const actionStr = uniqueActions.length > 0 ? `, ${uniqueActions.join('/')}` : '';
-    lines.push(`- Write editor config (${targetDir}/${actionStr})`);
+  if (report.eslintMigrated) {
+    log(`${styleText('gray', '•')} ESLint rules migrated to Oxlint`);
   }
-
-  prompts.log.info([styleText('bold', 'Migration plan:'), ...lines].join('\n') + '\n');
+  if (report.prettierMigrated) {
+    log(`${styleText('gray', '•')} Prettier migrated to Oxfmt`);
+  }
+  if (report.gitHooksConfigured) {
+    log(`${styleText('gray', '•')} Git hooks configured`);
+  }
+  if (report.warnings.length > 0) {
+    log(`${styleText('yellow', '!')} Warnings:`);
+    for (const warning of report.warnings) {
+      log(`  - ${warning}`);
+    }
+  }
+  if (report.manualSteps.length > 0) {
+    log(`${styleText('blue', '→')} Manual follow-up:`);
+    for (const step of report.manualSteps) {
+      log(`  - ${step}`);
+    }
+  }
 }
 
 async function executeMigrationPlan(
   workspaceInfoOptional: WorkspaceInfoOptional,
   plan: MigrationPlan,
   interactive: boolean,
-) {
+): Promise<{
+  installDurationMs: number;
+  packageManagerVersion: string;
+  report: MigrationReport;
+}> {
+  const report = createMigrationReport();
+  const migrationProgress = interactive ? prompts.spinner({ indicator: 'timer' }) : undefined;
+  let migrationProgressStarted = false;
+  const updateMigrationProgress = (message: string) => {
+    if (!migrationProgress) {
+      return;
+    }
+    if (migrationProgressStarted) {
+      migrationProgress.message(message);
+      return;
+    }
+    migrationProgress.start(message);
+    migrationProgressStarted = true;
+  };
+  const clearMigrationProgress = () => {
+    if (migrationProgress && migrationProgressStarted) {
+      migrationProgress.clear();
+      migrationProgressStarted = false;
+    }
+  };
+  const failMigrationProgress = (message: string) => {
+    if (migrationProgress && migrationProgressStarted) {
+      migrationProgress.error(message);
+      migrationProgressStarted = false;
+    }
+  };
+
   // 1. Download package manager + version validation
+  updateMigrationProgress('Preparing migration');
   const downloadResult = await downloadPackageManager(
     plan.packageManager,
     workspaceInfoOptional.packageManagerVersion,
     interactive,
+    true,
   );
   const workspaceInfo: WorkspaceInfo = {
     ...workspaceInfoOptional,
@@ -481,11 +545,13 @@ async function executeMigrationPlan(
     plan.packageManager === PackageManager.yarn &&
     semver.satisfies(downloadResult.version, '>=4.0.0 <4.10.0')
   ) {
-    await upgradeYarn(workspaceInfo.rootDir, interactive);
+    updateMigrationProgress('Upgrading Yarn');
+    await upgradeYarn(workspaceInfo.rootDir, interactive, true);
   } else if (
     plan.packageManager === PackageManager.pnpm &&
     semver.satisfies(downloadResult.version, '< 9.5.0')
   ) {
+    failMigrationProgress('Migration failed');
     prompts.log.error(
       `✘ pnpm@${downloadResult.version} is not supported by auto migration, please upgrade pnpm to >=9.5.0 first`,
     );
@@ -494,6 +560,7 @@ async function executeMigrationPlan(
     plan.packageManager === PackageManager.npm &&
     semver.satisfies(downloadResult.version, '< 8.3.0')
   ) {
+    failMigrationProgress('Migration failed');
     prompts.log.error(
       `✘ npm@${downloadResult.version} is not supported by auto migration, please upgrade npm to >=8.3.0 first`,
     );
@@ -501,37 +568,53 @@ async function executeMigrationPlan(
   }
 
   // 3. Run vp install to ensure the project is ready
-  await runViteInstall(workspaceInfo.rootDir, interactive);
+  updateMigrationProgress('Installing dependencies');
+  const initialInstallSummary = await runViteInstall(
+    workspaceInfo.rootDir,
+    interactive,
+    undefined,
+    {
+      silent: true,
+    },
+  );
 
   // 4. Check vite and vitest version is supported by migration
+  updateMigrationProgress('Validating toolchain');
   const isViteSupported = checkViteVersion(workspaceInfo.rootDir);
   const isVitestSupported = checkVitestVersion(workspaceInfo.rootDir);
   if (!isViteSupported || !isVitestSupported) {
+    failMigrationProgress('Migration failed');
     cancelAndExit('Vite+ cannot automatically migrate this project yet.', 1);
   }
 
   // 5. ESLint → Oxlint migration (before main rewrite so .oxlintrc.json gets picked up)
   if (plan.migrateEslint) {
+    updateMigrationProgress('Migrating ESLint');
     const eslintOk = await migrateEslintToOxlint(
       workspaceInfo.rootDir,
       interactive,
       plan.eslintConfigFile,
       workspaceInfo.packages,
+      { silent: true, report },
     );
     if (!eslintOk) {
+      failMigrationProgress('Migration failed');
       cancelAndExit('ESLint migration failed. Fix the issue and re-run `vp migrate`.', 1);
     }
   }
 
   // 5b. Prettier → Oxfmt migration (before main rewrite so .oxfmtrc.json gets picked up)
   if (plan.migratePrettier) {
+    updateMigrationProgress('Migrating Prettier');
     const prettierOk = await migratePrettierToOxfmt(
       workspaceInfo.rootDir,
       interactive,
       plan.prettierConfigFile,
       workspaceInfo.packages,
+      { silent: true, report },
     );
     if (!prettierOk) {
+      failMigrationProgress('Migration failed');
       cancelAndExit('Prettier migration failed. Fix the issue and re-run `vp migrate`.', 1);
     }
   }
@@ -542,39 +625,62 @@ async function executeMigrationPlan(
   const skipStagedMigration = !plan.shouldSetupHooks;
 
   // 7. Rewrite configs
+  updateMigrationProgress('Rewriting configs');
   if (workspaceInfo.isMonorepo) {
-    rewriteMonorepo(workspaceInfo, skipStagedMigration);
+    rewriteMonorepo(workspaceInfo, skipStagedMigration, true, report);
   } else {
-    rewriteStandaloneProject(workspaceInfo.rootDir, workspaceInfo, skipStagedMigration);
+    rewriteStandaloneProject(
+      workspaceInfo.rootDir,
+      workspaceInfo,
+      skipStagedMigration,
+      true,
+      report,
+    );
   }
 
   // 8. Install git hooks
   if (plan.shouldSetupHooks) {
-    installGitHooks(workspaceInfo.rootDir);
+    updateMigrationProgress('Configuring git hooks');
+    installGitHooks(workspaceInfo.rootDir, true, report);
   }
 
   // 9. Write agent instructions (using pre-resolved decisions)
+  updateMigrationProgress('Writing agent instructions');
   await writeAgentInstructions({
     projectRoot: workspaceInfo.rootDir,
     targetPaths: plan.selectedAgentTargetPaths,
     interactive,
     conflictDecisions: plan.agentConflictDecisions,
+    silent: true,
   });
 
   // 10. Write editor configs (using pre-resolved decisions)
+  updateMigrationProgress('Writing editor configs');
   await writeEditorConfigs({
     projectRoot: workspaceInfo.rootDir,
     editorId: plan.selectedEditor,
     interactive,
     conflictDecisions: plan.editorConflictDecisions,
+    silent: true,
   });
 
   // 11. Reinstall after migration
   // npm needs --force to re-resolve packages with newly added overrides,
   // otherwise the stale lockfile prevents override resolution.
   const installArgs = plan.packageManager === PackageManager.npm ? ['--force'] : undefined;
-  await runViteInstall(workspaceInfo.rootDir, interactive, installArgs);
-  prompts.outro(green('✔ Migration completed!'));
+  updateMigrationProgress('Installing dependencies');
+  const finalInstallSummary = await runViteInstall(
+    workspaceInfo.rootDir,
+    interactive,
+    installArgs,
+    { silent: true },
+  );
+  clearMigrationProgress();
+  return {
+    installDurationMs: initialInstallSummary.durationMs + finalInstallSummary.durationMs,
+    packageManagerVersion: downloadResult.version,
+    report,
+  };
 }
 
 async function main() {
@@ -586,14 +692,38 @@ async function main() {
     return;
   }
 
-  prompts.intro(vitePlusHeader());
+  log(`${vitePlusHeader()}\n`);
 
   const workspaceInfoOptional = await detectWorkspace(projectPath);
+  const resolvedPackageManager = workspaceInfoOptional.packageManager ?? 'unknown';
 
   // Early return if already using Vite+ (only ESLint/hooks migration may be needed)
   const rootPkg = readNearestPackageJson<PackageDependencies>(workspaceInfoOptional.rootDir);
   if (hasVitePlusDependency(rootPkg)) {
     let didMigrate = false;
+    let installDurationMs = 0;
+    const report = createMigrationReport();
+    const migrationProgress = options.interactive
+      ? prompts.spinner({ indicator: 'timer' })
+      : undefined;
+    let migrationProgressStarted = false;
+    const updateMigrationProgress = (message: string) => {
+      if (!migrationProgress) {
+        return;
+      }
+      if (migrationProgressStarted) {
+        migrationProgress.message(message);
+        return;
+      }
+      migrationProgress.start(message);
+      migrationProgressStarted = true;
+    };
+    const clearMigrationProgress = () => {
+      if (migrationProgress && migrationProgressStarted) {
+        migrationProgress.clear();
+        migrationProgressStarted = false;
+      }
+    };
 
     // Check if ESLint migration is needed
     const eslintMigrated = await promptEslintMigration(
@@ -611,9 +741,21 @@ async function main() {
 
     // Merge configs and reinstall once if any tool migration happened
     if (eslintMigrated || prettierMigrated) {
-      mergeViteConfigFiles(workspaceInfoOptional.rootDir);
-      await runViteInstall(workspaceInfoOptional.rootDir, options.interactive);
+      updateMigrationProgress('Rewriting configs');
+      mergeViteConfigFiles(workspaceInfoOptional.rootDir, true, report);
+      updateMigrationProgress('Installing dependencies');
+      const installSummary = await runViteInstall(
+        workspaceInfoOptional.rootDir,
+        options.interactive,
+        undefined,
+        {
+          silent: true,
+        },
+      );
+      installDurationMs += installSummary.durationMs;
       didMigrate = true;
+      report.eslintMigrated = eslintMigrated;
+      report.prettierMigrated = prettierMigrated;
     }
 
     // Check if husky/lint-staged migration is needed
@@ -624,13 +766,24 @@ async function main() {
       rootPkg?.dependencies?.['lint-staged'];
     if (hasHooksToMigrate) {
       const shouldSetupHooks = await promptGitHooks(options);
-      if (shouldSetupHooks && installGitHooks(workspaceInfoOptional.rootDir)) {
+      if (shouldSetupHooks) {
+        updateMigrationProgress('Configuring git hooks');
+      }
+      if (shouldSetupHooks && installGitHooks(workspaceInfoOptional.rootDir, true, report)) {
         didMigrate = true;
       }
     }
 
     if (didMigrate) {
-      prompts.outro(green('✔ Migration completed!'));
+      clearMigrationProgress();
+      showMigrationSummary({
+        projectRoot: workspaceInfoOptional.rootDir,
+        packageManager: resolvedPackageManager,
+        packageManagerVersion: workspaceInfoOptional.packageManagerVersion,
+        installDurationMs,
+        report,
+        updatedExistingVitePlus: true,
+      });
     } else {
       prompts.outro(`This project is already using Vite+! ${accent(`Happy coding!`)}`);
     }
@@ -646,7 +799,14 @@ async function main() {
   );
 
   // Phase 2: Execute without prompts
-  await executeMigrationPlan(workspaceInfoOptional, plan, options.interactive);
+  const result = await executeMigrationPlan(workspaceInfoOptional, plan, options.interactive);
+  showMigrationSummary({
+    projectRoot: workspaceInfoOptional.rootDir,
+    packageManager: plan.packageManager,
+    packageManagerVersion: result.packageManagerVersion,
+    installDurationMs: result.installDurationMs,
+    report: result.report,
+  });
 }
 
 main().catch((err) => {

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -35,6 +35,7 @@ import {
   detectConfigs,
   type ConfigFiles,
 } from './detector.js';
+import { addManualStep, addMigrationWarning, type MigrationReport } from './report.js';
 
 // All known lint-staged config file names.
 // JSON-parseable ones come first so rewriteLintStagedConfigFile can rewrite them.
@@ -71,6 +72,20 @@ const REMOVE_PACKAGES = [
   '@vitest/browser-playwright',
   '@vitest/browser-webdriverio',
 ] as const;
+
+function warnMigration(message: string, report?: MigrationReport) {
+  addMigrationWarning(report, message);
+  if (!report) {
+    prompts.log.warn(message);
+  }
+}
+
+function infoMigration(message: string, report?: MigrationReport) {
+  addManualStep(report, message);
+  if (!report) {
+    prompts.log.info(message);
+  }
+}
 
 export function checkViteVersion(projectPath: string): boolean {
   return checkPackageVersion(projectPath, 'vite', '7.0.0');
@@ -187,9 +202,22 @@ export async function migrateEslintToOxlint(
   interactive: boolean,
   eslintConfigFile?: string,
   packages?: WorkspacePackage[],
+  options?: { silent?: boolean; report?: MigrationReport },
 ): Promise<boolean> {
   const vpBin = process.env.VITE_PLUS_CLI_BIN ?? 'vp';
-  const spinner = getSpinner(interactive);
+  const spinner = options?.silent
+    ? {
+        start: () => {},
+        stop: () => {},
+        pause: () => {},
+        resume: () => {},
+        cancel: () => {},
+        error: () => {},
+        clear: () => {},
+        message: () => {},
+        isCancelled: false,
+      }
+    : getSpinner(interactive);
 
   // Steps 1-2: Only run @oxlint/migrate if there's an eslint config at root
   if (eslintConfigFile) {
@@ -228,8 +256,12 @@ export async function migrateEslintToOxlint(
     // Continue with cleanup regardless — .oxlintrc.json was generated successfully
   }
 
+  if (options?.report) {
+    options.report.eslintMigrated = true;
+  }
+
   // Step 3: Delete all eslint config files at root
-  deleteEslintConfigFiles(projectPath);
+  deleteEslintConfigFiles(projectPath, options?.report, options?.silent);
 
   // Step 4: Remove eslint dependency and rewrite eslint scripts (root only)
   rewriteEslintPackageJson(path.join(projectPath, 'package.json'));
@@ -242,19 +274,24 @@ export async function migrateEslintToOxlint(
   }
 
   // Step 5: Rewrite eslint references in lint-staged config files
-  rewriteEslintLintStagedConfigFiles(projectPath);
+  rewriteEslintLintStagedConfigFiles(projectPath, options?.report);
 
   return true;
 }
 
-function deleteEslintConfigFiles(basePath: string): void {
+function deleteEslintConfigFiles(basePath: string, report?: MigrationReport, silent = false): void {
   const configs = detectConfigs(basePath);
   for (const file of [configs.eslintConfig, configs.eslintLegacyConfig]) {
     if (file) {
       const configPath = path.join(basePath, file);
       if (fs.existsSync(configPath)) {
         fs.unlinkSync(configPath);
-        prompts.log.success(`✔ Removed ${displayRelative(configPath)}`);
+        if (report) {
+          report.removedConfigCount++;
+        }
+        if (!silent) {
+          prompts.log.success(`✔ Removed ${displayRelative(configPath)}`);
+        }
       }
     }
   }
@@ -302,6 +339,7 @@ function rewriteToolLintStagedConfigFiles(
   projectPath: string,
   rewriteFn: (json: string) => string | null,
   toolName: string,
+  report?: MigrationReport,
 ): void {
   for (const filename of LINT_STAGED_JSON_CONFIG_FILES) {
     const configPath = path.join(projectPath, filename);
@@ -309,8 +347,9 @@ function rewriteToolLintStagedConfigFiles(
       continue;
     }
     if (filename === '.lintstagedrc' && !isJsonFile(configPath)) {
-      prompts.log.warn(
-        `⚠ ${displayRelative(configPath)} is not JSON — please update ${toolName} references manually`,
+      warnMigration(
+        `${displayRelative(configPath)} is not JSON — please update ${toolName} references manually`,
+        report,
       );
       continue;
     }
@@ -327,14 +366,15 @@ function rewriteToolLintStagedConfigFiles(
     if (!fs.existsSync(configPath)) {
       continue;
     }
-    prompts.log.warn(
-      `⚠ ${displayRelative(configPath)} — please update ${toolName} references manually`,
+    warnMigration(
+      `${displayRelative(configPath)} — please update ${toolName} references manually`,
+      report,
     );
   }
 }
 
-function rewriteEslintLintStagedConfigFiles(projectPath: string): void {
-  rewriteToolLintStagedConfigFiles(projectPath, rewriteEslint, 'eslint');
+function rewriteEslintLintStagedConfigFiles(projectPath: string, report?: MigrationReport): void {
+  rewriteToolLintStagedConfigFiles(projectPath, rewriteEslint, 'eslint', report);
 }
 
 export function detectPrettierProject(
@@ -417,9 +457,22 @@ export async function migratePrettierToOxfmt(
   interactive: boolean,
   prettierConfigFile?: string,
   packages?: WorkspacePackage[],
+  options?: { silent?: boolean; report?: MigrationReport },
 ): Promise<boolean> {
   const vpBin = process.env.VITE_PLUS_CLI_BIN ?? 'vp';
-  const spinner = getSpinner(interactive);
+  const spinner = options?.silent
+    ? {
+        start: () => {},
+        stop: () => {},
+        pause: () => {},
+        resume: () => {},
+        cancel: () => {},
+        error: () => {},
+        clear: () => {},
+        message: () => {},
+        isCancelled: false,
+      }
+    : getSpinner(interactive);
 
   // Step 1: Generate .oxfmtrc.json from Prettier config
   if (prettierConfigFile) {
@@ -461,8 +514,12 @@ export async function migratePrettierToOxfmt(
     }
   }
 
+  if (options?.report) {
+    options.report.prettierMigrated = true;
+  }
+
   // Step 2: Delete all prettier config files at root
-  deletePrettierConfigFiles(projectPath);
+  deletePrettierConfigFiles(projectPath, options?.report, options?.silent);
 
   // Step 3: Remove prettier dependency and rewrite prettier scripts (root)
   rewritePrettierPackageJson(path.join(projectPath, 'package.json'));
@@ -475,27 +532,37 @@ export async function migratePrettierToOxfmt(
   }
 
   // Step 4: Rewrite prettier references in lint-staged config files
-  rewritePrettierLintStagedConfigFiles(projectPath);
+  rewritePrettierLintStagedConfigFiles(projectPath, options?.report);
 
   // Step 5: Warn about .prettierignore if it exists
   const prettierIgnorePath = path.join(projectPath, '.prettierignore');
   if (fs.existsSync(prettierIgnorePath)) {
-    prompts.log.warn(
-      `⚠ ${displayRelative(prettierIgnorePath)} found — Oxfmt uses .oxfmtignore. Please migrate manually.`,
+    warnMigration(
+      `${displayRelative(prettierIgnorePath)} found — Oxfmt uses .oxfmtignore. Please migrate manually.`,
+      options?.report,
     );
   }
 
   return true;
 }
 
-function deletePrettierConfigFiles(basePath: string): void {
+function deletePrettierConfigFiles(
+  basePath: string,
+  report?: MigrationReport,
+  silent = false,
+): void {
   // Delete detected prettier config file (like deleteEslintConfigFiles uses detectConfigs)
   const configs = detectConfigs(basePath);
   if (configs.prettierConfig && configs.prettierConfig !== PRETTIER_PACKAGE_JSON_CONFIG) {
     const configPath = path.join(basePath, configs.prettierConfig);
     if (fs.existsSync(configPath)) {
       fs.unlinkSync(configPath);
-      prompts.log.success(`✔ Removed ${displayRelative(configPath)}`);
+      if (report) {
+        report.removedConfigCount++;
+      }
+      if (!silent) {
+        prompts.log.success(`✔ Removed ${displayRelative(configPath)}`);
+      }
     }
   }
   // Also clean up any stale prettier config files that detectConfigs didn't pick
@@ -507,7 +574,12 @@ function deletePrettierConfigFiles(basePath: string): void {
     const configPath = path.join(basePath, file);
     if (fs.existsSync(configPath)) {
       fs.unlinkSync(configPath);
-      prompts.log.success(`✔ Removed ${displayRelative(configPath)}`);
+      if (report) {
+        report.removedConfigCount++;
+      }
+      if (!silent) {
+        prompts.log.success(`✔ Removed ${displayRelative(configPath)}`);
+      }
     }
   }
   // Remove "prettier" key from package.json if present
@@ -566,8 +638,8 @@ function rewritePrettierPackageJson(packageJsonPath: string): void {
   });
 }
 
-function rewritePrettierLintStagedConfigFiles(projectPath: string): void {
-  rewriteToolLintStagedConfigFiles(projectPath, rewritePrettier, 'prettier');
+function rewritePrettierLintStagedConfigFiles(projectPath: string, report?: MigrationReport): void {
+  rewriteToolLintStagedConfigFiles(projectPath, rewritePrettier, 'prettier', report);
 }
 
 /**
@@ -579,6 +651,7 @@ export function rewriteStandaloneProject(
   workspaceInfo: WorkspaceInfo,
   skipStagedMigration?: boolean,
   silent = false,
+  report?: MigrationReport,
 ): void {
   const packageJsonPath = path.join(projectPath, 'package.json');
   if (!fs.existsSync(packageJsonPath)) {
@@ -642,18 +715,18 @@ export function rewriteStandaloneProject(
 
   // Merge extracted staged config into vite.config.ts, then remove lint-staged from package.json
   if (extractedStagedConfig) {
-    if (mergeStagedConfigToViteConfig(projectPath, extractedStagedConfig, silent)) {
+    if (mergeStagedConfigToViteConfig(projectPath, extractedStagedConfig, silent, report)) {
       removeLintStagedFromPackageJson(packageJsonPath);
     }
   }
 
   if (!skipStagedMigration) {
-    rewriteLintStagedConfigFile(projectPath);
+    rewriteLintStagedConfigFile(projectPath, report);
   }
-  mergeViteConfigFiles(projectPath, silent);
-  mergeTsdownConfigFile(projectPath, silent);
+  mergeViteConfigFiles(projectPath, silent, report);
+  mergeTsdownConfigFile(projectPath, silent, report);
   // rewrite imports in all TypeScript/JavaScript files
-  rewriteAllImports(projectPath, silent);
+  rewriteAllImports(projectPath, silent, report);
   // set package manager
   setPackageManager(projectPath, workspaceInfo.downloadPackageManager);
 }
@@ -666,6 +739,7 @@ export function rewriteMonorepo(
   workspaceInfo: WorkspaceInfo,
   skipStagedMigration?: boolean,
   silent = false,
+  report?: MigrationReport,
 ): void {
   // rewrite root workspace
   if (workspaceInfo.packageManager === PackageManager.pnpm) {
@@ -686,16 +760,17 @@ export function rewriteMonorepo(
       workspaceInfo.packageManager,
       skipStagedMigration,
       silent,
+      report,
     );
   }
 
   if (!skipStagedMigration) {
-    rewriteLintStagedConfigFile(workspaceInfo.rootDir);
+    rewriteLintStagedConfigFile(workspaceInfo.rootDir, report);
   }
-  mergeViteConfigFiles(workspaceInfo.rootDir, silent);
-  mergeTsdownConfigFile(workspaceInfo.rootDir, silent);
+  mergeViteConfigFiles(workspaceInfo.rootDir, silent, report);
+  mergeTsdownConfigFile(workspaceInfo.rootDir, silent, report);
   // rewrite imports in all TypeScript/JavaScript files
-  rewriteAllImports(workspaceInfo.rootDir, silent);
+  rewriteAllImports(workspaceInfo.rootDir, silent, report);
   // set package manager
   setPackageManager(workspaceInfo.rootDir, workspaceInfo.downloadPackageManager);
 }
@@ -709,9 +784,10 @@ export function rewriteMonorepoProject(
   packageManager: PackageManager,
   skipStagedMigration?: boolean,
   silent = false,
+  report?: MigrationReport,
 ): void {
-  mergeViteConfigFiles(projectPath, silent);
-  mergeTsdownConfigFile(projectPath, silent);
+  mergeViteConfigFiles(projectPath, silent, report);
+  mergeTsdownConfigFile(projectPath, silent, report);
 
   const packageJsonPath = path.join(projectPath, 'package.json');
   if (!fs.existsSync(packageJsonPath)) {
@@ -731,7 +807,7 @@ export function rewriteMonorepoProject(
 
   // Merge extracted staged config into vite.config.ts, then remove lint-staged from package.json
   if (extractedStagedConfig) {
-    if (mergeStagedConfigToViteConfig(projectPath, extractedStagedConfig, silent)) {
+    if (mergeStagedConfigToViteConfig(projectPath, extractedStagedConfig, silent, report)) {
       removeLintStagedFromPackageJson(packageJsonPath);
     }
   }
@@ -1050,7 +1126,7 @@ function removeLintStagedFromPackageJson(packageJsonPath: string): void {
 
 // Migrate standalone lint-staged config files into staged in vite.config.ts.
 // JSON-parseable files are inlined automatically; non-JSON files get a warning.
-function rewriteLintStagedConfigFile(projectPath: string): void {
+function rewriteLintStagedConfigFile(projectPath: string, report?: MigrationReport): void {
   let hasUnsupported = false;
 
   for (const filename of LINT_STAGED_JSON_CONFIG_FILES) {
@@ -1059,8 +1135,9 @@ function rewriteLintStagedConfigFile(projectPath: string): void {
       continue;
     }
     if (filename === '.lintstagedrc' && !isJsonFile(configPath)) {
-      prompts.log.warn(
-        `✘ ${displayRelative(configPath)} is not JSON format — please migrate to "staged" in vite.config.ts manually`,
+      warnMigration(
+        `${displayRelative(configPath)} is not JSON format — please migrate to "staged" in vite.config.ts manually`,
+        report,
       );
       hasUnsupported = true;
       continue;
@@ -1071,17 +1148,18 @@ function rewriteLintStagedConfigFile(projectPath: string): void {
       const config = readJsonFile(configPath);
       const updated = rewriteScripts(JSON.stringify(config), readRulesYaml());
       const finalConfig = updated ? JSON.parse(updated) : config;
-      if (!mergeStagedConfigToViteConfig(projectPath, finalConfig)) {
+      if (!mergeStagedConfigToViteConfig(projectPath, finalConfig, true, report)) {
         // Merge failed — preserve the original config file so the user doesn't lose their rules
         continue;
       }
       fs.unlinkSync(configPath);
-      prompts.log.success(
-        `✔ Inlined ${displayRelative(configPath)} into "staged" in vite.config.ts`,
-      );
+      if (report) {
+        report.inlinedLintStagedConfigCount++;
+      }
     } else {
-      prompts.log.warn(
-        `⚠ ${displayRelative(configPath)} found but "staged" already exists in vite.config.ts — please merge manually`,
+      warnMigration(
+        `${displayRelative(configPath)} found but "staged" already exists in vite.config.ts — please merge manually`,
+        report,
       );
     }
   }
@@ -1091,14 +1169,16 @@ function rewriteLintStagedConfigFile(projectPath: string): void {
     if (!fs.existsSync(configPath)) {
       continue;
     }
-    prompts.log.warn(
-      `✘ ${displayRelative(configPath)} — please migrate to "staged" in vite.config.ts manually`,
+    warnMigration(
+      `${displayRelative(configPath)} — please migrate to "staged" in vite.config.ts manually`,
+      report,
     );
     hasUnsupported = true;
   }
   if (hasUnsupported) {
-    prompts.log.warn(
-      `Only "staged" in vite.config.ts is supported. See https://viteplus.dev/migration/#lint-staged`,
+    infoMigration(
+      'Only "staged" in vite.config.ts is supported. See https://viteplus.dev/migration/#lint-staged',
+      report,
     );
   }
 }
@@ -1107,7 +1187,12 @@ function rewriteLintStagedConfigFile(projectPath: string): void {
  * Ensure vite.config.ts exists, create it if not
  * @returns The vite config filename
  */
-function ensureViteConfig(projectPath: string, configs: ConfigFiles, silent = false): string {
+function ensureViteConfig(
+  projectPath: string,
+  configs: ConfigFiles,
+  silent = false,
+  report?: MigrationReport,
+): string {
   if (!configs.viteConfig) {
     configs.viteConfig = 'vite.config.ts';
     const viteConfigPath = path.join(projectPath, 'vite.config.ts');
@@ -1118,6 +1203,9 @@ function ensureViteConfig(projectPath: string, configs: ConfigFiles, silent = fa
 export default defineConfig({});
 `,
     );
+    if (report) {
+      report.createdViteConfigCount++;
+    }
     if (!silent) {
       prompts.log.success(`✔ Created vite.config.ts in ${displayRelative(viteConfigPath)}`);
     }
@@ -1130,19 +1218,23 @@ export default defineConfig({});
  * - For JSON files: merge content directly into `pack` field and delete the JSON file
  * - For TS/JS files: import the config file
  */
-function mergeTsdownConfigFile(projectPath: string, silent = false): void {
+function mergeTsdownConfigFile(
+  projectPath: string,
+  silent = false,
+  report?: MigrationReport,
+): void {
   const configs = detectConfigs(projectPath);
   if (!configs.tsdownConfig) {
     return;
   }
-  const viteConfig = ensureViteConfig(projectPath, configs, silent);
+  const viteConfig = ensureViteConfig(projectPath, configs, silent, report);
 
   const fullViteConfigPath = path.join(projectPath, viteConfig);
   const fullTsdownConfigPath = path.join(projectPath, configs.tsdownConfig);
 
   // For JSON files, merge content directly and delete the file
   if (configs.tsdownConfig.endsWith('.json')) {
-    mergeAndRemoveJsonConfig(projectPath, viteConfig, configs.tsdownConfig, 'pack');
+    mergeAndRemoveJsonConfig(projectPath, viteConfig, configs.tsdownConfig, 'pack', silent, report);
     return;
   }
 
@@ -1151,6 +1243,9 @@ function mergeTsdownConfigFile(projectPath: string, silent = false): void {
   const result = mergeTsdownConfig(fullViteConfigPath, tsdownRelativePath);
   if (result.updated) {
     fs.writeFileSync(fullViteConfigPath, result.content);
+    if (report) {
+      report.tsdownImportCount++;
+    }
     if (!silent) {
       prompts.log.success(
         `✔ Added import for ${displayRelative(fullTsdownConfigPath)} in ${displayRelative(fullViteConfigPath)}`,
@@ -1158,22 +1253,25 @@ function mergeTsdownConfigFile(projectPath: string, silent = false): void {
     }
   }
   // Show documentation link for manual merging since we only added the import
-  if (!silent) {
-    prompts.log.info(
-      `Please manually merge ${displayRelative(fullTsdownConfigPath)} into ${displayRelative(fullViteConfigPath)}, see https://viteplus.dev/migration/#tsdown`,
-    );
-  }
+  infoMigration(
+    `Please manually merge ${displayRelative(fullTsdownConfigPath)} into ${displayRelative(fullViteConfigPath)}, see https://viteplus.dev/migration/#tsdown`,
+    report,
+  );
 }
 
 /**
  * Merge oxlint and oxfmt config into vite.config.ts
  */
-export function mergeViteConfigFiles(projectPath: string, silent = false): void {
+export function mergeViteConfigFiles(
+  projectPath: string,
+  silent = false,
+  report?: MigrationReport,
+): void {
   const configs = detectConfigs(projectPath);
   if (!configs.oxfmtConfig && !configs.oxlintConfig) {
     return;
   }
-  const viteConfig = ensureViteConfig(projectPath, configs, silent);
+  const viteConfig = ensureViteConfig(projectPath, configs, silent, report);
   if (configs.oxlintConfig) {
     // Inject options.typeAware and options.typeCheck defaults before merging
     const fullOxlintPath = path.join(projectPath, configs.oxlintConfig);
@@ -1189,16 +1287,16 @@ export function mergeViteConfigFiles(projectPath: string, silent = false): void 
       if (oxlintJson.options.typeCheck === undefined) {
         oxlintJson.options.typeCheck = true;
       }
-    } else if (!silent) {
-      prompts.log.warn(BASEURL_TSCONFIG_WARNING);
+    } else {
+      warnMigration(BASEURL_TSCONFIG_WARNING, report);
     }
     fs.writeFileSync(fullOxlintPath, JSON.stringify(oxlintJson, null, 2));
     // merge oxlint config into vite.config.ts
-    mergeAndRemoveJsonConfig(projectPath, viteConfig, configs.oxlintConfig, 'lint', silent);
+    mergeAndRemoveJsonConfig(projectPath, viteConfig, configs.oxlintConfig, 'lint', silent, report);
   }
   if (configs.oxfmtConfig) {
     // merge oxfmt config into vite.config.ts
-    mergeAndRemoveJsonConfig(projectPath, viteConfig, configs.oxfmtConfig, 'fmt', silent);
+    mergeAndRemoveJsonConfig(projectPath, viteConfig, configs.oxfmtConfig, 'fmt', silent, report);
   }
 }
 
@@ -1208,6 +1306,7 @@ function mergeAndRemoveJsonConfig(
   jsonConfigPath: string,
   configKey: string,
   silent = false,
+  report?: MigrationReport,
 ): void {
   const fullViteConfigPath = path.join(projectPath, viteConfigPath);
   const fullJsonConfigPath = path.join(projectPath, jsonConfigPath);
@@ -1215,17 +1314,22 @@ function mergeAndRemoveJsonConfig(
   if (result.updated) {
     fs.writeFileSync(fullViteConfigPath, result.content);
     fs.unlinkSync(fullJsonConfigPath);
+    if (report) {
+      report.mergedConfigCount++;
+    }
     if (!silent) {
       prompts.log.success(
         `✔ Merged ${displayRelative(fullJsonConfigPath)} into ${displayRelative(fullViteConfigPath)}`,
       );
     }
   } else {
-    prompts.log.warn(
-      `✘ Failed to merge ${displayRelative(fullJsonConfigPath)} into ${displayRelative(fullViteConfigPath)}`,
+    warnMigration(
+      `Failed to merge ${displayRelative(fullJsonConfigPath)} into ${displayRelative(fullViteConfigPath)}`,
+      report,
     );
-    prompts.log.info(
-      `Please complete the merge manually and follow the instructions in the documentation: https://viteplus.dev/config/`,
+    infoMigration(
+      'Please complete the merge manually and follow the instructions in the documentation: https://viteplus.dev/config/',
+      report,
     );
   }
 }
@@ -1238,9 +1342,10 @@ function mergeStagedConfigToViteConfig(
   projectPath: string,
   stagedConfig: Record<string, string | string[]>,
   silent = false,
+  report?: MigrationReport,
 ): boolean {
   const configs = detectConfigs(projectPath);
-  const viteConfig = ensureViteConfig(projectPath, configs);
+  const viteConfig = ensureViteConfig(projectPath, configs, silent, report);
   const fullViteConfigPath = path.join(projectPath, viteConfig);
 
   // Write staged config to a temp JSON file for mergeJsonConfig NAPI
@@ -1256,14 +1361,21 @@ function mergeStagedConfigToViteConfig(
 
   if (result.updated) {
     fs.writeFileSync(fullViteConfigPath, result.content);
+    if (report) {
+      report.mergedStagedConfigCount++;
+    }
     if (!silent) {
       prompts.log.success(`✔ Merged staged config into ${displayRelative(fullViteConfigPath)}`);
     }
     return true;
   } else {
-    prompts.log.warn(`✘ Failed to merge staged config into ${displayRelative(fullViteConfigPath)}`);
-    prompts.log.info(
+    warnMigration(
+      `Failed to merge staged config into ${displayRelative(fullViteConfigPath)}`,
+      report,
+    );
+    infoMigration(
       `Please add staged config to ${displayRelative(fullViteConfigPath)} manually, see https://viteplus.dev/config/`,
+      report,
     );
     return false;
   }
@@ -1287,10 +1399,20 @@ function hasStagedConfigInViteConfig(projectPath: string): boolean {
  * This rewrites vite/vitest imports to @voidzero-dev/vite-plus
  * @param projectPath - The root directory to search for files
  */
-function rewriteAllImports(projectPath: string, silent = false): void {
+function rewriteAllImports(projectPath: string, silent = false, report?: MigrationReport): void {
   const result = rewriteImportsInDirectory(projectPath);
   const modified = result.modifiedFiles.length;
   const errors = result.errors.length;
+
+  if (report) {
+    report.rewrittenImportFileCount += modified;
+    report.rewrittenImportErrors.push(
+      ...result.errors.map((error) => ({
+        path: displayRelative(error.path),
+        message: error.message,
+      })),
+    );
+  }
 
   if (!silent && modified > 0) {
     prompts.log.success(`Rewrote imports in ${modified === 1 ? 'one file' : `${modified} files`}`);
@@ -1298,9 +1420,18 @@ function rewriteAllImports(projectPath: string, silent = false): void {
   }
 
   if (errors > 0) {
-    prompts.log.warn(`⚠ ${errors === 1 ? 'one file had an error' : `${errors} files had errors`}:`);
-    for (const error of result.errors) {
-      prompts.log.error(`  ${displayRelative(error.path)}: ${error.message}`);
+    if (report) {
+      warnMigration(
+        `${errors === 1 ? 'one file had an error' : `${errors} files had errors`} while rewriting imports`,
+        report,
+      );
+    } else {
+      prompts.log.warn(
+        `⚠ ${errors === 1 ? 'one file had an error' : `${errors} files had errors`}:`,
+      );
+      for (const error of result.errors) {
+        prompts.log.error(`  ${displayRelative(error.path)}: ${error.message}`);
+      }
     }
   }
 }
@@ -1374,9 +1505,13 @@ function collapseHuskyInstall(script: string): string {
  * High-level helper: detect old hooks dir, set up git hooks, and rewrite
  * the prepare script.  Returns true if hooks were successfully installed.
  */
-export function installGitHooks(projectPath: string, silent = false): boolean {
+export function installGitHooks(
+  projectPath: string,
+  silent = false,
+  report?: MigrationReport,
+): boolean {
   const oldHooksDir = getOldHooksDir(projectPath);
-  if (setupGitHooks(projectPath, oldHooksDir, silent)) {
+  if (setupGitHooks(projectPath, oldHooksDir, silent, report)) {
     rewritePrepareScript(projectPath);
     return true;
   }
@@ -1443,10 +1578,15 @@ export function preflightGitHooksSetup(projectPath: string): string | null {
  * Skips if another hook tool is detected (warns user).
  * Returns true if hooks were successfully set up, false if skipped.
  */
-export function setupGitHooks(projectPath: string, oldHooksDir?: string, silent = false): boolean {
+export function setupGitHooks(
+  projectPath: string,
+  oldHooksDir?: string,
+  silent = false,
+  report?: MigrationReport,
+): boolean {
   const reason = preflightGitHooksSetup(projectPath);
   if (reason) {
-    prompts.log.warn(`⚠ ${reason}`);
+    warnMigration(reason, report);
     return false;
   }
 
@@ -1498,7 +1638,7 @@ export function setupGitHooks(projectPath: string, oldHooksDir?: string, silent 
     const finalConfig: Record<string, string | string[]> = updated
       ? JSON.parse(updated)
       : stagedConfig;
-    stagedMerged = mergeStagedConfigToViteConfig(projectPath, finalConfig, silent);
+    stagedMerged = mergeStagedConfigToViteConfig(projectPath, finalConfig, silent, report);
   }
 
   // Only remove lint-staged key from package.json after staged config is
@@ -1574,16 +1714,19 @@ export function setupGitHooks(projectPath: string, oldHooksDir?: string, silent 
     // already set, .git not found, etc.).
     const stdout = configResult.stdout?.toString().trim() ?? '';
     if (stdout) {
-      prompts.log.warn(`⚠ Git hooks not configured — ${stdout}`);
+      warnMigration(`Git hooks not configured — ${stdout}`, report);
       return false;
     }
     removeReplacedHookPackages(packageJsonPath);
+    if (report) {
+      report.gitHooksConfigured = true;
+    }
     if (!silent) {
       prompts.log.success('✔ Git hooks configured');
     }
     return true;
   }
-  prompts.log.warn('Failed to install git hooks');
+  warnMigration('Failed to install git hooks', report);
   return false;
 }
 

--- a/packages/cli/src/migration/report.ts
+++ b/packages/cli/src/migration/report.ts
@@ -1,0 +1,47 @@
+export interface MigrationReport {
+  createdViteConfigCount: number;
+  mergedConfigCount: number;
+  mergedStagedConfigCount: number;
+  inlinedLintStagedConfigCount: number;
+  removedConfigCount: number;
+  tsdownImportCount: number;
+  rewrittenImportFileCount: number;
+  rewrittenImportErrors: Array<{ path: string; message: string }>;
+  eslintMigrated: boolean;
+  prettierMigrated: boolean;
+  gitHooksConfigured: boolean;
+  warnings: string[];
+  manualSteps: string[];
+}
+
+export function createMigrationReport(): MigrationReport {
+  return {
+    createdViteConfigCount: 0,
+    mergedConfigCount: 0,
+    mergedStagedConfigCount: 0,
+    inlinedLintStagedConfigCount: 0,
+    removedConfigCount: 0,
+    tsdownImportCount: 0,
+    rewrittenImportFileCount: 0,
+    rewrittenImportErrors: [],
+    eslintMigrated: false,
+    prettierMigrated: false,
+    gitHooksConfigured: false,
+    warnings: [],
+    manualSteps: [],
+  };
+}
+
+export function addMigrationWarning(report: MigrationReport | undefined, warning: string) {
+  if (!report || report.warnings.includes(warning)) {
+    return;
+  }
+  report.warnings.push(warning);
+}
+
+export function addManualStep(report: MigrationReport | undefined, step: string) {
+  if (!report || report.manualSteps.includes(step)) {
+    return;
+  }
+  report.manualSteps.push(step);
+}

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -141,8 +141,8 @@ export async function runViteFmt(
   }
 }
 
-export async function upgradeYarn(cwd: string, interactive?: boolean) {
-  const spinner = getSpinner(interactive);
+export async function upgradeYarn(cwd: string, interactive?: boolean, silent = false) {
+  const spinner = silent ? getSilentSpinner() : getSpinner(interactive);
   spinner.start(`Running yarn set version stable...`);
   const { exitCode, stderr, stdout } = await runCommandSilently({
     command: 'yarn',

--- a/packages/prompts/src/progress-bar.ts
+++ b/packages/prompts/src/progress-bar.ts
@@ -63,12 +63,20 @@ export function progress({
   };
   return {
     start,
+    pause: spin.pause.bind(spin),
+    resume: (msg?: string) => {
+      const nextMessage = msg ?? previousMessage;
+      previousMessage = nextMessage;
+      spin.resume(drawProgress('active', nextMessage));
+    },
     stop: spin.stop.bind(spin),
     cancel: spin.cancel.bind(spin),
     error: spin.error.bind(spin),
     clear: spin.clear.bind(spin),
     advance,
-    isCancelled: spin.isCancelled,
     message: (msg: string) => advance(0, msg),
+    get isCancelled() {
+      return spin.isCancelled;
+    },
   };
 }

--- a/packages/prompts/src/spinner.ts
+++ b/packages/prompts/src/spinner.ts
@@ -26,6 +26,8 @@ export interface SpinnerOptions extends CommonOptions {
 
 export interface SpinnerResult {
   start(msg?: string): void;
+  pause(): void;
+  resume(msg?: string): void;
   stop(msg?: string): void;
   cancel(msg?: string): void;
   error(msg?: string): void;
@@ -40,11 +42,11 @@ const removeTrailingDots = (msg: string): string => {
   return msg.replace(/\.+$/, '');
 };
 
-const formatTimer = (origin: number): string => {
-  const duration = (performance.now() - origin) / 1000;
+const formatTimer = (durationMs: number): string => {
+  const duration = durationMs / 1000;
   const min = Math.floor(duration / 60);
   const secs = Math.floor(duration % 60);
-  return min > 0 ? `[${min}m ${secs}s]` : `[${secs}s]`;
+  return color.gray(min > 0 ? `(${min}m ${secs}s)` : `(${secs}s)`);
 };
 
 export const spinner = ({
@@ -67,8 +69,16 @@ export const spinner = ({
   let _message = '';
   let _prevMessage: string | undefined;
   let _origin: number = performance.now();
+  let _elapsedMs = 0;
   const columns = getColumns(output);
   const styleFn = opts?.styleFrame ?? defaultStyleFn;
+
+  const getElapsedMs = () => {
+    if (!isSpinnerActive) {
+      return _elapsedMs;
+    }
+    return _elapsedMs + (performance.now() - _origin);
+  };
 
   const handleExit = (code: number) => {
     const msg =
@@ -135,11 +145,11 @@ export const spinner = ({
 
   const hasGuide = opts.withGuide ?? false;
 
-  const start = (msg = ''): void => {
+  const startLoop = (): void => {
     isSpinnerActive = true;
     unblock = block({ output });
-    _message = removeTrailingDots(msg);
     _origin = performance.now();
+    _prevMessage = undefined;
     if (hasGuide) {
       output.write(`${color.gray(S_BAR)}\n`);
     }
@@ -158,7 +168,7 @@ export const spinner = ({
       if (isCI) {
         outputMessage = `${frame}  ${_message}...`;
       } else if (indicator === 'timer') {
-        outputMessage = `${frame}  ${_message} ${formatTimer(_origin)}`;
+        outputMessage = `${frame}  ${_message} ${formatTimer(getElapsedMs())}`;
       } else {
         const loadingDots = '.'.repeat(Math.floor(indicatorTimer)).slice(0, 3);
         outputMessage = `${frame}  ${_message}${loadingDots}`;
@@ -176,13 +186,20 @@ export const spinner = ({
     }, delay);
   };
 
-  const _stop = (msg = '', code = 0, silent: boolean = false): void => {
+  const start = (msg = ''): void => {
+    _elapsedMs = 0;
+    _message = removeTrailingDots(msg);
+    startLoop();
+  };
+
+  const _stop = (msg = '', code = 0, silent: boolean = false, preserveElapsed = false): void => {
     if (!isSpinnerActive) {
       return;
     }
     isSpinnerActive = false;
     clearInterval(loop);
     clearPrevMessage();
+    const elapsedMs = getElapsedMs();
     const step =
       code === 0
         ? completeColor(S_STEP_SUBMIT)
@@ -192,15 +209,33 @@ export const spinner = ({
     _message = msg ?? _message;
     if (!silent) {
       if (indicator === 'timer') {
-        output.write(`${step} ${_message} ${formatTimer(_origin)}\n\n`);
+        output.write(`${step} ${_message} ${formatTimer(elapsedMs)}\n\n`);
       } else {
         output.write(`${step} ${_message}\n\n`);
       }
     }
+    if (!preserveElapsed) {
+      _elapsedMs = 0;
+    }
+    _prevMessage = undefined;
     clearHooks();
     unblock();
   };
 
+  const pause = (): void => {
+    if (!isSpinnerActive) {
+      return;
+    }
+    _elapsedMs = getElapsedMs();
+    _stop(_message, 0, true, true);
+  };
+  const resume = (msg = _message): void => {
+    if (isSpinnerActive) {
+      return;
+    }
+    _message = removeTrailingDots(msg);
+    startLoop();
+  };
   const stop = (msg = ''): void => _stop(msg, 0);
   const cancel = (msg = ''): void => _stop(msg, 1);
   const error = (msg = ''): void => _stop(msg, 2);
@@ -212,6 +247,8 @@ export const spinner = ({
 
   return {
     start,
+    pause,
+    resume,
     stop,
     message,
     cancel,


### PR DESCRIPTION
This PR:

* Fixes wrong folder creation behavior when running something like `vp create https://github.com/nkzw-tech/fate-template`. It now uses the name of the template instead of creating `https:/github.com/nkzw-tech/fate-template` as a folder.
* Warns and asks the user to pick a new folder name when the folder already exists.
* Adds a progress spinner to `vp create` and `vp migrate`.
* Cleans up the `vp migrate` output to align with `vp create` and list manual migration steps at the end:

<img width="880" height="736" alt="CleanShot 2026-03-10 at 10 33 10@2x" src="https://github.com/user-attachments/assets/a55c333c-1683-43c1-a15e-d13aadcd80d4" />
