### PR TITLE
refactor: remove old versioned marker system from agent instructions injection

### DIFF
--- a/packages/cli/src/config/__tests__/agent.spec.ts
+++ b/packages/cli/src/config/__tests__/agent.spec.ts
@@ -32,7 +32,7 @@ vi.mock('node:fs', () => ({
   default: fsMock,
 }));
 
-import { hasExistingAgentInstructions, injectAgentBlock } from '../agent.js';
+import { injectAgentBlock } from '../agent.js';
 
 beforeEach(() => {
   files.clear();
@@ -43,33 +43,6 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
-});
-
-describe('hasExistingAgentInstructions', () => {
-  it('returns true when AGENTS.md has start marker', () => {
-    files.set(
-      join('/project', 'AGENTS.md'),
-      '<!--VITE PLUS START-->\ncontent\n<!--VITE PLUS END-->',
-    );
-    expect(hasExistingAgentInstructions('/project')).toBe(true);
-  });
-
-  it('returns true when CLAUDE.md has start marker', () => {
-    files.set(
-      join('/project', 'CLAUDE.md'),
-      '<!--VITE PLUS START-->\ncontent\n<!--VITE PLUS END-->',
-    );
-    expect(hasExistingAgentInstructions('/project')).toBe(true);
-  });
-
-  it('returns false when files exist without markers', () => {
-    files.set(join('/project', 'AGENTS.md'), '# No markers here');
-    expect(hasExistingAgentInstructions('/project')).toBe(false);
-  });
-
-  it('returns false when no files exist', () => {
-    expect(hasExistingAgentInstructions('/project')).toBe(false);
-  });
 });
 
 describe('injectAgentBlock', () => {

--- a/packages/cli/src/config/agent.ts
+++ b/packages/cli/src/config/agent.ts
@@ -4,9 +4,9 @@ import { dirname, join } from 'node:path';
 import * as prompts from '@voidzero-dev/vite-plus-prompts';
 
 import {
-  AGENT_INSTRUCTIONS_START_MARKER,
   detectAgents,
   getAgentById,
+  hasExistingAgentInstructions,
   replaceMarkedAgentInstructionsSection,
   type AgentConfig,
   type McpConfigTarget,
@@ -91,18 +91,7 @@ function readAgentPrompt(): string {
 
 // --- Agent instructions injection ---
 
-export function hasExistingAgentInstructions(root: string): boolean {
-  for (const file of ['AGENTS.md', 'CLAUDE.md']) {
-    const fullPath = join(root, file);
-    if (existsSync(fullPath)) {
-      const content = readFileSync(fullPath, 'utf-8');
-      if (content.includes(AGENT_INSTRUCTIONS_START_MARKER)) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
+export { hasExistingAgentInstructions };
 
 export function injectAgentBlock(root: string, filePath: string): void {
   const fullPath = join(root, filePath);

--- a/packages/cli/src/utils/__tests__/agent.spec.ts
+++ b/packages/cli/src/utils/__tests__/agent.spec.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   detectExistingAgentTargetPaths,
   detectExistingAgentTargetPath,
+  hasExistingAgentInstructions,
   replaceMarkedAgentInstructionsSection,
   resolveAgentTargetPaths,
   writeAgentInstructions,
@@ -101,6 +102,15 @@ class InMemoryFs {
       throw new Error(`ENOENT: no such file "${String(filePath)}"`);
     }
     this.nodes.delete(normalizedPath);
+  }
+
+  readFileSync(filePath: fs.PathLike): string {
+    const resolvedPath = this.resolvePath(filePath);
+    const node = this.nodes.get(resolvedPath);
+    if (!node || node.kind !== 'file') {
+      throw new Error(`ENOENT: no such file "${String(filePath)}"`);
+    }
+    return node.content;
   }
 
   isSymlink(filePath: string): boolean {
@@ -197,6 +207,9 @@ beforeEach(async () => {
 
   vi.spyOn(fs, 'existsSync').mockImplementation((filePath) => mockFs.existsSync(filePath));
   vi.spyOn(fs, 'lstatSync').mockImplementation((filePath) => mockFs.lstatSync(filePath));
+  vi.spyOn(fs, 'readFileSync').mockImplementation((filePath) =>
+    mockFs.readFileSync(filePath as fs.PathLike),
+  );
 
   vi.spyOn(fsPromises, 'appendFile').mockImplementation(async (filePath, data) =>
     mockFs.appendFile(filePath as fs.PathLike, String(data)),
@@ -373,5 +386,36 @@ describe('writeAgentInstructions symlink behavior', () => {
     expect(selectSpy).not.toHaveBeenCalled();
     expect(await mockFs.readText(targetPath)).toContain('template block');
     expect(successSpy).not.toHaveBeenCalledWith('Updated agent instructions in AGENTS.md');
+  });
+});
+
+describe('hasExistingAgentInstructions', () => {
+  it('returns true when an agent file has start marker', async () => {
+    const dir = await createProjectDir();
+    await mockFs.writeFile(
+      path.join(dir, 'AGENTS.md'),
+      '<!--VITE PLUS START-->\ncontent\n<!--VITE PLUS END-->',
+    );
+    expect(hasExistingAgentInstructions(dir)).toBe(true);
+  });
+
+  it('returns true when CLAUDE.md has start marker', async () => {
+    const dir = await createProjectDir();
+    await mockFs.writeFile(
+      path.join(dir, 'CLAUDE.md'),
+      '<!--VITE PLUS START-->\ncontent\n<!--VITE PLUS END-->',
+    );
+    expect(hasExistingAgentInstructions(dir)).toBe(true);
+  });
+
+  it('returns false when files exist without markers', async () => {
+    const dir = await createProjectDir();
+    await mockFs.writeFile(path.join(dir, 'AGENTS.md'), '# No markers here');
+    expect(hasExistingAgentInstructions(dir)).toBe(false);
+  });
+
+  it('returns false when no files exist', async () => {
+    const dir = await createProjectDir();
+    expect(hasExistingAgentInstructions(dir)).toBe(false);
   });
 });

--- a/packages/cli/src/utils/agent.ts
+++ b/packages/cli/src/utils/agent.ts
@@ -189,7 +189,7 @@ export const AGENTS = [
 
 type AgentSelection = string | string[] | false;
 const AGENT_STANDARD_PATH = 'AGENTS.md';
-export const AGENT_INSTRUCTIONS_START_MARKER = '<!--VITE PLUS START-->';
+const AGENT_INSTRUCTIONS_START_MARKER = '<!--VITE PLUS START-->';
 const AGENT_INSTRUCTIONS_END_MARKER = '<!--VITE PLUS END-->';
 
 export async function selectAgentTargetPaths({
@@ -263,6 +263,20 @@ export function detectExistingAgentTargetPaths(projectRoot: string) {
 
 export function detectExistingAgentTargetPath(projectRoot: string) {
   return detectExistingAgentTargetPaths(projectRoot)?.[0];
+}
+
+export function hasExistingAgentInstructions(projectRoot: string): boolean {
+  const targetPaths = detectExistingAgentTargetPaths(projectRoot);
+  if (!targetPaths) {
+    return false;
+  }
+  for (const targetPath of targetPaths) {
+    const content = fs.readFileSync(path.join(projectRoot, targetPath), 'utf-8');
+    if (content.includes(AGENT_INSTRUCTIONS_START_MARKER)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 export function resolveAgentTargetPaths(agent?: string | string[]) {


### PR DESCRIPTION
Replace the `<!--injected-by-vite-plus-v...-->` marker system with the
`<!--VITE PLUS START-->` / `<!--VITE PLUS END-->` markers already used
by `utils/agent.ts`. This removes `getOwnVersion()`, version comparison
logic, and the old regex constants, reusing `replaceMarkedAgentInstructionsSection()`
from the shared utility instead.