### PR TITLE
chore: bump vite-task to 6fdc4f10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1747,7 +1747,7 @@ dependencies = [
 [[package]]
 name = "fspy"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=4bbcba1733a4cd3816beac9a69ddd6f67834e49e#4bbcba1733a4cd3816beac9a69ddd6f67834e49e"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1782,7 +1782,7 @@ dependencies = [
 [[package]]
 name = "fspy_detours_sys"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=4bbcba1733a4cd3816beac9a69ddd6f67834e49e#4bbcba1733a4cd3816beac9a69ddd6f67834e49e"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
 dependencies = [
  "cc",
  "winapi",
@@ -1791,7 +1791,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_unix"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=4bbcba1733a4cd3816beac9a69ddd6f67834e49e#4bbcba1733a4cd3816beac9a69ddd6f67834e49e"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1806,7 +1806,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_windows"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=4bbcba1733a4cd3816beac9a69ddd6f67834e49e#4bbcba1733a4cd3816beac9a69ddd6f67834e49e"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
 dependencies = [
  "bincode",
  "constcat",
@@ -1822,7 +1822,7 @@ dependencies = [
 [[package]]
 name = "fspy_seccomp_unotify"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=4bbcba1733a4cd3816beac9a69ddd6f67834e49e#4bbcba1733a4cd3816beac9a69ddd6f67834e49e"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
 dependencies = [
  "bincode",
  "futures-util",
@@ -1839,7 +1839,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=4bbcba1733a4cd3816beac9a69ddd6f67834e49e#4bbcba1733a4cd3816beac9a69ddd6f67834e49e"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
 dependencies = [
  "allocator-api2",
  "bincode",
@@ -1857,7 +1857,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared_unix"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=4bbcba1733a4cd3816beac9a69ddd6f67834e49e#4bbcba1733a4cd3816beac9a69ddd6f67834e49e"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4549,7 +4549,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal_test_client"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=4bbcba1733a4cd3816beac9a69ddd6f67834e49e#4bbcba1733a4cd3816beac9a69ddd6f67834e49e"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
 
 [[package]]
 name = "quinn"
@@ -7236,7 +7236,7 @@ dependencies = [
 [[package]]
 name = "vite_glob"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=4bbcba1733a4cd3816beac9a69ddd6f67834e49e#4bbcba1733a4cd3816beac9a69ddd6f67834e49e"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
 dependencies = [
  "thiserror 2.0.18",
  "vite_path",
@@ -7279,7 +7279,7 @@ dependencies = [
 [[package]]
 name = "vite_graph_ser"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=4bbcba1733a4cd3816beac9a69ddd6f67834e49e#4bbcba1733a4cd3816beac9a69ddd6f67834e49e"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
 dependencies = [
  "petgraph 0.8.3",
  "serde",
@@ -7361,7 +7361,7 @@ dependencies = [
 [[package]]
 name = "vite_path"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=4bbcba1733a4cd3816beac9a69ddd6f67834e49e#4bbcba1733a4cd3816beac9a69ddd6f67834e49e"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
 dependencies = [
  "bincode",
  "diff-struct",
@@ -7375,7 +7375,7 @@ dependencies = [
 [[package]]
 name = "vite_select"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=4bbcba1733a4cd3816beac9a69ddd6f67834e49e#4bbcba1733a4cd3816beac9a69ddd6f67834e49e"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -7401,7 +7401,7 @@ dependencies = [
 [[package]]
 name = "vite_shell"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=4bbcba1733a4cd3816beac9a69ddd6f67834e49e#4bbcba1733a4cd3816beac9a69ddd6f67834e49e"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
 dependencies = [
  "bincode",
  "brush-parser 0.3.0 (git+https://github.com/reubeno/brush?rev=dcb760933b10ee0433d7b740a5709b06f5c67c6b)",
@@ -7414,7 +7414,7 @@ dependencies = [
 [[package]]
 name = "vite_str"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=4bbcba1733a4cd3816beac9a69ddd6f67834e49e#4bbcba1733a4cd3816beac9a69ddd6f67834e49e"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
 dependencies = [
  "bincode",
  "compact_str",
@@ -7425,7 +7425,7 @@ dependencies = [
 [[package]]
 name = "vite_task"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=4bbcba1733a4cd3816beac9a69ddd6f67834e49e#4bbcba1733a4cd3816beac9a69ddd6f67834e49e"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7460,7 +7460,7 @@ dependencies = [
 [[package]]
 name = "vite_task_graph"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=4bbcba1733a4cd3816beac9a69ddd6f67834e49e#4bbcba1733a4cd3816beac9a69ddd6f67834e49e"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7482,7 +7482,7 @@ dependencies = [
 [[package]]
 name = "vite_task_plan"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=4bbcba1733a4cd3816beac9a69ddd6f67834e49e#4bbcba1733a4cd3816beac9a69ddd6f67834e49e"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7508,7 +7508,7 @@ dependencies = [
 [[package]]
 name = "vite_workspace"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=4bbcba1733a4cd3816beac9a69ddd6f67834e49e#4bbcba1733a4cd3816beac9a69ddd6f67834e49e"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
 dependencies = [
  "clap",
  "petgraph 0.8.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ dunce = "1.0.5"
 fast-glob = "1.0.0"
 flate2 = { version = "=1.1.9", features = ["zlib-rs"] }
 form_urlencoded = "1.2.1"
-fspy = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "4bbcba1733a4cd3816beac9a69ddd6f67834e49e" }
+fspy = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "6fdc4f106563491be4fb36381b84c5937d74fe9c" }
 futures = "0.3.31"
 futures-util = "0.3.31"
 glob = "0.3.2"
@@ -183,14 +183,14 @@ vfs = "0.12.1"
 vite_command = { path = "crates/vite_command" }
 vite_error = { path = "crates/vite_error" }
 vite_js_runtime = { path = "crates/vite_js_runtime" }
-vite_glob = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "4bbcba1733a4cd3816beac9a69ddd6f67834e49e" }
+vite_glob = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "6fdc4f106563491be4fb36381b84c5937d74fe9c" }
 vite_install = { path = "crates/vite_install" }
 vite_migration = { path = "crates/vite_migration" }
 vite_shared = { path = "crates/vite_shared" }
-vite_path = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "4bbcba1733a4cd3816beac9a69ddd6f67834e49e" }
-vite_str = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "4bbcba1733a4cd3816beac9a69ddd6f67834e49e" }
-vite_task = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "4bbcba1733a4cd3816beac9a69ddd6f67834e49e" }
-vite_workspace = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "4bbcba1733a4cd3816beac9a69ddd6f67834e49e" }
+vite_path = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "6fdc4f106563491be4fb36381b84c5937d74fe9c" }
+vite_str = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "6fdc4f106563491be4fb36381b84c5937d74fe9c" }
+vite_task = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "6fdc4f106563491be4fb36381b84c5937d74fe9c" }
+vite_workspace = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "6fdc4f106563491be4fb36381b84c5937d74fe9c" }
 walkdir = "2.5.0"
 wax = "0.6.0"
 which = "8.0.0"

--- a/packages/cli/snap-tests/build-vite-env/snap.txt
+++ b/packages/cli/snap-tests/build-vite-env/snap.txt
@@ -20,7 +20,7 @@ dist/assets/index-BnIqjoTZ.js  <variable> kB │ gzip: <variable> kB
 ✓ built in <variable>ms
 
 ---
-[vp run] cache hit, <variable>ms saved.
+vp run: cache hit, <variable>ms saved.
 
 > VITE_MY_VAR=2 vp run build # env changed, should miss cache
 $ vp build ✗ cache miss: envs changed, executing

--- a/packages/cli/snap-tests/cache-clean/snap.txt
+++ b/packages/cli/snap-tests/cache-clean/snap.txt
@@ -8,7 +8,7 @@ $ vp fmt ✓ cache hit, replaying
 Finished in <variable>ms on 4 files using <variable> threads.
 
 ---
-[vp run] cache hit, <variable>ms saved.
+vp run: cache hit, <variable>ms saved.
 
 > vp cache clean # clean the cache
 > vp run hello # cache miss after clean

--- a/packages/cli/snap-tests/cache-scripts-enabled/snap.txt
+++ b/packages/cli/snap-tests/cache-scripts-enabled/snap.txt
@@ -8,4 +8,4 @@ $ node hello.mjs ✓ cache hit, replaying
 hello from script
 
 ---
-[vp run] cache hit, <variable>ms saved.
+vp run: cache hit, <variable>ms saved.

--- a/packages/cli/snap-tests/change-passthrough-env-config/snap.txt
+++ b/packages/cli/snap-tests/change-passthrough-env-config/snap.txt
@@ -8,7 +8,7 @@ $ node -p process.env.MY_ENV ✓ cache hit, replaying
 1
 
 ---
-[vp run] cache hit, <variable>ms saved.
+vp run: cache hit, <variable>ms saved.
 
 > # add a new pass through env via VITE_TASK_PASS_THROUGH_ENVS
 > VITE_TASK_PASS_THROUGH_ENVS=MY_ENV,MY_ENV2 MY_ENV=2 vp run hello # cache should be invalidated because passThroughEnvs config changed

--- a/packages/cli/snap-tests/command-install-shortcut/snap.txt
+++ b/packages/cli/snap-tests/command-install-shortcut/snap.txt
@@ -22,4 +22,4 @@ dependencies:
 Done in <variable>ms using pnpm v<semver>
 
 ---
-[vp run] cache hit, <variable>ms saved.
+vp run: cache hit, <variable>ms saved.

--- a/packages/cli/snap-tests/command-pack-monorepo/snap.txt
+++ b/packages/cli/snap-tests/command-pack-monorepo/snap.txt
@@ -4,7 +4,7 @@ index.cjs
 
 > vp run hello#build 2>&1 | grep 'cache hit' # should hit cache
 ~/packages/hello$ vp pack ✓ cache hit, replaying
-[vp run] cache hit, <variable>ms saved.
+vp run: cache hit, <variable>ms saved.
 
 > vp run array-config#build # should build the library supports array config
 > ls packages/array-config/dist # should have the library
@@ -13,7 +13,7 @@ index.mjs
 
 > vp run array-config#build 2>&1 | grep 'cache hit' # should hit cache
 ~/packages/array-config$ vp pack ✓ cache hit, replaying
-[vp run] cache hit, <variable>ms saved.
+vp run: cache hit, <variable>ms saved.
 
 > vp run default-config#build # should build the library supports default config
 > ls packages/default-config/dist # should have the library
@@ -21,4 +21,4 @@ index.mjs
 
 > vp run default-config#build 2>&1 | grep 'cache hit' # should hit cache
 ~/packages/default-config$ vp pack ✓ cache hit, replaying
-[vp run] cache hit, <variable>ms saved.
+vp run: cache hit, <variable>ms saved.

--- a/packages/cli/snap-tests/command-pack/snap.txt
+++ b/packages/cli/snap-tests/command-pack/snap.txt
@@ -71,4 +71,4 @@ $ vp pack src/index.ts ✓ cache hit, replaying
 ✔ Build complete in <variable>ms
 
 ---
-[vp run] cache hit, <variable>ms saved.
+vp run: cache hit, <variable>ms saved.

--- a/packages/cli/snap-tests/ignore_dist/snap.txt
+++ b/packages/cli/snap-tests/ignore_dist/snap.txt
@@ -11,4 +11,4 @@ Found 0 warnings and 0 errors.
 Finished in <variable>ms on 1 file with <variable> rules using <variable> threads.
 
 ---
-[vp run] cache hit, <variable>ms saved.
+vp run: cache hit, <variable>ms saved.

--- a/packages/cli/snap-tests/npm-install-with-options/snap.txt
+++ b/packages/cli/snap-tests/npm-install-with-options/snap.txt
@@ -32,4 +32,4 @@ tslib
 $ vp install --production --silent ✓ cache hit, replaying
 
 ---
-[vp run] cache hit, <variable>ms saved.
+vp run: cache hit, <variable>ms saved.

--- a/packages/cli/snap-tests/oxlint-typeaware/snap.txt
+++ b/packages/cli/snap-tests/oxlint-typeaware/snap.txt
@@ -11,7 +11,7 @@ Found 0 warnings and 0 errors.
 Finished in <variable>ms on 1 file with <variable> rules using <variable> threads.
 
 ---
-[vp run] cache hit, <variable>ms saved.
+vp run: cache hit, <variable>ms saved.
 
 > vp run lint-typeaware
 $ vp lint --type-aware ./src

--- a/packages/cli/snap-tests/plain-terminal-ui-nested/snap.txt
+++ b/packages/cli/snap-tests/plain-terminal-ui-nested/snap.txt
@@ -8,7 +8,7 @@ Found 0 warnings and 0 errors.
 Finished in <variable>ms on 3 files with <variable> rules using <variable> threads.
 
 ---
-[vp run] 0/2 cache hit (0%). (Run `vp run --last-details` for full details)
+vp run: 0/2 cache hit (0%). (Run `vp run --last-details` for full details)
 
 > echo 'console.log(123)' > a.ts
 > vp run hello # report cache status from the inner runner
@@ -21,4 +21,4 @@ Found 0 warnings and 0 errors.
 Finished in <variable>ms on 3 files with <variable> rules using <variable> threads.
 
 ---
-[vp run] 1/2 cache hit (50%), <variable>ms saved. (Run `vp run --last-details` for full details)
+vp run: 1/2 cache hit (50%), <variable>ms saved. (Run `vp run --last-details` for full details)

--- a/packages/cli/snap-tests/plain-terminal-ui/snap.txt
+++ b/packages/cli/snap-tests/plain-terminal-ui/snap.txt
@@ -8,7 +8,7 @@ $ node hello.mjs ✓ cache hit, replaying
 input_content 1
 
 ---
-[vp run] cache hit, <variable>ms saved.
+vp run: cache hit, <variable>ms saved.
 
 > FOO=2 vp run hello # env changed
 $ node hello.mjs ✗ cache miss: envs changed, executing

--- a/packages/cli/snap-tests/vp-run-expansion/snap.txt
+++ b/packages/cli/snap-tests/vp-run-expansion/snap.txt
@@ -8,4 +8,4 @@ $ node -p '40+2' ✓ cache hit, replaying
 42
 
 ---
-[vp run] cache hit, <variable>ms saved.
+vp run: cache hit, <variable>ms saved.

--- a/packages/cli/snap-tests/yarn-install-with-options/snap.txt
+++ b/packages/cli/snap-tests/yarn-install-with-options/snap.txt
@@ -91,4 +91,4 @@ success Saved lockfile.
 Done in <variable>ms.
 
 ---
-[vp run] cache hit, <variable>ms saved.
+vp run: cache hit, <variable>ms saved.

--- a/packages/tools/src/utils.ts
+++ b/packages/tools/src/utils.ts
@@ -165,6 +165,8 @@ export function replaceUnstableOutput(output: string, cwd?: string) {
       .replaceAll(/\n\s+at .+/g, '')
       // replace git stash hashes: "git stash (abc1234)" => "git stash (<hash>)"
       .replaceAll(/git stash \([0-9a-f]+\)/g, 'git stash (<hash>)')
+      // normalize cat error spacing: Windows "cat:file" vs Unix "cat: file"
+      .replaceAll(/\bcat:(\S)/g, 'cat: $1')
   );
 }
 


### PR DESCRIPTION
## Summary
- Bumps vite-task dependency from 4bbcba17 to 6fdc4f10

Includes:
- feat: tree-view task selector with grouped packages (#219)
- fix: align package headers with top-level items in task selector (#220)
- chore: Adjust vp run output styling (#213)
- Improve shell quote handling with proper nested quote support (#217)

Updates snap tests for output styling change.

## Test plan
- [x] cargo check --all-targets --all-features passes locally
- [ ] CI passes on all platforms