### PR TITLE
fix: show error output when `vp check --fix` fmt fails

### DIFF
--- a/packages/cli/binding/src/cli.rs
+++ b/packages/cli/binding/src/cli.rs
@@ -1036,6 +1036,14 @@ fn print_summary_line(message: &str) {
     }
 }
 
+fn print_error_block(error_msg: &str, combined_output: &str, summary_msg: &str) {
+    output::error(error_msg);
+    if !combined_output.trim().is_empty() {
+        print_stdout_block(combined_output);
+    }
+    print_summary_line(summary_msg);
+}
+
 fn print_pass_line(message: &str, detail: Option<&str>) {
     if let Some(detail) = detail {
         output::raw(&format!("{} {message} {}", "pass:".bright_blue().bold(), detail.dimmed()));
@@ -1200,11 +1208,11 @@ async fn execute_direct_subcommand(
                             ));
                         }
                         None => {
-                            output::error("Formatting could not start");
-                            if !combined_output.trim().is_empty() {
-                                print_stdout_block(&combined_output);
-                            }
-                            print_summary_line("Formatting failed before analysis started");
+                            print_error_block(
+                                "Formatting could not start",
+                                &combined_output,
+                                "Formatting failed before analysis started",
+                            );
                         }
                     }
                 }
@@ -1216,6 +1224,13 @@ async fn execute_direct_subcommand(
                     );
                 }
                 if status != ExitStatus::SUCCESS {
+                    if fix {
+                        print_error_block(
+                            "Formatting could not complete",
+                            &combined_output,
+                            "Formatting failed during fix",
+                        );
+                    }
                     resolver.cleanup_temp_files().await;
                     return Ok(status);
                 }
@@ -1326,11 +1341,11 @@ async fn execute_direct_subcommand(
                     } else {
                         format!("{}{}", captured.stdout, captured.stderr)
                     };
-                    output::error("Formatting could not finish after lint fixes");
-                    if !combined_output.trim().is_empty() {
-                        print_stdout_block(&combined_output);
-                    }
-                    print_summary_line("Formatting failed after lint fixes were applied");
+                    print_error_block(
+                        "Formatting could not finish after lint fixes",
+                        &combined_output,
+                        "Formatting failed after lint fixes were applied",
+                    );
                     resolver.cleanup_temp_files().await;
                     return Ok(status);
                 }

--- a/packages/cli/snap-tests/check-fix-missing-stderr/package.json
+++ b/packages/cli/snap-tests/check-fix-missing-stderr/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "check-fix-missing-stderr",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/packages/cli/snap-tests/check-fix-missing-stderr/snap.txt
+++ b/packages/cli/snap-tests/check-fix-missing-stderr/snap.txt
@@ -1,0 +1,13 @@
+[1]> vp check --fix
+error: Formatting could not complete
+Failed to parse configuration.
+invalid type: string "invalid", expected struct Oxfmtrc
+
+Formatting failed during fix
+
+[1]> vp check
+error: Formatting could not start
+Failed to parse configuration.
+invalid type: string "invalid", expected struct Oxfmtrc
+
+Formatting failed before analysis started

--- a/packages/cli/snap-tests/check-fix-missing-stderr/src/index.js
+++ b/packages/cli/snap-tests/check-fix-missing-stderr/src/index.js
@@ -1,0 +1,5 @@
+function hello() {
+  return "hello";
+}
+
+export { hello };

--- a/packages/cli/snap-tests/check-fix-missing-stderr/steps.json
+++ b/packages/cli/snap-tests/check-fix-missing-stderr/steps.json
@@ -1,0 +1,6 @@
+{
+  "commands": [
+    "vp check --fix",
+    "vp check"
+  ]
+}

--- a/packages/cli/snap-tests/check-fix-missing-stderr/vite.config.ts
+++ b/packages/cli/snap-tests/check-fix-missing-stderr/vite.config.ts
@@ -1,0 +1,3 @@
+export default {
+  fmt: "invalid",
+};


### PR DESCRIPTION
When fmt failed during `vp check --fix`, the error output was silently
swallowed because display logic was gated behind `if !fix`. Now the
error is shown via a new `print_error_block` helper that consolidates
the repeated error display pattern across all three fmt error paths.