### PR TITLE
fix(test): resolve vendor-aliases paths from package root, not distRoot

### DIFF
--- a/packages/test/build.ts
+++ b/packages/test/build.ts
@@ -1459,7 +1459,7 @@ async function patchVitestBrowserPackage() {
   // This allows imports like @vitest/runner to be resolved to our copied @vitest files
   const mappingEntries = Object.entries(VITEST_PACKAGE_TO_PATH)
     .filter(([pkg]) => pkg.startsWith('@vitest/'))
-    .map(([pkg, file]) => `'${pkg}': resolve(distRoot, '${file}')`)
+    .map(([pkg, file]) => `'${pkg}': resolve(packageRoot, '${file}')`)
     .join(',\n      ');
 
   // distRoot is @vitest/browser/ so we need to go up two levels to reach the actual dist root


### PR DESCRIPTION
The vendorMap in the vendor-aliases plugin was resolving @vitest/* paths
relative to distRoot (dist/@vitest/browser/), producing doubled paths like
dist/@vitest/browser/@vitest/browser/context.js. Use packageRoot (dist/)
instead, fixing resolution for third-party imports like @storybook/addon-vitest.

- Close https://github.com/voidzero-dev/vite-plus/issues/963

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line change in the test build-time patcher that only affects how `@vitest/*` alias paths are resolved in the injected browser plugin.
> 
> **Overview**
> Fixes the injected `vitest:vendor-aliases` plugin so its `@vitest/*` alias map resolves files from the dist *package root* (`packageRoot`/`dist/`) instead of `distRoot` (`dist/@vitest/browser/`).
> 
> This prevents incorrect doubled paths when third-party tools import `@vitest/*` modules in browser mode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33c61645098034687eabe74b18a55024ed4d19f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->