### PR TITLE
feat(deps): upgrade upstream dependencies

### DIFF
--- a/packages/cli/snap-tests/command-helper/snap.txt
+++ b/packages/cli/snap-tests/command-helper/snap.txt
@@ -70,6 +70,7 @@ Options:
   --public-dir <dir>            Alias for --copy, deprecated 
   --tsconfig <tsconfig>         Set tsconfig path 
   --unbundle                    Unbundle mode 
+  --root <dir>                  Root directory of input files 
   --exe                         Bundle as executable 
   -W, --workspace [dir]         Enable workspace mode 
   -F, --filter <pattern>        Filter configs (cwd or name), e.g. /pkg-name$/ or pkg-name 

--- a/packages/cli/snap-tests/command-pack/snap.txt
+++ b/packages/cli/snap-tests/command-pack/snap.txt
@@ -44,6 +44,7 @@ Options:
   --public-dir <dir>            Alias for --copy, deprecated 
   --tsconfig <tsconfig>         Set tsconfig path 
   --unbundle                    Unbundle mode 
+  --root <dir>                  Root directory of input files 
   --exe                         Bundle as executable 
   -W, --workspace [dir]         Enable workspace mode 
   -F, --filter <pattern>        Filter configs (cwd or name), e.g. /pkg-name$/ or pkg-name 

--- a/packages/cli/src/pack-bin.ts
+++ b/packages/cli/src/pack-bin.ts
@@ -72,6 +72,7 @@ cli
   .option('--public-dir <dir>', 'Alias for --copy, deprecated')
   .option('--tsconfig <tsconfig>', 'Set tsconfig path')
   .option('--unbundle', 'Unbundle mode')
+  .option('--root <dir>', 'Root directory of input files')
   .option('--exe', 'Bundle as executable')
   .option('-W, --workspace [dir]', 'Enable workspace mode')
   .option('-F, --filter <pattern>', 'Filter configs (cwd or name), e.g. /pkg-name$/ or pkg-name')


### PR DESCRIPTION
Automated daily upgrade of upstream dependencies:
- rolldown (latest tag)
- rolldown-vite (latest tag)
- vitest (latest npm version)
- tsdown (latest npm version)

Build status: success

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new CLI flag and updates help-text snapshots, with no changes to build execution logic beyond passing the new flag through the existing config resolution path.
> 
> **Overview**
> Adds a new `--root <dir>` flag to `vp pack` to allow specifying the root directory for input files.
> 
> Updates CLI help snapshot tests (`command-helper` and `command-pack`) to include the new option in the generated help output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5c1c294e4fba9d31a7a81ea8ef0a745bb3499a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->