### PR TITLE
chore: ignore subtreed directories in renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,9 @@
     "packages/cli/snap-tests/**",
     "packages/cli/snap-tests-global/**",
     "packages/cli/snap-tests-todo/**",
-    "bench/fixtures/**"
+    "bench/fixtures/**",
+    "rolldown/**",
+    "rolldown-vite/**"
   ],
   "packageRules": [
     {
@@ -13,7 +15,14 @@
       "enabled": false
     },
     {
-      "matchPackageNames": ["fspy", "vite_glob", "vite_path", "vite_str", "vite_task", "vite_workspace"],
+      "matchPackageNames": [
+        "fspy",
+        "vite_glob",
+        "vite_path",
+        "vite_str",
+        "vite_task",
+        "vite_workspace"
+      ],
       "enabled": false
     }
   ]


### PR DESCRIPTION
## Summary
- Add `rolldown/**` and `rolldown-vite/**` to Renovate `ignorePaths` to prevent Renovate from scanning subtreed/cloned directories (fixes "Failed to load yarnrc file" warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)