### PR TITLE
fix(cli): strip trailing slash from registry URL in install script

### DIFF
--- a/crates/vite_global_cli/src/commands/upgrade/registry.rs
+++ b/crates/vite_global_cli/src/commands/upgrade/registry.rs
@@ -45,7 +45,8 @@ pub async fn resolve_version(
     registry_override: Option<&str>,
 ) -> Result<ResolvedVersion, Error> {
     let default_registry = npm_registry();
-    let registry = registry_override.unwrap_or(&default_registry);
+    let registry_raw = registry_override.unwrap_or(&default_registry);
+    let registry = registry_raw.trim_end_matches('/');
     let client = HttpClient::new();
 
     // Step 1: Fetch main package metadata to resolve version

--- a/crates/vite_shared/src/env_config.rs
+++ b/crates/vite_shared/src/env_config.rs
@@ -133,7 +133,9 @@ impl EnvConfig {
             vite_plus_home: std::env::var(env_vars::VITE_PLUS_HOME).ok().map(PathBuf::from),
             npm_registry: std::env::var(env_vars::NPM_CONFIG_REGISTRY)
                 .or_else(|_| std::env::var(env_vars::NPM_CONFIG_REGISTRY_UPPER))
-                .unwrap_or_else(|_| "https://registry.npmjs.org".into()),
+                .unwrap_or_else(|_| "https://registry.npmjs.org".into())
+                .trim_end_matches('/')
+                .to_string(),
             node_dist_mirror: std::env::var(env_vars::VITE_NODE_DIST_MIRROR).ok(),
             is_ci: std::env::var("CI").is_ok(),
             bypass_shim: std::env::var(env_vars::VITE_PLUS_BYPASS).is_ok(),


### PR DESCRIPTION
## Summary
Fixes the Windows install script failing with a 404 error when the user's npm registry URL has a trailing slash (e.g., `https://registry.npmmirror.com/`).

The trailing slash causes a double slash in the constructed URL (`https://registry.npmmirror.com//pnpm/latest`), which returns 404. The install shell scripts (`install.ps1` and `install.sh`) already strip trailing slashes for their own URL construction, but the Rust binary (`vp.exe`) reads `NPM_CONFIG_REGISTRY` directly from the environment without stripping.

**Fix:** Strip trailing slashes from the registry URL in two places:
- `EnvConfig::from_env()` — where the registry URL is read from environment variables (affects all commands)
- `resolve_version()` — where a registry override parameter is used for upgrades

Fixes #904