### PR TITLE
ci: add graphite optimizer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,21 @@ defaults:
     shell: bash
 
 jobs:
+  optimize-ci:
+    runs-on: ubuntu-latest # or whichever runner you use for your CI
+    outputs:
+      skip: ${{ steps.check_skip.outputs.skip }}
+    steps:
+      - name: Optimize CI
+        id: check_skip
+        uses: withgraphite/graphite-ci-action@ee395f3a78254c006d11339669c6cabddf196f72
+        with:
+          graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
+
   detect-changes:
     runs-on: ubuntu-latest
+    needs: optimize-ci
+    if: needs.optimize-ci.outputs.skip == 'false'
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes only GitHub Actions workflow control flow, but could inadvertently skip CI if the optimizer output or secret is misconfigured.
> 
> **Overview**
> Introduces a new `optimize-ci` job using `withgraphite/graphite-ci-action` (token via `GRAPHITE_CI_OPTIMIZER_TOKEN`) to decide whether CI should run.
> 
> Updates `detect-changes` to depend on `optimize-ci` and to short-circuit the workflow when the optimizer indicates `skip == 'true'`, preventing downstream jobs from running in that case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c827f16906d379ee15d5ad954e4d39c1632793e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->