### PR TITLE
chore: add metadata to publishable package.json files

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,18 @@
 {
   "name": "vite-plus",
   "version": "0.0.0",
+  "description": "The Unified Toolchain for the Web",
+  "homepage": "https://viteplus.dev/guide",
+  "bugs": {
+    "url": "https://github.com/voidzero-dev/vite-plus/issues"
+  },
   "license": "MIT",
+  "author": "VoidZero Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/voidzero-dev/vite-plus.git",
+    "directory": "packages/cli"
+  },
   "bin": {
     "oxfmt": "./bin/oxfmt",
     "oxlint": "./bin/oxlint",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,18 @@
 {
   "name": "@voidzero-dev/vite-plus-core",
   "version": "0.0.0",
+  "description": "The Unified Toolchain for the Web",
+  "homepage": "https://viteplus.dev/guide",
+  "bugs": {
+    "url": "https://github.com/voidzero-dev/vite-plus/issues"
+  },
   "license": "MIT",
+  "author": "VoidZero Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/voidzero-dev/vite-plus.git",
+    "directory": "packages/core"
+  },
   "files": [
     "dist"
   ],

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -1,6 +1,18 @@
 {
   "name": "@voidzero-dev/vite-plus-prompts",
   "version": "0.0.0",
+  "description": "The Unified Toolchain for the Web",
+  "homepage": "https://viteplus.dev/guide",
+  "bugs": {
+    "url": "https://github.com/voidzero-dev/vite-plus/issues"
+  },
+  "license": "MIT",
+  "author": "VoidZero Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/voidzero-dev/vite-plus.git",
+    "directory": "packages/prompts"
+  },
   "files": [
     "dist"
   ],

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,7 +1,18 @@
 {
   "name": "@voidzero-dev/vite-plus-test",
   "version": "0.0.0",
+  "description": "The Unified Toolchain for the Web",
+  "homepage": "https://viteplus.dev/guide",
+  "bugs": {
+    "url": "https://github.com/voidzero-dev/vite-plus/issues"
+  },
   "license": "MIT",
+  "author": "VoidZero Inc.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/voidzero-dev/vite-plus.git",
+    "directory": "packages/test"
+  },
   "files": [
     "*.cjs",
     "*.cts",


### PR DESCRIPTION
## Summary
- Add `author`, `description`, `homepage`, `repository`, and `bugs` fields to all 4 publishable package.json files (`vite-plus`, `@voidzero-dev/vite-plus-core`, `@voidzero-dev/vite-plus-prompts`, `@voidzero-dev/vite-plus-test`)
- These fields ensure packages display properly on npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)