### PR TITLE
fix(env): check all shell profiles in `vp env doctor` IDE integration

### DIFF
--- a/crates/vite_global_cli/src/commands/env/doctor.rs
+++ b/crates/vite_global_cli/src/commands/env/doctor.rs
@@ -457,15 +457,8 @@ fn check_profile_files(vite_plus_home: &str) -> Option<String> {
         search_strings.push(format!("{home_dir}{suffix}{env_suffix}"));
     }
 
-    #[cfg(target_os = "macos")]
-    let profile_files: &[&str] = &[".zshenv", ".profile"];
-
-    #[cfg(target_os = "linux")]
-    let profile_files: &[&str] = &[".profile"];
-
-    // Fallback for other Unix platforms
-    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-    let profile_files: &[&str] = &[".profile"];
+    // Check all profiles the install script may have written to
+    let profile_files: &[&str] = &[".zshenv", ".zshrc", ".bash_profile", ".bashrc", ".profile"];
 
     for file in profile_files {
         let full_path = format!("{home_dir}/{file}");


### PR DESCRIPTION
## Summary

- The install script writes env sourcing to `.zshrc`, `.bashrc`, `.bash_profile`, and `.profile`
- But `vp env doctor` only checked `.zshenv` + `.profile` (macOS) or `.profile` alone (Linux)
- This caused false "IDE integration not set up" warnings on Linux with zsh/bash

Fixes #881

Now checks all profiles the install script may have written to, matching the same set used by `vp implode` for cleanup.

## Context

`install.sh` writes to:
- **zsh**: `.zshenv` + `.zshrc`
- **bash**: `.bash_profile` + `.bashrc` + `.profile`

`doctor.rs` only checked:
- **macOS**: `.zshenv`, `.profile`
- **Linux**: `.profile`

So a Linux user running zsh (env in `.zshrc`) or bash (env in `.bashrc`) got a false negative.