### PR TITLE
docs: Update migration docs to include Vitest.

### DIFF
--- a/docs/guide/migrate.md
+++ b/docs/guide/migrate.md
@@ -92,7 +92,25 @@ Finally, verify the migration by running: `vp install`, `vp check`, `vp test`, a
 Summarize the migration at the end and report any manual follow-up still required.
 ```
 
-## tsdown
+## Tool-Specific Migrations
+
+### Vitest
+
+Vitest is automatically migrated through `vp migrate`. If you are migrating manually, you have to update all the imports to `vite-plus/test` instead:
+
+```ts
+// before
+import { describe, expect, it, vi } from 'vitest';
+
+const { page } = await import('@vitest/browser/context');
+
+// after
+import { describe, expect, it, vi } from 'vite-plus/test';
+
+const { page } = await import('vite-plus/test/browser/context');
+```
+
+### tsdown
 
 If your project uses a `tsdown.config.ts`, move its options into the `pack` block in `vite.config.ts`:
 
@@ -105,9 +123,7 @@ export default defineConfig({
   dts: true,
   format: ['esm', 'cjs'],
 });
-```
 
-```ts
 // after — vite.config.ts
 import { defineConfig } from 'vite-plus';
 
@@ -122,9 +138,9 @@ export default defineConfig({
 
 After merging, delete `tsdown.config.ts`. See the [Pack guide](/guide/pack) for the full configuration reference.
 
-## lint-staged
+### lint-staged
 
-Vite+ replaces lint-staged with its own `staged` block in `vite.config.ts`. Only the `staged` config format is supported — standalone `.lintstagedrc` in non-JSON format and `lint-staged.config.*` are not migrated automatically.
+Vite+ replaces lint-staged with its own `staged` block in `vite.config.ts`. Only the `staged` config format is supported. Standalone `.lintstagedrc` in non-JSON format and `lint-staged.config.*` are not migrated automatically.
 
 Move your lint-staged rules into the `staged` block:
 


### PR DESCRIPTION
Fixes #894

I don't really like adding these sections since users should just use `vp migrate`, but it's better to document than confuse users.