### PR TITLE
chore(ci): remove VITE_TASK_TOKEN from workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,9 +84,6 @@ jobs:
       - run: rustup target add x86_64-unknown-linux-musl
         if: ${{ matrix.os == 'ubuntu-latest' }}
 
-      - name: Configure Git for access to vite-task
-        run: git config --global url."https://x-access-token:${{ secrets.VITE_TASK_TOKEN }}@github.com/".insteadOf "ssh://git@github.com/"
-
       - run: cargo check --all-targets --all-features
         env:
           RUSTFLAGS: '-D warnings --cfg tokio_unstable' # also update .cargo/config.toml
@@ -103,9 +100,6 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/clone
-
-      - name: Configure Git for access to vite-task
-        run: git config --global url."https://x-access-token:${{ secrets.VITE_TASK_TOKEN }}@github.com/".insteadOf "ssh://git@github.com/"
 
       - uses: oxc-project/setup-rust@d286d43bc1f606abbd98096666ff8be68c8d5f57 # v1.0.0
         with:
@@ -137,9 +131,6 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/clone
-
-      - name: Configure Git for access to vite-task
-        run: git config --global url."https://x-access-token:${{ secrets.VITE_TASK_TOKEN }}@github.com/".insteadOf "ssh://git@github.com/"
 
       - uses: oxc-project/setup-rust@d286d43bc1f606abbd98096666ff8be68c8d5f57 # v1.0.0
         with:
@@ -189,9 +180,6 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/clone
-
-      - name: Configure Git for access to vite-task
-        run: git config --global url."https://x-access-token:${{ secrets.VITE_TASK_TOKEN }}@github.com/".insteadOf "ssh://git@github.com/"
 
       # Disable Windows Defender real-time scanning to speed up I/O-heavy builds (~30-50% faster)
       - name: Disable Windows Defender
@@ -574,9 +562,6 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/clone
-
-      - name: Configure Git for access to vite-task
-        run: git config --global url."https://x-access-token:${{ secrets.VITE_TASK_TOKEN }}@github.com/".insteadOf "ssh://git@github.com/"
 
       - uses: oxc-project/setup-rust@d286d43bc1f606abbd98096666ff8be68c8d5f57 # v1.0.0
         with:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -80,9 +80,6 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/clone
 
-      - name: Configure Git for access to vite-task
-        run: git config --global url."https://x-access-token:${{ secrets.VITE_TASK_TOKEN }}@github.com/".insteadOf "ssh://git@github.com/"
-
       # Disable Windows Defender real-time scanning to speed up I/O-heavy builds (~30-50% faster)
       - name: Disable Windows Defender
         if: runner.os == 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,9 +95,6 @@ jobs:
           fi
           echo "Version replacement verified successfully"
 
-      - name: Configure Git for access to vite-task
-        run: git config --global url."https://x-access-token:${{ secrets.VITE_TASK_TOKEN }}@github.com/".insteadOf "ssh://git@github.com/"
-
       - name: Build
         uses: ./.github/actions/build-upstream
         with:
@@ -164,9 +161,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
-
-      - name: Configure Git for access to vite-task
-        run: git config --global url."https://x-access-token:${{ secrets.VITE_TASK_TOKEN }}@github.com/".insteadOf "ssh://git@github.com/"
 
       - name: Download cli dist
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/upgrade-deps.yml
+++ b/.github/workflows/upgrade-deps.yml
@@ -19,9 +19,6 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/clone
 
