### PR TITLE
feat(cli): add Gemini CLI agent instructions

### DIFF
--- a/packages/cli/src/utils/__tests__/agent.spec.ts
+++ b/packages/cli/src/utils/__tests__/agent.spec.ts
@@ -334,13 +334,15 @@ describe('writeAgentInstructions symlink behavior', () => {
 
     await writeAgentInstructions({
       projectRoot: dir,
-      targetPaths: ['AGENTS.md', 'CLAUDE.md', '.github/copilot-instructions.md'],
+      targetPaths: ['AGENTS.md', 'CLAUDE.md', 'GEMINI.md', '.github/copilot-instructions.md'],
       interactive: false,
     });
 
     expect(mockFs.isSymlink(path.join(dir, 'AGENTS.md'))).toBe(false);
     expect(mockFs.isSymlink(path.join(dir, 'CLAUDE.md'))).toBe(true);
     expect(mockFs.readlinkSync(path.join(dir, 'CLAUDE.md'))).toBe('AGENTS.md');
+    expect(mockFs.isSymlink(path.join(dir, 'GEMINI.md'))).toBe(true);
+    expect(mockFs.readlinkSync(path.join(dir, 'GEMINI.md'))).toBe('AGENTS.md');
     expect(mockFs.isSymlink(path.join(dir, '.github/copilot-instructions.md'))).toBe(true);
     expect(mockFs.readlinkSync(path.join(dir, '.github/copilot-instructions.md'))).toBe(
       path.join('..', 'AGENTS.md'),

--- a/packages/cli/src/utils/agent.ts
+++ b/packages/cli/src/utils/agent.ts
@@ -171,6 +171,7 @@ const AGENT_ALIASES: Record<string, string> = {
 export const AGENTS = [
   { id: 'chatgpt-codex', label: 'ChatGPT (Codex)', targetPath: 'AGENTS.md' },
   { id: 'claude', label: 'Claude Code', targetPath: 'CLAUDE.md' },
+  { id: 'gemini', label: 'Gemini CLI', targetPath: 'GEMINI.md' },
   {
     id: 'copilot',
     label: 'GitHub Copilot',


### PR DESCRIPTION
Gemini CLI [looks for instructions in GEMINI.md](https://geminicli.com/docs/cli/gemini-md/) file. Since `gemini-cli` is already added in the agent registry, it would be convenient to add an option to generate this file during the `vp create` workflow.