### PR TITLE
fix(create): prevent vp create library template from hanging in silent mode

### DIFF
--- a/packages/cli/src/create/templates/builtin.ts
+++ b/packages/cli/src/create/templates/builtin.ts
@@ -27,9 +27,10 @@ export async function executeBuiltinTemplate(
     }
   } else if (templateInfo.command === BuiltinTemplate.library) {
     templateInfo.command = 'create-tsdown@latest';
-    if (!templateInfo.interactive) {
-      // set default template for tsdown
-      if (!templateInfo.args.find((arg) => arg.startsWith('--template') || arg.startsWith('-t'))) {
+    // create-tsdown doesn't support non-interactive mode;
+    // add default template when running silently to prevent hang on piped stdin
+    if (!templateInfo.interactive || options?.silent) {
+      if (!templateInfo.args.some((arg) => arg.startsWith('--template') || arg.startsWith('-t'))) {
         templateInfo.args.push('--template', 'default');
       }
     }


### PR DESCRIPTION
When running `vp create` interactively without `--verbose`, create-tsdown
hangs because stdin is piped in silent/compact mode. Add `--template default`
flag when running silently to prevent the hang.

![image.png](https://app.graphite.com/user-attachments/assets/d6164993-9ee8-432b-bc3e-eaa459ae798a.png)

