### PR TITLE
fix(create): enable typeAware and typeCheck by default in `vp create`

### DIFF
--- a/packages/cli/snap-tests-global/create-missing-typecheck/snap.txt
+++ b/packages/cli/snap-tests-global/create-missing-typecheck/snap.txt
@@ -1,0 +1,24 @@
+> vp create vite:application --no-interactive # create standalone app
+> cat vite-plus-application/vite.config.ts # check standalone vite.config.ts has typeAware and typeCheck
+import { defineConfig } from "vite-plus";
+
+export default defineConfig({
+  staged: {
+    "*": "vp check --fix",
+  },
+  lint: { options: { typeAware: true, typeCheck: true } },
+});
+
+> vp create vite:monorepo --no-interactive # create monorepo
+> cat vite-plus-monorepo/vite.config.ts # check monorepo root vite.config.ts has typeAware and typeCheck
+import { defineConfig } from "vite-plus";
+
+export default defineConfig({
+  staged: {
+    "*": "vp check --fix",
+  },
+  lint: { options: { typeAware: true, typeCheck: true } },
+});
+
+> cat vite-plus-monorepo/apps/website/vite.config.ts 2>&1 || true # sub-app should NOT have typeAware/typeCheck
+cat: vite-plus-monorepo/apps/website/vite.config.ts: No such file or directory

--- a/packages/cli/snap-tests-global/create-missing-typecheck/steps.json
+++ b/packages/cli/snap-tests-global/create-missing-typecheck/steps.json
@@ -1,0 +1,15 @@
+{
+  "commands": [
+    {
+      "command": "vp create vite:application --no-interactive # create standalone app",
+      "ignoreOutput": true
+    },
+    "cat vite-plus-application/vite.config.ts # check standalone vite.config.ts has typeAware and typeCheck",
+    {
+      "command": "vp create vite:monorepo --no-interactive # create monorepo",
+      "ignoreOutput": true
+    },
+    "cat vite-plus-monorepo/vite.config.ts # check monorepo root vite.config.ts has typeAware and typeCheck",
+    "cat vite-plus-monorepo/apps/website/vite.config.ts 2>&1 || true # sub-app should NOT have typeAware/typeCheck"
+  ]
+}

--- a/packages/cli/snap-tests-global/migration-chained-lint-staged-pre-commit/snap.txt
+++ b/packages/cli/snap-tests-global/migration-chained-lint-staged-pre-commit/snap.txt
@@ -30,10 +30,10 @@ VITE+ - The Unified Toolchain for the Web
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({
+  lint: {"options":{"typeAware":true,"typeCheck":true}},
   staged: {
     "*.js": "vp lint --fix"
   },
-  
 });
 
 > cat .vite-hooks/pre-commit # check npx lint-staged replaced but --diff HEAD~1 && npm test preserved

--- a/packages/cli/snap-tests-global/migration-env-prefix-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-env-prefix-lint-staged/snap.txt
@@ -30,10 +30,10 @@ VITE+ - The Unified Toolchain for the Web
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({
+  lint: {"options":{"typeAware":true,"typeCheck":true}},
   staged: {
     "*.js": "vp lint --fix"
   },
-  
 });
 
 > cat .vite-hooks/pre-commit # check env prefix preserved with vp staged

--- a/packages/cli/snap-tests-global/migration-existing-husky-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-husky-lint-staged/snap.txt
@@ -30,10 +30,10 @@ VITE+ - The Unified Toolchain for the Web
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({
+  lint: {"options":{"typeAware":true,"typeCheck":true}},
   staged: {
     "*.js": "vp lint --fix"
   },
-  
 });
 
 > cat .vite-hooks/pre-commit # check pre-commit hook rewritten

