### PR TITLE
fix(env): detect default fish config path in `vp env doctor`

### DIFF
--- a/crates/vite_global_cli/src/commands/env/doctor.rs
+++ b/crates/vite_global_cli/src/commands/env/doctor.rs
@@ -896,4 +896,38 @@ mod tests {
         assert!(result.is_some(), "Should find vite-plus.fish in XDG_CONFIG_HOME");
         assert!(result.unwrap().contains("vite-plus.fish"));
     }
+
+    #[test]
+    #[serial]
+    #[cfg(not(windows))]
+    fn test_check_profile_files_default_fish_config() {
+        let temp = TempDir::new().unwrap();
+        let fake_home = temp.path().join("home");
+        std::fs::create_dir_all(&fake_home).unwrap();
+
+        let fish_dir = fake_home.join(".config/fish/conf.d");
+        std::fs::create_dir_all(&fish_dir).unwrap();
+        std::fs::write(fish_dir.join("vite-plus.fish"), "source \"$HOME/.vite-plus/env.fish\"\n")
+            .unwrap();
+
+        let _guard = ProfileEnvGuard::new(&fake_home, None, None);
+
+        let result = check_profile_files("$HOME/.vite-plus");
+        assert!(result.is_some(), "Should find vite-plus.fish in default fish conf.d");
+        assert!(result.unwrap().contains("vite-plus.fish"));
+    }
+
+    #[test]
+    #[serial]
+    #[cfg(not(windows))]
+    fn test_check_profile_files_no_fish_config() {
+        let temp = TempDir::new().unwrap();
+        let fake_home = temp.path().join("home");
+        std::fs::create_dir_all(&fake_home).unwrap();
+
+        let _guard = ProfileEnvGuard::new(&fake_home, None, None);
+
+        let result = check_profile_files("$HOME/.vite-plus");
+        assert_eq!(result, None);
+    }
 }


### PR DESCRIPTION
Follows up on @fengmk2's [comment](https://github.com/voidzero-dev/vite-plus/pull/892#issuecomment-4062943249) in #892.

## Summary

`vp env doctor` did not detect fish shell config at `~/.config/fish/conf.d/vite-plus.fish`. 
This PR adds that check so doctor correctly reports IDE integration for fish users.

## Changes

- Check `~/.config/fish/conf.d/vite-plus.fish` in `check_profile_files` before returning `None`
- Add tests for default fish config detection (`test_check_profile_files_default_fish_config`, `test_check_profile_files_no_fish_config`)

## Note

This will likely conflict with #892 since both touch `check_profile_files`. Conflict resolution will be needed after whichever merges first.
