### PR TITLE
fix(cli): allow oxlint/oxfmt wrappers to support non-LSP editor modes

### DIFF
--- a/packages/cli/bin/oxfmt
+++ b/packages/cli/bin/oxfmt
@@ -1,14 +1,10 @@
 #!/usr/bin/env node
 
-// LSP-only wrapper for oxfmt.
-// This enables IDE extensions (e.g., oxc-vscode) to discover and start the LSP server.
+// CLI wrapper for oxfmt.
+// This enables IDE extensions and editors to discover and use the oxfmt binary.
+// Supports all CLI modes: --lsp for LSP-aware editors, and flags like
+// --stdin-filepath, --check, etc. for non-LSP editors.
 // Binary resolution follows the same approach as `src/resolve-fmt.ts`.
-
-if (!process.argv.includes('--lsp')) {
-  console.error('This oxfmt wrapper is for IDE extension use only (--lsp mode).');
-  console.error('To format your code, run: vp fmt');
-  process.exit(1);
-}
 
 import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';

--- a/packages/cli/bin/oxlint
+++ b/packages/cli/bin/oxlint
@@ -1,14 +1,10 @@
 #!/usr/bin/env node
 
-// LSP-only wrapper for oxlint.
-// This enables IDE extensions (e.g., oxc-vscode) to discover and start the LSP server.
+// CLI wrapper for oxlint.
+// This enables IDE extensions and editors to discover and use the oxlint binary.
+// Supports all CLI modes: --lsp for LSP-aware editors, and flags like
+// --reporter=json, --stdin-filepath, etc. for non-LSP editors.
 // Binary resolution follows the same approach as `src/resolve-lint.ts`.
-
-if (!process.argv.includes('--lsp')) {
-  console.error('This oxlint wrapper is for IDE extension use only (--lsp mode).');
-  console.error('To lint your code, run: vp lint');
-  process.exit(1);
-}
 
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';

--- a/packages/cli/snap-tests/bin-oxfmt-wrapper/snap.txt
+++ b/packages/cli/snap-tests/bin-oxfmt-wrapper/snap.txt
@@ -1,10 +1,41 @@
-[1]> node ../node_modules/vite-plus/bin/oxfmt # should reject non-LSP usage
-This oxfmt wrapper is for IDE extension use only (--lsp mode).
-To format your code, run: vp fmt
+> node ../node_modules/vite-plus/bin/oxfmt --help # should show oxfmt help
+Usage: [-c=PATH] [PATH]...
 
-[1]> node ../node_modules/vite-plus/bin/oxfmt --help # should reject non-LSP usage
-This oxfmt wrapper is for IDE extension use only (--lsp mode).
-To format your code, run: vp fmt
+Mode Options:
+        --init               Initialize `.oxfmtrc.json` with default values
+        --migrate=SOURCE     Migrate configuration to `.oxfmtrc.json` from specified source
+                             Available sources: prettier, biome
+        --lsp                Start language server protocol (LSP) server
+        --stdin-filepath=PATH  Specify the file name to use to infer which parser to use
+
+Output Options:
+        --write              Format and write files in place (default)
+        --check              Check if files are formatted, also show statistics
+        --list-different     List files that would be changed
+
+Config Options
+    -c, --config=PATH        Path to the configuration file (.json, .jsonc, .ts, .mts, .cts, .js,
+                             .mjs, .cjs)
+
+Ignore Options
+        --ignore-path=PATH   Path to ignore file(s). Can be specified multiple times. If not
+                             specified, .gitignore and .prettierignore in the current directory are
+                             used.
+        --with-node-modules  Format code in node_modules directory (skipped by default)
+
+Runtime Options
+        --no-error-on-unmatched-pattern  Do not exit with error when pattern is unmatched
+        --threads=INT        Number of threads to use. Set to 1 for using only 1 CPU core.
+
+Available positional items:
+    PATH                     Single file, path or list of paths. Glob patterns are also supported.
+                             (Be sure to quote them, otherwise your shell may expand them before
+                             passing.) Exclude patterns with `!` prefix like `'!**/fixtures/*.js'`
+                             are also supported. If not provided, current working directory is used.
+
+Available options:
+    -h, --help               Prints help information
+    -V, --version            Prints version information
 
 > node ../node_modules/vite-plus/bin/oxfmt --lsp --help # should exercise import path
 Usage: [-c=PATH] [PATH]...
