### PR TITLE
fix(ci): exclude snap test directories from Renovate dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>Boshen/renovate", "helpers:pinGitHubActionDigestsToSemver"]
+  "extends": ["github>Boshen/renovate", "helpers:pinGitHubActionDigestsToSemver"],
+  "ignorePaths": ["packages/cli/snap-tests/**", "packages/cli/snap-tests-global/**"]
 }


### PR DESCRIPTION
Snap test fixtures contain intentionally pinned dependency versions
that should not be auto-upgraded by Renovate.