### PR TITLE
fix: resolve `vp` hanging on launch in Warp terminal

### DIFF
--- a/crates/vite_global_cli/src/command_picker.rs
+++ b/crates/vite_global_cli/src/command_picker.rs
@@ -160,8 +160,11 @@ fn run_picker(command_order: &[usize]) -> io::Result<Option<PickedCommand>> {
     let mut viewport_start = 0usize;
     let mut query = String::new();
 
+    let is_warp = vite_shared::header::is_warp_terminal();
+    let header_overhead = if is_warp { 10 } else { 9 };
+
     terminal::enable_raw_mode()?;
-    execute!(stdout, cursor::Hide)?;
+    execute!(stdout, terminal::EnterAlternateScreen, cursor::Hide)?;
 
     let pick_result = loop {
         let filtered_indices = filtered_command_indices(&query, command_order);
@@ -177,37 +180,45 @@ fn run_picker(command_order: &[usize]) -> io::Result<Option<PickedCommand>> {
 
         let (_, rows) = terminal::size().unwrap_or((80, 24));
         let rows = if rows == 0 { 24 } else { rows };
-        let viewport_size = compute_viewport_size(rows.into(), filtered_indices.len());
+        let viewport_size =
+            compute_viewport_size(rows.into(), filtered_indices.len(), header_overhead);
         viewport_start = align_viewport(viewport_start, selected_position, viewport_size);
-        render_picker(
+        match render_picker(
             &mut stdout,
             &query,
             &filtered_indices,
             selected_position,
             viewport_start,
             viewport_size,
-        )?;
+        ) {
+            Ok(()) => {}
+            Err(err) => break Err(err),
+        }
 
-        if let Event::Key(KeyEvent { code, modifiers, .. }) = event::read()? {
-            match handle_key_event(
-                code,
-                modifiers,
-                &mut query,
-                &mut selected_position,
-                filtered_indices.len(),
-            ) {
-                ControlFlow::Continue(()) => continue,
-                ControlFlow::Break(Some(())) => {
-                    let Some(index) = filtered_indices.get(selected_position).copied() else {
-                        continue;
-                    };
-                    break Ok(Some(PickedCommand {
-                        command: COMMANDS[index].command,
-                        append_help: COMMANDS[index].append_help,
-                    }));
+        match event::read() {
+            Ok(Event::Key(KeyEvent { code, modifiers, .. })) => {
+                match handle_key_event(
+                    code,
+                    modifiers,
+                    &mut query,
+                    &mut selected_position,
+                    filtered_indices.len(),
+                ) {
+                    ControlFlow::Continue(()) => continue,
+                    ControlFlow::Break(Some(())) => {
+                        let Some(index) = filtered_indices.get(selected_position).copied() else {
+                            continue;
+                        };
+                        break Ok(Some(PickedCommand {
+                            command: COMMANDS[index].command,
+                            append_help: COMMANDS[index].append_help,
+                        }));
+                    }
+                    ControlFlow::Break(None) => break Ok(None),
                 }
-                ControlFlow::Break(None) => break Ok(None),
             }
+            Ok(_) => continue,
+            Err(err) => break Err(err),
         }
     };
 
@@ -221,13 +232,7 @@ fn run_picker(command_order: &[usize]) -> io::Result<Option<PickedCommand>> {
 
 fn cleanup_picker(stdout: &mut io::Stdout) -> io::Result<()> {
     terminal::disable_raw_mode()?;
-    execute!(
-        stdout,
-        cursor::Show,
-        terminal::Clear(ClearType::All),
-        cursor::MoveTo(0, 0),
-        ResetColor
-    )?;
+    execute!(stdout, cursor::Show, terminal::LeaveAlternateScreen, ResetColor)?;
     Ok(())
 }
 
@@ -294,21 +299,26 @@ fn render_picker(
 ) -> io::Result<()> {
     let (columns, _) = terminal::size().unwrap_or((80, 24));
     let columns = if columns == 0 { 80 } else { columns };
-    let max_width = usize::from(columns).saturating_sub(4);
+    // Warp terminal needs extra padding since it renders alternate screen
+    // content flush against the edges of its block-mode renderer.
+    let pad = if vite_shared::header::is_warp_terminal() { " " } else { "" };
+    let max_width = usize::from(columns).saturating_sub(4 + pad.len());
     let viewport_end = (viewport_start + viewport_size).min(filtered_indices.len());
     let instruction = truncate_line(
         &format!("Select a command (↑/↓, Enter to run, Esc to cancel): {query}"),
         max_width,
     );
 
+    execute!(stdout, cursor::MoveTo(0, 0), terminal::Clear(ClearType::All),)?;
+    if vite_shared::header::is_warp_terminal() {
+        execute!(stdout, Print(NEWLINE))?;
+    }
     execute!(
         stdout,
-        cursor::MoveTo(0, 0),
-        terminal::Clear(ClearType::All),
-        Print(vite_shared::header::vite_plus_header()),
+        Print(format!("{pad}{}", vite_shared::header::vite_plus_header())),
         Print(NEWLINE),
         Print(NEWLINE),
-        Print(instruction),
+        Print(format!("{pad}{instruction}")),
         Print(NEWLINE),
         Print(NEWLINE)
     )?;
@@ -317,7 +327,7 @@ fn render_picker(
         execute!(
             stdout,
             SetForegroundColor(crossterm::style::Color::DarkGrey),
-            Print("  ↑ more"),
+            Print(format!("{pad}  ↑ more")),
             Print(NEWLINE),
             ResetColor
         )?;
@@ -337,7 +347,7 @@ fn render_picker(
             execute!(
                 stdout,
                 SetForegroundColor(crossterm::style::Color::DarkGrey),
-                Print(format!("  {marker} ")),
+                Print(format!("{pad}  {marker} ")),
                 ResetColor
             )?;
             if is_selected {
@@ -371,7 +381,7 @@ fn render_picker(
             execute!(
                 stdout,
                 SetForegroundColor(crossterm::style::Color::DarkGrey),
-                Print(format!("  {marker} ")),
+                Print(format!("{pad}  {marker} ")),
                 ResetColor
             )?;
             execute!(stdout, SetForegroundColor(SELECTED_COLOR), SetAttribute(Attribute::Bold),)?;
@@ -391,7 +401,7 @@ fn render_picker(
             execute!(
                 stdout,
                 SetForegroundColor(crossterm::style::Color::DarkGrey),
-                Print(format!("  {marker} ")),
+                Print(format!("{pad}  {marker} ")),
                 ResetColor,
                 Print(label),
             )?;
@@ -403,7 +413,7 @@ fn render_picker(
         execute!(
             stdout,
             SetForegroundColor(crossterm::style::Color::DarkGrey),
-            Print("  ↓ more"),
+            Print(format!("{pad}  ↓ more")),
             Print(NEWLINE),
             ResetColor
         )?;
@@ -420,7 +430,7 @@ fn render_picker(
             stdout,
             Print(NEWLINE),
             SetForegroundColor(crossterm::style::Color::DarkGrey),
-            Print("  "),
+            Print(format!("{pad}  ")),
             Print(no_match),
             Print(NEWLINE),
             ResetColor
@@ -430,9 +440,12 @@ fn render_picker(
     stdout.flush()
 }
 
-fn compute_viewport_size(terminal_rows: usize, total_commands: usize) -> usize {
-    // Header + instructions + query + spacing takes ~9 rows.
-    terminal_rows.saturating_sub(9).clamp(6, total_commands.max(6))
+fn compute_viewport_size(
+    terminal_rows: usize,
+    total_commands: usize,
+    header_overhead: usize,
+) -> usize {
+    terminal_rows.saturating_sub(header_overhead).clamp(6, total_commands.max(6))
 }
 
 fn align_viewport(current_start: usize, selected_index: usize, viewport_size: usize) -> usize {
@@ -572,9 +585,12 @@ mod tests {
 
     #[test]
     fn viewport_size_is_clamped() {
-        assert_eq!(compute_viewport_size(12, 30), 6);
-        assert_eq!(compute_viewport_size(24, 30), 15);
-        assert_eq!(compute_viewport_size(100, 8), 8);
+        assert_eq!(compute_viewport_size(12, 30, 9), 6);
+        assert_eq!(compute_viewport_size(24, 30, 9), 15);
+        assert_eq!(compute_viewport_size(100, 8, 9), 8);
+        // Warp adds 1 extra row of overhead
+        assert_eq!(compute_viewport_size(12, 30, 10), 6);
+        assert_eq!(compute_viewport_size(24, 30, 10), 14);
     }
 
     #[test]

--- a/crates/vite_shared/src/header.rs
+++ b/crates/vite_shared/src/header.rs
@@ -6,7 +6,10 @@
 //! - ANSI palette queries for blue/magenta with timeout
 //! - Gradient/fade generation and RGB ANSI coloring
 
-use std::{io::IsTerminal, sync::OnceLock};
+use std::{
+    io::IsTerminal,
+    sync::{LazyLock, OnceLock},
+};
 #[cfg(unix)]
 use std::{
     io::Write,
@@ -30,6 +33,15 @@ const ANSI_MAGENTA_INDEX: u8 = 5;
 const HEADER_SUFFIX_FADE_GAMMA: f64 = 1.35;
 
 static HEADER_COLORS: OnceLock<HeaderColors> = OnceLock::new();
+
+/// Whether the terminal is Warp, which does not respond to OSC color queries
+/// and renders alternate screen content flush against block edges.
+#[must_use]
+pub fn is_warp_terminal() -> bool {
+    static IS_WARP: LazyLock<bool> =
+        LazyLock::new(|| std::env::var("TERM_PROGRAM").as_deref() == Ok("WarpTerminal"));
+    *IS_WARP
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct Rgb(u8, u8, u8);
@@ -181,6 +193,13 @@ fn query_terminal_colors(palette_indices: &[u8]) -> (Option<Rgb>, Vec<(u8, Rgb)>
     };
 
     if std::env::var_os("CI").is_some() {
+        return (None, vec![]);
+    }
+
+    // Warp terminal does not respond to OSC color queries in its block-mode
+    // renderer. Sending the queries causes the process to appear stuck until
+    // the user presses a key (which is consumed as a fake "response").
+    if is_warp_terminal() {
         return (None, vec![]);
     }
 


### PR DESCRIPTION
## Background

The global `vp` CLI appeared to hang in Warp terminal, requiring a
keypress before any output was displayed. This affected both the bare
`vp` command (interactive picker) and subcommands like `vp create` that
delegate to Node.js. The issue did not occur in other terminals such as
iTerm2 or Terminal.app.

## Root Cause

`vite_shared::header::vite_plus_header()` calls `query_terminal_colors()`
which sends OSC escape sequences (`\x1b]10;?\x1b\\` for foreground color
and `\x1b]4;N;?\x1b\\` for palette colors) to `/dev/tty` in raw mode to
read the terminal's color values for the header gradient. Most terminals
respond to these queries, but Warp's block-mode renderer does not. The
function then blocks on `poll()`/`read()` waiting for a response that
never comes, consuming the next keypress as a fake "response" instead.

Since the header is rendered on nearly every command, this caused the
CLI to appear stuck on every invocation in Warp.

## Fix

1. **Skip OSC color queries in Warp** (`header.rs`): Early-return from
   `query_terminal_colors()` when `TERM_PROGRAM=WarpTerminal`, falling
   back to default blue/magenta colors. This matches the existing CI
   environment skip pattern.

2. **Use alternate screen for the picker** (`command_picker.rs`): Switch
   the interactive command picker to use `EnterAlternateScreen` /
   `LeaveAlternateScreen` instead of `Clear(ClearType::All)` + manual
   cursor reset. This is standard TUI practice and avoids a large blank
   area that Warp's block-mode renderer created with the previous
   clear-based approach.

3. **Conditional padding for Warp** (`command_picker.rs`): Warp renders
   alternate screen content flush against the edges. Add a 1-line top
   margin and 1-space left margin only when running in Warp to improve
   readability, without affecting other terminals.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches terminal I/O and TUI screen-management paths, which can regress rendering or leave terminals in a bad state if edge cases are missed, but changes are scoped to UI behavior and add explicit cleanup/error handling.
> 
> **Overview**
> Fixes `vp` appearing to hang in Warp by detecting Warp (`TERM_PROGRAM=WarpTerminal`) and **skipping OSC color queries** in `vite_shared::header::query_terminal_colors`, falling back to default header colors.
> 
> Updates the interactive command picker to use the terminal **alternate screen** (`EnterAlternateScreen`/`LeaveAlternateScreen`) with safer event/error handling, and adds Warp-specific padding plus a viewport-size adjustment (`compute_viewport_size` now accounts for header overhead; tests updated accordingly).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5bebc9522b67830087a8f3659f3d10e9cbac01b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->