### PR TITLE
fix(migration): strip prettier-only flags during prettier → vp fmt migration

### DIFF
--- a/crates/vite_migration/src/prettier.rs
+++ b/crates/vite_migration/src/prettier.rs
@@ -23,6 +23,10 @@ const PRETTIER_CONFIG: ScriptRewriteConfig = ScriptRewriteConfig {
         "--debug-benchmark",
         "--debug-repeat",
         "--experimental-cli",
+        "--ignore-unknown",
+        "-u",
+        "--no-color",
+        "--no-plugin-search",
     ],
     value_flags: &[
         "--config",
@@ -216,6 +220,28 @@ mod tests {
         // Combined with other flags
         assert_eq!(rewrite_prettier_script("prettier -w --single-quote ."), "vp fmt .");
         assert_eq!(rewrite_prettier_script("prettier -c --single-quote ."), "vp fmt --check .");
+    }
+
+    #[test]
+    fn test_rewrite_prettier_ignore_unknown_stripped() {
+        // --ignore-unknown is a prettier-only flag, should be stripped
+        assert_eq!(
+            rewrite_prettier_script(
+                "prettier . --cache --write --ignore-unknown --experimental-cli"
+            ),
+            "vp fmt ."
+        );
+        // -u is short for --ignore-unknown
+        assert_eq!(rewrite_prettier_script("prettier --write -u ."), "vp fmt .");
+        // --ignore-unknown with --check
+        assert_eq!(
+            rewrite_prettier_script("prettier --ignore-unknown --check ."),
+            "vp fmt --check ."
+        );
+        // --no-color stripped
+        assert_eq!(rewrite_prettier_script("prettier --no-color --write ."), "vp fmt .");
+        // --no-plugin-search stripped
+        assert_eq!(rewrite_prettier_script("prettier --no-plugin-search --write ."), "vp fmt .");
     }
 
     #[test]

--- a/packages/cli/snap-tests-global/migration-prettier-ignore-unknown/.prettierrc.json
+++ b/packages/cli/snap-tests-global/migration-prettier-ignore-unknown/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "semi": true,
+  "singleQuote": true
+}

--- a/packages/cli/snap-tests-global/migration-prettier-ignore-unknown/package.json
+++ b/packages/cli/snap-tests-global/migration-prettier-ignore-unknown/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "migration-prettier-ignore-unknown",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "format": "prettier . --cache --write --ignore-unknown --experimental-cli",
+    "format:check": "prettier --check -u ."
+  },
+  "devDependencies": {
+    "prettier": "^3.0.0",
+    "vite": "^7.0.0"
+  }
+}

--- a/packages/cli/snap-tests-global/migration-prettier-ignore-unknown/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier-ignore-unknown/snap.txt
@@ -1,0 +1,35 @@
+> vp migrate --no-interactive # migration should strip --ignore-unknown and -u flags
+VITE+ - The Unified Toolchain for the Web
+
+
+Prettier configuration detected. Auto-migrating to Oxfmt...
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied
+• Prettier migrated to Oxfmt
+
+> cat package.json # check prettier removed and --ignore-unknown stripped from scripts
+{
+  "name": "migration-prettier-ignore-unknown",
+  "scripts": {
+    "dev": "vp dev",
+    "build": "vp build",
+    "format": "vp fmt .",
+    "format:check": "vp fmt --check .",
+    "prepare": "vp config"
+  },
+  "devDependencies": {
+    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
+    "vite-plus": "latest"
+  },
+  "pnpm": {
+    "overrides": {
+      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
+      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
+    }
+  },
+  "packageManager": "pnpm@<semver>"
+}
+
+> cat .prettierrc.json && exit 1 || true # check prettier config is removed
+cat: .prettierrc.json: No such file or directory

--- a/packages/cli/snap-tests-global/migration-prettier-ignore-unknown/steps.json
+++ b/packages/cli/snap-tests-global/migration-prettier-ignore-unknown/steps.json
@@ -1,0 +1,7 @@
+{
+  "commands": [
+    "vp migrate --no-interactive # migration should strip --ignore-unknown and -u flags",
+    "cat package.json # check prettier removed and --ignore-unknown stripped from scripts",
+    "cat .prettierrc.json && exit 1 || true # check prettier config is removed"
+  ]
+}


### PR DESCRIPTION
Flags like --ignore-unknown/-u, --no-color, and --no-plugin-search are
valid in prettier but not in oxfmt, causing vp fmt to fail after migration.
Add them to the boolean_flags strip list so they are removed during
script rewriting.