### PR TITLE
fix(env): check all shell profiles in `vp env doctor`

### DIFF
--- a/crates/vite_global_cli/src/commands/env/doctor.rs
+++ b/crates/vite_global_cli/src/commands/env/doctor.rs
@@ -457,15 +457,9 @@ fn check_profile_files(vite_plus_home: &str) -> Option<String> {
         search_strings.push(format!("{home_dir}{suffix}{env_suffix}"));
     }
 
-    #[cfg(target_os = "macos")]
-    let profile_files: &[&str] = &[".zshenv", ".profile"];
-
-    #[cfg(target_os = "linux")]
-    let profile_files: &[&str] = &[".profile"];
-
-    // Fallback for other Unix platforms
-    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-    let profile_files: &[&str] = &[".profile"];
+    // Check all profile files the install script may write to.
+    // This matches install.sh and implode.rs for consistency.
+    let profile_files: &[&str] = &[".zshenv", ".zshrc", ".bash_profile", ".bashrc", ".profile"];
 
     for file in profile_files {
         let full_path = format!("{home_dir}/{file}");


### PR DESCRIPTION
## Summary

- `check_profile_files` only checked `.zshenv` + `.profile` on macOS and `.profile` on Linux
- But `install.sh` writes to all of: `.zshenv`, `.zshrc`, `.bash_profile`, `.bashrc`, `.profile`
- This caused `vp env doctor` to falsely report missing IDE integration on Linux with zsh (env in `.zshrc`) or bash (env in `.bashrc`)
- Unified the profile list to match `install.sh` and `implode.rs`, removing the platform-specific `#[cfg]` branches

## Test plan

- [ ] `vp env doctor` on Linux with env sourced from `.bashrc` no longer shows false warning
- [ ] `vp env doctor` on macOS with env sourced from `.zshrc` no longer shows false warning
- [ ] `vp env doctor` still detects when no profile has the env sourcing line

Closes #881

🤖 Generated with [Claude Code](https://claude.com/claude-code)