--- a/packages/cli/snap-tests-global/migration-existing-husky-v8-hooks/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-husky-v8-hooks/snap.txt
@@ -6,6 +6,7 @@ VITE+ - The Unified Toolchain for the Web
 ⚠ Detected husky <9.0.0 — please upgrade to husky v9+ first, then re-run migration.
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
+• 1 config update applied
 
 > cat package.json # husky/lint-staged should remain in devDeps, prepare should stay as husky
 {

--- a/packages/cli/snap-tests-global/migration-existing-husky-v8-multi-hooks/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-husky-v8-multi-hooks/snap.txt
@@ -6,6 +6,7 @@ VITE+ - The Unified Toolchain for the Web
 ⚠ Detected husky <9.0.0 — please upgrade to husky v9+ first, then re-run migration.
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
+• 1 config update applied
 
 > cat package.json # husky/lint-staged should remain in devDeps, prepare should stay as husky
 {

--- a/packages/cli/snap-tests-global/migration-existing-lint-staged-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-lint-staged-config/snap.txt
@@ -33,10 +33,10 @@ cat: .lintstagedrc.json: No such file or directory
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({
+  lint: {"options":{"typeAware":true,"typeCheck":true}},
   staged: {
     "*.ts": "vp lint --fix"
   },
-  
 });
 
 > cat .vite-hooks/pre-commit # check pre-commit hook created

--- a/packages/cli/snap-tests-global/migration-existing-pnpm-exec-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-pnpm-exec-lint-staged/snap.txt
@@ -30,10 +30,10 @@ VITE+ - The Unified Toolchain for the Web
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({
+  lint: {"options":{"typeAware":true,"typeCheck":true}},
   staged: {
     "*.js": "vp lint --fix"
   },
-  
 });
 
 > cat .vite-hooks/pre-commit # check pnpm exec lint-staged replaced with vp staged

--- a/packages/cli/snap-tests-global/migration-from-tsdown-json-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-from-tsdown-json-config/snap.txt
@@ -24,6 +24,7 @@ export default defineConfig({
       "cwd": "./src"
     }
   },
+  lint: {"options":{"typeAware":true,"typeCheck":true}},
   server: {
     port: 3000,
   },
@@ -73,6 +74,7 @@ export default defineConfig({
       "cwd": "./src"
     }
   },
+  lint: {"options":{"typeAware":true,"typeCheck":true}},
   server: {
     port: 3000,
   },

--- a/packages/cli/snap-tests-global/migration-from-tsdown/snap.txt
+++ b/packages/cli/snap-tests-global/migration-from-tsdown/snap.txt
@@ -27,6 +27,7 @@ export default defineConfig({
     "*": "vp check --fix"
   },
   pack: tsdownConfig,
+  lint: {"options":{"typeAware":true,"typeCheck":true}},
 });
 
 > cat package.json # check package.json
@@ -77,6 +78,7 @@ export default defineConfig({
     "*": "vp check --fix"
   },
   pack: tsdownConfig,
+  lint: {"options":{"typeAware":true,"typeCheck":true}},
 });
 
 > cat package.json # check package.json