-      - name: Configure Git for access to vite-task
-        run: git config --global url."https://x-access-token:${{ secrets.VITE_TASK_TOKEN }}@github.com/".insteadOf "ssh://git@github.com/"
-
       - uses: oxc-project/setup-rust@d286d43bc1f606abbd98096666ff8be68c8d5f57 # v1.0.0
         with:
           save-cache: ${{ github.ref_name == 'main' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -122,7 +122,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1409,7 +1409,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1564,7 +1564,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1747,7 +1747,7 @@ dependencies = [
 [[package]]
 name = "fspy"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1782,7 +1782,7 @@ dependencies = [
 [[package]]
 name = "fspy_detours_sys"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
 dependencies = [
  "cc",
  "winapi",
@@ -1791,7 +1791,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_unix"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1806,7 +1806,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_windows"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
 dependencies = [
  "bincode",
  "constcat",
@@ -1822,7 +1822,7 @@ dependencies = [
 [[package]]
 name = "fspy_seccomp_unotify"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
 dependencies = [
  "bincode",
  "futures-util",
@@ -1839,7 +1839,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
 dependencies = [
  "allocator-api2",
  "bincode",
@@ -1857,7 +1857,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared_unix"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2607,7 +2607,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2724,7 +2724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
 dependencies = [
  "scopeguard",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3253,7 +3253,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4549,7 +4549,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal_test_client"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
 
 [[package]]
 name = "quinn"
@@ -4603,7 +4603,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5815,7 +5815,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5967,7 +5967,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6302,7 +6302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6474,7 +6474,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7236,7 +7236,7 @@ dependencies = [
 [[package]]
 name = "vite_glob"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
 dependencies = [
  "thiserror 2.0.18",
  "vite_path",
@@ -7279,7 +7279,7 @@ dependencies = [
 [[package]]
 name = "vite_graph_ser"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
 dependencies = [
  "petgraph 0.8.3",
  "serde",
@@ -7361,7 +7361,7 @@ dependencies = [
 [[package]]
 name = "vite_path"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
 dependencies = [
  "bincode",
  "diff-struct",
@@ -7375,7 +7375,7 @@ dependencies = [
 [[package]]
 name = "vite_select"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -7401,7 +7401,7 @@ dependencies = [
 [[package]]
 name = "vite_shell"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
 dependencies = [
  "bincode",
  "brush-parser 0.3.0 (git+https://github.com/reubeno/brush?rev=dcb760933b10ee0433d7b740a5709b06f5c67c6b)",
@@ -7428,7 +7428,7 @@ dependencies = [
 [[package]]
 name = "vite_str"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
 dependencies = [
  "bincode",
  "compact_str",
@@ -7439,7 +7439,7 @@ dependencies = [
 [[package]]
 name = "vite_task"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7474,7 +7474,7 @@ dependencies = [
 [[package]]
 name = "vite_task_graph"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7496,7 +7496,7 @@ dependencies = [
 [[package]]
 name = "vite_task_plan"
 version = "0.1.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7522,7 +7522,7 @@ dependencies = [
 [[package]]
 name = "vite_workspace"
 version = "0.0.0"
-source = "git+ssh://git@github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=398a147fd1ed42a88585d3a9481f200c3e56a2f4#398a147fd1ed42a88585d3a9481f200c3e56a2f4"
 dependencies = [
  "clap",
  "petgraph 0.8.3",
@@ -7800,7 +7800,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ dunce = "1.0.5"
 fast-glob = "1.0.0"
 flate2 = { version = "=1.1.9", features = ["zlib-rs"] }
 form_urlencoded = "1.2.1"
-fspy = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "398a147fd1ed42a88585d3a9481f200c3e56a2f4" }
+fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "398a147fd1ed42a88585d3a9481f200c3e56a2f4" }
 futures = "0.3.31"
 futures-util = "0.3.31"
 glob = "0.3.2"
@@ -183,15 +183,15 @@ vfs = "0.12.1"
 vite_command = { path = "crates/vite_command" }
 vite_error = { path = "crates/vite_error" }
 vite_js_runtime = { path = "crates/vite_js_runtime" }
-vite_glob = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "398a147fd1ed42a88585d3a9481f200c3e56a2f4" }
+vite_glob = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "398a147fd1ed42a88585d3a9481f200c3e56a2f4" }
 vite_install = { path = "crates/vite_install" }
 vite_migration = { path = "crates/vite_migration" }
 vite_shared = { path = "crates/vite_shared" }
 vite_static_config = { path = "crates/vite_static_config" }
-vite_path = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "398a147fd1ed42a88585d3a9481f200c3e56a2f4" }
-vite_str = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "398a147fd1ed42a88585d3a9481f200c3e56a2f4" }
-vite_task = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "398a147fd1ed42a88585d3a9481f200c3e56a2f4" }
-vite_workspace = { git = "ssh://git@github.com/voidzero-dev/vite-task.git", rev = "398a147fd1ed42a88585d3a9481f200c3e56a2f4" }
+vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "398a147fd1ed42a88585d3a9481f200c3e56a2f4" }
+vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "398a147fd1ed42a88585d3a9481f200c3e56a2f4" }
+vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "398a147fd1ed42a88585d3a9481f200c3e56a2f4" }
+vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "398a147fd1ed42a88585d3a9481f200c3e56a2f4" }
 walkdir = "2.5.0"
 wax = "0.6.0"
 which = "8.0.0"
@@ -296,7 +296,7 @@ string_wizard = { path = "./rolldown/crates/string_wizard", features = ["serde"]
 # To use: Ensure vite-task is cloned at ../vite-task relative to vite-plus.
 # Comment out this section before committing.
 # =============================================================================
-# [patch."ssh://git@github.com/voidzero-dev/vite-task.git"]
+# [patch."https://github.com/voidzero-dev/vite-task.git"]
 # fspy = { path = "../vite-task/crates/fspy" }
 # vite_glob = { path = "../vite-task/crates/vite_glob" }
 # vite_path = { path = "../vite-task/crates/vite_path" }


### PR DESCRIPTION
## Summary
- Remove `VITE_TASK_TOKEN` git config steps from all CI workflows (ci, e2e-test, release, upgrade-deps)
- vite-task is now public, so private repo access tokens are no longer needed

## Test plan
- CI should pass without the token since vite-task is publicly accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)