### PR TITLE
fix(create): skip hooks prompt in monorepo and enable verbose for remote templates

### DIFF
--- a/packages/cli/src/create/bin.ts
+++ b/packages/cli/src/create/bin.ts
@@ -346,7 +346,7 @@ function showCreateSummary(options: {
 
 async function main() {
   const { templateName, options, templateArgs } = parseArgs();
-  const compactOutput = !options.verbose;
+  let compactOutput = !options.verbose;
 
   // #region Handle help flag
   if (options.help) {
@@ -513,6 +513,13 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
   }
 
   const isBuiltinTemplate = selectedTemplateName.startsWith('vite:');
+
+  // Remote templates (e.g., @tanstack/create-start, custom templates) run their own
+  // interactive CLI, so verbose mode is needed to show their output.
+  if (!isBuiltinTemplate) {
+    compactOutput = false;
+  }
+
   if (targetDir && !isBuiltinTemplate) {
     cancelAndExit('The --directory option is only available for builtin templates', 1);
   }
@@ -687,7 +694,9 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
       onCancel: () => cancelAndExit(),
     }));
 
-  shouldSetupHooks = await promptGitHooks(options);
+  if (!isMonorepo) {
+    shouldSetupHooks = await promptGitHooks(options);
+  }
 
   const createProgress =
     options.interactive && compactOutput ? prompts.spinner({ indicator: 'timer' }) : undefined;

--- a/packages/cli/src/create/templates/monorepo.ts
+++ b/packages/cli/src/create/templates/monorepo.ts
@@ -32,7 +32,7 @@ export async function executeMonorepoTemplate(
 
   // Ask user to init git repository before creation starts.
   let initGit = true; // Default to yes
-  if (interactive) {
+  if (interactive && !options?.silent) {
     const selected = await prompts.confirm({
       message: `Initialize git repository:`,
       initialValue: true,


### PR DESCRIPTION
- Skip pre-commit hooks prompt when running `vp create` inside a monorepo,
since hooks are managed at the monorepo root
- Enable verbose mode by default for non-builtin templates (e.g.,`
``@tanstack/create-start`, custom templates) so their interactive CLI
output is visible
- Skip git init prompt in monorepo template when running in silent mode

closes VP-238