### PR TITLE
fix(create): block `vite:generator` template outside a monorepo

### DIFF
--- a/packages/cli/snap-tests-global/create-generator-outside-monorepo/package.json
+++ b/packages/cli/snap-tests-global/create-generator-outside-monorepo/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "standalone-project",
+  "version": "0.0.0"
+}

--- a/packages/cli/snap-tests-global/create-generator-outside-monorepo/snap.txt
+++ b/packages/cli/snap-tests-global/create-generator-outside-monorepo/snap.txt
@@ -1,0 +1,6 @@
+[1]> vp create vite:generator --no-interactive
+
+The vite:generator template requires a monorepo workspace.
+Run this command inside a Vite+ monorepo, or create one first with `vp create vite:monorepo`
+Cannot create a generator outside a monorepo
+

--- a/packages/cli/snap-tests-global/create-generator-outside-monorepo/steps.json
+++ b/packages/cli/snap-tests-global/create-generator-outside-monorepo/steps.json
@@ -1,0 +1,3 @@
+{
+  "commands": ["vp create vite:generator --no-interactive"]
+}

--- a/packages/cli/snap-tests-global/new-check/snap.txt
+++ b/packages/cli/snap-tests-global/new-check/snap.txt
@@ -61,7 +61,7 @@ Vite+ Built-in Templates:
   vite:monorepo     Create a new monorepo
   vite:application  Create a new application
   vite:library      Create a new library
-  vite:generator    Scaffold a new code generator
+  vite:generator    Scaffold a new code generator (monorepo only)
 
 Popular Templates (shorthand):
   vite             Official Vite templates (create-vite)

--- a/packages/cli/src/create/bin.ts
+++ b/packages/cli/src/create/bin.ts
@@ -139,7 +139,7 @@ const listTemplatesMessage = renderCliDoc({
         { label: 'vite:monorepo', description: 'Create a new monorepo' },
         { label: 'vite:application', description: 'Create a new application' },
         { label: 'vite:library', description: 'Create a new library' },
-        { label: 'vite:generator', description: 'Scaffold a new code generator' },
+        { label: 'vite:generator', description: 'Scaffold a new code generator (monorepo only)' },
       ],
     },
     {
@@ -528,6 +528,12 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
       'You are already in a monorepo workspace.\nUse a different template or run this command outside the monorepo',
     );
     cancelAndExit('Cannot create a monorepo inside an existing monorepo', 1);
+  }
+  if (selectedTemplateName === BuiltinTemplate.generator && !isMonorepo) {
+    prompts.log.info(
+      'The vite:generator template requires a monorepo workspace.\nRun this command inside a Vite+ monorepo, or create one first with `vp create vite:monorepo`',
+    );
+    cancelAndExit('Cannot create a generator outside a monorepo', 1);
   }
 
   if (isInSubdirectory && !compactOutput) {


### PR DESCRIPTION
The generator template uses `catalog:` dependencies that only resolve
inside a monorepo with pnpm-workspace.yaml. Add a guard in non-interactive
mode to show a helpful error instead of failing at pnpm install time.