### PR TITLE
fix(install): avoid false musl detection on WSL/glibc systems

### DIFF
--- a/packages/cli/install.sh
+++ b/packages/cli/install.sh
@@ -153,11 +153,16 @@ detect_libc() {
 
   # Check ldd output for musl/glibc
   if command -v ldd &> /dev/null; then
-    if ldd --version 2>&1 | grep -qi musl; then
+    ldd_out="$(ldd --version 2>&1 || true)"
+    if echo "$ldd_out" | grep -qi musl; then
       echo "musl"
       return
     fi
-    if ldd --version 2>&1 | grep -qi 'gnu libc\|glibc'; then
+    if echo "$ldd_out" | grep -qi 'gnu libc'; then
+      echo "gnu"
+      return
+    fi
+    if echo "$ldd_out" | grep -qi 'glibc'; then
       echo "gnu"
       return
     fi


### PR DESCRIPTION
Fixes a false `musl` detection in the install script on glibc-based Linux systems,
especially WSL environments where musl happens to be installed.

The previous logic treated the presence of a musl loader file such as
`/lib/ld-musl-x86_64.so.1` as proof that the system was musl-based. On WSL/Ubuntu,
that can be a false positive, which causes the installer to request the wrong
platform package:

`vite-plus-cli-linux-x64-musl-<version>.tgz`

instead of:

`vite-plus-cli-linux-x64-gnu-<version>.tgz`

This then fails during extraction with:

```text
gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```

## Minimal reproduction

Environment used for reproduction:

- WSL
- glibc-based distro (Ubuntu)
- musl also installed, so `/lib/ld-musl-x86_64.so.1` exists

### 1. Verify the environment is actually glibc-based

Run:

```bash
ldd --version | head -1
getconf GNU_LIBC_VERSION
```

Expected output is something like:

```text
ldd (Ubuntu GLIBC 2.39-0ubuntu8.7) 2.39
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
Written by Roland McGrath and Ulrich Drepper.
glibc 2.39
```

This shows the correct target should be `linux-x64-gnu`, not `linux-x64-musl`.

### 2. Run the installer as-is

```bash
curl -fsSL https://vite.plus | bash
```

Observed output:

```text
Setting up VITE+...

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```

At this point the installer does not show which tarball URL failed, because the
download path uses a silent `curl` and `tar` only reports the extraction error.

### 3. To see the actual failing package URL, patch the installer locally

Save the installer locally, then change the `curl` line inside
`download_and_extract()` from:

```bash
curl -sL "$url" -o "$temp_file"
```

to:

```bash
echo "Downloading: $url" >&2
curl -fsSL "$url" -o "$temp_file"
```

Then run the local copy:

```bash
bash install.sh
```

Expected output now shows the real issue:

```text
Setting up VITE+...
Downloading: https://registry.npmjs.org/@voidzero-dev/vite-plus-cli-linux-x64-musl/-/vite-plus-cli-linux-x64-musl-0.1.11.tgz
error: Network error (curl exit code 22)

  This may be caused by:
    - Network connectivity issues
    - Firewall or proxy blocking the connection
    - DNS configuration problems

  Failed URL: https://registry.npmjs.org/@voidzero-dev/vite-plus-cli-linux-x64-musl/-/vite-plus-cli-linux-x64-musl-0.1.11.tgz

  To debug, run:
    curl -v "https://registry.npmjs.org/@voidzero-dev/vite-plus-cli-linux-x64-musl/-/vite-plus-cli-linux-x64-musl-0.1.11.tgz"
```

This reveals that the installer is incorrectly inferring `linux-x64-musl`, and fails because there's no `musl` package in the registry.

### 4. Expected behavior

For the same environment, the installer should resolve the GNU package instead:

```text
https://registry.npmjs.org/@voidzero-dev/vite-plus-cli-linux-x64-gnu/-/vite-plus-cli-linux-x64-gnu-0.1.11.tgz
```