### PR TITLE
feat(deps): upgrade upstream dependencies

### DIFF
--- a/docs/.vitepress/env.d.ts
+++ b/docs/.vitepress/env.d.ts
@@ -5,6 +5,9 @@ declare module '*.vue' {
   export default component;
 }
 
+// CSS module declarations
+declare module '*.css' {}
+
 // Asset module declarations
 declare module '*.riv' {
   const src: string;

--- a/packages/cli/templates/generator/tsconfig.json
+++ b/packages/cli/templates/generator/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "nodenext",
     "moduleResolution": "nodenext",
     "noEmit": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["node"]
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -136,8 +136,8 @@
   },
   "peerDependencies": {
     "@arethetypeswrong/core": "^0.18.1",
-    "@tsdown/css": "0.21.2",
-    "@tsdown/exe": "0.21.2",
+    "@tsdown/css": "0.21.3",
+    "@tsdown/exe": "0.21.3",
     "@types/node": "^20.19.0 || >=22.12.0",
     "@vitejs/devtools": "^0.0.0-alpha.31",
     "esbuild": "^0.27.0",
@@ -219,6 +219,6 @@
   "bundledVersions": {
     "vite": "8.0.0",
     "rolldown": "1.0.0-rc.9",
-    "tsdown": "0.21.2"
+    "tsdown": "0.21.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,8 +166,8 @@ catalogs:
       specifier: '=1.55.0'
       version: 1.55.0
     oxlint-tsgolint:
-      specifier: '=0.16.0'
-      version: 0.16.0
+      specifier: '=0.17.0'
+      version: 0.17.0
     pathe:
       specifier: ^2.0.3
       version: 2.0.3
@@ -221,10 +221,10 @@ catalogs:
       version: 6.0.0
     tinyexec:
       specifier: ^1.0.1
-      version: 1.0.2
+      version: 1.0.4
     tsdown:
-      specifier: ^0.21.2
-      version: 0.21.2
+      specifier: ^0.21.3
+      version: 0.21.3
     typescript:
       specifier: ^5.9.3
       version: 5.9.3
@@ -303,7 +303,7 @@ importers:
         version: 0.40.0
       oxlint:
         specifier: 'catalog:'
-        version: 1.55.0(oxlint-tsgolint@0.16.0)
+        version: 1.55.0(oxlint-tsgolint@0.17.0)
       playwright:
         specifier: 'catalog:'
         version: 1.57.0
@@ -382,10 +382,10 @@ importers:
         version: 0.40.0
       oxlint:
         specifier: 'catalog:'
-        version: 1.55.0(oxlint-tsgolint@0.16.0)
+        version: 1.55.0(oxlint-tsgolint@0.17.0)
       oxlint-tsgolint:
         specifier: 'catalog:'
-        version: 0.16.0
+        version: 0.17.0
       picocolors:
         specifier: 'catalog:'
         version: 1.1.1
@@ -443,7 +443,7 @@ importers:
         version: 7.7.4
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.2(@arethetypeswrong/core@0.18.2)(@tsdown/css@0.21.2)(@tsdown/exe@0.21.2)(@typescript/native-preview@7.0.0-dev.20260122.2)(@vitejs/devtools@0.1.0(@pnpm/logger@1001.0.1)(typescript@5.9.3)(vite@packages+core)(vue@3.5.27(typescript@5.9.3)))(oxc-resolver@11.14.0)(publint@0.3.18)(typescript@5.9.3)(unplugin-unused@0.5.6)
+        version: 0.21.3(@arethetypeswrong/core@0.18.2)(@tsdown/css@0.21.3)(@tsdown/exe@0.21.3)(@typescript/native-preview@7.0.0-dev.20260122.2)(@vitejs/devtools@0.1.0(@pnpm/logger@1001.0.1)(typescript@5.9.3)(vite@packages+core)(vue@3.5.27(typescript@5.9.3)))(oxc-resolver@11.14.0)(publint@0.3.18)(typescript@5.9.3)(unplugin-unused@0.5.6)
       validate-npm-package-name:
         specifier: 'catalog:'
         version: 7.0.2
@@ -466,11 +466,11 @@ importers:
         specifier: 'catalog:'
         version: 0.115.0
       '@tsdown/css':
-        specifier: 0.21.2
-        version: 0.21.2(jiti@2.6.1)(postcss-import@16.1.1(postcss@8.5.8))(postcss@8.5.8)(sass-embedded@1.97.3(source-map-js@1.2.1))(sass@1.97.3)(tsdown@0.21.2)(tsx@4.21.0)(yaml@2.8.2)
+        specifier: 0.21.3
+        version: 0.21.3(jiti@2.6.1)(postcss-import@16.1.1(postcss@8.5.8))(postcss@8.5.8)(sass-embedded@1.97.3(source-map-js@1.2.1))(sass@1.97.3)(tsdown@0.21.3)(tsx@4.21.0)(yaml@2.8.2)
       '@tsdown/exe':
-        specifier: 0.21.2
-        version: 0.21.2(tsdown@0.21.2)
+        specifier: 0.21.3
+        version: 0.21.3(tsdown@0.21.3)
       '@types/node':
         specifier: ^20.19.0 || >=22.12.0
         version: 24.12.0
@@ -588,7 +588,7 @@ importers:
         version: 1.2.2
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.2(@arethetypeswrong/core@0.18.2)(@tsdown/css@0.21.2)(@tsdown/exe@0.21.2)(@typescript/native-preview@7.0.0-dev.20260122.2)(@vitejs/devtools@0.1.0(@pnpm/logger@1001.0.1)(typescript@5.9.3)(vite@packages+core)(vue@3.5.27(typescript@5.9.3)))(oxc-resolver@11.14.0)(publint@0.3.18)(typescript@5.9.3)(unplugin-unused@0.5.6)
+        version: 0.21.3(@arethetypeswrong/core@0.18.2)(@tsdown/css@0.21.3)(@tsdown/exe@0.21.3)(@typescript/native-preview@7.0.0-dev.20260122.2)(@vitejs/devtools@0.1.0(@pnpm/logger@1001.0.1)(typescript@5.9.3)(vite@packages+core)(vue@3.5.27(typescript@5.9.3)))(oxc-resolver@11.14.0)(publint@0.3.18)(typescript@5.9.3)(unplugin-unused@0.5.6)
       vite:
         specifier: workspace:@voidzero-dev/vite-plus-core@*
         version: 'link:'
@@ -620,7 +620,7 @@ importers:
         version: 1.3.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.2(@arethetypeswrong/core@0.18.2)(@tsdown/css@0.21.2)(@tsdown/exe@0.21.2)(@typescript/native-preview@7.0.0-dev.20260122.2)(@vitejs/devtools@0.1.0(@pnpm/logger@1001.0.1)(typescript@5.9.3)(vite@packages+core)(vue@3.5.27(typescript@5.9.3)))(oxc-resolver@11.14.0)(publint@0.3.18)(typescript@5.9.3)(unplugin-unused@0.5.6)
+        version: 0.21.3(@arethetypeswrong/core@0.18.2)(@tsdown/css@0.21.3)(@tsdown/exe@0.21.3)(@typescript/native-preview@7.0.0-dev.20260122.2)(@vitejs/devtools@0.1.0(@pnpm/logger@1001.0.1)(typescript@5.9.3)(vite@packages+core)(vue@3.5.27(typescript@5.9.3)))(oxc-resolver@11.14.0)(publint@0.3.18)(typescript@5.9.3)(unplugin-unused@0.5.6)
 
   packages/test:
     dependencies:
@@ -674,7 +674,7 @@ importers:
         version: 2.9.0
       tinyexec:
         specifier: ^1.0.2
-        version: 1.0.2
+        version: 1.0.4
       tinyglobby:
         specifier: ^0.2.15
         version: 0.2.15
@@ -1454,7 +1454,7 @@ importers:
         version: 0.0.35
       tinyexec:
         specifier: 'catalog:'
-        version: 1.0.2
+        version: 1.0.4
 
 packages:
 
@@ -4030,8 +4030,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint-tsgolint/darwin-arm64@0.16.0':
-    resolution: {integrity: sha512-WQt5lGwRPJBw7q2KNR0mSPDAaMmZmVvDlEEti96xLO7ONhyomQc6fBZxxwZ4qTFedjJnrHX94sFelZ4OKzS7UQ==}
+  '@oxlint-tsgolint/darwin-arm64@0.17.0':
+    resolution: {integrity: sha512-z3XwCDuOAKgk7bO4y5tyH8Zogwr51G56R0XGKC3tlAbrAq8DecoxAd3qhRZqWBMG2Gzl5bWU3Ghu7lrxuLPzYw==}
     cpu: [arm64]
     os: [darwin]
 
@@ -4040,8 +4040,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint-tsgolint/darwin-x64@0.16.0':
-    resolution: {integrity: sha512-VJo29XOzdkalvCTiE2v6FU3qZlgHaM8x8hUEVJGPU2i5W+FlocPpmn00+Ld2n7Q0pqIjyD5EyvZ5UmoIEJMfqg==}
+  '@oxlint-tsgolint/darwin-x64@0.17.0':
+    resolution: {integrity: sha512-TZgVXy0MtI8nt0MYiceuZhHPwHcwlIZ/YwzFTAKrgdHiTvVzFbqHVdXi5wbZfT/o1nHGw9fbGWPlb6qKZ4uZ9Q==}
     cpu: [x64]
     os: [darwin]
 
@@ -4050,8 +4050,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@oxlint-tsgolint/linux-arm64@0.16.0':
-    resolution: {integrity: sha512-MPfqRt1+XRHv9oHomcBMQ3KpTE+CSkZz14wUxDQoqTNdUlV0HWdzwIE9q65I3D9YyxEnqpM7j4qtDQ3apqVvbQ==}
+  '@oxlint-tsgolint/linux-arm64@0.17.0':
+    resolution: {integrity: sha512-IDfhFl/Y8bjidCvAP6QAxVyBsl78TmfCHlfjtEv2XtJXgYmIwzv6muO18XMp74SZ2qAyD4y2n2dUedrmghGHeA==}
     cpu: [arm64]
     os: [linux]
 
@@ -4060,8 +4060,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@oxlint-tsgolint/linux-x64@0.16.0':
-    resolution: {integrity: sha512-XQSwVUsnwLokMhe1TD6IjgvW5WMTPzOGGkdFDtXWQmlN2YeTw94s/NN0KgDrn2agM1WIgAenEkvnm0u7NgwEyw==}
+  '@oxlint-tsgolint/linux-x64@0.17.0':
+    resolution: {integrity: sha512-Bgdgqx/m8EnfjmmlRLEeYy9Yhdt1GdFrMr5mTu/NyLRGkB1C9VLAikdxB7U9QambAGTAmjMbHNFDFk8Vx69Huw==}
     cpu: [x64]
     os: [linux]
 
@@ -4070,8 +4070,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint-tsgolint/win32-arm64@0.16.0':
-    resolution: {integrity: sha512-EWdlspQiiFGsP2AiCYdhg5dTYyAlj6y1nRyNI2dQWq4Q/LITFHiSRVPe+7m7K7lcsZCEz2icN/bCeSkZaORqIg==}
+  '@oxlint-tsgolint/win32-arm64@0.17.0':
+    resolution: {integrity: sha512-dO6wyKMDqFWh1vwr+zNZS7/ovlfGgl4S3P1LDy4CKjP6V6NGtdmEwWkWax8j/I8RzGZdfXKnoUfb/qhVg5bx0w==}
     cpu: [arm64]
     os: [win32]
 
@@ -4080,8 +4080,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxlint-tsgolint/win32-x64@0.16.0':
-    resolution: {integrity: sha512-1ufk8cgktXJuJZHKF63zCHAkaLMwZrEXnZ89H2y6NO85PtOXqu4zbdNl0VBpPP3fCUuUBu9RvNqMFiv0VsbXWA==}
+  '@oxlint-tsgolint/win32-x64@0.17.0':
+    resolution: {integrity: sha512-lPGYFp3yX2nh6hLTpIuMnJbZnt3Df42VkoA/fSkMYi2a/LXdDytQGpgZOrb5j47TICARd34RauKm0P3OA4Oxbw==}
     cpu: [x64]
     os: [win32]
 
@@ -4734,15 +4734,15 @@ packages:
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
-  '@tsdown/css@0.21.2':
-    resolution: {integrity: sha512-Q1hJZ7L3oZsK8pTZw1uD6+jkXOivXiqiME6gu3Q5P28ef+Gh5odeq3tUDJ6E44P7zlfW9QqzvQ4820z6uvI8ZA==}
+  '@tsdown/css@0.21.3':
+    resolution: {integrity: sha512-ggFsEbtl3T75KM8Y84Tz7PrpzLqj7njWjEcm5ZUkrmL+xIJtzJx7RupPocIsf6mMPf3IVSnyNbZxwDlbKg5mTw==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       postcss: ^8.4.0
       postcss-import: ^16.0.0
       sass: '*'
       sass-embedded: '*'
-      tsdown: 0.21.2
+      tsdown: 0.21.3
     peerDependenciesMeta:
       postcss:
         optional: true
@@ -4753,11 +4753,11 @@ packages:
       sass-embedded:
         optional: true
 
-  '@tsdown/exe@0.21.2':
-    resolution: {integrity: sha512-73DZirFHxTzxA5y9XkWQpn+RrAOQOBpTcynJn2o3nO32fi6hSJmBw1XAwjLj/r8PDQ/BpYd7jFDZLlEIKOHlBg==}
+  '@tsdown/exe@0.21.3':
+    resolution: {integrity: sha512-brfC5I+VzoYu5EILTHZGEVeE79EZfCQ2J/JkxObX3QCKKIcclCL7fjjtOWbebd63kQQkGAl2tIpAkv7bGnAd7g==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
-      tsdown: 0.21.2
+      tsdown: 0.21.3
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -7921,8 +7921,8 @@ packages:
     resolution: {integrity: sha512-iwvFmhKQVZzVTFygUVI4t2S/VKEm+Mqkw3jQRJwfDuTcUYI5LCIYzdO5Dbuv4mFOkXZCcXaRRh0m+uydB5xdqw==}
     hasBin: true
 
-  oxlint-tsgolint@0.16.0:
-    resolution: {integrity: sha512-4RuJK2jP08XwqtUu+5yhCbxEauCm6tv2MFHKEMsjbosK2+vy5us82oI3VLuHwbNyZG7ekZA26U2LLHnGR4frIA==}
+  oxlint-tsgolint@0.17.0:
+    resolution: {integrity: sha512-TdrKhDZCgEYqONFo/j+KvGan7/k3tP5Ouz88wCqpOvJtI2QmcLfGsm1fcMvDnTik48Jj6z83IJBqlkmK9DnY1A==}
     hasBin: true
 
   oxlint@1.55.0:
@@ -8990,8 +8990,8 @@ packages:
     resolution: {integrity: sha512-BWlWpVbbZXaYjRV0twGLNQO00Zj4HA/sjLOQP2IvzQqGwRGp+2kh7UU3ijyJ3ywFRogYDRbiHDMrUOfaMnN56g==}
     engines: {node: '>=20.0.0'}
 
-  tinyexec@1.0.2:
-    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+  tinyexec@1.0.4:
+    resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
     engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
@@ -9084,14 +9084,14 @@ packages:
       unplugin-unused:
         optional: true
 
-  tsdown@0.21.2:
-    resolution: {integrity: sha512-pP8eAcd1XAWjl5gjosuJs0BAuVoheUe3V8VDHx31QK7YOgXjcCMsBSyFWO3CMh/CSUkjRUzR96JtGH3WJFTExQ==}
+  tsdown@0.21.3:
+    resolution: {integrity: sha512-oKKeMC8+IgNsB+81hvF5VBsqhqL/nr0g9vse+ujbK40vv0i3ReFI6gUts7hQH7J53ylQNjMgf2Vu6n0+P/uddA==}
     engines: {node: '>=20.19.0'}
     hasBin: true
     peerDependencies:
       '@arethetypeswrong/core': ^0.18.1
-      '@tsdown/css': 0.21.2
-      '@tsdown/exe': 0.21.2
+      '@tsdown/css': 0.21.3
+      '@tsdown/exe': 0.21.3
       '@vitejs/devtools': '*'
       publint: ^0.3.0
       typescript: ^5.0.0
@@ -9748,7 +9748,7 @@ snapshots:
   '@antfu/install-pkg@1.1.0':
     dependencies:
       package-manager-detector: 1.6.0
-      tinyexec: 1.0.2
+      tinyexec: 1.0.4
 
   '@arethetypeswrong/core@0.18.2':
     dependencies:
@@ -12086,37 +12086,37 @@ snapshots:
   '@oxlint-tsgolint/darwin-arm64@0.15.0':
     optional: true
 
-  '@oxlint-tsgolint/darwin-arm64@0.16.0':
+  '@oxlint-tsgolint/darwin-arm64@0.17.0':
     optional: true
 
   '@oxlint-tsgolint/darwin-x64@0.15.0':
     optional: true
 
-  '@oxlint-tsgolint/darwin-x64@0.16.0':
+  '@oxlint-tsgolint/darwin-x64@0.17.0':
     optional: true
 
   '@oxlint-tsgolint/linux-arm64@0.15.0':
     optional: true
 
-  '@oxlint-tsgolint/linux-arm64@0.16.0':
+  '@oxlint-tsgolint/linux-arm64@0.17.0':
     optional: true
 
   '@oxlint-tsgolint/linux-x64@0.15.0':
     optional: true
 
-  '@oxlint-tsgolint/linux-x64@0.16.0':
+  '@oxlint-tsgolint/linux-x64@0.17.0':
     optional: true
 
   '@oxlint-tsgolint/win32-arm64@0.15.0':
     optional: true
 
-  '@oxlint-tsgolint/win32-arm64@0.16.0':
+  '@oxlint-tsgolint/win32-arm64@0.17.0':
     optional: true
 
   '@oxlint-tsgolint/win32-x64@0.15.0':
     optional: true
 
-  '@oxlint-tsgolint/win32-x64@0.16.0':
+  '@oxlint-tsgolint/win32-x64@0.17.0':
     optional: true
 
   '@oxlint/binding-android-arm-eabi@1.55.0':
@@ -12617,12 +12617,12 @@ snapshots:
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
-  '@tsdown/css@0.21.2(jiti@2.6.1)(postcss-import@16.1.1(postcss@8.5.8))(postcss@8.5.8)(sass-embedded@1.97.3(source-map-js@1.2.1))(sass@1.97.3)(tsdown@0.21.2)(tsx@4.21.0)(yaml@2.8.2)':
+  '@tsdown/css@0.21.3(jiti@2.6.1)(postcss-import@16.1.1(postcss@8.5.8))(postcss@8.5.8)(sass-embedded@1.97.3(source-map-js@1.2.1))(sass@1.97.3)(tsdown@0.21.3)(tsx@4.21.0)(yaml@2.8.2)':
     dependencies:
       lightningcss: 1.32.0
       postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(yaml@2.8.2)
       rolldown: link:rolldown/packages/rolldown
-      tsdown: 0.21.2(@arethetypeswrong/core@0.18.2)(@tsdown/css@0.21.2)(@tsdown/exe@0.21.2)(@typescript/native-preview@7.0.0-dev.20260122.2)(@vitejs/devtools@0.1.0(@pnpm/logger@1001.0.1)(typescript@5.9.3)(vite@packages+core)(vue@3.5.27(typescript@5.9.3)))(oxc-resolver@11.14.0)(publint@0.3.18)(typescript@5.9.3)(unplugin-unused@0.5.6)
+      tsdown: 0.21.3(@arethetypeswrong/core@0.18.2)(@tsdown/css@0.21.3)(@tsdown/exe@0.21.3)(@typescript/native-preview@7.0.0-dev.20260122.2)(@vitejs/devtools@0.1.0(@pnpm/logger@1001.0.1)(typescript@5.9.3)(vite@packages+core)(vue@3.5.27(typescript@5.9.3)))(oxc-resolver@11.14.0)(publint@0.3.18)(typescript@5.9.3)(unplugin-unused@0.5.6)
     optionalDependencies:
       postcss: 8.5.8
       postcss-import: 16.1.1(postcss@8.5.8)
@@ -12633,12 +12633,12 @@ snapshots:
       - tsx
       - yaml
 
-  '@tsdown/exe@0.21.2(tsdown@0.21.2)':
+  '@tsdown/exe@0.21.3(tsdown@0.21.3)':
     dependencies:
       obug: 2.1.1
       semver: 7.7.4
-      tinyexec: 1.0.2
-      tsdown: 0.21.2(@arethetypeswrong/core@0.18.2)(@tsdown/css@0.21.2)(@tsdown/exe@0.21.2)(@typescript/native-preview@7.0.0-dev.20260122.2)(@vitejs/devtools@0.1.0(@pnpm/logger@1001.0.1)(typescript@5.9.3)(vite@packages+core)(vue@3.5.27(typescript@5.9.3)))(oxc-resolver@11.14.0)(publint@0.3.18)(typescript@5.9.3)(unplugin-unused@0.5.6)
+      tinyexec: 1.0.4
+      tsdown: 0.21.3(@arethetypeswrong/core@0.18.2)(@tsdown/css@0.21.3)(@tsdown/exe@0.21.3)(@typescript/native-preview@7.0.0-dev.20260122.2)(@vitejs/devtools@0.1.0(@pnpm/logger@1001.0.1)(typescript@5.9.3)(vite@packages+core)(vue@3.5.27(typescript@5.9.3)))(oxc-resolver@11.14.0)(publint@0.3.18)(typescript@5.9.3)(unplugin-unused@0.5.6)
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -13290,7 +13290,7 @@ snapshots:
       pathe: 2.0.3
       perfect-debounce: 2.1.0
       sirv: 3.0.2(patch_hash=c07c56eb72faea34341d465cde2314e89db472106ed378181e3447893af6bf95)
-      tinyexec: 1.0.2
+      tinyexec: 1.0.4
       vite: link:packages/core
       ws: 8.19.0
     transitivePeerDependencies:
@@ -13335,7 +13335,7 @@ snapshots:
       pathe: 2.0.3
       perfect-debounce: 2.1.0
       sirv: 3.0.2(patch_hash=c07c56eb72faea34341d465cde2314e89db472106ed378181e3447893af6bf95)
-      tinyexec: 1.0.2
+      tinyexec: 1.0.4
       vite: link:packages/core
       ws: 8.19.0
     transitivePeerDependencies:
@@ -15746,7 +15746,7 @@ snapshots:
       listr2: 9.0.5
       micromatch: 4.0.8
       string-argv: 0.3.2
-      tinyexec: 1.0.2
+      tinyexec: 1.0.4
       yaml: 2.8.2
 
   listr2@9.0.5:
@@ -16309,14 +16309,14 @@ snapshots:
       '@oxlint-tsgolint/win32-arm64': 0.15.0
       '@oxlint-tsgolint/win32-x64': 0.15.0
 
-  oxlint-tsgolint@0.16.0:
+  oxlint-tsgolint@0.17.0:
     optionalDependencies:
-      '@oxlint-tsgolint/darwin-arm64': 0.16.0
-      '@oxlint-tsgolint/darwin-x64': 0.16.0
-      '@oxlint-tsgolint/linux-arm64': 0.16.0
-      '@oxlint-tsgolint/linux-x64': 0.16.0
-      '@oxlint-tsgolint/win32-arm64': 0.16.0
-      '@oxlint-tsgolint/win32-x64': 0.16.0
+      '@oxlint-tsgolint/darwin-arm64': 0.17.0
+      '@oxlint-tsgolint/darwin-x64': 0.17.0
+      '@oxlint-tsgolint/linux-arm64': 0.17.0
+      '@oxlint-tsgolint/linux-x64': 0.17.0
+      '@oxlint-tsgolint/win32-arm64': 0.17.0
+      '@oxlint-tsgolint/win32-x64': 0.17.0
 
   oxlint@1.55.0(oxlint-tsgolint@0.15.0):
     optionalDependencies:
@@ -16341,7 +16341,7 @@ snapshots:
       '@oxlint/binding-win32-x64-msvc': 1.55.0
       oxlint-tsgolint: 0.15.0
 
-  oxlint@1.55.0(oxlint-tsgolint@0.16.0):
+  oxlint@1.55.0(oxlint-tsgolint@0.17.0):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.55.0
       '@oxlint/binding-android-arm64': 1.55.0
@@ -16362,7 +16362,7 @@ snapshots:
       '@oxlint/binding-win32-arm64-msvc': 1.55.0
       '@oxlint/binding-win32-ia32-msvc': 1.55.0
       '@oxlint/binding-win32-x64-msvc': 1.55.0
-      oxlint-tsgolint: 0.16.0
+      oxlint-tsgolint: 0.17.0
 
   p-limit@3.1.0:
     dependencies:
@@ -17429,7 +17429,7 @@ snapshots:
 
   tinybench@6.0.0: {}
 
-  tinyexec@1.0.2: {}
+  tinyexec@1.0.4: {}
 
   tinyglobby@0.2.15:
     dependencies:
@@ -17492,7 +17492,7 @@ snapshots:
       rolldown: link:rolldown/packages/rolldown
       rolldown-plugin-dts: 0.22.5(@typescript/native-preview@7.0.0-dev.20260122.2)(oxc-resolver@11.14.0)(rolldown@rolldown+packages+rolldown)(typescript@5.9.3)
       semver: 7.7.4
-      tinyexec: 1.0.2
+      tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
       unconfig-core: 7.5.0
@@ -17511,7 +17511,7 @@ snapshots:
       - synckit
       - vue-tsc
 
-  tsdown@0.21.2(@arethetypeswrong/core@0.18.2)(@tsdown/css@0.21.2)(@tsdown/exe@0.21.2)(@typescript/native-preview@7.0.0-dev.20260122.2)(@vitejs/devtools@0.1.0(@pnpm/logger@1001.0.1)(typescript@5.9.3)(vite@packages+core)(vue@3.5.27(typescript@5.9.3)))(oxc-resolver@11.14.0)(publint@0.3.18)(typescript@5.9.3)(unplugin-unused@0.5.6):
+  tsdown@0.21.3(@arethetypeswrong/core@0.18.2)(@tsdown/css@0.21.3)(@tsdown/exe@0.21.3)(@typescript/native-preview@7.0.0-dev.20260122.2)(@vitejs/devtools@0.1.0(@pnpm/logger@1001.0.1)(typescript@5.9.3)(vite@packages+core)(vue@3.5.27(typescript@5.9.3)))(oxc-resolver@11.14.0)(publint@0.3.18)(typescript@5.9.3)(unplugin-unused@0.5.6):
     dependencies:
       ansis: 4.2.0
       cac: 7.0.0
@@ -17524,15 +17524,15 @@ snapshots:
       rolldown: link:rolldown/packages/rolldown
       rolldown-plugin-dts: 0.22.5(@typescript/native-preview@7.0.0-dev.20260122.2)(oxc-resolver@11.14.0)(rolldown@rolldown+packages+rolldown)(typescript@5.9.3)
       semver: 7.7.4
-      tinyexec: 1.0.2
+      tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
       unconfig-core: 7.5.0
       unrun: 0.2.32
     optionalDependencies:
       '@arethetypeswrong/core': 0.18.2
-      '@tsdown/css': 0.21.2(jiti@2.6.1)(postcss-import@16.1.1(postcss@8.5.8))(postcss@8.5.8)(sass-embedded@1.97.3(source-map-js@1.2.1))(sass@1.97.3)(tsdown@0.21.2)(tsx@4.21.0)(yaml@2.8.2)
-      '@tsdown/exe': 0.21.2(tsdown@0.21.2)
+      '@tsdown/css': 0.21.3(jiti@2.6.1)(postcss-import@16.1.1(postcss@8.5.8))(postcss@8.5.8)(sass-embedded@1.97.3(source-map-js@1.2.1))(sass@1.97.3)(tsdown@0.21.3)(tsx@4.21.0)(yaml@2.8.2)
+      '@tsdown/exe': 0.21.3(tsdown@0.21.3)
       '@vitejs/devtools': 0.1.0(@pnpm/logger@1001.0.1)(typescript@5.9.3)(vite@packages+core)(vue@3.5.27(typescript@5.9.3))
       publint: 0.3.18
       typescript: 5.9.3
@@ -17851,7 +17851,7 @@ snapshots:
       picomatch: 4.0.3
       std-env: 4.0.0
       tinybench: 2.9.0
-      tinyexec: 1.0.2
+      tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
       vite: link:packages/core

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -83,7 +83,7 @@ catalog:
   oxc-transform: =0.115.0
   oxfmt: =0.40.0
   oxlint: =1.55.0
-  oxlint-tsgolint: =0.16.0
+  oxlint-tsgolint: =0.17.0
   pathe: ^2.0.3
   picocolors: ^1.1.1
   picomatch: ^4.0.2
@@ -104,7 +104,7 @@ catalog:
   terser: ^5.44.1
   tinybench: ^6.0.0
   tinyexec: ^1.0.1
-  tsdown: ^0.21.2
+  tsdown: ^0.21.3
   tsx: ^4.20.6
   typescript: ^5.9.3
   unified: ^11.0.5


### PR DESCRIPTION
Automated daily upgrade of upstream dependencies:
- rolldown (latest tag)
- rolldown-vite (latest tag)
- vitest (latest npm version)
- tsdown (latest npm version)

Build status: success

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily bumps build/lint tool dependencies and lockfile entries, with minimal impact on runtime behavior. Risk is limited to potential CI/build or packaging regressions from the upgraded toolchain versions.
> 
> **Overview**
> Upgrades the toolchain dependencies, including `tsdown` to `0.21.3` (and matching `@tsdown/css`/`@tsdown/exe` peer/bundled versions), plus related updates in `pnpm-lock.yaml`.
> 
> Tweaks TypeScript ergonomics in templates/docs by adding a `*.css` module declaration for VitePress and including Node typings (`"types": ["node"]`) in the CLI generator `tsconfig.json`. Also bumps `oxlint-tsgolint` and `tinyexec` versions via workspace catalog/lockfile updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd6f74fb922c5a43713b0342558e06ba5a4771ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->