### PR TITLE
fix(cli): show errors when vp install fails and bypass npm & pnpm minimum release age

### DIFF
--- a/packages/cli/install.ps1
+++ b/packages/cli/install.ps1
@@ -324,12 +324,13 @@ function Main {
     # Install production dependencies (skip if VITE_PLUS_SKIP_DEPS_INSTALL is set,
     # e.g. during local dev where install-global-cli.ts handles deps separately)
     if (-not $env:VITE_PLUS_SKIP_DEPS_INSTALL) {
+        $installLog = Join-Path $VersionDir "install.log"
         Push-Location $VersionDir
         try {
             $env:CI = "true"
-            & "$BinDir\vp.exe" install
+            & "$BinDir\vp.exe" install --silent *> $installLog
             if ($LASTEXITCODE -ne 0) {
-                Write-Error "Failed to install dependencies. Please check the error output above."
+                Write-Host "error: Failed to install dependencies. See log for details: $installLog" -ForegroundColor Red
                 exit 1
             }
         } finally {

--- a/packages/cli/install.sh
+++ b/packages/cli/install.sh
@@ -603,9 +603,10 @@ NPMRC_EOF
   # Install production dependencies (skip if VITE_PLUS_SKIP_DEPS_INSTALL is set,
   # e.g. during local dev where install-global-cli.ts handles deps separately)
   if [ -z "${VITE_PLUS_SKIP_DEPS_INSTALL:-}" ]; then
-    if ! (cd "$VERSION_DIR" && CI=true "$BIN_DIR/vp" install 2>&1); then
-      error "Failed to install dependencies. Re-run without piping to see full output:
-    curl -fsSL https://vite.plus -o /tmp/vp-install.sh && bash /tmp/vp-install.sh"
+    local install_log="$VERSION_DIR/install.log"
+    if ! (cd "$VERSION_DIR" && CI=true "$BIN_DIR/vp" install --silent > "$install_log" 2>&1); then
+      error "Failed to install dependencies. See log for details: $install_log"
+      exit 1
     fi
   fi
 


### PR DESCRIPTION
## Summary
resolve #833 

- Remove `--silent` from `vp install` in `install.sh` so that pnpm/npm errors are visible to the user instead of being silently swallowed
- Add a local `.npmrc` with `minimum-release-age=0` to the version directory to isolate the installer from the user's global pnpm configuration (e.g. `minimumReleaseAge` blocking recently-published packages)

Previously, when `vp install --silent` failed (for any reason), `set -e` would abort `install.sh` with no error output, leaving `~/.vite-plus/` in a partial state: no `node_modules`, no `bin/` symlink, no `env` file, and no PATH configuration.