### PR TITLE
feat(deps): upgrade upstream dependencies

### DIFF
--- a/packages/cli/snap-tests/command-helper/snap.txt
+++ b/packages/cli/snap-tests/command-helper/snap.txt
@@ -70,6 +70,7 @@ Options:
   --public-dir <dir>            Alias for --copy, deprecated 
   --tsconfig <tsconfig>         Set tsconfig path 
   --unbundle                    Unbundle mode 
+  --root <dir>                  Root directory of input files 
   --exe                         Bundle as executable 
   -W, --workspace [dir]         Enable workspace mode 
   -F, --filter <pattern>        Filter configs (cwd or name), e.g. /pkg-name$/ or pkg-name 

--- a/packages/cli/snap-tests/command-pack/snap.txt
+++ b/packages/cli/snap-tests/command-pack/snap.txt
@@ -44,6 +44,7 @@ Options:
   --public-dir <dir>            Alias for --copy, deprecated 
   --tsconfig <tsconfig>         Set tsconfig path 
   --unbundle                    Unbundle mode 
+  --root <dir>                  Root directory of input files 
   --exe                         Bundle as executable 
   -W, --workspace [dir]         Enable workspace mode 
   -F, --filter <pattern>        Filter configs (cwd or name), e.g. /pkg-name$/ or pkg-name 

--- a/packages/cli/src/pack-bin.ts
+++ b/packages/cli/src/pack-bin.ts
@@ -72,6 +72,7 @@ cli
   .option('--public-dir <dir>', 'Alias for --copy, deprecated')
   .option('--tsconfig <tsconfig>', 'Set tsconfig path')
   .option('--unbundle', 'Unbundle mode')
+  .option('--root <dir>', 'Root directory of input files')
   .option('--exe', 'Bundle as executable')
   .option('-W, --workspace [dir]', 'Enable workspace mode')
   .option('-F, --filter <pattern>', 'Filter configs (cwd or name), e.g. /pkg-name$/ or pkg-name')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5551,6 +5551,7 @@ packages:
   basic-ftp@5.0.5:
     resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.0, please upgrade
 
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
@@ -9124,6 +9125,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}


### PR DESCRIPTION
Automated daily upgrade of upstream dependencies:
- rolldown (latest tag)
- rolldown-vite (latest tag)
- vitest (latest npm version)
- tsdown (latest npm version)

Build status: success

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new CLI flag and updates snapshots; behavior change is limited to consumers who opt into `--root`, plus minor lockfile metadata updates.
> 
> **Overview**
> `vp pack` now exposes a new `--root <dir>` flag to set the root directory for input files, and the CLI help snapshot tests are updated accordingly.
> 
> The `pnpm-lock.yaml` is refreshed to include new deprecation metadata for some transitive packages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 498e8b9a572f0cee86e46959c3e8da63ccaba524. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->