### PR TITLE
fix(cli): remove UTF-8 BOM from install.ps1 to fix irm | iex install

### DIFF
--- a/.github/workflows/test-standalone-install.yml
+++ b/.github/workflows/test-standalone-install.yml
@@ -200,6 +200,12 @@ jobs:
         run: |
           & ./packages/cli/install.ps1
 
+      - name: Run install.ps1 via irm simulation (catches BOM issues)
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          Get-Content ./packages/cli/install.ps1 -Raw | Invoke-Expression
+
       - name: Set PATH
         shell: bash
         run: |

--- a/packages/cli/install.ps1
+++ b/packages/cli/install.ps1
@@ -1,4 +1,4 @@
-﻿# Vite+ CLI Installer for Windows
+# Vite+ CLI Installer for Windows
 # https://vite.plus/ps1
 #
 # Usage:
@@ -379,10 +379,11 @@ exec "`$VITE_PLUS_HOME/current/bin/vp.exe" "`$@"
     $DIM = "$e[2m"
     $BOLD_BRIGHT_BLUE = "$e[1;94m"
     $NC = "$e[0m"
+    $CHECKMARK = [char]0x2714
 
     # Print success message
     Write-Host ""
-    Write-Host "${GREEN}✔${NC} ${BOLD_BRIGHT_BLUE}VITE+${NC} successfully installed!"
+    Write-Host "${GREEN}${CHECKMARK}${NC} ${BOLD_BRIGHT_BLUE}VITE+${NC} successfully installed!"
     Write-Host ""
     Write-Host "  The Unified Toolchain for the Web."
     Write-Host ""


### PR DESCRIPTION
The BOM (EF BB BF) was being included as text by `irm`, causing
PowerShell to try executing `ï»¿#` as a command. Replace literal ✔
with `[char]0x2714` for PS5.1 compatibility without BOM, and add an
irm simulation CI test to catch regressions.