@@ -44,4 +75,3 @@ Available positional items:
 Available options:
     -h, --help               Prints help information
     -V, --version            Prints version information
-

--- a/packages/cli/snap-tests/bin-oxfmt-wrapper/steps.json
+++ b/packages/cli/snap-tests/bin-oxfmt-wrapper/steps.json
@@ -1,7 +1,6 @@
 {
   "commands": [
-    "node ../node_modules/vite-plus/bin/oxfmt # should reject non-LSP usage",
-    "node ../node_modules/vite-plus/bin/oxfmt --help # should reject non-LSP usage",
+    "node ../node_modules/vite-plus/bin/oxfmt --help # should show oxfmt help",
     "node ../node_modules/vite-plus/bin/oxfmt --lsp --help # should exercise import path"
   ]
 }

--- a/packages/cli/snap-tests/bin-oxlint-wrapper/snap.txt
+++ b/packages/cli/snap-tests/bin-oxlint-wrapper/snap.txt
@@ -1,10 +1,103 @@
-[1]> node ../node_modules/vite-plus/bin/oxlint # should reject non-LSP usage
-This oxlint wrapper is for IDE extension use only (--lsp mode).
-To lint your code, run: vp lint
+> node ../node_modules/vite-plus/bin/oxlint --help # should show oxlint help
+Usage: [-c=<./.oxlintrc.json>] [PATH]...
 
-[1]> node ../node_modules/vite-plus/bin/oxlint --help # should reject non-LSP usage
-This oxlint wrapper is for IDE extension use only (--lsp mode).
-To lint your code, run: vp lint
+Basic Configuration
+    -c, --config=<./.oxlintrc.json>  Oxlint configuration file
+                              * `.json` and `.jsonc` config files are supported in all runtimes
+                              * JavaScript/TypeScript config files are experimental and require
+                              running via Node.js
+                              * you can use comments in configuration files.
+                              * tries to be compatible with ESLint v8's format
+        --tsconfig=<./tsconfig.json>  Override the TypeScript config used for import resolution.
+                              Oxlint automatically discovers the relevant `tsconfig.json` for each
+                              file. Use this only when your project uses a non-standard tsconfig
+                              name or location.
+        --init                Initialize oxlint configuration with default values
+
+Allowing / Denying Multiple Lints
+   Accumulate rules and categories from left to right on the command-line.
+   For example `-D correctness -A no-debugger` or `-A all -D no-debugger`.
+   The categories are:
+   * `correctness` - Code that is outright wrong or useless (default)
+   * `suspicious`  - Code that is most likely wrong or useless
+   * `pedantic`    - Lints which are rather strict or have occasional false positives
+   * `perf`        - Code that could be written in a more performant way
+   * `style`       - Code that should be written in a more idiomatic way
+   * `restriction` - Lints which prevent the use of language and library features
+   * `nursery`     - New lints that are still under development
+   * `all`         - All categories listed above except `nursery`. Does not enable plugins
+  automatically.
+    -A, --allow=NAME          Allow the rule or category (suppress the lint)
+    -W, --warn=NAME           Deny the rule or category (emit a warning)
+    -D, --deny=NAME           Deny the rule or category (emit an error)
+
+Enable/Disable Plugins
+        --disable-unicorn-plugin  Disable unicorn plugin, which is turned on by default
+        --disable-oxc-plugin  Disable oxc unique rules, which is turned on by default
+        --disable-typescript-plugin  Disable TypeScript plugin, which is turned on by default
+        --import-plugin       Enable import plugin and detect ESM problems.
+        --react-plugin        Enable react plugin, which is turned off by default
+        --jsdoc-plugin        Enable jsdoc plugin and detect JSDoc problems
+        --jest-plugin         Enable the Jest plugin and detect test problems
+        --vitest-plugin       Enable the Vitest plugin and detect test problems
+        --jsx-a11y-plugin     Enable the JSX-a11y plugin and detect accessibility problems
+        --nextjs-plugin       Enable the Next.js plugin and detect Next.js problems
+        --react-perf-plugin   Enable the React performance plugin and detect rendering performance
+                              problems
+        --promise-plugin      Enable the promise plugin and detect promise usage problems
+        --node-plugin         Enable the node plugin and detect node usage problems
+        --vue-plugin          Enable the vue plugin and detect vue usage problems
+
+Fix Problems
+        --fix                 Fix as many issues as possible. Only unfixed issues are reported in
+                              the output.
+        --fix-suggestions     Apply auto-fixable suggestions. May change program behavior.
+        --fix-dangerously     Apply dangerous fixes and suggestions
+
+Ignore Files
+        --ignore-path=PATH    Specify the file to use as your `.eslintignore`
+        --ignore-pattern=PAT  Specify patterns of files to ignore (in addition to those in
+                              `.eslintignore`)
+        --no-ignore           Disable excluding files from `.eslintignore` files, --ignore-path
+                              flags and --ignore-pattern flags
+
+Handle Warnings
+        --quiet               Disable reporting on warnings, only errors are reported
+        --deny-warnings       Ensure warnings produce a non-zero exit code
+        --max-warnings=INT    Specify a warning threshold, which can be used to force exit with an
+                              error status if there are too many warning-level rule violations in
+                              your project
+
+Output
+    -f, --format=ARG          Use a specific output format. Possible values: `checkstyle`,
+                              `default`, `github`, `gitlab`, `json`, `junit`, `stylish`, `unix`
+
+Miscellaneous
+        --silent              Do not display any diagnostics
+        --threads=INT         Number of threads to use. Set to 1 for using only 1 CPU core.
+        --print-config        This option outputs the configuration to be used. When present, no
+                              linting is performed and only config-related options are valid.
+
+Inline Configuration Comments
+        --report-unused-disable-directives  Report directive comments like `// oxlint-disable-line`,
+                              when no errors would have been reported on that line anyway
+        --report-unused-disable-directives-severity=SEVERITY  Same as
+                              `--report-unused-disable-directives`, but allows you to specify the
+                              severity level of the reported errors. Only one of these two options
+                              can be used at a time.
+
+Available positional items:
+    PATH                      Single file, single path or list of paths
+
+Available options:
+        --rules               List all the rules that are currently registered
+        --lsp                 Start the language server
+        --disable-nested-config  Disable the automatic loading of nested configuration files
+        --type-aware          Enable rules that require type information
+        --type-check          Enable experimental type checking (includes TypeScript compiler
+                              diagnostics)
+    -h, --help                Prints help information
+    -V, --version             Prints version information
 
 > node ../node_modules/vite-plus/bin/oxlint --lsp --help # should exercise import path
 Usage: [-c=<./.oxlintrc.json>] [PATH]...
