### PR TITLE
fix: correct broken doc paths in skill routing table and clean up stray text

### DIFF
--- a/docs/guide/lint.md
+++ b/docs/guide/lint.md
@@ -6,7 +6,7 @@
 
 `vp lint` is built on [Oxlint](https://oxc.rs/docs/guide/usage/linter.html), the Oxc linter. Oxlint is designed as a fast replacement for ESLint for most frontend projects and ships with built-in support for core ESLint rules and many popular community rules.
 
-Use `vp lint` to lint your project, and `vp check` to format, lint and type-check all at once.docs/guide/fmt.md
+Use `vp lint` to lint your project, and `vp check` to format, lint and type-check all at once.
 
 ## Usage
 

--- a/packages/cli/build.ts
+++ b/packages/cli/build.ts
@@ -448,7 +448,7 @@ async function copySkillDocs() {
 
   // Find all markdown files recursively and copy them with their relative paths.
   const mdFiles = globSync('**/*.md', { cwd: docsSourceDir }).filter(
-    (f) => !f.includes('node_modules'),
+    (f) => !f.includes('node_modules') && f !== 'index.md',
   );
   // eslint-disable-next-line unicorn/no-array-sort -- sorted traversal keeps output deterministic
   mdFiles.sort();

--- a/packages/cli/skills/vite-plus/SKILL.md
+++ b/packages/cli/skills/vite-plus/SKILL.md
@@ -28,25 +28,31 @@ Then ask what to do next.
 
 ## Task Routing
 
-| User intent                       | Docs file(s)                                                                     |
-| --------------------------------- | -------------------------------------------------------------------------------- |
-| CLI command syntax, flags         | `docs/vite/guide/cli.md`                                                         |
-| Initial setup, getting started    | `docs/index.md`, `docs/vite/guide/index.md`, `docs/lib/guide/getting-started.md` |
-| Dev server, development workflow  | `docs/vite/guide/index.md`, `docs/vite/guide/cli.md`                             |
-| Build configuration, optimization | `docs/config/index.md`, `docs/config/shared-options.md`                          |
-| Testing with Vitest               | `docs/vite/guide/tasks.md`, `docs/vite/guide/task/getting-started.md`            |
-| Linting with Oxlint               | `docs/vite/guide/cli.md`                                                         |
-| Formatting with Oxfmt             | `docs/vite/guide/cli.md`                                                         |
-| Monorepo setup and management     | `docs/vite/guide/monorepo.md`                                                    |
-| Migration from existing tools     | `docs/vite/guide/migration.md`                                                   |
-| Caching and performance           | `docs/vite/guide/caching.md`                                                     |
-| Library mode                      | `docs/lib/guide/getting-started.md`                                              |
-| Troubleshooting                   | `docs/vite/guide/troubleshooting.md`                                             |
-| Configuration and shared options  | `docs/config/shared-options.md`                                                  |
-| API reference                     | `docs/apis/index.md`                                                             |
+| User intent                       | Docs file(s)                                          |
+| --------------------------------- | ----------------------------------------------------- |
+| Initial setup, getting started    | `docs/guide/index.md`                                 |
+| Dev server, development workflow  | `docs/guide/dev.md`, `docs/guide/index.md`            |
+| Build configuration, optimization | `docs/guide/build.md`, `docs/config/build.md`         |
+| Testing with Vitest               | `docs/guide/test.md`, `docs/config/test.md`           |
+| Linting with Oxlint               | `docs/guide/lint.md`, `docs/config/lint.md`           |
+| Formatting with Oxfmt             | `docs/guide/fmt.md`, `docs/config/fmt.md`             |
+| Check (format, lint, types)       | `docs/guide/check.md`                                 |
+| Monorepo tasks                    | `docs/guide/run.md`, `docs/config/run.md`             |
+| Migration from existing tools     | `docs/guide/migrate.md`                               |
+| Caching and performance           | `docs/guide/cache.md`                                 |
+| Library mode (pack)               | `docs/guide/pack.md`, `docs/config/pack.md`           |
+| Troubleshooting                   | `docs/guide/troubleshooting.md`                       |
+| Configuration overview            | `docs/config/index.md`                                |
+| Staged files / pre-commit         | `docs/guide/commit-hooks.md`, `docs/config/staged.md` |
+| Install dependencies              | `docs/guide/install.md`                               |
+| Node.js version management        | `docs/guide/env.md`                                   |
+| Create a new project              | `docs/guide/create.md`                                |
+| CI setup                          | `docs/guide/ci.md`                                    |
+| IDE integration                   | `docs/guide/ide-integration.md`                       |
+| Upgrade Vite+                     | `docs/guide/upgrade.md`                               |
+| Execute one-off binaries          | `docs/guide/vpx.md`                                   |
 
 ## Working Rules
 
-- For CLI-heavy tasks, open `docs/vite/guide/cli.md` first.
 - For multi-topic tasks, combine only the needed doc files.
 - If docs and memory differ, follow docs.


### PR DESCRIPTION
The SKILL.md task routing table referenced non-existent paths (e.g.
docs/vite/guide/cli.md) instead of the actual paths (docs/guide/...).
Also removes a stray filename fragment in docs/guide/lint.md and
excludes the VitePress homepage index.md from skill docs copy since
it contains no textual content for AI agents.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation and build-time packaging tweaks; main risk is unintentionally omitting a needed markdown file from the skill docs bundle.
> 
> **Overview**
> Fixes Vite+ skill doc routing by replacing outdated `docs/vite/...` references with the current `docs/guide/*` and `docs/config/*` paths, expanding the routing table to cover more common tasks.
> 
> Cleans up a stray text fragment in `docs/guide/lint.md` and updates the CLI build’s `copySkillDocs()` to skip the VitePress `index.md` when bundling markdown docs into the skill package.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9225ff8f114dc92f7acead21bb3a61dee1cd5fec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->