### PR TITLE
chore: ignore vitest-dev and vite-task crates in renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,5 +6,15 @@
     "packages/cli/snap-tests-global/**",
     "packages/cli/snap-tests-todo/**",
     "bench/fixtures/**"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["vitest-dev"],
+      "enabled": false
+    },
+    {
+      "matchPackageNames": ["fspy", "vite_glob", "vite_path", "vite_str", "vite_task", "vite_workspace"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Disable Renovate for `vitest-dev` (pnpm catalog alias for `npm:vitest`, not a real npm package)
- Disable Renovate for vite-task git crates (`fspy`, `vite_glob`, `vite_path`, `vite_str`, `vite_task`, `vite_workspace`) which are updated manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)