### PR TITLE
fix(ci): switch from Namespace runners to free GitHub-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-          - os: namespace-profile-mac-default
+          - os: macos-latest
             target: aarch64-apple-darwin
     runs-on: ${{ matrix.os }}
     steps:
@@ -174,7 +174,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-          - os: namespace-profile-mac-default
+          - os: macos-latest
           - os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:
@@ -186,12 +186,6 @@ jobs:
         if: runner.os == 'Windows'
         shell: powershell
         run: Set-MpPreference -DisableRealtimeMonitoring $true
-
-      - run: |
-          brew install rustup
-          rustup install stable
-          echo "PATH=/opt/homebrew/opt/rustup/bin:$PATH" >> $GITHUB_ENV
-        if: ${{ matrix.os == 'namespace-profile-mac-default' }}
 
       - uses: oxc-project/setup-rust@d286d43bc1f606abbd98096666ff8be68c8d5f57 # v1.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,9 +48,9 @@ jobs:
       matrix:
         settings:
           - target: aarch64-apple-darwin
-            os: namespace-profile-mac-default
+            os: macos-latest
           - target: x86_64-apple-darwin
-            os: namespace-profile-mac-default
+            os: macos-latest
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
           - target: x86_64-unknown-linux-gnu

--- a/.github/workflows/test-standalone-install.yml
+++ b/.github/workflows/test-standalone-install.yml
@@ -35,7 +35,7 @@ jobs:
             name: Linux x64 glibc
           - os: macos-15-intel
             name: macOS x64
-          - os: namespace-profile-mac-default
+          - os: macos-latest
             name: macOS ARM64
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
Replace `namespace-profile-mac-default` with `macos-latest` across CI,
release, and install test workflows. Remove the manual `brew install
rustup` step that was only needed on the Namespace runner.