### PR TITLE
ci: update Claude Code Action to version 2.1.72

### DIFF
--- a/.github/workflows/upgrade-deps.yml
+++ b/.github/workflows/upgrade-deps.yml
@@ -61,7 +61,7 @@ jobs:
         env:
           RELEASE_BUILD: 'true'
 
-      - uses: anthropics/claude-code-action@a017b830c03e23789b11fb69ed571ea61c12e45c # v1.0.0
+      - uses: anthropics/claude-code-action@eb99fb38f09dedf69f423f1315d6c0272ace56a0 # Claude Code to 2.1.72
         env:
           RELEASE_BUILD: 'true'
         with:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single CI dependency bump pinned by SHA; affects only the automated dependency-upgrade workflow execution.
> 
> **Overview**
> Updates the `upgrade-deps` GitHub workflow to use a newer pinned commit of `anthropics/claude-code-action` (Claude Code 2.1.72) when attempting to auto-fix failures in the `build-upstream` steps.
> 
> No other workflow logic or permissions are changed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04e29af2ebb9d7c52c03799a3d5cde88515049ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->