### PR TITLE
fix: lock oxlint, oxfmt, and oxlint-tsgolint to exact versions

### DIFF
--- a/.github/scripts/upgrade-deps.mjs
+++ b/.github/scripts/upgrade-deps.mjs
@@ -82,15 +82,15 @@ async function updatePnpmWorkspace(versions) {
   );
 
   // Update oxfmt in catalog
-  content = content.replace(/oxfmt: \^[\d.]+(-[\w.]+)?/, `oxfmt: ^${versions.oxfmt}`);
+  content = content.replace(/oxfmt: =[\d.]+(-[\w.]+)?/, `oxfmt: =${versions.oxfmt}`);
 
   // Update oxlint in catalog (but not oxlint-tsgolint)
-  content = content.replace(/oxlint: \^[\d.]+(-[\w.]+)?\n/, `oxlint: ^${versions.oxlint}\n`);
+  content = content.replace(/oxlint: =[\d.]+(-[\w.]+)?\n/, `oxlint: =${versions.oxlint}\n`);
 
   // Update oxlint-tsgolint in catalog
   content = content.replace(
-    /oxlint-tsgolint: \^[\d.]+(-[\w.]+)?/,
-    `oxlint-tsgolint: ^${versions.oxlintTsgolint}`,
+    /oxlint-tsgolint: =[\d.]+(-[\w.]+)?/,
+    `oxlint-tsgolint: =${versions.oxlintTsgolint}`,
   );
 
   fs.writeFileSync(filePath, content);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,13 +160,13 @@ catalogs:
       specifier: '=0.115.0'
       version: 0.115.0
     oxfmt:
-      specifier: ^0.38.0
+      specifier: '=0.38.0'
       version: 0.38.0
     oxlint:
-      specifier: ^1.53.0
+      specifier: '=1.53.0'
       version: 1.53.0
     oxlint-tsgolint:
-      specifier: ^0.16.0
+      specifier: '=0.16.0'
       version: 0.16.0
     pathe:
       specifier: ^2.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -81,9 +81,9 @@ catalog:
   oxc-minify: =0.115.0
   oxc-parser: =0.115.0
   oxc-transform: =0.115.0
-  oxfmt: ^0.38.0
-  oxlint: ^1.53.0
-  oxlint-tsgolint: ^0.16.0
+  oxfmt: =0.38.0
+  oxlint: =1.53.0
+  oxlint-tsgolint: =0.16.0
   pathe: ^2.0.3
   picocolors: ^1.1.1
   picomatch: ^4.0.2


### PR DESCRIPTION
Use `=x.y.z` instead of `^x.y.z` to prevent unintended upgrades,
matching the pattern already used by oxc-minify, oxc-parser, and
oxc-transform.