### PR TITLE
chore: group vite-task dependencies in renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,7 +23,7 @@
         "vite_task",
         "vite_workspace"
       ],
-      "enabled": false
+      "groupName": "vite-task dependencies"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Group `fspy`, `vite_glob`, `vite_path`, `vite_str`, `vite_task`, and `vite_workspace` into a single Renovate PR instead of disabling them or creating 6 separate PRs
- Replaces `"enabled": false` with `"groupName": "vite-task dependencies"`

Closes #929, #928, #927, #924, #923, #922

🤖 Generated with [Claude Code](https://claude.com/claude-code)