@@ -106,4 +199,3 @@ Available options:
                               diagnostics)
     -h, --help                Prints help information
     -V, --version             Prints version information
-

--- a/packages/cli/snap-tests/bin-oxlint-wrapper/steps.json
+++ b/packages/cli/snap-tests/bin-oxlint-wrapper/steps.json
@@ -1,7 +1,6 @@
 {
   "commands": [
-    "node ../node_modules/vite-plus/bin/oxlint # should reject non-LSP usage",
-    "node ../node_modules/vite-plus/bin/oxlint --help # should reject non-LSP usage",
+    "node ../node_modules/vite-plus/bin/oxlint --help # should show oxlint help",
     "node ../node_modules/vite-plus/bin/oxlint --lsp --help # should exercise import path"
   ]
 }


### PR DESCRIPTION
## Summary

- Remove the `--lsp`-only guard from `bin/oxlint` and `bin/oxfmt` wrappers so all CLI flags are passed through to the underlying binaries
- Enables non-LSP-aware editors to use flags like `--stdin-filepath`, `--reporter=json`, `--check`, etc.
- Update snapshot tests to reflect the new pass-through behavior

Fixes #979

## Test plan

- [ ] Verify `bin/oxlint --help` shows full oxlint help (no longer rejects non-LSP usage)
- [ ] Verify `bin/oxfmt --help` shows full oxfmt help (no longer rejects non-LSP usage)
- [ ] Verify `bin/oxlint --lsp` still works for LSP-aware editors
- [ ] Verify `bin/oxfmt --lsp` still works for LSP-aware editors
- [ ] Verify `bin/oxfmt --stdin-filepath=foo.ts` works for non-LSP editors
- [ ] Verify `bin/oxlint --format=json` works for non-LSP editors
- [ ] Run snap tests: `pnpm -F vite-plus snap-test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)