### PR TITLE
chore: Improve wording for global `vp` install.

### DIFF
--- a/packages/cli/install.ps1
+++ b/packages/cli/install.ps1
@@ -395,8 +395,8 @@ exec "`$VITE_PLUS_HOME/current/bin/vp.exe" "`$@"
     # Show Node.js manager status
     if ($nodeManagerResult -eq "true" -or $nodeManagerResult -eq "already") {
         Write-Host ""
-        Write-Host "  Node.js is now managed by Vite+ (via ${BRIGHT_BLUE}vp env${NC})."
-        Write-Host "  Run ${BRIGHT_BLUE}vp env doctor${NC} to verify your setup."
+        Write-Host "  Vite+ is now managing Node.js via ${BRIGHT_BLUE}vp env${NC}."
+        Write-Host "  Run ${BRIGHT_BLUE}vp env doctor${NC} to verify your setup, or ${BRIGHT_BLUE}vp env off${NC} to opt out."
     }
 
     Write-Host ""

--- a/packages/cli/install.sh
+++ b/packages/cli/install.sh
@@ -617,8 +617,8 @@ WRAPPER_EOF
 
   if [ "$NODE_MANAGER_ENABLED" = "true" ] || [ "$NODE_MANAGER_ENABLED" = "already" ]; then
     echo ""
-    echo -e "  Node.js is now managed by Vite+ (via ${BRIGHT_BLUE}vp env${NC})."
-    echo -e "  Run ${BRIGHT_BLUE}vp env doctor${NC} to verify your setup."
+    echo -e "  Vite+ is now managing Node.js via ${BRIGHT_BLUE}vp env${NC}."
+    echo -e "  Run ${BRIGHT_BLUE}vp env doctor${NC} to verify your setup, or ${BRIGHT_BLUE}vp env off${NC} to opt out."
   fi
 
   echo ""


### PR DESCRIPTION
We are taking control of the global `node` binary. Let's be very nice about it and tell people how to opt-out right away if they don't want it.

<img width="880" height="736" alt="CleanShot 2026-03-10 at 11 04 14@2x" src="https://github.com/user-attachments/assets/895160e9-4b18-4a23-af1a-637fcabbed53" />
