### PR TITLE
fix(install): suppress banner/tips and improve post-install messages

### DIFF
--- a/crates/vite_global_cli/src/cli.rs
+++ b/crates/vite_global_cli/src/cli.rs
@@ -1538,7 +1538,7 @@ pub async fn run_command_with_options(
             packages,
             pass_through_args,
         } => {
-            print_runtime_header(render_options.show_header);
+            print_runtime_header(render_options.show_header && !silent);
             // If packages are provided, redirect to Add command
             if let Some(pkgs) = packages
                 && !pkgs.is_empty()

--- a/crates/vite_global_cli/src/tips/mod.rs
+++ b/crates/vite_global_cli/src/tips/mod.rs
@@ -79,7 +79,7 @@ fn all() -> &'static [&'static dyn Tip] {
 /// - The `VITE_PLUS_CLI_TEST` env var is set (test mode)
 /// - No tips match the given context
 pub fn get_tip(context: &TipContext) -> Option<&'static str> {
-    if std::env::var_os("VITE_PLUS_CLI_TEST").is_some() {
+    if std::env::var_os("VITE_PLUS_CLI_TEST").is_some() || std::env::var_os("CI").is_some() {
         return None;
     }
 

--- a/packages/cli/install.ps1
+++ b/packages/cli/install.ps1
@@ -322,11 +322,8 @@ function Main {
         Push-Location $VersionDir
         try {
             $env:CI = "true"
-            $ErrorActionPreference = "SilentlyContinue"
-            & "$BinDir\vp.exe" install --silent 2>&1 | Out-Null
-            $ErrorActionPreference = "Stop"
+            & "$BinDir\vp.exe" install --silent
         } finally {
-            $ErrorActionPreference = "Stop"
             Pop-Location
         }
     }

--- a/packages/cli/install.sh
+++ b/packages/cli/install.sh
@@ -577,7 +577,7 @@ WRAPPER_EOF
   # Install production dependencies (skip if VITE_PLUS_SKIP_DEPS_INSTALL is set,
   # e.g. during local dev where install-global-cli.ts handles deps separately)
   if [ -z "${VITE_PLUS_SKIP_DEPS_INSTALL:-}" ]; then
-    (cd "$VERSION_DIR" && CI=true "$BIN_DIR/vp" install --silent > /dev/null 2>&1)
+    (cd "$VERSION_DIR" && CI=true "$BIN_DIR/vp" install --silent)
   fi
 
   # Create/update current symlink (use relative path for portability)

--- a/packages/cli/snap-tests-global/command-install-auto-create-package-json/snap.txt
+++ b/packages/cli/snap-tests-global/command-install-auto-create-package-json/snap.txt
@@ -2,8 +2,6 @@
 no package.json
 
 > vp install --silent && cat package.json # should auto-create package.json and install
-VITE+ - The Unified Toolchain for the Web
-
 {
   "type": "module",
   "packageManager": "pnpm@<semver>"

--- a/packages/cli/snap-tests-global/command-install-bug-31/snap.txt
+++ b/packages/cli/snap-tests-global/command-install-bug-31/snap.txt
@@ -1,22 +1,11 @@
 > vp install --no-frozen-lockfile --silent # install dependencies work
-VITE+ - The Unified Toolchain for the Web
-
-
 > mkdir -p packages/sub-project && echo '{"name": "sub-project", "dependencies": { "testnpm2": "1.0.0" }}' > packages/sub-project/package.json # create sub project and package.json
 > vp install --no-frozen-lockfile --silent # install again should work and without cache
-VITE+ - The Unified Toolchain for the Web
-
-
 > ls packages/sub-project/node_modules/testnpm2/package.json # check testnpm2 is installed
 packages/sub-project/node_modules/testnpm2/package.json
 
 > mkdir -p others/other && echo '{"name": "other", "dependencies": { "testnpm2": "1.0.0" }}' > others/other/package.json # create non workspace project
 > vp install --no-frozen-lockfile --silent # should install cache hit
-VITE+ - The Unified Toolchain for the Web
-
-
 > test -d others/other/node_modules/testnpm2 && echo 'Error: directory exists.' >&2 && exit 1 || true # check testnpm2 is not installed
 > rm -rf packages/sub-project # remove sub project
 > vp install --no-frozen-lockfile --silent | sed -E 's|packages.*|packages*|' # should install again without cache
-VITE+ - The Unified Toolchain for the Web
-


### PR DESCRIPTION
## Summary

- Suppress VITE+ header banner when `--silent` is passed to `vp install`
- Suppress tips (e.g. "Available short aliases") when `CI` env var is set, since tips are for interactive users
- Replace `vp dev` with `vp migrate` in post-install "Get started" section (dev is a project command, not available after fresh global install)
- Change "Run vp help for more information" to "Run vp help to see available commands"

## Test plan

- [x] `cargo test -p vite_global_cli` — 294 passed
- [x] Verify snap test diffs are correct (banner lines removed from `--silent` output)
- [x] CI: install.ps1 on PowerShell 5.1 no longer leaks tips/banner
- [x] CI: [install.sh](http://install.sh) no longer leaks tips/banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)