### PR TITLE
chore: bump vite-task to latest main (1acf3eec)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -122,7 +122,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1409,7 +1409,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1564,7 +1564,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1747,7 +1747,7 @@ dependencies = [
 [[package]]
 name = "fspy"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0#1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1782,7 +1782,7 @@ dependencies = [
 [[package]]
 name = "fspy_detours_sys"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0#1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0"
 dependencies = [
  "cc",
  "winapi",
@@ -1791,7 +1791,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_unix"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0#1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1806,7 +1806,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_windows"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0#1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0"
 dependencies = [
  "bincode",
  "constcat",
@@ -1822,7 +1822,7 @@ dependencies = [
 [[package]]
 name = "fspy_seccomp_unotify"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0#1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0"
 dependencies = [
  "bincode",
  "futures-util",
@@ -1839,7 +1839,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0#1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0"
 dependencies = [
  "allocator-api2",
  "bincode",
@@ -1857,7 +1857,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared_unix"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0#1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2333,7 +2333,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2607,7 +2607,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2724,7 +2724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
 dependencies = [
  "scopeguard",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3253,7 +3253,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4549,7 +4549,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal_test_client"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0#1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0"
 
 [[package]]
 name = "quinn"
@@ -4564,7 +4564,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4601,7 +4601,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5815,7 +5815,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5967,7 +5967,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6302,7 +6302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6474,7 +6474,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7160,6 +7160,7 @@ dependencies = [
  "rustc-hash",
  "tokio",
  "vite_path",
+ "vite_str",
  "vite_task",
 ]
 
@@ -7235,7 +7236,7 @@ dependencies = [
 [[package]]
 name = "vite_glob"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0#1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0"
 dependencies = [
  "thiserror 2.0.18",
  "vite_path",
@@ -7278,7 +7279,7 @@ dependencies = [
 [[package]]
 name = "vite_graph_ser"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0#1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0"
 dependencies = [
  "petgraph 0.8.3",
  "serde",
@@ -7360,7 +7361,7 @@ dependencies = [
 [[package]]
 name = "vite_path"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0#1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0"
 dependencies = [
  "bincode",
  "diff-struct",
@@ -7374,7 +7375,7 @@ dependencies = [
 [[package]]
 name = "vite_select"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0#1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -7400,7 +7401,7 @@ dependencies = [
 [[package]]
 name = "vite_shell"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0#1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0"
 dependencies = [
  "bincode",
  "brush-parser 0.3.0 (git+https://github.com/reubeno/brush?rev=dcb760933b10ee0433d7b740a5709b06f5c67c6b)",
@@ -7427,7 +7428,7 @@ dependencies = [
 [[package]]
 name = "vite_str"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0#1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0"
 dependencies = [
  "bincode",
  "compact_str",
@@ -7438,7 +7439,7 @@ dependencies = [
 [[package]]
 name = "vite_task"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0#1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7473,7 +7474,7 @@ dependencies = [
 [[package]]
 name = "vite_task_graph"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0#1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7495,7 +7496,7 @@ dependencies = [
 [[package]]
 name = "vite_task_plan"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0#1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7521,7 +7522,7 @@ dependencies = [
 [[package]]
 name = "vite_workspace"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=6fdc4f106563491be4fb36381b84c5937d74fe9c#6fdc4f106563491be4fb36381b84c5937d74fe9c"
+source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0#1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0"
 dependencies = [
  "clap",
  "petgraph 0.8.3",
@@ -7799,7 +7800,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ dunce = "1.0.5"
 fast-glob = "1.0.0"
 flate2 = { version = "=1.1.9", features = ["zlib-rs"] }
 form_urlencoded = "1.2.1"
-fspy = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "6fdc4f106563491be4fb36381b84c5937d74fe9c" }
+fspy = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0" }
 futures = "0.3.31"
 futures-util = "0.3.31"
 glob = "0.3.2"
@@ -183,15 +183,15 @@ vfs = "0.12.1"
 vite_command = { path = "crates/vite_command" }
 vite_error = { path = "crates/vite_error" }
 vite_js_runtime = { path = "crates/vite_js_runtime" }
-vite_glob = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "6fdc4f106563491be4fb36381b84c5937d74fe9c" }
+vite_glob = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0" }
 vite_install = { path = "crates/vite_install" }
 vite_migration = { path = "crates/vite_migration" }
 vite_shared = { path = "crates/vite_shared" }
 vite_static_config = { path = "crates/vite_static_config" }
-vite_path = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "6fdc4f106563491be4fb36381b84c5937d74fe9c" }
-vite_str = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "6fdc4f106563491be4fb36381b84c5937d74fe9c" }
-vite_task = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "6fdc4f106563491be4fb36381b84c5937d74fe9c" }
-vite_workspace = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "6fdc4f106563491be4fb36381b84c5937d74fe9c" }
+vite_path = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0" }
+vite_str = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0" }
+vite_task = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0" }
+vite_workspace = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "1acf3eec06a91ceaeba880bb2b52b3c93a3f56a0" }
 walkdir = "2.5.0"
 wax = "0.6.0"
 which = "8.0.0"

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -10,6 +10,7 @@ criterion = { workspace = true }
 rustc-hash = { workspace = true }
 tokio = { workspace = true, features = ["rt"] }
 vite_path = { workspace = true }
+vite_str = { workspace = true }
 vite_task = { workspace = true }
 
 [[bench]]

--- a/bench/benches/workspace_load.rs
+++ b/bench/benches/workspace_load.rs
@@ -4,8 +4,9 @@ use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use rustc_hash::FxHashMap;
 use tokio::runtime::Runtime;
 use vite_path::{AbsolutePath, AbsolutePathBuf};
+use vite_str::Str;
 use vite_task::{
-    CommandHandler, HandledCommand, Session, SessionCallbacks, plan_request::ScriptCommand,
+    CommandHandler, HandledCommand, Session, SessionConfig, plan_request::ScriptCommand,
 };
 
 /// A no-op command handler for benchmarking purposes.
@@ -38,16 +39,17 @@ impl vite_task::loader::UserConfigLoader for NoOpUserConfigLoader {
 
 /// Owned session callbacks for benchmarking.
 #[derive(Default)]
-struct BenchSessionCallbacks {
+struct BenchSessionConfig {
     command_handler: NoOpCommandHandler,
     user_config_loader: NoOpUserConfigLoader,
 }
 
-impl BenchSessionCallbacks {
-    fn as_callbacks(&mut self) -> SessionCallbacks<'_> {
-        SessionCallbacks {
+impl BenchSessionConfig {
+    fn as_callbacks(&mut self) -> SessionConfig<'_> {
+        SessionConfig {
             command_handler: &mut self.command_handler,
             user_config_loader: &mut self.user_config_loader,
+            program_name: Str::from("vp"),
         }
     }
 }
@@ -67,7 +69,7 @@ fn bench_workspace_load(c: &mut Criterion) {
     session_group.bench_function("ensure_task_graph_loaded", |b| {
         b.iter(|| {
             runtime.block_on(async {
-                let mut owned_callbacks = BenchSessionCallbacks::default();
+                let mut owned_callbacks = BenchSessionConfig::default();
                 let envs: FxHashMap<Arc<OsStr>, Arc<OsStr>> = FxHashMap::default();
                 let mut session = Session::init_with(
                     envs,
@@ -85,7 +87,7 @@ fn bench_workspace_load(c: &mut Criterion) {
     session_group.bench_with_input(BenchmarkId::new("packages", 100), &fixture_path, |b, path| {
         b.iter(|| {
             runtime.block_on(async {
-                let mut owned_callbacks = BenchSessionCallbacks::default();
+                let mut owned_callbacks = BenchSessionConfig::default();
                 let envs: FxHashMap<Arc<OsStr>, Arc<OsStr>> = FxHashMap::default();
                 let mut session =
                     Session::init_with(envs, path.clone().into(), owned_callbacks.as_callbacks())

--- a/packages/cli/binding/src/cli.rs
+++ b/packages/cli/binding/src/cli.rs
@@ -21,7 +21,7 @@ use vite_path::{AbsolutePath, AbsolutePathBuf};
 use vite_shared::{PrependOptions, output, prepend_to_path_env};
 use vite_str::Str;
 use vite_task::{
-    Command, CommandHandler, ExitStatus, HandledCommand, ScriptCommand, Session, SessionCallbacks,
+    Command, CommandHandler, ExitStatus, HandledCommand, ScriptCommand, Session, SessionConfig,
     config::{
         UserRunConfig,
         user::{EnabledCacheConfig, UserCacheConfig},
@@ -387,9 +387,9 @@ impl SubcommandResolver {
                         .chain(args.into_iter().map(Str::from))
                         .collect(),
                     cache_config: UserCacheConfig::with_config(EnabledCacheConfig {
-                        envs: Some(Box::new([Str::from("OXLINT_TSGOLINT_PATH")])),
-                        pass_through_envs: None,
-                        inputs: None,
+                        env: Some(Box::new([Str::from("OXLINT_TSGOLINT_PATH")])),
+                        untracked_env: None,
+                        input: None,
                     }),
                     envs: merge_resolved_envs(envs, resolved.envs),
                 })
@@ -430,9 +430,9 @@ impl SubcommandResolver {
                         .chain(args.into_iter().map(Str::from))
                         .collect(),
                     cache_config: UserCacheConfig::with_config(EnabledCacheConfig {
-                        envs: None,
-                        pass_through_envs: None,
-                        inputs: None,
+                        env: None,
+                        untracked_env: None,
+                        input: None,
                     }),
                     envs: merge_resolved_envs(envs, resolved.envs),
                 })
@@ -455,9 +455,9 @@ impl SubcommandResolver {
                         .chain(args.into_iter().map(Str::from))
                         .collect(),
                     cache_config: UserCacheConfig::with_config(EnabledCacheConfig {
-                        envs: Some(Box::new([Str::from("VITE_*")])),
-                        pass_through_envs: None,
-                        inputs: None,
+                        env: Some(Box::new([Str::from("VITE_*")])),
+                        untracked_env: None,
+                        input: None,
                     }),
                     envs: merge_resolved_envs_with_version(envs, resolved.envs),
                 })
@@ -483,9 +483,9 @@ impl SubcommandResolver {
                     program: Arc::from(OsStr::new("node")),
                     args: iter::once(Str::from(js_path_str)).chain(vitest_args).collect(),
                     cache_config: UserCacheConfig::with_config(EnabledCacheConfig {
-                        envs: None,
-                        pass_through_envs: None,
-                        inputs: None,
+                        env: None,
+                        untracked_env: None,
+                        input: None,
                     }),
                     envs: merge_resolved_envs_with_version(envs, resolved.envs),
                 })
@@ -507,9 +507,9 @@ impl SubcommandResolver {
                         .chain(args.into_iter().map(Str::from))
                         .collect(),
                     cache_config: UserCacheConfig::with_config(EnabledCacheConfig {
-                        envs: None,
-                        pass_through_envs: None,
-                        inputs: None,
+                        env: None,
+                        untracked_env: None,
+                        input: None,
                     }),
                     envs: merge_resolved_envs(envs, resolved.envs),
                 })
@@ -573,9 +573,9 @@ impl SubcommandResolver {
                         .chain(args.into_iter().map(Str::from))
                         .collect(),
                     cache_config: UserCacheConfig::with_config(EnabledCacheConfig {
-                        envs: None,
-                        pass_through_envs: None,
-                        inputs: None,
+                        env: None,
+                        untracked_env: None,
+                        input: None,
                     }),
                     envs: merge_resolved_envs(envs, resolved.envs),
                 })
@@ -604,9 +604,9 @@ impl SubcommandResolver {
                     ),
                     args: resolve_command.args.into_iter().map(Str::from).collect(),
                     cache_config: UserCacheConfig::with_config(EnabledCacheConfig {
-                        envs: None,
-                        pass_through_envs: None,
-                        inputs: None,
+                        env: None,
+                        untracked_env: None,
+                        input: None,
                     }),
                     envs: merged_envs,
                 })
@@ -1403,9 +1403,10 @@ async fn execute_vite_task_command(
         prepend_to_path_env(&bin_prefix, PrependOptions::default());
     }
 
-    let session = Session::init(SessionCallbacks {
+    let session = Session::init(SessionConfig {
         command_handler: &mut command_handler,
         user_config_loader: &mut config_loader,
+        program_name: Str::from("vp"),
     })?;
 
     // Main execution (consumes session)

--- a/packages/cli/snap-tests/change-passthrough-env-config/snap.txt
+++ b/packages/cli/snap-tests/change-passthrough-env-config/snap.txt
@@ -11,7 +11,7 @@ $ node -p process.env.MY_ENV ✓ cache hit, replaying
 vp run: cache hit, <variable>ms saved.
 
 > # add a new pass through env via VITE_TASK_PASS_THROUGH_ENVS
-> VITE_TASK_PASS_THROUGH_ENVS=MY_ENV,MY_ENV2 MY_ENV=2 vp run hello # cache should be invalidated because passThroughEnvs config changed
-$ node -p process.env.MY_ENV ✗ cache miss: pass-through env config changed, executing
+> VITE_TASK_PASS_THROUGH_ENVS=MY_ENV,MY_ENV2 MY_ENV=2 vp run hello # cache should be invalidated because untrackedEnv config changed
+$ node -p process.env.MY_ENV ✗ cache miss: untracked env config changed, executing
 2
 

--- a/packages/cli/snap-tests/change-passthrough-env-config/steps.json
+++ b/packages/cli/snap-tests/change-passthrough-env-config/steps.json
@@ -4,6 +4,6 @@
     "MY_ENV=1 vp run hello",
     "MY_ENV=2 vp run hello # MY_ENV is pass-through. should hit the cache created in step 1",
     "# add a new pass through env via VITE_TASK_PASS_THROUGH_ENVS",
-    "VITE_TASK_PASS_THROUGH_ENVS=MY_ENV,MY_ENV2 MY_ENV=2 vp run hello # cache should be invalidated because passThroughEnvs config changed"
+    "VITE_TASK_PASS_THROUGH_ENVS=MY_ENV,MY_ENV2 MY_ENV=2 vp run hello # cache should be invalidated because untrackedEnv config changed"
   ]
 }

--- a/packages/cli/snap-tests/change-passthrough-env-config/vite.config.ts
+++ b/packages/cli/snap-tests/change-passthrough-env-config/vite.config.ts
@@ -1,11 +1,11 @@
-const passThroughEnvs = process.env.VITE_TASK_PASS_THROUGH_ENVS?.split(',') ?? ['MY_ENV'];
+const untrackedEnv = process.env.VITE_TASK_PASS_THROUGH_ENVS?.split(',') ?? ['MY_ENV'];
 
 export default {
   run: {
     tasks: {
       hello: {
         command: 'node -p process.env.MY_ENV',
-        passThroughEnvs,
+        untrackedEnv,
         cache: true,
       },
     },

--- a/packages/cli/snap-tests/plain-terminal-ui/snap.txt
+++ b/packages/cli/snap-tests/plain-terminal-ui/snap.txt
@@ -31,13 +31,13 @@ $ node hello.mjs ✗ cache miss: 'input.txt' modified, executing
 bar undefined
 
 
-> # set passThroughEnvs via env var
-> VITE_TASK_PASS_THROUGH_ENVS=PTE vp run hello # passThroughEnvs changed
-$ node hello.mjs ✗ cache miss: pass-through env config changed, executing
+> # set untrackedEnv via env var
+> VITE_TASK_PASS_THROUGH_ENVS=PTE vp run hello # untrackedEnv changed
+$ node hello.mjs ✗ cache miss: untracked env config changed, executing
 bar undefined
 
 
-> # set cwd via env var (keep passThroughEnvs from previous step)
+> # set cwd via env var (keep untrackedEnv from previous step)
 > VITE_TASK_PASS_THROUGH_ENVS=PTE VITE_TASK_CWD=subfolder vp run hello # cwd changed
 ~/subfolder$ node hello.mjs ✗ cache miss: working directory changed, executing
 hello from subfolder

--- a/packages/cli/snap-tests/plain-terminal-ui/steps.json
+++ b/packages/cli/snap-tests/plain-terminal-ui/steps.json
@@ -10,9 +10,9 @@
     "vp run hello # env removed",
     "echo bar > input.txt",
     "vp run hello # input changed",
-    "# set passThroughEnvs via env var",
-    "VITE_TASK_PASS_THROUGH_ENVS=PTE vp run hello # passThroughEnvs changed",
-    "# set cwd via env var (keep passThroughEnvs from previous step)",
+    "# set untrackedEnv via env var",
+    "VITE_TASK_PASS_THROUGH_ENVS=PTE vp run hello # untrackedEnv changed",
+    "# set cwd via env var (keep untrackedEnv from previous step)",
     "VITE_TASK_PASS_THROUGH_ENVS=PTE VITE_TASK_CWD=subfolder vp run hello # cwd changed"
   ]
 }

--- a/packages/cli/snap-tests/plain-terminal-ui/vite.config.ts
+++ b/packages/cli/snap-tests/plain-terminal-ui/vite.config.ts
@@ -1,4 +1,4 @@
-const passThroughEnvs = process.env.VITE_TASK_PASS_THROUGH_ENVS?.split(',');
+const untrackedEnv = process.env.VITE_TASK_PASS_THROUGH_ENVS?.split(',');
 const cwd = process.env.VITE_TASK_CWD;
 
 export default {
@@ -6,9 +6,9 @@ export default {
     tasks: {
       hello: {
         command: 'node hello.mjs',
-        envs: ['FOO', 'BAR'],
+        env: ['FOO', 'BAR'],
         cache: true,
-        ...(passThroughEnvs && { passThroughEnvs }),
+        ...(untrackedEnv && { untrackedEnv }),
         ...(cwd && { cwd }),
       },
     },

--- a/packages/cli/snap-tests/run-task-command-conflict/snap.txt
+++ b/packages/cli/snap-tests/run-task-command-conflict/snap.txt
@@ -1,5 +1,4 @@
 > # Test that conflicting package.json and vite.config.ts task commands render cleanly
 [1]> vp run build
 error: Failed to load task graph
-* Failed to resolve task config for task run-task-command-conflict-test#build
-* Both package.json script and vite.config.* task define commands for the task
+* Task run-task-command-conflict-test#build conflicts with a package.json script of the same name. Remove the script from package.json or rename the task

--- a/packages/cli/src/run-config.ts
+++ b/packages/cli/src/run-config.ts
@@ -3,10 +3,8 @@
 export type Task = {
   /**
    * The command to run for the task.
-   *
-   * If omitted, the script from `package.json` with the same name will be used
    */
-  command?: string;
+  command: string;
   /**
    * The working directory for the task, relative to the package root (not workspace root).
    */
@@ -24,11 +22,11 @@ export type Task = {
       /**
        * Environment variable names to be fingerprinted and passed to the task.
        */
-      envs?: Array<string>;
+      env?: Array<string>;
       /**
        * Environment variable names to be passed to the task without fingerprinting.
        */
-      passThroughEnvs?: Array<string>;
+      untrackedEnv?: Array<string>;
       /**
        * Files to include in the cache fingerprint.
        *
@@ -40,7 +38,7 @@ export type Task = {
        *
        * Patterns are relative to the package directory.
        */
-      inputs?: Array<
+      input?: Array<
         | string
         | {
             /**


### PR DESCRIPTION
## Summary
- Bump vite-task dependency from `6fdc4f1` to `1acf3eec` (latest main)
- Adapt to API changes: `SessionCallbacks` → `SessionConfig` with `program_name`, `EnabledCacheConfig` field renames (`envs`→`env`, `pass_through_envs`→`untracked_env`, `inputs`→`input`)
- Update `run-config.ts` types, snap test configs and expected outputs

## Test plan
- [x] `cargo check --all-targets --all-features` passes locally
- [x] `cargo fmt --check` passes
- [ ] CI passes