### PR TITLE
feat(create): use degit to download vite:library template from GitHub

### DIFF
--- a/packages/cli/src/create/templates/builtin.ts
+++ b/packages/cli/src/create/templates/builtin.ts
@@ -3,10 +3,11 @@ import path from 'node:path';
 
 import type { WorkspaceInfo } from '../../types/index.js';
 import type { ExecutionResult } from '../command.js';
+import { discoverTemplate } from '../discovery.js';
 import { setPackageName } from '../utils.js';
 import { executeGeneratorScaffold } from './generator.js';
 import { runRemoteTemplateCommand } from './remote.js';
-import { BuiltinTemplate, type BuiltinTemplateInfo } from './types.js';
+import { BuiltinTemplate, type BuiltinTemplateInfo, LibraryTemplateRepo } from './types.js';
 
 export async function executeBuiltinTemplate(
   workspaceInfo: WorkspaceInfo,
@@ -25,18 +26,25 @@ export async function executeBuiltinTemplate(
     if (!templateInfo.interactive) {
       templateInfo.args.push('--no-interactive');
     }
+    templateInfo.args.unshift(templateInfo.targetDir);
   } else if (templateInfo.command === BuiltinTemplate.library) {
-    templateInfo.command = 'create-tsdown@latest';
-    // create-tsdown doesn't support non-interactive mode;
-    // add default template when running silently to prevent hang on piped stdin
-    if (!templateInfo.interactive || options?.silent) {
-      if (!templateInfo.args.some((arg) => arg.startsWith('--template') || arg.startsWith('-t'))) {
-        templateInfo.args.push('--template', 'default');
-      }
-    }
+    // Use degit to download the template directly from GitHub
+    const libraryTemplateInfo = discoverTemplate(
+      LibraryTemplateRepo,
+      [templateInfo.targetDir],
+      workspaceInfo,
+    );
+    const result = await runRemoteTemplateCommand(
+      workspaceInfo,
+      workspaceInfo.rootDir,
+      libraryTemplateInfo,
+      false,
+      options?.silent ?? false,
+    );
+    const fullPath = path.join(workspaceInfo.rootDir, templateInfo.targetDir);
+    setPackageName(fullPath, templateInfo.packageName);
+    return { ...result, projectDir: templateInfo.targetDir };
   }
-
-  templateInfo.args.unshift(templateInfo.targetDir);
 
   // Handle remote/external templates with fspy monitoring
   const result = await runRemoteTemplateCommand(

--- a/packages/cli/src/create/templates/monorepo.ts
+++ b/packages/cli/src/create/templates/monorepo.ts
@@ -13,7 +13,7 @@ import type { ExecutionResult } from '../command.js';
 import { discoverTemplate } from '../discovery.js';
 import { copyDir, formatDisplayTargetDir, setPackageName } from '../utils.js';
 import { runRemoteTemplateCommand } from './remote.js';
-import { type BuiltinTemplateInfo } from './types.js';
+import { type BuiltinTemplateInfo, LibraryTemplateRepo } from './types.js';
 
 export const InitialMonorepoAppDir = 'apps/website';
 
@@ -168,11 +168,7 @@ export async function executeMonorepoTemplate(
     prompts.log.step('Creating default library in packages/utils...');
   }
   const libraryDir = 'packages/utils';
-  const libraryTemplateInfo = discoverTemplate(
-    'create-tsdown@latest',
-    [libraryDir, '--template', 'default'],
-    workspaceInfo,
-  );
+  const libraryTemplateInfo = discoverTemplate(LibraryTemplateRepo, [libraryDir], workspaceInfo);
   const libraryResult = await runRemoteTemplateCommand(
     workspaceInfo,
     fullPath,

--- a/packages/cli/src/create/templates/types.ts
+++ b/packages/cli/src/create/templates/types.ts
@@ -1,3 +1,5 @@
+export const LibraryTemplateRepo = 'github:sxzz/tsdown-templates/vite-plus';
+
 export const BuiltinTemplate = {
   generator: 'vite:generator',
   monorepo: 'vite:monorepo',


### PR DESCRIPTION
Replace `create-tsdown@latest` with degit-based template download from
`sxzz/tsdown-templates/vite-plus` for the vite:library template. This
avoids npm registry dependency and GitHub API rate limit issues.

Closes #910