### PR TITLE
fix(cli): skip OSC color queries in tmux to prevent hang on launch

### DIFF
--- a/crates/vite_shared/src/header.rs
+++ b/crates/vite_shared/src/header.rs
@@ -203,6 +203,12 @@ fn query_terminal_colors(palette_indices: &[u8]) -> (Option<Rgb>, Vec<(u8, Rgb)>
         return (None, vec![]);
     }
 
+    // tmux does not reliably forward OSC color query responses back to the
+    // child process, causing the same hang-until-keypress behavior as Warp.
+    if std::env::var_os("TMUX").is_some() {
+        return (None, vec![]);
+    }
+
     let mut tty = match OpenOptions::new().read(true).write(true).open("/dev/tty") {
         Ok(file) => file,
         Err(_) => return (None, vec![]),


### PR DESCRIPTION
tmux does not reliably forward OSC color query responses back to child
processes, causing the CLI to appear stuck until a keypress is consumed
as a fake response — the same issue fixed for Warp terminal in #762.

Closes #822

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an early-return guard in header color probing based on the `TMUX` env var, only affecting optional terminal color detection/formatting.
> 
> **Overview**
> Prevents the header color-probing routine (`query_terminal_colors`) from sending OSC color queries when inside *tmux* by short-circuiting if `TMUX` is set, matching the existing Warp terminal workaround.
> 
> This avoids a launch-time hang where tmux may not forward OSC query responses back to the child process, at the cost of falling back to default header colors under tmux.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d86e10fd80d2c0baf46ea28afc8c8f225f2c7dc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->