### PR TITLE
feat(deps): upgrade upstream dependencies

### DIFF
--- a/packages/cli/src/pack-bin.ts
+++ b/packages/cli/src/pack-bin.ts
@@ -72,6 +72,7 @@ cli
   .option('--public-dir <dir>', 'Alias for --copy, deprecated')
   .option('--tsconfig <tsconfig>', 'Set tsconfig path')
   .option('--unbundle', 'Unbundle mode')
+  .option('--root <dir>', 'Root directory of input files')
   .option('--exe', 'Bundle as executable')
   .option('-W, --workspace [dir]', 'Enable workspace mode')
   .option('-F, --filter <pattern>', 'Filter configs (cwd or name), e.g. /pkg-name$/ or pkg-name')


### PR DESCRIPTION
Automated daily upgrade of upstream dependencies:
- rolldown (latest tag)
- rolldown-vite (latest tag)
- vitest (latest npm version)
- tsdown (latest npm version)

Build status: success

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI surface-area change only; no behavioral changes beyond accepting and forwarding an additional option.
> 
> **Overview**
> Adds a new `--root <dir>` flag to `vp pack` so callers can specify the root directory of input files when invoking the pack CLI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit daab44f0821d5423c14264f9c996b789dfe30155. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->