### PR TITLE
fix(create): normalize target directory to forward slashes on Windows

### DIFF
--- a/packages/cli/src/create/__tests__/utils.spec.ts
+++ b/packages/cli/src/create/__tests__/utils.spec.ts
@@ -17,7 +17,8 @@ describe('formatTargetDir', () => {
     expect(formatTargetDir('../../foo/bar')).matchSnapshot();
   });
 
-  it.skipIf(process.platform === 'win32')('should format target dir with valid input', () => {
+  // Should work on all platforms (including Windows) - directory must always use forward slashes
+  it('should format target dir with valid input', () => {
     expect(formatTargetDir('./my-package')).matchSnapshot();
     expect(formatTargetDir('my-package')).matchSnapshot();
     expect(formatTargetDir('@my-scope/my-package')).matchSnapshot();
@@ -26,6 +27,17 @@ describe('formatTargetDir', () => {
     expect(formatTargetDir('./foo/bar/@scope/my-package')).matchSnapshot();
     expect(formatTargetDir('./foo/bar/@scope/my-package/')).matchSnapshot();
     expect(formatTargetDir('./foo/bar/@scope/my-package/sub-package')).matchSnapshot();
+  });
+
+  // Regression test for https://github.com/voidzero-dev/vite-plus/issues/938
+  // On Windows, path.join/normalize produce backslashes which break when passed as CLI args.
+  // Nested paths are the critical cases since they involve path separators.
+  it('should always use forward slashes in directory (issue #938)', () => {
+    expect(formatTargetDir('foo/@my-scope/my-package').directory).toBe('foo/my-package');
+    expect(formatTargetDir('./foo/bar/@scope/my-package').directory).toBe('foo/bar/my-package');
+    expect(formatTargetDir('./foo/bar/@scope/my-package/sub-package').directory).toBe(
+      'foo/bar/@scope/my-package/sub-package',
+    );
   });
 
   it('should format target dir with invalid package name', () => {

--- a/packages/cli/src/create/bin.ts
+++ b/packages/cli/src/create/bin.ts
@@ -584,7 +584,7 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
       const selected = await promptPackageNameAndTargetDir(defaultPackageName, options.interactive);
       packageName = selected.packageName;
       targetDir = selectedParentDir
-        ? path.join(selectedParentDir, selected.targetDir)
+        ? path.join(selectedParentDir, selected.targetDir).split(path.sep).join('/')
         : selected.targetDir;
     }
   }
@@ -782,7 +782,7 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
       const selected = await promptPackageNameAndTargetDir(defaultPackageName, options.interactive);
       packageName = selected.packageName;
       targetDir = templateInfo.parentDir
-        ? path.join(templateInfo.parentDir, selected.targetDir)
+        ? path.join(templateInfo.parentDir, selected.targetDir).split(path.sep).join('/')
         : selected.targetDir;
     }
     pauseCreateProgress();

--- a/packages/cli/src/create/utils.ts
+++ b/packages/cli/src/create/utils.ts
@@ -85,7 +85,7 @@ export function formatTargetDir(input: string): {
       error: `Parsed package name "${packageName}" is invalid: ${message}`,
     };
   }
-  return { directory: targetDir, packageName };
+  return { directory: targetDir.split(path.sep).join('/'), packageName };
 }
 
 // Get the project directory from the project name


### PR DESCRIPTION
On Windows, `path.join` and `path.normalize` produce backslash-separated
paths (e.g., `packages\core`). When passed as CLI arguments to external
commands like `create-vite`, the backslash gets lost, creating
`packagescore` instead of `packages/core`.

Normalize all relative target directory paths to forward slashes at the
source: in `formatTargetDir()` and in `bin.ts` path joins.

Closes #938