### PR TITLE
fix(cli): add repository field to CLI binary package.json for npm provenance

### DIFF
--- a/packages/cli/publish-native-addons.ts
+++ b/packages/cli/publish-native-addons.ts
@@ -116,6 +116,7 @@ for (const [platform, rustTarget] of Object.entries(RUST_TARGETS)) {
     cpu: [meta.cpu],
     files: [binaryName],
     description: `Vite+ CLI binary for ${platform}`,
+    repository: cliPackageJson.repository,
   };
   writeFileSync(join(platformCliDir, 'package.json'), JSON.stringify(cliPackage, null, 2) + '\n');
 


### PR DESCRIPTION
npm publish was failing with E422 because sigstore provenance verification
requires repository.url to match the GitHub repo, but the generated
package.json for @voidzero-dev/vite-plus-cli-{platform} packages had no
repository field.