--- a/packages/cli/snap-tests-global/migration-husky-v8-preserves-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-husky-v8-preserves-lint-staged/snap.txt
@@ -6,6 +6,7 @@ VITE+ - The Unified Toolchain for the Web
 ⚠ Detected husky <9.0.0 — please upgrade to husky v9+ first, then re-run migration.
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
+• 1 config update applied
 
 > cat package.json # lint-staged config should still be in package.json
 {

--- a/packages/cli/snap-tests-global/migration-lint-staged-in-scripts/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lint-staged-in-scripts/snap.txt
@@ -31,8 +31,8 @@ VITE+ - The Unified Toolchain for the Web
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({
+  lint: {"options":{"typeAware":true,"typeCheck":true}},
   staged: {
     "*.js": "vp lint --fix"
   },
-  
 });

--- a/packages/cli/snap-tests-global/migration-lint-staged-ts-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lint-staged-ts-config/snap.txt
@@ -6,6 +6,7 @@ VITE+ - The Unified Toolchain for the Web
 ⚠ Unsupported lint-staged config format — skipping git hooks setup. Please configure git hooks manually.
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
+• 1 config update applied
 
 > cat package.json # check lint-staged NOT added to package.json, husky/lint-staged removed from devDependencies
 {

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-json/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-json/snap.txt
@@ -65,6 +65,7 @@ VITE+ - The Unified Toolchain for the Web
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({
+  lint: {"options":{"typeAware":true,"typeCheck":true}},
   staged: {
     "*.@(js|ts|tsx|yml|yaml|md|json|html|toml)": [
       "vp fmt --staged",
@@ -74,5 +75,4 @@ export default defineConfig({
       "vp lint --fix"
     ]
   },
-  
 });

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-not-support/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-not-support/snap.txt
@@ -6,6 +6,7 @@ VITE+ - The Unified Toolchain for the Web
 ⚠ Unsupported lint-staged config format — skipping git hooks setup. Please configure git hooks manually.
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
+• 1 config update applied
 
 > cat .lintstagedrc # check .lintstagedrc is not updated
 '*.js':

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-staged-exists/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-staged-exists/snap.txt
@@ -34,6 +34,7 @@ lintstagedrc.json still exists
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({
+  lint: {"options":{"typeAware":true,"typeCheck":true}},
   staged: {
     '*.js': 'vp check --fix',
   },

--- a/packages/cli/snap-tests-global/migration-monorepo-husky-v8-preserves-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-husky-v8-preserves-lint-staged/snap.txt
@@ -5,6 +5,7 @@ VITE+ - The Unified Toolchain for the Web
 ⚠ Detected husky <9.0.0 — please upgrade to husky v9+ first, then re-run migration.
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
+• 1 config update applied
 
 > cat package.json # root lint-staged config should still be in package.json
 {

--- a/packages/cli/snap-tests-global/migration-monorepo-pnpm-overrides-dependency-selector/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-pnpm-overrides-dependency-selector/snap.txt
@@ -13,6 +13,7 @@ export default defineConfig({
   staged: {
     "*": "vp check --fix"
   },
+  lint: {"options":{"typeAware":true,"typeCheck":true}},
   plugins: [react()],
 });
 

--- a/packages/cli/snap-tests-global/migration-no-hooks-with-husky/snap.txt
+++ b/packages/cli/snap-tests-global/migration-no-hooks-with-husky/snap.txt
@@ -4,6 +4,7 @@ VITE+ - The Unified Toolchain for the Web
 
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
+• 1 config update applied
 
 > cat package.json # prepare script, lint-staged config, check-staged script, and deps should all be preserved
 {

--- a/packages/cli/snap-tests-global/migration-no-hooks/snap.txt
+++ b/packages/cli/snap-tests-global/migration-no-hooks/snap.txt
@@ -4,6 +4,7 @@ VITE+ - The Unified Toolchain for the Web
 
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
+• 1 config update applied
 
 > cat package.json # check package.json has no prepare script and no lint-staged config
 {

--- a/packages/cli/snap-tests-global/migration-other-hook-tool/snap.txt
+++ b/packages/cli/snap-tests-global/migration-other-hook-tool/snap.txt
@@ -5,6 +5,7 @@ VITE+ - The Unified Toolchain for the Web
 ⚠ Detected simple-git-hooks — skipping git hooks setup. Please configure git hooks manually.
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
+• 1 config update applied
 
 > cat package.json # lint-staged config, scripts, and simple-git-hooks config should all be preserved
 {

--- a/packages/cli/snap-tests-global/migration-partially-migrated-pre-commit/snap.txt
+++ b/packages/cli/snap-tests-global/migration-partially-migrated-pre-commit/snap.txt
@@ -6,6 +6,7 @@ VITE+ - The Unified Toolchain for the Web
 ⚠ Detected husky <9.0.0 — please upgrade to husky v9+ first, then re-run migration.
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
+• 1 config update applied
 
 > cat package.json # husky/lint-staged should remain in devDeps, prepare should stay as husky
 {

--- a/packages/cli/snap-tests-global/migration-prettier-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier-lint-staged/snap.txt
@@ -32,6 +32,7 @@ Prettier configuration detected. Auto-migrating to Oxfmt...
 import { defineConfig } from "vite-plus";
 
 export default defineConfig({
+  lint: {"options":{"typeAware":true,"typeCheck":true}},
   staged: {
     "*.ts": "vp fmt"
   },

--- a/packages/cli/snap-tests-global/migration-prettier-pkg-json/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier-pkg-json/snap.txt
@@ -36,6 +36,7 @@ export default defineConfig({
   staged: {
     "*": "vp check --fix"
   },
+  lint: {"options":{"typeAware":true,"typeCheck":true}},
   fmt: {
     semi: true,
     singleQuote: true,

--- a/packages/cli/snap-tests-global/migration-prettier/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier/snap.txt
@@ -41,6 +41,7 @@ export default defineConfig({
   staged: {
     "*": "vp check --fix"
   },
+  lint: {"options":{"typeAware":true,"typeCheck":true}},
   fmt: {
     semi: true,
     singleQuote: true,

--- a/packages/cli/snap-tests-global/migration-standalone-npm/snap.txt
+++ b/packages/cli/snap-tests-global/migration-standalone-npm/snap.txt
@@ -4,6 +4,7 @@ VITE+ - The Unified Toolchain for the Web
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  npm <semver>
 ✓ Dependencies installed in <variable>ms
+• 1 config update applied
 
 > cat package.json # check package.json has overrides field (not pnpm.overrides)
 {

--- a/packages/cli/snap-tests-global/migration-subpath/snap.txt
+++ b/packages/cli/snap-tests-global/migration-subpath/snap.txt
@@ -6,6 +6,7 @@ VITE+ - The Unified Toolchain for the Web
 ⚠ Subdirectory project detected — skipping git hooks setup. Configure hooks at the repository root.
 ◇ Migrated foo to Vite+<repeat>
 • Node <semver>  pnpm <semver>
+• 1 config update applied
 
 > cat foo/package.json # check package.json
 {
@@ -31,8 +32,13 @@ VITE+ - The Unified Toolchain for the Web
   "packageManager": "pnpm@<semver>"
 }
 
-[1]> cat foo/vite.config.ts # check vite.config.ts
-cat: foo/vite.config.ts: No such file or directory
+> cat foo/vite.config.ts # check vite.config.ts
+import { defineConfig } from 'vite-plus';
+
+export default defineConfig({
+  lint: {"options":{"typeAware":true,"typeCheck":true}},
+  
+});
 
 > git config --local core.hooksPath || echo 'core.hooksPath is not set' # should NOT be set
 core.hooksPath is not set

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -724,6 +724,7 @@ export function rewriteStandaloneProject(
     rewriteLintStagedConfigFile(projectPath, report);
   }
   mergeViteConfigFiles(projectPath, silent, report);
+  injectLintTypeCheckDefaults(projectPath, silent, report);
   mergeTsdownConfigFile(projectPath, silent, report);
   // rewrite imports in all TypeScript/JavaScript files
   rewriteAllImports(projectPath, silent, report);
@@ -768,6 +769,7 @@ export function rewriteMonorepo(
     rewriteLintStagedConfigFile(workspaceInfo.rootDir, report);
   }
   mergeViteConfigFiles(workspaceInfo.rootDir, silent, report);
+  injectLintTypeCheckDefaults(workspaceInfo.rootDir, silent, report);
   mergeTsdownConfigFile(workspaceInfo.rootDir, silent, report);
   // rewrite imports in all TypeScript/JavaScript files
   rewriteAllImports(workspaceInfo.rootDir, silent, report);
@@ -1297,6 +1299,47 @@ export function mergeViteConfigFiles(
   if (configs.oxfmtConfig) {
     // merge oxfmt config into vite.config.ts
     mergeAndRemoveJsonConfig(projectPath, viteConfig, configs.oxfmtConfig, 'fmt', silent, report);
+  }
+}
+
+/**
+ * Inject typeAware and typeCheck defaults into vite.config.ts lint config.
+ * Called after mergeViteConfigFiles() to handle the case where no .oxlintrc.json exists
+ * (e.g., newly created projects from create-vite templates).
+ */
+export function injectLintTypeCheckDefaults(
+  projectPath: string,
+  silent = false,
+  report?: MigrationReport,
+): void {
+  if (hasBaseUrlInTsconfig(projectPath)) {
+    return;
+  }
+
+  const configs = detectConfigs(projectPath);
+  // Check if lint config already exists in vite.config.ts
+  if (configs.viteConfig) {
+    const content = fs.readFileSync(path.join(projectPath, configs.viteConfig), 'utf8');
+    if (/\blint\s*:/.test(content)) {
+      return;
+    }
+  }
+
+  const viteConfig = ensureViteConfig(projectPath, configs, silent, report);
+  const tempConfigPath = path.join(projectPath, '.vite-plus-lint-init.oxlintrc.json');
+  fs.writeFileSync(
+    tempConfigPath,
+    JSON.stringify({ options: { typeAware: true, typeCheck: true } }),
+  );
+  const fullViteConfigPath = path.join(projectPath, viteConfig);
+  let result;
+  try {
+    result = mergeJsonConfig(fullViteConfigPath, tempConfigPath, 'lint');
+  } finally {
+    fs.rmSync(tempConfigPath, { force: true });
+  }
+  if (result.updated) {
+    fs.writeFileSync(fullViteConfigPath, result.content);
   }
 }
 


### PR DESCRIPTION
Projects created via `vp create` were missing `typeAware: true` and
`typeCheck: true` in the lint config because the injection logic only
ran when an existing `.oxlintrc.json` was found. Add
`injectLintTypeCheckDefaults()` that runs after `mergeViteConfigFiles()`
to inject these defaults when no lint config exists yet.