### PR TITLE
feat(install): add bun as a package manager

### DIFF
--- a/.claude/skills/add-ecosystem-ci/SKILL.md
+++ b/.claude/skills/add-ecosystem-ci/SKILL.md
@@ -84,10 +84,40 @@ Present the auto-detected configuration and ask user to confirm or modify:
 
 ## Step 4: Verify
 
-Test the clone locally:
+### 4.1 Build fresh tgz packages
+
+Always rebuild tgz packages from latest source to avoid using stale cached versions:
+
+```bash
+# Rebuild the global CLI first (includes Rust binary + NAPI binding)
+pnpm bootstrap-cli
+
+# Pack fresh tgz files into tmp/tgz/
+rm -rf tmp/tgz && mkdir -p tmp/tgz
+cd packages/core && pnpm pack --pack-destination ../../tmp/tgz && cd ../..
+cd packages/test && pnpm pack --pack-destination ../../tmp/tgz && cd ../..
+cd packages/cli && pnpm pack --pack-destination ../../tmp/tgz && cd ../..
+ls -la tmp/tgz
+```
+
+### 4.2 Clone and test locally
 
 ```bash
 node ecosystem-ci/clone.ts project-name
+```
+
+### 4.3 Patch and run commands
+
+```bash
+# Run from the ecosystem-ci temp directory
+cd $(node -e "const os=require('os'); console.log(os.tmpdir() + '/vite-plus-ecosystem-ci')")
+
+# Migrate the project (uses tgz files from tmp/tgz/)
+node /path/to/vite-plus/ecosystem-ci/patch-project.ts project-name
+
+# Run the configured commands
+cd project-name
+vp run build
 ```
 
 3. **Add OS exclusion to `.github/workflows/e2e-test.yml`** (if not running on both):

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -289,6 +289,11 @@ jobs:
             node-version: 24
             command: |
               vp test run
+          - name: bun-vite-template
+            node-version: 24
+            command: |
+              vp run build
+              vp run test
         exclude:
           # frm-stack uses Docker (testcontainers) which doesn't work the same way on Windows
           - os: windows-latest

--- a/crates/vite_global_cli/src/shim/dispatch.rs
+++ b/crates/vite_global_cli/src/shim/dispatch.rs
@@ -27,7 +27,7 @@ const RECURSION_ENV_VAR: &str = env_vars::VITE_PLUS_TOOL_RECURSION;
 
 /// Package manager tools that should resolve Node.js version from the project context
 /// rather than using the install-time version.
-const PACKAGE_MANAGER_TOOLS: &[&str] = &["pnpm", "yarn"];
+const PACKAGE_MANAGER_TOOLS: &[&str] = &["pnpm", "yarn", "bun"];
 
 fn is_package_manager_tool(tool: &str) -> bool {
     PACKAGE_MANAGER_TOOLS.contains(&tool)

--- a/crates/vite_install/src/commands/add.rs
+++ b/crates/vite_install/src/commands/add.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, process::ExitStatus};
 use vite_command::run_command;
 use vite_error::Error;
 use vite_path::AbsolutePath;
+use vite_shared::output;
 
 use crate::package_manager::{
     PackageManager, PackageManagerType, ResolveCommandResult, format_path_env,
@@ -193,6 +194,47 @@ impl PackageManager {
 
                 if options.save_exact {
                     args.push("--save-exact".into());
+                }
+            }
+            PackageManagerType::Bun => {
+                bin_name = "bun".into();
+                args.push("add".into());
+
+                if let Some(save_dependency_type) = options.save_dependency_type {
+                    match save_dependency_type {
+                        SaveDependencyType::Production => {
+                            // default, no flag needed
+                        }
+                        SaveDependencyType::Dev => {
+                            args.push("--dev".into());
+                        }
+                        SaveDependencyType::Peer => {
+                            args.push("--peer".into());
+                        }
+                        SaveDependencyType::Optional => {
+                            args.push("--optional".into());
+                        }
+                    }
+                }
+                if options.save_exact {
+                    args.push("--exact".into());
+                }
+                if let Some(filters) = options.filters {
+                    if !filters.is_empty() {
+                        output::warn("bun add does not support --filter");
+                    }
+                }
+                if options.workspace_root {
+                    output::warn("bun add does not support --workspace-root");
+                }
+                if options.workspace_only {
+                    output::warn("bun add does not support --workspace-only");
+                }
+                if options.save_catalog_name.is_some() {
+                    output::warn("bun add does not support --save-catalog-name");
+                }
+                if options.allow_build.is_some() {
+                    output::warn("bun add does not support --allow-build");
                 }
             }
         }

--- a/crates/vite_install/src/commands/audit.rs
+++ b/crates/vite_install/src/commands/audit.rs
@@ -142,6 +142,28 @@ impl PackageManager {
                     }
                 }
             }
+            PackageManagerType::Bun => {
+                bin_name = "bun".into();
+                args.push("audit".into());
+
+                if options.fix {
+                    output::warn("bun audit does not support --fix");
+                    return None;
+                }
+
+                if let Some(level) = options.level {
+                    args.push("--audit-level".into());
+                    args.push(level.to_string());
+                }
+
+                if options.production {
+                    output::warn("--production not supported by bun audit, ignoring flag");
+                }
+
+                if options.json {
+                    args.push("--json".into());
+                }
+            }
         }
 
         // Add pass-through args
@@ -318,6 +340,70 @@ mod tests {
         let result = result.unwrap();
         assert_eq!(result.bin_path, "yarn");
         assert_eq!(result.args, vec!["audit", "--level", "high"]);
+    }
+
+    #[test]
+    fn test_bun_audit_basic() {
+        let pm = create_mock_package_manager(PackageManagerType::Bun, "1.3.11");
+        let result = pm.resolve_audit_command(&AuditCommandOptions {
+            fix: false,
+            json: false,
+            level: None,
+            production: false,
+            pass_through_args: None,
+        });
+        assert!(result.is_some());
+        let result = result.unwrap();
+        assert_eq!(result.bin_path, "bun");
+        assert!(result.args.contains(&"audit".to_string()), "should contain 'audit'");
+        assert!(!result.args.contains(&"pm".to_string()), "should NOT use 'bun pm audit'");
+    }
+
+    #[test]
+    fn test_bun_audit_level() {
+        let pm = create_mock_package_manager(PackageManagerType::Bun, "1.3.11");
+        let result = pm.resolve_audit_command(&AuditCommandOptions {
+            fix: false,
+            json: false,
+            level: Some("high"),
+            production: false,
+            pass_through_args: None,
+        });
+        assert!(result.is_some());
+        let result = result.unwrap();
+        assert!(
+            result.args.contains(&"--audit-level".to_string()),
+            "should use --audit-level not --level"
+        );
+        assert!(result.args.contains(&"high".to_string()));
+    }
+
+    #[test]
+    fn test_bun_audit_fix_not_supported() {
+        let pm = create_mock_package_manager(PackageManagerType::Bun, "1.3.11");
+        let result = pm.resolve_audit_command(&AuditCommandOptions {
+            fix: true,
+            json: false,
+            level: None,
+            production: false,
+            pass_through_args: None,
+        });
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_bun_audit_json() {
+        let pm = create_mock_package_manager(PackageManagerType::Bun, "1.3.11");
+        let result = pm.resolve_audit_command(&AuditCommandOptions {
+            fix: false,
+            json: true,
+            level: None,
+            production: false,
+            pass_through_args: None,
+        });
+        assert!(result.is_some());
+        let result = result.unwrap();
+        assert_eq!(result.args, vec!["audit", "--json"]);
     }
 
     #[test]

--- a/crates/vite_install/src/commands/cache.rs
+++ b/crates/vite_install/src/commands/cache.rs
@@ -117,6 +117,28 @@ impl PackageManager {
                     }
                 }
             }
+            PackageManagerType::Bun => {
+                bin_name = "bun".into();
+
+                match options.subcommand {
+                    "dir" | "path" => {
+                        args.push("pm".into());
+                        args.push("cache".into());
+                    }
+                    "clean" => {
+                        args.push("pm".into());
+                        args.push("cache".into());
+                        args.push("rm".into());
+                    }
+                    _ => {
+                        output::warn(&format!(
+                            "bun pm cache subcommand '{}' not supported",
+                            options.subcommand
+                        ));
+                        return None;
+                    }
+                }
+            }
         }
 
         // Add pass-through args

--- a/crates/vite_install/src/commands/config.rs
+++ b/crates/vite_install/src/commands/config.rs
@@ -127,6 +127,32 @@ impl PackageManager {
                     }
                 }
             }
+            PackageManagerType::Bun => {
+                output::warn(
+                    "bun uses bunfig.toml for configuration, not a config command. Falling back to npm config.",
+                );
+
+                // Fall back to npm config
+                args.push("config".into());
+                args.push(options.subcommand.to_string());
+
+                if let Some(key) = options.key {
+                    args.push(key.to_string());
+                }
+
+                if let Some(value) = options.value {
+                    args.push(value.to_string());
+                }
+
+                if options.json {
+                    args.push("--json".into());
+                }
+
+                if let Some(location) = options.location {
+                    args.push("--location".into());
+                    args.push(location.to_string());
+                }
+            }
         }
 
         // Add pass-through args

--- a/crates/vite_install/src/commands/dedupe.rs
+++ b/crates/vite_install/src/commands/dedupe.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, process::ExitStatus};
 use vite_command::run_command;
 use vite_error::Error;
 use vite_path::AbsolutePath;
+use vite_shared::output;
 
 use crate::package_manager::{
     PackageManager, PackageManagerType, ResolveCommandResult, format_path_env,
@@ -62,6 +63,11 @@ impl PackageManager {
                 if options.check {
                     args.push("--dry-run".into());
                 }
+            }
+            PackageManagerType::Bun => {
+                bin_name = "bun".into();
+                output::warn("bun does not support dedupe, falling back to bun install");
+                args.push("install".into());
             }
         }
 

--- a/crates/vite_install/src/commands/deprecate.rs
+++ b/crates/vite_install/src/commands/deprecate.rs
@@ -3,8 +3,11 @@ use std::{collections::HashMap, process::ExitStatus};
 use vite_command::run_command;
 use vite_error::Error;
 use vite_path::AbsolutePath;
+use vite_shared::output;
 
-use crate::package_manager::{PackageManager, ResolveCommandResult, format_path_env};
+use crate::package_manager::{
+    PackageManager, PackageManagerType, ResolveCommandResult, format_path_env,
+};
 
 /// Options for the deprecate command.
 #[derive(Debug, Default)]
@@ -31,6 +34,7 @@ impl PackageManager {
 
     /// Resolve the deprecate command.
     /// All package managers delegate to npm deprecate.
+    /// Bun does not support deprecate, falls back to npm.
     #[must_use]
     pub fn resolve_deprecate_command(
         &self,
@@ -39,6 +43,12 @@ impl PackageManager {
         let bin_name: String = "npm".to_string();
         let envs = HashMap::from([("PATH".to_string(), format_path_env(self.get_bin_prefix()))]);
         let mut args: Vec<String> = Vec::new();
+
+        if self.client == PackageManagerType::Bun {
+            output::warn(
+                "bun does not support the deprecate command, falling back to npm deprecate",
+            );
+        }
 
         args.push("deprecate".into());
         args.push(options.package.to_string());

--- a/crates/vite_install/src/commands/dist_tag.rs
+++ b/crates/vite_install/src/commands/dist_tag.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, process::ExitStatus};
 use vite_command::run_command;
 use vite_error::Error;
 use vite_path::AbsolutePath;
+use vite_shared::output;
 
 use crate::package_manager::{
     PackageManager, PackageManagerType, ResolveCommandResult, format_path_env,
@@ -63,6 +64,11 @@ impl PackageManager {
                     args.push("npm".into());
                     args.push("tag".into());
                 }
+            }
+            PackageManagerType::Bun => {
+                output::warn("bun does not support dist-tag, falling back to npm dist-tag");
+                bin_name = "npm".into();
+                args.push("dist-tag".into());
             }
         }
 

--- a/crates/vite_install/src/commands/dlx.rs
+++ b/crates/vite_install/src/commands/dlx.rs
@@ -52,6 +52,7 @@ impl PackageManager {
                     self.resolve_yarn_dlx(options, envs)
                 }
             }
+            PackageManagerType::Bun => self.resolve_bun_dlx(options, envs),
         }
     }
 
@@ -186,6 +187,36 @@ impl PackageManager {
 
         let args = build_npx_args(options);
         ResolveCommandResult { bin_path: "npx".into(), args, envs }
+    }
+
+    fn resolve_bun_dlx(
+        &self,
+        options: &DlxCommandOptions,
+        envs: HashMap<String, String>,
+    ) -> ResolveCommandResult {
+        let mut args = Vec::new();
+
+        // Use `bun x` instead of `bunx` for better cross-platform compatibility.
+        // Some installation methods (e.g. mise) don't add bunx to PATH on Windows.
+        args.push("x".into());
+
+        // --packages flags must come before the package spec
+        for pkg in options.packages {
+            args.push("--package".into());
+            args.push(pkg.clone());
+        }
+
+        // Add package spec
+        args.push(options.package_spec.into());
+
+        // Add command arguments
+        args.extend(options.args.iter().cloned());
+
+        if options.shell_mode {
+            output::warn("bun x does not support shell mode (-c)");
+        }
+
+        ResolveCommandResult { bin_path: "bun".into(), args, envs }
     }
 }
 

--- a/crates/vite_install/src/commands/fund.rs
+++ b/crates/vite_install/src/commands/fund.rs
@@ -3,8 +3,11 @@ use std::{collections::HashMap, process::ExitStatus};
 use vite_command::run_command;
 use vite_error::Error;
 use vite_path::AbsolutePath;
+use vite_shared::output;
 
-use crate::package_manager::{PackageManager, ResolveCommandResult, format_path_env};
+use crate::package_manager::{
+    PackageManager, PackageManagerType, ResolveCommandResult, format_path_env,
+};
 
 /// Options for the fund command.
 #[derive(Debug, Default)]
@@ -28,11 +31,16 @@ impl PackageManager {
 
     /// Resolve the fund command.
     /// All package managers delegate to npm fund.
+    /// Bun does not support fund, falls back to npm.
     #[must_use]
     pub fn resolve_fund_command(&self, options: &FundCommandOptions) -> ResolveCommandResult {
         let bin_name: String = "npm".to_string();
         let envs = HashMap::from([("PATH".to_string(), format_path_env(self.get_bin_prefix()))]);
         let mut args: Vec<String> = Vec::new();
+
+        if self.client == PackageManagerType::Bun {
+            output::warn("bun does not support the fund command, falling back to npm fund");
+        }
 
         args.push("fund".into());
 

--- a/crates/vite_install/src/commands/install.rs
+++ b/crates/vite_install/src/commands/install.rs
@@ -1,9 +1,9 @@
 use std::{collections::HashMap, iter, process::ExitStatus};
 
-use tracing::warn;
 use vite_command::run_command;
 use vite_error::Error;
 use vite_path::AbsolutePath;
+use vite_shared::output;
 
 use crate::package_manager::{
     PackageManager, PackageManagerType, ResolveCommandResult, format_path_env,
@@ -165,8 +165,8 @@ impl PackageManager {
                         args.push("--mode".into());
                         args.push("update-lockfile".into());
                         if options.ignore_scripts {
-                            warn!(
-                                "yarn@2+ --mode can only be specified once; --lockfile-only takes priority over --ignore-scripts"
+                            output::warn(
+                                "yarn@2+ --mode can only be specified once; --lockfile-only takes priority over --ignore-scripts",
                             );
                         }
                     } else if options.ignore_scripts {
@@ -177,15 +177,17 @@ impl PackageManager {
                         args.push("--refresh-lockfile".into());
                     }
                     if options.silent {
-                        warn!(
-                            "yarn@2+ does not support --silent, use YARN_ENABLE_PROGRESS=false instead"
+                        output::warn(
+                            "yarn@2+ does not support --silent, use YARN_ENABLE_PROGRESS=false instead",
                         );
                     }
                     if options.prod {
-                        warn!("yarn@2+ requires configuration in .yarnrc.yml for --prod behavior");
+                        output::warn(
+                            "yarn@2+ requires configuration in .yarnrc.yml for --prod behavior",
+                        );
                     }
                     if options.resolution_only {
-                        warn!("yarn@2+ does not support --resolution-only");
+                        output::warn("yarn@2+ does not support --resolution-only");
                     }
                 } else {
                     // yarn@1 (Classic)
@@ -220,10 +222,10 @@ impl PackageManager {
                         args.push("--no-lockfile".into());
                     }
                     if options.fix_lockfile {
-                        warn!("yarn@1 does not support --fix-lockfile");
+                        output::warn("yarn@1 does not support --fix-lockfile");
                     }
                     if options.resolution_only {
-                        warn!("yarn@1 does not support --resolution-only");
+                        output::warn("yarn@1 does not support --resolution-only");
                     }
                     if options.workspace_root {
                         args.push("-W".into());
@@ -269,10 +271,10 @@ impl PackageManager {
                     args.push("--no-package-lock".into());
                 }
                 if options.fix_lockfile {
-                    warn!("npm does not support --fix-lockfile");
+                    output::warn("npm does not support --fix-lockfile");
                 }
                 if options.resolution_only {
-                    warn!("npm does not support --resolution-only");
+                    output::warn("npm does not support --resolution-only");
                 }
                 if options.silent {
                     args.push("--loglevel".into());
@@ -286,6 +288,60 @@ impl PackageManager {
                         args.push("--workspace".into());
                         args.push(filter.clone());
                     }
+                }
+            }
+            PackageManagerType::Bun => {
+                bin_name = "bun".into();
+                args.push("install".into());
+
+                if options.prod {
+                    args.push("--production".into());
+                }
+                // --no-frozen-lockfile takes higher priority over --frozen-lockfile
+                if options.no_frozen_lockfile {
+                    args.push("--no-frozen-lockfile".into());
+                } else if options.frozen_lockfile {
+                    args.push("--frozen-lockfile".into());
+                }
+                if options.force {
+                    args.push("--force".into());
+                }
+                if options.silent {
+                    args.push("--silent".into());
+                }
+                if options.no_optional {
+                    args.push("--omit".into());
+                    args.push("optional".into());
+                }
+                if options.ignore_scripts {
+                    args.push("--ignore-scripts".into());
+                }
+                if options.lockfile_only {
+                    args.push("--lockfile-only".into());
+                }
+                if options.prefer_offline {
+                    output::warn("bun does not support --prefer-offline");
+                }
+                if options.offline {
+                    output::warn("bun does not support --offline");
+                }
+                if options.no_lockfile {
+                    output::warn("bun does not support --no-lockfile");
+                }
+                if options.fix_lockfile {
+                    output::warn("bun does not support --fix-lockfile");
+                }
+                if options.resolution_only {
+                    output::warn("bun does not support --resolution-only");
+                }
+                if let Some(filters) = options.filters {
+                    for filter in filters {
+                        args.push("--filter".into());
+                        args.push(filter.clone());
+                    }
+                }
+                if options.workspace_root {
+                    output::warn("bun does not support --workspace-root");
                 }
             }
         }
@@ -676,6 +732,55 @@ mod tests {
             ..Default::default()
         });
         assert_eq!(result.args, vec!["install"]);
+    }
+
+    #[test]
+    fn test_bun_basic_install() {
+        let pm = create_mock_package_manager(PackageManagerType::Bun, "1.3.11");
+        let result = pm.resolve_install_command_with_options(&InstallCommandOptions::default());
+        assert_eq!(result.bin_path, "bun");
+        assert_eq!(result.args, vec!["install"]);
+    }
+
+    #[test]
+    fn test_bun_frozen_lockfile() {
+        let pm = create_mock_package_manager(PackageManagerType::Bun, "1.3.11");
+        let result = pm.resolve_install_command_with_options(&InstallCommandOptions {
+            frozen_lockfile: true,
+            ..Default::default()
+        });
+        assert!(result.args.contains(&"--frozen-lockfile".to_string()));
+    }
+
+    #[test]
+    fn test_bun_ignore_scripts() {
+        let pm = create_mock_package_manager(PackageManagerType::Bun, "1.3.11");
+        let result = pm.resolve_install_command_with_options(&InstallCommandOptions {
+            ignore_scripts: true,
+            ..Default::default()
+        });
+        assert!(result.args.contains(&"--ignore-scripts".to_string()));
+    }
+
+    #[test]
+    fn test_bun_no_optional() {
+        let pm = create_mock_package_manager(PackageManagerType::Bun, "1.3.11");
+        let result = pm.resolve_install_command_with_options(&InstallCommandOptions {
+            no_optional: true,
+            ..Default::default()
+        });
+        assert!(result.args.contains(&"--omit".to_string()));
+        assert!(result.args.contains(&"optional".to_string()));
+    }
+
+    #[test]
+    fn test_bun_prod_install() {
+        let pm = create_mock_package_manager(PackageManagerType::Bun, "1.3.11");
+        let result = pm.resolve_install_command_with_options(&InstallCommandOptions {
+            prod: true,
+            ..Default::default()
+        });
+        assert!(result.args.contains(&"--production".to_string()));
     }
 
     #[test]

--- a/crates/vite_install/src/commands/link.rs
+++ b/crates/vite_install/src/commands/link.rs
@@ -49,6 +49,10 @@ impl PackageManager {
                 bin_name = "npm".into();
                 args.push("link".into());
             }
+            PackageManagerType::Bun => {
+                bin_name = "bun".into();
+                args.push("link".into());
+            }
         }
 
         // Add package/directory if specified

--- a/crates/vite_install/src/commands/list.rs
+++ b/crates/vite_install/src/commands/list.rs
@@ -198,6 +198,64 @@ impl PackageManager {
                     }
                 }
             }
+            PackageManagerType::Bun => {
+                args.push("pm".into());
+                args.push("ls".into());
+
+                if let Some(pattern) = options.pattern {
+                    args.push(pattern.to_string());
+                }
+
+                if options.depth.is_some() {
+                    output::warn("--depth not supported by bun pm ls, ignoring flag");
+                }
+
+                if options.json {
+                    output::warn("--json not supported by bun pm ls, ignoring flag");
+                }
+
+                if options.long {
+                    output::warn("--long not supported by bun pm ls, ignoring flag");
+                }
+
+                if options.parseable {
+                    output::warn("--parseable not supported by bun pm ls, ignoring flag");
+                }
+
+                if options.prod {
+                    output::warn("--prod not supported by bun pm ls, ignoring flag");
+                }
+
+                if options.dev {
+                    output::warn("--dev not supported by bun pm ls, ignoring flag");
+                }
+
+                if options.no_optional {
+                    output::warn("--no-optional not supported by bun pm ls, ignoring flag");
+                }
+
+                if options.exclude_peers {
+                    output::warn("--exclude-peers not supported by bun pm ls, ignoring flag");
+                }
+
+                if options.only_projects {
+                    output::warn("--only-projects not supported by bun pm ls, ignoring flag");
+                }
+
+                if options.find_by.is_some() {
+                    output::warn("--find-by not supported by bun pm ls, ignoring flag");
+                }
+
+                if options.recursive {
+                    output::warn("--recursive not supported by bun pm ls, ignoring flag");
+                }
+
+                if let Some(filters) = options.filters {
+                    if !filters.is_empty() {
+                        output::warn("--filter not supported by bun pm ls, ignoring flag");
+                    }
+                }
+            }
         }
 
         // Add pass-through args

--- a/crates/vite_install/src/commands/login.rs
+++ b/crates/vite_install/src/commands/login.rs
@@ -55,6 +55,10 @@ impl PackageManager {
                     args.push("login".into());
                 }
             }
+            PackageManagerType::Bun => {
+                bin_name = "npm".into();
+                args.push("login".into());
+            }
         }
 
         if let Some(registry) = options.registry {

--- a/crates/vite_install/src/commands/logout.rs
+++ b/crates/vite_install/src/commands/logout.rs
@@ -55,6 +55,10 @@ impl PackageManager {
                     args.push("logout".into());
                 }
             }
+            PackageManagerType::Bun => {
+                bin_name = "npm".into();
+                args.push("logout".into());
+            }
         }
 
         if let Some(registry) = options.registry {

--- a/crates/vite_install/src/commands/outdated.rs
+++ b/crates/vite_install/src/commands/outdated.rs
@@ -219,6 +219,53 @@ impl PackageManager {
                     bin_name = "npm".into();
                     Self::format_npm_outdated_args(&mut args, options);
                 }
+                PackageManagerType::Bun => {
+                    bin_name = "bun".into();
+                    args.push("outdated".into());
+
+                    if let Some(filters) = options.filters {
+                        for filter in filters {
+                            args.push("--filter".into());
+                            args.push(filter.clone());
+                        }
+                    }
+
+                    if options.recursive {
+                        args.push("--recursive".into());
+                    }
+
+                    // Add packages
+                    args.extend_from_slice(options.packages);
+
+                    if let Some(format) = options.format {
+                        if format == Format::Json {
+                            output::warn("bun outdated does not support --format json");
+                        }
+                    }
+
+                    if options.long {
+                        output::warn("bun outdated does not support --long");
+                    }
+                    if options.workspace_root {
+                        output::warn("bun outdated does not support --workspace-root");
+                    }
+                    if options.prod {
+                        args.push("--production".into());
+                    }
+                    if options.dev {
+                        output::warn("bun outdated does not support --dev");
+                    }
+                    if options.no_optional {
+                        args.push("--omit".into());
+                        args.push("optional".into());
+                    }
+                    if options.compatible {
+                        output::warn("bun outdated does not support --compatible");
+                    }
+                    if options.sort_by.is_some() {
+                        output::warn("bun outdated does not support --sort-by");
+                    }
+                }
             }
         }
 

--- a/crates/vite_install/src/commands/owner.rs
+++ b/crates/vite_install/src/commands/owner.rs
@@ -29,6 +29,7 @@ impl PackageManager {
 
     /// Resolve the owner command.
     /// All package managers delegate to npm owner.
+    /// Bun does not support owner, falls back to npm.
     #[must_use]
     pub fn resolve_owner_command(&self, subcommand: &OwnerSubcommand) -> ResolveCommandResult {
         let bin_name: String = "npm".to_string();

--- a/crates/vite_install/src/commands/pack.rs
+++ b/crates/vite_install/src/commands/pack.rs
@@ -173,6 +173,39 @@ impl PackageManager {
                     args.push("--json".into());
                 }
             }
+            PackageManagerType::Bun => {
+                args.push("pm".into());
+                args.push("pack".into());
+
+                if options.recursive {
+                    output::warn("--recursive not supported by bun pm pack, ignoring flag");
+                }
+
+                if let Some(filters) = options.filters {
+                    if !filters.is_empty() {
+                        output::warn("--filter not supported by bun pm pack, ignoring flag");
+                    }
+                }
+
+                if let Some(out) = options.out {
+                    args.push("--filename".into());
+                    args.push(out.to_string());
+                }
+
+                if let Some(dest) = options.pack_destination {
+                    args.push("--destination".into());
+                    args.push(dest.to_string());
+                }
+
+                if let Some(level) = options.pack_gzip_level {
+                    args.push("--gzip-level".into());
+                    args.push(level.to_string());
+                }
+
+                if options.json {
+                    output::warn("--json not supported by bun pm pack, ignoring flag");
+                }
+            }
         }
 
         // Add pass-through args
@@ -517,6 +550,28 @@ mod tests {
         // Verify directory was created
         assert!(dest_path.as_path().exists());
         assert!(dest_path.as_path().is_dir());
+    }
+
+    #[test]
+    fn test_bun_pack_with_out_maps_to_filename() {
+        let pm = create_mock_package_manager(PackageManagerType::Bun, "1.3.11");
+        let result = pm.resolve_pack_command(&PackCommandOptions {
+            out: Some("custom.tgz"),
+            ..Default::default()
+        });
+        assert!(result.args.contains(&"--filename".to_string()));
+        assert!(result.args.contains(&"custom.tgz".to_string()));
+    }
+
+    #[test]
+    fn test_bun_pack_with_gzip_level() {
+        let pm = create_mock_package_manager(PackageManagerType::Bun, "1.3.11");
+        let result = pm.resolve_pack_command(&PackCommandOptions {
+            pack_gzip_level: Some(5),
+            ..Default::default()
+        });
+        assert!(result.args.contains(&"--gzip-level".to_string()));
+        assert!(result.args.contains(&"5".to_string()));
     }
 
     #[tokio::test]

--- a/crates/vite_install/src/commands/ping.rs
+++ b/crates/vite_install/src/commands/ping.rs
@@ -28,6 +28,7 @@ impl PackageManager {
 
     /// Resolve the ping command.
     /// All package managers delegate to npm ping.
+    /// Bun does not support ping, falls back to npm.
     #[must_use]
     pub fn resolve_ping_command(&self, options: &PingCommandOptions) -> ResolveCommandResult {
         let bin_name: String = "npm".to_string();

--- a/crates/vite_install/src/commands/prune.rs
+++ b/crates/vite_install/src/commands/prune.rs
@@ -75,6 +75,12 @@ impl PackageManager {
                 );
                 return None;
             }
+            PackageManagerType::Bun => {
+                output::warn(
+                    "bun does not have a 'prune' command. bun install will prune extraneous packages automatically.",
+                );
+                return None;
+            }
         }
 
         // Add pass-through args

--- a/crates/vite_install/src/commands/publish.rs
+++ b/crates/vite_install/src/commands/publish.rs
@@ -168,6 +168,64 @@ impl PackageManager {
                     output::warn("--json not supported by npm, ignoring flag");
                 }
             }
+            PackageManagerType::Bun => {
+                bin_name = "bun".into();
+
+                args.push("publish".into());
+
+                if let Some(target) = options.target {
+                    args.push(target.to_string());
+                }
+
+                if options.dry_run {
+                    args.push("--dry-run".into());
+                }
+
+                if let Some(tag) = options.tag {
+                    args.push("--tag".into());
+                    args.push(tag.to_string());
+                }
+
+                if let Some(access) = options.access {
+                    args.push("--access".into());
+                    args.push(access.to_string());
+                }
+
+                if let Some(otp) = options.otp {
+                    args.push("--otp".into());
+                    args.push(otp.to_string());
+                }
+
+                if options.no_git_checks {
+                    output::warn("--no-git-checks not supported by bun, ignoring flag");
+                }
+
+                if options.publish_branch.is_some() {
+                    output::warn("--publish-branch not supported by bun, ignoring flag");
+                }
+
+                if options.report_summary {
+                    output::warn("--report-summary not supported by bun, ignoring flag");
+                }
+
+                if options.force {
+                    output::warn("--force not supported by bun publish, ignoring flag");
+                }
+
+                if options.json {
+                    output::warn("--json not supported by bun publish, ignoring flag");
+                }
+
+                if options.recursive {
+                    output::warn("--recursive not supported by bun publish, ignoring flag");
+                }
+
+                if let Some(filters) = options.filters {
+                    if !filters.is_empty() {
+                        output::warn("--filter not supported by bun publish, ignoring flag");
+                    }
+                }
+            }
         }
 
         // Add pass-through args

--- a/crates/vite_install/src/commands/rebuild.rs
+++ b/crates/vite_install/src/commands/rebuild.rs
@@ -63,6 +63,10 @@ impl PackageManager {
 
                 return None;
             }
+            PackageManagerType::Bun => {
+                output::warn("bun does not support the rebuild command");
+                return None;
+            }
         }
 
         // Add pass-through args

--- a/crates/vite_install/src/commands/remove.rs
+++ b/crates/vite_install/src/commands/remove.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, process::ExitStatus};
 use vite_command::run_command;
 use vite_error::Error;
 use vite_path::AbsolutePath;
+use vite_shared::output;
 
 use crate::package_manager::{
     PackageManager, PackageManagerType, ResolveCommandResult, format_path_env,
@@ -126,6 +127,20 @@ impl PackageManager {
                     args.push("--workspaces".into());
                 }
                 // not support: save_dev, save_optional, save_prod, just ignore them
+            }
+            PackageManagerType::Bun => {
+                bin_name = "bun".into();
+                args.push("remove".into());
+
+                if let Some(filters) = options.filters {
+                    if !filters.is_empty() {
+                        output::warn("bun remove does not support --filter");
+                    }
+                }
+                if options.workspace_root {
+                    output::warn("bun remove does not support --workspace-root");
+                }
+                // bun remove doesn't support save_dev, save_optional, save_prod flags
             }
         }
 

--- a/crates/vite_install/src/commands/run.rs
+++ b/crates/vite_install/src/commands/run.rs
@@ -31,6 +31,7 @@ impl PackageManager {
             PackageManagerType::Pnpm => "pnpm",
             PackageManagerType::Npm => "npm",
             PackageManagerType::Yarn => "yarn",
+            PackageManagerType::Bun => "bun",
         };
 
         ResolveCommandResult { bin_path: bin_path.to_string(), args: cmd_args, envs }

--- a/crates/vite_install/src/commands/search.rs
+++ b/crates/vite_install/src/commands/search.rs
@@ -31,6 +31,7 @@ impl PackageManager {
 
     /// Resolve the search command.
     /// All package managers delegate to npm search.
+    /// Bun does not support search, falls back to npm.
     #[must_use]
     pub fn resolve_search_command(&self, options: &SearchCommandOptions) -> ResolveCommandResult {
         let bin_name: String = "npm".to_string();

--- a/crates/vite_install/src/commands/token.rs
+++ b/crates/vite_install/src/commands/token.rs
@@ -43,6 +43,7 @@ impl PackageManager {
 
     /// Resolve the token command.
     /// All package managers delegate to npm token.
+    /// Bun does not support token, falls back to npm.
     #[must_use]
     pub fn resolve_token_command(&self, subcommand: &TokenSubcommand) -> ResolveCommandResult {
         let bin_name: String = "npm".to_string();

--- a/crates/vite_install/src/commands/unlink.rs
+++ b/crates/vite_install/src/commands/unlink.rs
@@ -63,6 +63,14 @@ impl PackageManager {
                     output::warn("npm doesn't support --recursive for unlink command");
                 }
             }
+            PackageManagerType::Bun => {
+                bin_name = "bun".into();
+                args.push("unlink".into());
+
+                if options.recursive {
+                    output::warn("bun doesn't support --recursive for unlink command");
+                }
+            }
         }
 
         // Add package if specified

--- a/crates/vite_install/src/commands/update.rs
+++ b/crates/vite_install/src/commands/update.rs
@@ -179,6 +179,30 @@ impl PackageManager {
                     output::warn("npm doesn't support interactive mode. Running standard update.");
                 }
             }
+            PackageManagerType::Bun => {
+                bin_name = "bun".into();
+                args.push("update".into());
+
+                if options.latest {
+                    args.push("--latest".into());
+                }
+                if options.interactive {
+                    args.push("--interactive".into());
+                }
+                if options.prod {
+                    args.push("--production".into());
+                }
+                if options.no_optional {
+                    args.push("--omit".into());
+                    args.push("optional".into());
+                }
+                if options.no_save {
+                    args.push("--no-save".into());
+                }
+                if options.recursive {
+                    args.push("--recursive".into());
+                }
+            }
         }
 
         if let Some(pass_through_args) = options.pass_through_args {
@@ -592,5 +616,58 @@ mod tests {
             ]
         );
         assert_eq!(result.bin_path, "yarn");
+    }
+
+    #[test]
+    fn test_bun_basic_update() {
+        let pm = create_mock_package_manager(PackageManagerType::Bun, "1.3.11");
+        let result = pm.resolve_update_command(&UpdateCommandOptions::default());
+        assert_eq!(result.bin_path, "bun");
+        assert_eq!(result.args, vec!["update"]);
+    }
+
+    #[test]
+    fn test_bun_update_latest() {
+        let pm = create_mock_package_manager(PackageManagerType::Bun, "1.3.11");
+        let result =
+            pm.resolve_update_command(&UpdateCommandOptions { latest: true, ..Default::default() });
+        assert!(result.args.contains(&"--latest".to_string()));
+    }
+
+    #[test]
+    fn test_bun_update_prod() {
+        let pm = create_mock_package_manager(PackageManagerType::Bun, "1.3.11");
+        let result =
+            pm.resolve_update_command(&UpdateCommandOptions { prod: true, ..Default::default() });
+        assert!(result.args.contains(&"--production".to_string()));
+    }
+
+    #[test]
+    fn test_bun_update_no_optional() {
+        let pm = create_mock_package_manager(PackageManagerType::Bun, "1.3.11");
+        let result = pm.resolve_update_command(&UpdateCommandOptions {
+            no_optional: true,
+            ..Default::default()
+        });
+        assert!(result.args.contains(&"--omit".to_string()));
+        assert!(result.args.contains(&"optional".to_string()));
+    }
+
+    #[test]
+    fn test_bun_update_no_save() {
+        let pm = create_mock_package_manager(PackageManagerType::Bun, "1.3.11");
+        let result = pm
+            .resolve_update_command(&UpdateCommandOptions { no_save: true, ..Default::default() });
+        assert!(result.args.contains(&"--no-save".to_string()));
+    }
+
+    #[test]
+    fn test_bun_update_recursive() {
+        let pm = create_mock_package_manager(PackageManagerType::Bun, "1.3.11");
+        let result = pm.resolve_update_command(&UpdateCommandOptions {
+            recursive: true,
+            ..Default::default()
+        });
+        assert!(result.args.contains(&"--recursive".to_string()));
     }
 }

--- a/crates/vite_install/src/commands/view.rs
+++ b/crates/vite_install/src/commands/view.rs
@@ -4,7 +4,9 @@ use vite_command::run_command;
 use vite_error::Error;
 use vite_path::AbsolutePath;
 
-use crate::package_manager::{PackageManager, ResolveCommandResult, format_path_env};
+use crate::package_manager::{
+    PackageManager, PackageManagerType, ResolveCommandResult, format_path_env,
+};
 
 /// Options for the view command.
 #[derive(Debug, Default)]
@@ -30,23 +32,39 @@ impl PackageManager {
 
     /// Resolve the view command.
     /// All package managers delegate to npm view (pnpm and yarn use npm internally).
+    /// Bun uses `bun info` as a native alternative.
     #[must_use]
     pub fn resolve_view_command(&self, options: &ViewCommandOptions) -> ResolveCommandResult {
-        let bin_name: String = "npm".to_string();
         let envs = HashMap::from([("PATH".to_string(), format_path_env(self.get_bin_prefix()))]);
         let mut args: Vec<String> = Vec::new();
 
-        args.push("view".into());
+        let bin_name: String = if self.client == PackageManagerType::Bun {
+            args.push("info".into());
+            args.push(options.package.to_string());
 
-        args.push(options.package.to_string());
+            if let Some(field) = options.field {
+                args.push(field.to_string());
+            }
 
-        if let Some(field) = options.field {
-            args.push(field.to_string());
-        }
+            if options.json {
+                args.push("--json".into());
+            }
 
-        if options.json {
-            args.push("--json".into());
-        }
+            "bun".into()
+        } else {
+            args.push("view".into());
+            args.push(options.package.to_string());
+
+            if let Some(field) = options.field {
+                args.push(field.to_string());
+            }
+
+            if options.json {
+                args.push("--json".into());
+            }
+
+            "npm".into()
+        };
 
         // Add pass-through args
         if let Some(pass_through_args) = options.pass_through_args {

--- a/crates/vite_install/src/commands/whoami.rs
+++ b/crates/vite_install/src/commands/whoami.rs
@@ -62,6 +62,11 @@ impl PackageManager {
                 args.push("npm".into());
                 args.push("whoami".into());
             }
+            PackageManagerType::Bun => {
+                bin_name = "bun".into();
+                args.push("pm".into());
+                args.push("whoami".into());
+            }
         }
 
         if let Some(registry) = options.registry {

--- a/crates/vite_install/src/commands/why.rs
+++ b/crates/vite_install/src/commands/why.rs
@@ -200,6 +200,53 @@ impl PackageManager {
                     output::warn("--find-by not supported by npm");
                 }
             }
+            PackageManagerType::Bun => {
+                bin_name = "bun".into();
+
+                // bun has a direct `why` subcommand (not `bun pm why`)
+                args.push("why".into());
+
+                // Add packages
+                args.extend_from_slice(options.packages);
+
+                // Warn about unsupported flags
+                if options.json {
+                    output::warn("--json not supported by bun why");
+                }
+                if options.long {
+                    output::warn("--long not supported by bun why");
+                }
+                if options.parseable {
+                    output::warn("--parseable not supported by bun why");
+                }
+                if options.recursive {
+                    output::warn("--recursive not supported by bun why");
+                }
+                if let Some(filters) = options.filters {
+                    if !filters.is_empty() {
+                        output::warn("--filter not supported by bun why");
+                    }
+                }
+                if options.workspace_root {
+                    output::warn("--workspace-root not supported by bun why");
+                }
+                if options.prod || options.dev {
+                    output::warn("--prod/--dev not supported by bun why");
+                }
+                if let Some(depth) = options.depth {
+                    args.push("--depth".into());
+                    args.push(depth.to_string());
+                }
+                if options.no_optional {
+                    output::warn("--no-optional not supported by bun why");
+                }
+                if options.exclude_peers {
+                    output::warn("--exclude-peers not supported by bun why");
+                }
+                if options.find_by.is_some() {
+                    output::warn("--find-by not supported by bun why");
+                }
+            }
         }
 
         // Add pass-through args
@@ -379,5 +426,18 @@ mod tests {
         });
         assert_eq!(result.bin_path, "pnpm");
         assert_eq!(result.args, vec!["why", "--find-by", "customFinder", "react"]);
+    }
+
+    #[test]
+    fn test_bun_why_with_depth() {
+        let pm = create_mock_package_manager(PackageManagerType::Bun, "1.3.11");
+        let packages = vec!["testnpm2".to_string()];
+        let result = pm.resolve_why_command(&WhyCommandOptions {
+            packages: &packages,
+            depth: Some(2),
+            ..Default::default()
+        });
+        assert!(result.args.contains(&"--depth".to_string()));
+        assert!(result.args.contains(&"2".to_string()));
     }
 }

--- a/crates/vite_install/src/package_manager.rs
+++ b/crates/vite_install/src/package_manager.rs
@@ -44,6 +44,7 @@ pub enum PackageManagerType {
     Pnpm,
     Yarn,
     Npm,
+    Bun,
 }
 
 impl fmt::Display for PackageManagerType {
@@ -52,6 +53,7 @@ impl fmt::Display for PackageManagerType {
             Self::Pnpm => write!(f, "pnpm"),
             Self::Yarn => write!(f, "yarn"),
             Self::Npm => write!(f, "npm"),
+            Self::Bun => write!(f, "bun"),
         }
     }
 }
@@ -194,6 +196,11 @@ impl PackageManager {
                 ignores.push("!**/package-lock.json".into());
                 ignores.push("!**/npm-shrinkwrap.json".into());
             }
+            PackageManagerType::Bun => {
+                ignores.push("!**/bun.lock".into());
+                ignores.push("!**/bun.lockb".into());
+                ignores.push("!**/bunfig.toml".into());
+            }
         }
 
         // if the workspace is a monorepo, keep workspace packages' parent directories to watch for new packages being added
@@ -259,6 +266,7 @@ pub fn get_package_manager_type_and_version(
                 "pnpm" => return Ok((PackageManagerType::Pnpm, version.into(), hash)),
                 "yarn" => return Ok((PackageManagerType::Yarn, version.into(), hash)),
                 "npm" => return Ok((PackageManagerType::Npm, version.into(), hash)),
+                "bun" => return Ok((PackageManagerType::Bun, version.into(), hash)),
                 _ => return Err(Error::UnsupportedPackageManager(name.into())),
             }
         }
@@ -291,6 +299,16 @@ pub fn get_package_manager_type_and_version(
         return Ok((PackageManagerType::Npm, version, None));
     }
 
+    // if bun.lock (text format) or bun.lockb (binary format) exists, use bun@latest
+    let bun_lock_path = workspace_root.path.join("bun.lock");
+    if is_exists_file(&bun_lock_path)? {
+        return Ok((PackageManagerType::Bun, version, None));
+    }
+    let bun_lockb_path = workspace_root.path.join("bun.lockb");
+    if is_exists_file(&bun_lockb_path)? {
+        return Ok((PackageManagerType::Bun, version, None));
+    }
+
     // if .pnpmfile.cjs exists, use pnpm@latest
     let pnpmfile_cjs_path = workspace_root.path.join(".pnpmfile.cjs");
     if is_exists_file(&pnpmfile_cjs_path)? {
@@ -301,6 +319,12 @@ pub fn get_package_manager_type_and_version(
     let legacy_pnpmfile_cjs_path = workspace_root.path.join("pnpmfile.cjs");
     if is_exists_file(&legacy_pnpmfile_cjs_path)? {
         return Ok((PackageManagerType::Pnpm, version, None));
+    }
+
+    // if bunfig.toml exists, use bun@latest
+    let bunfig_toml_path = workspace_root.path.join("bunfig.toml");
+    if is_exists_file(&bunfig_toml_path)? {
+        return Ok((PackageManagerType::Bun, version, None));
     }
 
     // if yarn.config.cjs exists, use yarn@latest (yarn 2.0+)
@@ -372,9 +396,17 @@ pub async fn download_package_manager(
         }
     }
 
-    let tgz_url = get_npm_package_tgz_url(&package_name, &version);
     let home_dir = vite_shared::get_vite_plus_home()?;
     let bin_name = package_manager_type.to_string();
+
+    // For bun, use platform-specific download flow.
+    // The hash from `packageManager` field belongs to the main `bun` npm package,
+    // not the platform-specific binary, so we don't pass it through.
+    if matches!(package_manager_type, PackageManagerType::Bun) {
+        return download_bun_package_manager(&version, &home_dir).await;
+    }
+
+    let tgz_url = get_npm_package_tgz_url(&package_name, &version);
     // $VITE_PLUS_HOME/package_manager/pnpm/10.0.0
     let target_dir = home_dir.join("package_manager").join(&bin_name).join(&version);
     let install_dir = target_dir.join(&bin_name);
@@ -448,6 +480,136 @@ pub async fn download_package_manager(
     Ok((install_dir, package_name, version))
 }
 
+/// Get the platform-specific npm package name for bun.
+/// Returns the `@oven/bun-{os}-{arch}` package name for the current platform.
+fn get_bun_platform_package_name() -> Result<&'static str, Error> {
+    let name = match (env::consts::OS, env::consts::ARCH) {
+        ("macos", "aarch64") => "@oven/bun-darwin-aarch64",
+        ("macos", "x86_64") => "@oven/bun-darwin-x64",
+        #[cfg(target_env = "musl")]
+        ("linux", "aarch64") => "@oven/bun-linux-aarch64-musl",
+        #[cfg(not(target_env = "musl"))]
+        ("linux", "aarch64") => "@oven/bun-linux-aarch64",
+        #[cfg(target_env = "musl")]
+        ("linux", "x86_64") => "@oven/bun-linux-x64-musl",
+        #[cfg(not(target_env = "musl"))]
+        ("linux", "x86_64") => "@oven/bun-linux-x64",
+        ("windows", "x86_64") => "@oven/bun-windows-x64",
+        ("windows", "aarch64") => "@oven/bun-windows-aarch64",
+        (os, arch) => {
+            return Err(Error::UnsupportedPackageManager(
+                format!("bun (unsupported platform: {os}-{arch})").into(),
+            ));
+        }
+    };
+    Ok(name)
+}
+
+/// Download bun package manager (native binary) from npm.
+///
+/// Unlike JS-based package managers (pnpm/npm/yarn), bun is a native binary
+/// distributed via platform-specific npm packages (`@oven/bun-{os}-{arch}`).
+///
+/// Layout: `$VITE_PLUS_HOME/package_manager/bun/{version}/bun/bin/bun.native`
+async fn download_bun_package_manager(
+    version: &Str,
+    home_dir: &AbsolutePath,
+) -> Result<(AbsolutePathBuf, Str, Str), Error> {
+    let package_name: Str = "bun".into();
+    let platform_package_name = get_bun_platform_package_name()?;
+
+    // $VITE_PLUS_HOME/package_manager/bun/{version}
+    let target_dir = home_dir.join("package_manager").join("bun").join(version.as_str());
+    let install_dir = target_dir.join("bun");
+    let bin_prefix = install_dir.join("bin");
+    let bin_file = bin_prefix.join("bun");
+
+    // If shims already exist, return early
+    if is_exists_file(&bin_file)?
+        && is_exists_file(bin_file.with_extension("cmd"))?
+        && is_exists_file(bin_file.with_extension("ps1"))?
+    {
+        return Ok((install_dir, package_name, version.clone()));
+    }
+
+    let parent_dir = target_dir.parent().unwrap();
+    tokio::fs::create_dir_all(parent_dir).await?;
+
+    // Download the platform-specific package directly
+    let platform_tgz_url = get_npm_package_tgz_url(platform_package_name, version);
+    let target_dir_tmp = tempfile::tempdir_in(parent_dir)?.path().to_path_buf();
+
+    download_and_extract_tgz_with_hash(&platform_tgz_url, &target_dir_tmp, None).await.map_err(
+        |err| {
+            if let Error::Reqwest(e) = &err
+                && let Some(status) = e.status()
+                && status == reqwest::StatusCode::NOT_FOUND
+            {
+                Error::PackageManagerVersionNotFound {
+                    name: "bun".into(),
+                    version: version.clone(),
+                    url: platform_tgz_url.into(),
+                }
+            } else {
+                err
+            }
+        },
+    )?;
+
+    // Create the expected directory structure: bun/bin/
+    let tmp_bun_dir = target_dir_tmp.join("bun");
+    let tmp_bin_dir = tmp_bun_dir.join("bin");
+    tokio::fs::create_dir_all(&tmp_bin_dir).await?;
+
+    // The platform package extracts to `package/bin/` with the bun binary inside
+    // Find the native binary in the extracted package
+    let package_dir = target_dir_tmp.join("package");
+    let package_bin_dir = package_dir.join("bin");
+    let native_bin_src =
+        if cfg!(windows) { package_bin_dir.join("bun.exe") } else { package_bin_dir.join("bun") };
+
+    // Move native binary to bin/bun.native
+    let native_bin_dest = if cfg!(windows) {
+        tmp_bin_dir.join("bun.native.exe")
+    } else {
+        tmp_bin_dir.join("bun.native")
+    };
+    tokio::fs::rename(&native_bin_src, &native_bin_dest).await?;
+
+    // Set executable permission on the native binary
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        tokio::fs::set_permissions(&native_bin_dest, fs::Permissions::from_mode(0o755)).await?;
+    }
+
+    // Clean up the extracted package directory
+    remove_dir_all_force(&package_dir).await?;
+
+    // Acquire lock for atomic rename
+    let lock_path = parent_dir.join(format!("{version}.lock"));
+    tracing::debug!("Acquire lock file: {:?}", lock_path);
+    let lock_file = File::create(lock_path.as_path())?;
+    lock_file.lock()?;
+    tracing::debug!("Lock acquired: {:?}", lock_path);
+
+    if is_exists_file(&bin_file)? {
+        tracing::debug!("bun bin_file already exists after lock acquisition, skip rename");
+        return Ok((install_dir, package_name, version.clone()));
+    }
+
+    // Rename temp dir to final location
+    tracing::debug!("Rename {:?} to {:?}", target_dir_tmp, target_dir);
+    remove_dir_all_force(&target_dir).await?;
+    tokio::fs::rename(&target_dir_tmp, &target_dir).await?;
+
+    // Create native binary shims
+    tracing::debug!("Create shim files for bun");
+    create_shim_files(PackageManagerType::Bun, &bin_prefix).await?;
+
+    Ok((install_dir, package_name, version.clone()))
+}
+
 /// Remove the directory and all its contents.
 /// Ignore the error if the directory is not found.
 async fn remove_dir_all_force(path: impl AsRef<Path>) -> Result<(), std::io::Error> {
@@ -494,6 +656,12 @@ async fn create_shim_files(
             bin_names.push(("npm", "npm-cli"));
             bin_names.push(("npx", "npx-cli"));
         }
+        PackageManagerType::Bun => {
+            // bun is a native binary, not a JS package.
+            // Create native binary shims instead of Node.js-based shims.
+            let bin_prefix = bin_prefix.as_ref();
+            return create_bun_shim_files(bin_prefix).await;
+        }
     }
 
     let bin_prefix = bin_prefix.as_ref();
@@ -512,6 +680,37 @@ async fn create_shim_files(
         let to_bin = bin_prefix.join(bin_name);
         shim::write_shims(&source_file, &to_bin).await?;
     }
+    Ok(())
+}
+
+/// Create shim files for bun's native binary.
+///
+/// Bun is a native binary distributed via platform-specific npm packages.
+/// The native binary is placed at `bin_prefix/bun.native` (unix) or
+/// `bin_prefix/bun.native.exe` (windows), and we create shim wrappers
+/// that exec it directly (without Node.js).
+async fn create_bun_shim_files(bin_prefix: &AbsolutePath) -> Result<(), Error> {
+    // The native binary should already be at bin_prefix/bun.native (unix) or
+    // bin_prefix/bun.native.exe (windows), placed there by download_bun_platform_binary.
+    let native_bin = if cfg!(windows) {
+        bin_prefix.join("bun.native.exe")
+    } else {
+        bin_prefix.join("bun.native")
+    };
+    if !is_exists_file(&native_bin)? {
+        return Err(Error::CannotFindBinaryPath(
+            "bun native binary not found. Expected bin/bun.native".into(),
+        ));
+    }
+
+    // Create bun shim -> bun.native
+    let bun_shim = bin_prefix.join("bun");
+    shim::write_native_shims(&native_bin, &bun_shim).await?;
+
+    // Create bunx shim -> bun.native (bunx is just bun with different argv[0])
+    let bunx_shim = bin_prefix.join("bunx");
+    shim::write_native_shims(&native_bin, &bunx_shim).await?;
+
     Ok(())
 }
 
@@ -570,6 +769,7 @@ fn interactive_package_manager_menu() -> Result<PackageManagerType, Error> {
         ("pnpm (recommended)", PackageManagerType::Pnpm),
         ("npm", PackageManagerType::Npm),
         ("yarn", PackageManagerType::Yarn),
+        ("bun", PackageManagerType::Bun),
     ];
 
     let mut selected_index = 0;
@@ -664,6 +864,9 @@ fn interactive_package_manager_menu() -> Result<PackageManagerType, Error> {
                 KeyCode::Char('3') if options.len() > 2 => {
                     break Ok(options[2].1);
                 }
+                KeyCode::Char('4') if options.len() > 3 => {
+                    break Ok(options[3].1);
+                }
                 KeyCode::Esc | KeyCode::Char('q') => {
                     // Exit on escape/quit
                     terminal::disable_raw_mode()?;
@@ -693,6 +896,7 @@ fn interactive_package_manager_menu() -> Result<PackageManagerType, Error> {
             PackageManagerType::Pnpm => "pnpm",
             PackageManagerType::Npm => "npm",
             PackageManagerType::Yarn => "yarn",
+            PackageManagerType::Bun => "bun",
         };
         println!("\n✓ Selected package manager: {name}\n");
     }
@@ -733,6 +937,7 @@ fn simple_text_prompt() -> Result<PackageManagerType, Error> {
         ("pnpm", PackageManagerType::Pnpm),
         ("npm", PackageManagerType::Npm),
         ("yarn", PackageManagerType::Yarn),
+        ("bun", PackageManagerType::Bun),
     ];
 
     println!("\nNo package manager detected. Please select one:");
@@ -2107,5 +2312,164 @@ mod tests {
             assert!(matcher.is_match("README.md"), "Should ignore docs");
             assert!(matcher.is_match("src/app.ts"), "Should ignore source files");
         }
+
+        #[test]
+        fn test_bun_fingerprint_ignores() {
+            let temp_dir: TempDir = create_temp_dir();
+            let pm = create_mock_package_manager(temp_dir, PackageManagerType::Bun, false);
+            let ignores = pm.get_fingerprint_ignores().expect("Should get fingerprint ignores");
+            let matcher = GlobPatternSet::new(&ignores).expect("Should compile patterns");
+
+            // Should NOT ignore bun-specific files
+            assert!(!matcher.is_match("bun.lock"), "Should NOT ignore bun.lock");
+            assert!(!matcher.is_match("bun.lockb"), "Should NOT ignore bun.lockb");
+            assert!(!matcher.is_match("bunfig.toml"), "Should NOT ignore bunfig.toml");
+            assert!(!matcher.is_match(".npmrc"), "Should NOT ignore .npmrc");
+            assert!(!matcher.is_match("package.json"), "Should NOT ignore package.json");
+
+            // Should ignore other package manager files
+            assert!(matcher.is_match("pnpm-lock.yaml"), "Should ignore pnpm-lock.yaml");
+            assert!(matcher.is_match("yarn.lock"), "Should ignore yarn.lock");
+            assert!(matcher.is_match("package-lock.json"), "Should ignore package-lock.json");
+
+            // Regular files should be ignored
+            assert!(matcher.is_match("README.md"), "Should ignore docs");
+            assert!(matcher.is_match("src/app.ts"), "Should ignore source files");
+        }
+    }
+
+    // Tests for bun package manager detection
+    #[tokio::test]
+    async fn test_detect_package_manager_with_bun_lock() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let package_content = r#"{"name": "test-package"}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        // Create bun.lock (text format)
+        fs::write(temp_dir_path.join("bun.lock"), r#"# bun lockfile"#)
+            .expect("Failed to write bun.lock");
+
+        let (workspace_root, _) =
+            find_workspace_root(&temp_dir_path).expect("Should find workspace root");
+        let (pm_type, version, hash) =
+            get_package_manager_type_and_version(&workspace_root, None).expect("Should detect bun");
+        assert_eq!(pm_type, PackageManagerType::Bun);
+        assert_eq!(version.as_str(), "latest");
+        assert!(hash.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_detect_package_manager_with_bun_lockb() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let package_content = r#"{"name": "test-package"}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        // Create bun.lockb (binary format)
+        fs::write(temp_dir_path.join("bun.lockb"), b"\x00\x01\x02")
+            .expect("Failed to write bun.lockb");
+
+        let (workspace_root, _) =
+            find_workspace_root(&temp_dir_path).expect("Should find workspace root");
+        let (pm_type, version, hash) =
+            get_package_manager_type_and_version(&workspace_root, None).expect("Should detect bun");
+        assert_eq!(pm_type, PackageManagerType::Bun);
+        assert_eq!(version.as_str(), "latest");
+        assert!(hash.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_detect_package_manager_with_bunfig_toml() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let package_content = r#"{"name": "test-package"}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        // Create bunfig.toml
+        fs::write(temp_dir_path.join("bunfig.toml"), "[install]\noptional = true")
+            .expect("Failed to write bunfig.toml");
+
+        let (workspace_root, _) =
+            find_workspace_root(&temp_dir_path).expect("Should find workspace root");
+        let (pm_type, version, hash) =
+            get_package_manager_type_and_version(&workspace_root, None).expect("Should detect bun");
+        assert_eq!(pm_type, PackageManagerType::Bun);
+        assert_eq!(version.as_str(), "latest");
+        assert!(hash.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_detect_package_manager_with_package_manager_field_bun() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let package_content = r#"{"name": "test-package", "packageManager": "bun@1.2.0"}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        let (workspace_root, _) =
+            find_workspace_root(&temp_dir_path).expect("Should find workspace root");
+        let (pm_type, version, hash) = get_package_manager_type_and_version(&workspace_root, None)
+            .expect("Should detect bun from packageManager field");
+        assert_eq!(pm_type, PackageManagerType::Bun);
+        assert_eq!(version.as_str(), "1.2.0");
+        assert!(hash.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_detect_package_manager_with_package_manager_field_bun_with_hash() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let package_content =
+            r#"{"name": "test-package", "packageManager": "bun@1.2.0+sha512.abc123"}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        let (workspace_root, _) =
+            find_workspace_root(&temp_dir_path).expect("Should find workspace root");
+        let (pm_type, version, hash) = get_package_manager_type_and_version(&workspace_root, None)
+            .expect("Should detect bun with hash");
+        assert_eq!(pm_type, PackageManagerType::Bun);
+        assert_eq!(version.as_str(), "1.2.0");
+        assert_eq!(hash.unwrap().as_str(), "sha512.abc123");
+    }
+
+    #[tokio::test]
+    async fn test_detect_package_manager_bun_lock_priority_over_pnpmfile() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let package_content = r#"{"name": "test-package"}"#;
+        create_package_json(&temp_dir_path, package_content);
+
+        // Create both bun.lock and .pnpmfile.cjs
+        fs::write(temp_dir_path.join("bun.lock"), "# bun lockfile")
+            .expect("Failed to write bun.lock");
+        fs::write(temp_dir_path.join(".pnpmfile.cjs"), "module.exports = {}")
+            .expect("Failed to write .pnpmfile.cjs");
+
+        let (workspace_root, _) =
+            find_workspace_root(&temp_dir_path).expect("Should find workspace root");
+        let (pm_type, _, _) =
+            get_package_manager_type_and_version(&workspace_root, None).expect("Should detect bun");
+        assert_eq!(
+            pm_type,
+            PackageManagerType::Bun,
+            "bun.lock should be detected before .pnpmfile.cjs"
+        );
+    }
+
+    #[test]
+    fn test_get_bun_platform_package_name() {
+        let result = get_bun_platform_package_name();
+        assert!(result.is_ok(), "Should return a platform package name");
+        let name = result.unwrap();
+        assert!(
+            name.starts_with("@oven/bun-"),
+            "Package name should start with @oven/bun-, got: {name}"
+        );
+        // On musl targets, the package name should contain "-musl"
+        #[cfg(target_env = "musl")]
+        assert!(
+            name.ends_with("-musl"),
+            "On musl targets, package name should end with -musl, got: {name}"
+        );
     }
 }

--- a/crates/vite_install/src/shim.rs
+++ b/crates/vite_install/src/shim.rs
@@ -5,6 +5,91 @@ use pathdiff::diff_paths;
 use tokio::fs::write;
 use vite_error::Error;
 
+/// Write cmd/sh/pwsh shim files for native (non-Node.js) binaries.
+/// Unlike `write_shims` which wraps JS files with Node.js, this creates
+/// wrappers that exec the native binary directly.
+pub async fn write_native_shims(
+    source_file: impl AsRef<Path>,
+    to_bin: impl AsRef<Path>,
+) -> Result<(), Error> {
+    let to_bin = to_bin.as_ref();
+    let parent = to_bin
+        .parent()
+        .ok_or_else(|| Error::CannotFindBinaryPath("shim path has no parent directory".into()))?;
+    let relative_path = diff_paths(&source_file, parent).ok_or_else(|| {
+        Error::CannotFindBinaryPath("cannot compute relative path for shim".into())
+    })?;
+    let relative_file = relative_path
+        .to_str()
+        .ok_or_else(|| Error::CannotFindBinaryPath("shim path is not valid UTF-8".into()))?;
+
+    write(to_bin, native_sh_shim(relative_file)).await?;
+    write(to_bin.with_extension("cmd"), native_cmd_shim(relative_file)).await?;
+    write(to_bin.with_extension("ps1"), native_pwsh_shim(relative_file)).await?;
+
+    // set executable permission for unix
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        tokio::fs::set_permissions(to_bin, std::fs::Permissions::from_mode(0o755)).await?;
+    }
+
+    tracing::debug!("write_native_shims: {:?} -> {:?}", to_bin, relative_file);
+    Ok(())
+}
+
+/// Unix shell shim for native binaries.
+pub fn native_sh_shim(relative_file: &str) -> String {
+    formatdoc! {
+        r#"
+        #!/bin/sh
+        basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+        case `uname` in
+            *CYGWIN*|*MINGW*|*MSYS*)
+                if command -v cygpath > /dev/null 2>&1; then
+                    basedir=`cygpath -w "$basedir"`
+                fi
+            ;;
+        esac
+
+        exec "$basedir/{relative_file}" "$@"
+        "#
+    }
+}
+
+/// Windows Command Prompt shim for native binaries.
+pub fn native_cmd_shim(relative_file: &str) -> String {
+    formatdoc! {
+        r#"
+        @SETLOCAL
+        @"%~dp0\{relative_file}" %*
+        "#,
+        relative_file = relative_file.replace('/', "\\")
+    }
+    .replace('\n', "\r\n")
+}
+
+/// `PowerShell` shim for native binaries.
+pub fn native_pwsh_shim(relative_file: &str) -> String {
+    formatdoc! {
+        r#"
+        #!/usr/bin/env pwsh
+        $basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+        $ret=0
+        # Support pipeline input
+        if ($MyInvocation.ExpectingInput) {{
+            $input | & "$basedir/{relative_file}" $args
+        }} else {{
+            & "$basedir/{relative_file}" $args
+        }}
+        $ret=$LASTEXITCODE
+        exit $ret
+        "#
+    }
+}
+
 /// Write cmd/sh/pwsh shim files.
 pub async fn write_shims(
     source_file: impl AsRef<Path>,

--- a/ecosystem-ci/repo.json
+++ b/ecosystem-ci/repo.json
@@ -97,5 +97,10 @@
     "branch": "master",
     "hash": "01bd9ce1ac66ee3c21ed8a7f14311317d87fb999",
     "forceFreshMigration": true
+  },
+  "bun-vite-template": {
+    "repository": "https://github.com/why-reproductions-are-required/bun-vite-template.git",
+    "branch": "master",
+    "hash": "d84099b4a153c7e0f35e510725b2ceb24c6e09ad"
   }
 }

--- a/packages/cli/binding/src/package_manager.rs
+++ b/packages/cli/binding/src/package_manager.rs
@@ -62,6 +62,7 @@ pub async fn download_package_manager(
         "pnpm" => PackageManagerType::Pnpm,
         "yarn" => PackageManagerType::Yarn,
         "npm" => PackageManagerType::Npm,
+        "bun" => PackageManagerType::Bun,
         _ => {
             return Err(Error::from_reason(format!(
                 "Invalid package manager name: {}",

--- a/packages/cli/snap-tests-global/command-add-bun/package.json
+++ b/packages/cli/snap-tests-global/command-add-bun/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "command-add-bun",
+  "version": "1.0.0",
+  "packageManager": "bun@1.3.11"
+}

--- a/packages/cli/snap-tests-global/command-add-bun/snap.txt
+++ b/packages/cli/snap-tests-global/command-add-bun/snap.txt
@@ -1,0 +1,118 @@
+> vp add --help # should show help
+VITE+ - The Unified Toolchain for the Web
+
+Usage: vp add [OPTIONS] <PACKAGES>... [-- <PASS_THROUGH_ARGS>...]
+
+Add packages to dependencies
+
+Arguments:
+  <PACKAGES>...           Packages to add
+  [PASS_THROUGH_ARGS]...  Additional arguments to pass through to the package manager
+
+Options:
+  -P, --save-prod                     Save to `dependencies` (default)
+  -D, --save-dev                      Save to `devDependencies`
+  --save-peer                         Save to `peerDependencies` and `devDependencies`
+  -O, --save-optional                 Save to `optionalDependencies`
+  -E, --save-exact                    Save exact version rather than semver range
+  --save-catalog-name <CATALOG_NAME>  Save the new dependency to the specified catalog name
+  --save-catalog                      Save the new dependency to the default catalog
+  --allow-build <NAMES>               A list of package names allowed to run postinstall
+  --filter <PATTERN>                  Filter packages in monorepo (can be used multiple times)
+  -w, --workspace-root                Add to workspace root
+  --workspace                         Only add if package exists in workspace (pnpm-specific)
+  -g, --global                        Install globally
+  --node <NODE>                       Node.js version to use for global installation (only with -g)
+  -h, --help                          Print help
+
+Documentation: https://viteplus.dev/guide/install
+
+
+[2]> vp add # should error because no packages specified
+error: the following required arguments were not provided:
+  <PACKAGES>...
+
+Usage: vp add <PACKAGES>... [-- <PASS_THROUGH_ARGS>...]
+
+For more information, try '--help'.
+
+> vp add testnpm2 -D && cat package.json # should add package as dev dependencies
+bun add v<semver> (af24e281)
+
+installed testnpm2@<semver>
+
+1 package installed [<variable>ms]
+{
+  "name": "command-add-bun",
+  "version": "1.0.0",
+  "packageManager": "bun@<semver>",
+  "devDependencies": {
+    "testnpm2": "^1.0.1"
+  }
+}
+
+> vp add testnpm2 test-vite-plus-install && cat package.json # should add packages to dependencies
+bun add v<semver> (af24e281)
+
+installed testnpm2@<semver>
+installed test-vite-plus-install@<semver>
+
+2 packages installed [<variable>ms]
+{
+  "name": "command-add-bun",
+  "version": "1.0.0",
+  "packageManager": "bun@<semver>",
+  "devDependencies": {
+    "testnpm2": "^1.0.1"
+  },
+  "dependencies": {
+    "test-vite-plus-install": "^1.0.0"
+  }
+}
+
+> vp install test-vite-plus-package@1.0.0 --save-peer && cat package.json # should install package alias for add
+VITE+ - The Unified Toolchain for the Web
+
+bun add v<semver> (af24e281)
+
+installed test-vite-plus-package@<semver>
+
+1 package installed [<variable>ms]
+{
+  "name": "command-add-bun",
+  "version": "1.0.0",
+  "packageManager": "bun@<semver>",
+  "devDependencies": {
+    "testnpm2": "^1.0.1"
+  },
+  "dependencies": {
+    "test-vite-plus-install": "^1.0.0"
+  },
+  "peerDependencies": {
+    "test-vite-plus-package": "1.0.0"
+  }
+}
+
+> vp add test-vite-plus-package-optional -O && cat package.json # should add package as optional dependencies
+bun add v<semver> (af24e281)
+
+installed test-vite-plus-package-optional@<semver>
+
+1 package installed [<variable>ms]
+{
+  "name": "command-add-bun",
+  "version": "1.0.0",
+  "packageManager": "bun@<semver>",
+  "devDependencies": {
+    "testnpm2": "^1.0.1"
+  },
+  "dependencies": {
+    "test-vite-plus-install": "^1.0.0"
+  },
+  "peerDependencies": {
+    "test-vite-plus-package": "1.0.0"
+  },
+  "optionalDependencies": {
+    "test-vite-plus-package-optional": "^1.0.0"
+  }
+}

--- a/packages/cli/snap-tests-global/command-add-bun/steps.json
+++ b/packages/cli/snap-tests-global/command-add-bun/steps.json
@@ -1,0 +1,11 @@
+{
+  "ignoredPlatforms": ["win32"],
+  "commands": [
+    "vp add --help # should show help",
+    "vp add # should error because no packages specified",
+    "vp add testnpm2 -D && cat package.json # should add package as dev dependencies",
+    "vp add testnpm2 test-vite-plus-install && cat package.json # should add packages to dependencies",
+    "vp install test-vite-plus-package@1.0.0 --save-peer && cat package.json # should install package alias for add",
+    "vp add test-vite-plus-package-optional -O && cat package.json # should add package as optional dependencies"
+  ]
+}

--- a/packages/cli/snap-tests-global/command-cache-bun/package.json
+++ b/packages/cli/snap-tests-global/command-cache-bun/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "command-cache-bun",
+  "version": "1.0.0",
+  "packageManager": "bun@1.3.11"
+}

--- a/packages/cli/snap-tests-global/command-cache-bun/snap.txt
+++ b/packages/cli/snap-tests-global/command-cache-bun/snap.txt
@@ -1,0 +1,19 @@
+> vp pm cache --help # should show help
+VITE+ - The Unified Toolchain for the Web
+
+Usage: vp pm cache <SUBCOMMAND> [-- <PASS_THROUGH_ARGS>...]
+
+Manage package cache
+
+Arguments:
+  <SUBCOMMAND>            Subcommand: dir, path, clean
+  [PASS_THROUGH_ARGS]...  Additional arguments
+
+Options:
+  -h, --help  Print help
+
+Documentation: https://viteplus.dev/guide/install
+
+
+> vp pm cache dir > /dev/null # should show cache directory
+> vp pm cache path > /dev/null # should show cache path (alias for dir)

--- a/packages/cli/snap-tests-global/command-cache-bun/steps.json
+++ b/packages/cli/snap-tests-global/command-cache-bun/steps.json
@@ -1,0 +1,7 @@
+{
+  "commands": [
+    "vp pm cache --help # should show help",
+    "vp pm cache dir > /dev/null # should show cache directory",
+    "vp pm cache path > /dev/null # should show cache path (alias for dir)"
+  ]
+}

--- a/packages/cli/snap-tests-global/command-create-help/snap.txt
+++ b/packages/cli/snap-tests-global/command-create-help/snap.txt
@@ -13,15 +13,16 @@ Arguments:
             - Local: @company/generator-*, ./tools/create-ui-component
 
 Options:
-  --directory DIR   Target directory for the generated project.
-  --agent NAME      Create an agent instructions file for the specified agent.
-  --editor NAME     Write editor config files for the specified editor.
-  --hooks           Set up pre-commit hooks (default in non-interactive mode)
-  --no-hooks        Skip pre-commit hooks setup
-  --verbose         Show detailed scaffolding output
-  --no-interactive  Run in non-interactive mode
-  --list            List all available templates
-  -h, --help        Show this help message
+  --directory DIR         Target directory for the generated project.
+  --agent NAME            Create an agent instructions file for the specified agent.
+  --editor NAME           Write editor config files for the specified editor.
+  --hooks                 Set up pre-commit hooks (default in non-interactive mode)
+  --no-hooks              Skip pre-commit hooks setup
+  --package-manager NAME  Use specified package manager (pnpm, npm, yarn, bun)
+  --verbose               Show detailed scaffolding output
+  --no-interactive        Run in non-interactive mode
+  --list                  List all available templates
+  -h, --help              Show this help message
 
 Template Options:
   Any arguments after -- are passed directly to the template.
@@ -68,15 +69,16 @@ Arguments:
             - Local: @company/generator-*, ./tools/create-ui-component
 
 Options:
-  --directory DIR   Target directory for the generated project.
-  --agent NAME      Create an agent instructions file for the specified agent.
-  --editor NAME     Write editor config files for the specified editor.
-  --hooks           Set up pre-commit hooks (default in non-interactive mode)
-  --no-hooks        Skip pre-commit hooks setup
-  --verbose         Show detailed scaffolding output
-  --no-interactive  Run in non-interactive mode
-  --list            List all available templates
-  -h, --help        Show this help message
+  --directory DIR         Target directory for the generated project.
+  --agent NAME            Create an agent instructions file for the specified agent.
+  --editor NAME           Write editor config files for the specified editor.
+  --hooks                 Set up pre-commit hooks (default in non-interactive mode)
+  --no-hooks              Skip pre-commit hooks setup
+  --package-manager NAME  Use specified package manager (pnpm, npm, yarn, bun)
+  --verbose               Show detailed scaffolding output
+  --no-interactive        Run in non-interactive mode
+  --list                  List all available templates
+  -h, --help              Show this help message
 
 Template Options:
   Any arguments after -- are passed directly to the template.
@@ -123,15 +125,16 @@ Arguments:
             - Local: @company/generator-*, ./tools/create-ui-component
 
 Options:
-  --directory DIR   Target directory for the generated project.
-  --agent NAME      Create an agent instructions file for the specified agent.
-  --editor NAME     Write editor config files for the specified editor.
-  --hooks           Set up pre-commit hooks (default in non-interactive mode)
-  --no-hooks        Skip pre-commit hooks setup
-  --verbose         Show detailed scaffolding output
-  --no-interactive  Run in non-interactive mode
-  --list            List all available templates
-  -h, --help        Show this help message
+  --directory DIR         Target directory for the generated project.
+  --agent NAME            Create an agent instructions file for the specified agent.
+  --editor NAME           Write editor config files for the specified editor.
+  --hooks                 Set up pre-commit hooks (default in non-interactive mode)
+  --no-hooks              Skip pre-commit hooks setup
+  --package-manager NAME  Use specified package manager (pnpm, npm, yarn, bun)
+  --verbose               Show detailed scaffolding output
+  --no-interactive        Run in non-interactive mode
+  --list                  List all available templates
+  -h, --help              Show this help message
 
 Template Options:
   Any arguments after -- are passed directly to the template.

--- a/packages/cli/snap-tests-global/command-dlx-bun/package.json
+++ b/packages/cli/snap-tests-global/command-dlx-bun/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "command-dlx-bun",
+  "version": "1.0.0",
+  "packageManager": "bun@1.3.11"
+}

--- a/packages/cli/snap-tests-global/command-dlx-bun/snap.txt
+++ b/packages/cli/snap-tests-global/command-dlx-bun/snap.txt
@@ -1,0 +1,38 @@
+> vp dlx --help # should show help message
+VITE+ - The Unified Toolchain for the Web
+
+Usage: vp dlx [OPTIONS] <ARGS>...
+
+Execute a package binary without installing it
+
+Arguments:
+  <ARGS>...  Package to execute and arguments
+
+Options:
+  -p, --package <NAME>  Package(s) to install before running
+  -c, --shell-mode      Execute within a shell environment
+  -s, --silent          Suppress all output except the executed command's output
+  -h, --help            Print help
+
+Documentation: https://viteplus.dev/guide/vpx
+
+
+> vp dlx -s cowsay hello # should run cowsay with bun x
+ _______
+< hello >
+ -------
+        \   ^__^
+         \  (oo)\_______
+            (__)\       )\/\
+                ||----w |
+                ||     ||
+
+> vp dlx -s cowsay@1.6.0 hello # should run specific version
+ _______
+< hello >
+ -------
+        \   ^__^
+         \  (oo)\_______
+            (__)\       )\/\
+                ||----w |
+                ||     ||

--- a/packages/cli/snap-tests-global/command-dlx-bun/steps.json
+++ b/packages/cli/snap-tests-global/command-dlx-bun/steps.json
@@ -1,0 +1,8 @@
+{
+  "ignoredPlatforms": ["win32"],
+  "commands": [
+    "vp dlx --help # should show help message",
+    "vp dlx -s cowsay hello # should run cowsay with bun x",
+    "vp dlx -s cowsay@1.6.0 hello # should run specific version"
+  ]
+}

--- a/packages/cli/snap-tests-global/command-list-bun/package.json
+++ b/packages/cli/snap-tests-global/command-list-bun/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "command-list-bun",
+  "version": "1.0.0",
+  "dependencies": {
+    "testnpm2": "1.0.1"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "1.0.0"
+  },
+  "optionalDependencies": {
+    "test-vite-plus-package-optional": "1.0.0"
+  },
+  "packageManager": "bun@1.3.11"
+}

--- a/packages/cli/snap-tests-global/command-list-bun/snap.txt
+++ b/packages/cli/snap-tests-global/command-list-bun/snap.txt
@@ -1,0 +1,46 @@
+> vp install # should install packages first
+VITE+ - The Unified Toolchain for the Web
+
+bun install v<semver> (af24e281)
+
++ test-vite-plus-package@<semver>
++ test-vite-plus-package-optional@<semver>
++ testnpm2@<semver>
+
+3 packages installed [<variable>ms]
+
+> vp pm list --help # should show help
+VITE+ - The Unified Toolchain for the Web
+
+Usage: vp pm list [OPTIONS] [PATTERN] [-- <PASS_THROUGH_ARGS>...]
+
+List installed packages
+
+Arguments:
+  [PATTERN]               Package pattern to filter
+  [PASS_THROUGH_ARGS]...  Additional arguments
+
+Options:
+  --depth <DEPTH>          Maximum depth of dependency tree
+  --json                   Output in JSON format
+  --long                   Show extended information
+  --parseable              Parseable output format
+  -P, --prod               Only production dependencies
+  -D, --dev                Only dev dependencies
+  --no-optional            Exclude optional dependencies
+  --exclude-peers          Exclude peer dependencies
+  --only-projects          Show only project packages
+  --find-by <FINDER_NAME>  Use a finder function
+  -r, --recursive          List across all workspaces
+  --filter <PATTERN>       Filter packages in monorepo
+  -g, --global             List global packages
+  -h, --help               Print help
+
+Documentation: https://viteplus.dev/guide/install
+
+
+> vp pm list # should list installed packages
+<cwd> node_modules (3)
+├── test-vite-plus-package@<semver>
+├── test-vite-plus-package-optional@<semver>
+└── testnpm2@<semver>

--- a/packages/cli/snap-tests-global/command-list-bun/steps.json
+++ b/packages/cli/snap-tests-global/command-list-bun/steps.json
@@ -1,0 +1,8 @@
+{
+  "ignoredPlatforms": ["win32"],
+  "commands": [
+    "vp install # should install packages first",
+    "vp pm list --help # should show help",
+    "vp pm list # should list installed packages"
+  ]
+}

--- a/packages/cli/snap-tests-global/command-outdated-bun/package.json
+++ b/packages/cli/snap-tests-global/command-outdated-bun/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "command-outdated-bun",
+  "version": "1.0.0",
+  "dependencies": {
+    "testnpm2": "1.0.0"
+  },
+  "devDependencies": {
+    "test-vite-plus-top-package": "1.0.0"
+  },
+  "optionalDependencies": {
+    "test-vite-plus-other-optional": "1.0.0"
+  },
+  "packageManager": "bun@1.3.11"
+}

--- a/packages/cli/snap-tests-global/command-outdated-bun/snap.txt
+++ b/packages/cli/snap-tests-global/command-outdated-bun/snap.txt
@@ -1,0 +1,58 @@
+> vp outdated --help # should show help
+VITE+ - The Unified Toolchain for the Web
+
+Usage: vp outdated [OPTIONS] [PACKAGES]... [-- <PASS_THROUGH_ARGS>...]
+
+Check for outdated packages
+
+Arguments:
+  [PACKAGES]...           Package name(s) to check
+  [PASS_THROUGH_ARGS]...  Additional arguments to pass through to the package manager
+
+Options:
+  --long                Show extended information
+  --format <FORMAT>     Output format: table (default), list, or json
+  -r, --recursive       Check recursively across all workspaces
+  --filter <PATTERN>    Filter packages in monorepo
+  -w, --workspace-root  Include workspace root
+  -P, --prod            Only production and optional dependencies
+  -D, --dev             Only dev dependencies
+  --no-optional         Exclude optional dependencies
+  --compatible          Only show compatible versions
+  --sort-by <FIELD>     Sort results by field
+  -g, --global          Check globally installed packages
+  -h, --help            Print help
+
+Documentation: https://viteplus.dev/guide/install
+
+
+> vp install # should install packages first
+VITE+ - The Unified Toolchain for the Web
+
+bun install v<semver> (af24e281)
+
++ test-vite-plus-top-package@<semver>
++ test-vite-plus-other-optional@<semver>
++ testnpm2@<semver>
+
+4 packages installed [<variable>ms]
+
+> vp outdated testnpm2 # should show outdated package
+bun outdated v<semver> (af24e281)
+|--------------------------------------|
+| Package  | Current | Update | Latest |
+|----------|---------|--------|--------|
+| testnpm2 | <semver>   | <semver>  | <semver>  |
+|--------------------------------------|
+
+> vp outdated -r # should support recursive output
+bun outdated v<semver> (af24e281)
+|---------------------------------------------------------------------------------------------|
+| Package                                  | Current | Update | Latest | Workspace            |
+|------------------------------------------|---------|--------|--------|----------------------|
+| testnpm2                                 | <semver>   | <semver>  | <semver>  | command-outdated-bun |
+|------------------------------------------|---------|--------|--------|----------------------|
+| test-vite-plus-top-package (dev)         | <semver>   | <semver>  | <semver>  | command-outdated-bun |
+|------------------------------------------|---------|--------|--------|----------------------|
+| test-vite-plus-other-optional (optional) | <semver>   | <semver>  | <semver>  | command-outdated-bun |
+|---------------------------------------------------------------------------------------------|

--- a/packages/cli/snap-tests-global/command-outdated-bun/steps.json
+++ b/packages/cli/snap-tests-global/command-outdated-bun/steps.json
@@ -1,0 +1,9 @@
+{
+  "ignoredPlatforms": ["win32"],
+  "commands": [
+    "vp outdated --help # should show help",
+    "vp install # should install packages first",
+    "vp outdated testnpm2 # should show outdated package",
+    "vp outdated -r # should support recursive output"
+  ]
+}

--- a/packages/cli/snap-tests-global/command-publish-bun/package.json
+++ b/packages/cli/snap-tests-global/command-publish-bun/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "command-publish-bun",
+  "version": "1.0.0",
+  "packageManager": "bun@1.3.11"
+}

--- a/packages/cli/snap-tests-global/command-publish-bun/snap.txt
+++ b/packages/cli/snap-tests-global/command-publish-bun/snap.txt
@@ -1,0 +1,29 @@
+> vp pm publish --help # should show help
+VITE+ - The Unified Toolchain for the Web
+
+Usage: vp pm publish [OPTIONS] [TARBALL|FOLDER] [-- <PASS_THROUGH_ARGS>...]
+
+Publish package to registry
+
+Arguments:
+  [TARBALL|FOLDER]        Tarball or folder to publish
+  [PASS_THROUGH_ARGS]...  Additional arguments
+
+Options:
+  --dry-run                  Preview without publishing
+  --tag <TAG>                Publish tag
+  --access <ACCESS>          Access level (public/restricted)
+  --otp <OTP>                One-time password for authentication
+  --no-git-checks            Skip git checks
+  --publish-branch <BRANCH>  Set the branch name to publish from
+  --report-summary           Save publish summary
+  --force                    Force publish
+  --json                     Output in JSON format
+  -r, --recursive            Publish all workspace packages
+  --filter <PATTERN>         Filter packages in monorepo
+  -h, --help                 Print help
+
+Documentation: https://viteplus.dev/guide/install
+
+
+> #vp pm publish --dry-run # should preview publish without actually publishing (not working on CI, skip for now)

--- a/packages/cli/snap-tests-global/command-publish-bun/steps.json
+++ b/packages/cli/snap-tests-global/command-publish-bun/steps.json
@@ -1,0 +1,6 @@
+{
+  "commands": [
+    "vp pm publish --help # should show help",
+    "#vp pm publish --dry-run # should preview publish without actually publishing (not working on CI, skip for now)"
+  ]
+}

--- a/packages/cli/snap-tests-global/command-remove-bun/package.json
+++ b/packages/cli/snap-tests-global/command-remove-bun/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "command-remove-bun",
+  "version": "1.0.0",
+  "packageManager": "bun@1.3.11"
+}

--- a/packages/cli/snap-tests-global/command-remove-bun/snap.txt
+++ b/packages/cli/snap-tests-global/command-remove-bun/snap.txt
@@ -1,0 +1,100 @@
+> vp remove --help # should show help
+VITE+ - The Unified Toolchain for the Web
+
+Usage: vp remove [OPTIONS] <PACKAGES>... [-- <PASS_THROUGH_ARGS>...]
+
+Remove packages from dependencies
+
+Arguments:
+  <PACKAGES>...           Packages to remove
+  [PASS_THROUGH_ARGS]...  Additional arguments to pass through to the package manager
+
+Options:
+  -D, --save-dev        Only remove from `devDependencies` (pnpm-specific)
+  -O, --save-optional   Only remove from `optionalDependencies` (pnpm-specific)
+  -P, --save-prod       Only remove from `dependencies` (pnpm-specific)
+  --filter <PATTERN>    Filter packages in monorepo (can be used multiple times)
+  -w, --workspace-root  Remove from workspace root
+  -r, --recursive       Remove recursively from all workspace packages
+  -g, --global          Remove global packages
+  --dry-run             Preview what would be removed without actually removing (only with -g)
+  -h, --help            Print help
+
+Documentation: https://viteplus.dev/guide/install
+
+
+[2]> vp remove # should error because no packages specified
+error: the following required arguments were not provided:
+  <PACKAGES>...
+
+Usage: vp remove <PACKAGES>... [-- <PASS_THROUGH_ARGS>...]
+
+For more information, try '--help'.
+
+> vp remove testnpm2 -D && cat package.json # should error when remove not exists package from dev dependencies
+bun remove v<semver> (af24e281)
+package.json doesn't have dependencies, there's nothing to remove!
+{
+  "name": "command-remove-bun",
+  "version": "1.0.0",
+  "packageManager": "bun@<semver>"
+}
+
+> vp add testnpm2 && vp add -D test-vite-plus-install && vp add -O test-vite-plus-package-optional && cat package.json # should add packages to dependencies
+bun add v<semver> (af24e281)
+
+installed testnpm2@<semver>
+
+1 package installed [<variable>ms]
+bun add v<semver> (af24e281)
+
+installed test-vite-plus-install@<semver>
+
+1 package installed [<variable>ms]
+bun add v<semver> (af24e281)
+
+installed test-vite-plus-package-optional@<semver>
+
+1 package installed [<variable>ms]
+{
+  "name": "command-remove-bun",
+  "version": "1.0.0",
+  "packageManager": "bun@<semver>",
+  "dependencies": {
+    "testnpm2": "^1.0.1"
+  },
+  "devDependencies": {
+    "test-vite-plus-install": "^1.0.0"
+  },
+  "optionalDependencies": {
+    "test-vite-plus-package-optional": "^1.0.0"
+  }
+}
+
+> vp remove testnpm2 test-vite-plus-install && cat package.json # should remove packages from dependencies
+bun remove v<semver> (af24e281)
+
+- testnpm2
+- test-vite-plus-install
+2 packages removed [<variable>ms]
+{
+  "name": "command-remove-bun",
+  "version": "1.0.0",
+  "optionalDependencies": {
+    "test-vite-plus-package-optional": "^1.0.0"
+  },
+  "packageManager": "bun@<semver>"
+}
+
+> vp remove -O test-vite-plus-package-optional && cat package.json # should remove package from optional dependencies
+bun remove v<semver> (af24e281)
+
+package.json has no dependencies! Deleted empty lockfile
+
+- test-vite-plus-package-optional
+1 package removed [<variable>ms]
+{
+  "name": "command-remove-bun",
+  "version": "1.0.0",
+  "packageManager": "bun@<semver>"
+}

--- a/packages/cli/snap-tests-global/command-remove-bun/steps.json
+++ b/packages/cli/snap-tests-global/command-remove-bun/steps.json
@@ -1,0 +1,11 @@
+{
+  "ignoredPlatforms": ["win32"],
+  "commands": [
+    "vp remove --help # should show help",
+    "vp remove # should error because no packages specified",
+    "vp remove testnpm2 -D && cat package.json # should error when remove not exists package from dev dependencies",
+    "vp add testnpm2 && vp add -D test-vite-plus-install && vp add -O test-vite-plus-package-optional && cat package.json # should add packages to dependencies",
+    "vp remove testnpm2 test-vite-plus-install && cat package.json # should remove packages from dependencies",
+    "vp remove -O test-vite-plus-package-optional && cat package.json # should remove package from optional dependencies"
+  ]
+}

--- a/packages/cli/snap-tests-global/command-update-bun/package.json
+++ b/packages/cli/snap-tests-global/command-update-bun/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "command-update-bun",
+  "version": "1.0.0",
+  "dependencies": {
+    "testnpm2": "*"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "*"
+  },
+  "optionalDependencies": {
+    "test-vite-plus-package-optional": "*"
+  },
+  "packageManager": "bun@1.3.11"
+}

--- a/packages/cli/snap-tests-global/command-update-bun/snap.txt
+++ b/packages/cli/snap-tests-global/command-update-bun/snap.txt
@@ -1,0 +1,72 @@
+> vp update --help # should show help
+VITE+ - The Unified Toolchain for the Web
+
+Usage: vp update [OPTIONS] [PACKAGES]... [-- <PASS_THROUGH_ARGS>...]
+
+Update packages to their latest versions
+
+Arguments:
+  [PACKAGES]...           Packages to update (optional - updates all if omitted)
+  [PASS_THROUGH_ARGS]...  Additional arguments to pass through to the package manager
+
+Options:
+  -L, --latest          Update to latest version (ignore semver range)
+  -g, --global          Update global packages
+  -r, --recursive       Update recursively in all workspace packages
+  --filter <PATTERN>    Filter packages in monorepo (can be used multiple times)
+  -w, --workspace-root  Include workspace root
+  -D, --dev             Update only devDependencies
+  -P, --prod            Update only dependencies (production)
+  -i, --interactive     Interactive mode
+  --no-optional         Don't update optionalDependencies
+  --no-save             Update lockfile only, don't modify package.json
+  --workspace           Only update if package exists in workspace (pnpm-specific)
+  -h, --help            Print help
+
+Documentation: https://viteplus.dev/guide/install
+
+
+> vp update testnpm2 && cat package.json # should update package within semver range
+bun update v<semver> (af24e281)
+
++ test-vite-plus-package@<semver>
++ test-vite-plus-package-optional@<semver>
+
+installed testnpm2@<semver>
+
+3 packages installed [<variable>ms]
+{
+  "name": "command-update-bun",
+  "version": "1.0.0",
+  "dependencies": {
+    "testnpm2": "^1.0.1"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "*"
+  },
+  "optionalDependencies": {
+    "test-vite-plus-package-optional": "*"
+  },
+  "packageManager": "bun@<semver>"
+}
+
+> vp up testnpm2 --latest && cat package.json # should update to absolute latest version
+bun update v<semver> (af24e281)
+
+installed testnpm2@<semver>
+
+[<variable>ms] done
+{
+  "name": "command-update-bun",
+  "version": "1.0.0",
+  "dependencies": {
+    "testnpm2": "^1.0.1"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "*"
+  },
+  "optionalDependencies": {
+    "test-vite-plus-package-optional": "*"
+  },
+  "packageManager": "bun@<semver>"
+}

--- a/packages/cli/snap-tests-global/command-update-bun/steps.json
+++ b/packages/cli/snap-tests-global/command-update-bun/steps.json
@@ -1,0 +1,8 @@
+{
+  "ignoredPlatforms": ["win32"],
+  "commands": [
+    "vp update --help # should show help",
+    "vp update testnpm2 && cat package.json # should update package within semver range",
+    "vp up testnpm2 --latest && cat package.json # should update to absolute latest version"
+  ]
+}

--- a/packages/cli/snap-tests-global/command-view-bun/package.json
+++ b/packages/cli/snap-tests-global/command-view-bun/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "command-view-bun",
+  "version": "1.0.0",
+  "packageManager": "bun@1.3.11"
+}

--- a/packages/cli/snap-tests-global/command-view-bun/snap.txt
+++ b/packages/cli/snap-tests-global/command-view-bun/snap.txt
@@ -1,0 +1,24 @@
+> vp pm view --help # should show help
+VITE+ - The Unified Toolchain for the Web
+
+Usage: vp pm view [OPTIONS] <PACKAGE> [FIELD] [-- <PASS_THROUGH_ARGS>...]
+
+View package information from the registry
+
+Arguments:
+  <PACKAGE>               Package name with optional version
+  [FIELD]                 Specific field to view
+  [PASS_THROUGH_ARGS]...  Additional arguments
+
+Options:
+  --json      Output in JSON format
+  -h, --help  Print help
+
+Documentation: https://viteplus.dev/guide/install
+
+
+> vp pm view testnpm2 | grep 'registry' # should view package information
+ .tarball: https://registry.<domain>/testnpm2/-/testnpm2-1.0.1.tgz
+
+> vp pm view testnpm2 version # should view version field
+1.0.1

--- a/packages/cli/snap-tests-global/command-view-bun/steps.json
+++ b/packages/cli/snap-tests-global/command-view-bun/steps.json
@@ -1,0 +1,7 @@
+{
+  "commands": [
+    "vp pm view --help # should show help",
+    "vp pm view testnpm2 | grep 'registry' # should view package information",
+    "vp pm view testnpm2 version # should view version field"
+  ]
+}

--- a/packages/cli/snap-tests-global/command-why-bun/package.json
+++ b/packages/cli/snap-tests-global/command-why-bun/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "command-why-bun",
+  "version": "1.0.0",
+  "dependencies": {
+    "testnpm2": "1.0.1"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "1.0.0"
+  },
+  "optionalDependencies": {
+    "test-vite-plus-package-optional": "1.0.0"
+  },
+  "packageManager": "bun@1.3.11"
+}

--- a/packages/cli/snap-tests-global/command-why-bun/snap.txt
+++ b/packages/cli/snap-tests-global/command-why-bun/snap.txt
@@ -1,0 +1,45 @@
+> vp why --help # should show help
+VITE+ - The Unified Toolchain for the Web
+
+Usage: vp why [OPTIONS] <PACKAGES>... [-- <PASS_THROUGH_ARGS>...]
+
+Show why a package is installed
+
+Arguments:
+  <PACKAGES>...           Package(s) to check
+  [PASS_THROUGH_ARGS]...  Additional arguments to pass through to the package manager
+
+Options:
+  --json                   Output in JSON format
+  --long                   Show extended information
+  --parseable              Show parseable output
+  -r, --recursive          Check recursively across all workspaces
+  --filter <PATTERN>       Filter packages in monorepo
+  -w, --workspace-root     Check in workspace root
+  -P, --prod               Only production dependencies
+  -D, --dev                Only dev dependencies
+  --depth <DEPTH>          Limit tree depth
+  --no-optional            Exclude optional dependencies
+  -g, --global             Check globally installed packages
+  --exclude-peers          Exclude peer dependencies
+  --find-by <FINDER_NAME>  Use a finder function defined in .pnpmfile.cjs
+  -h, --help               Print help
+
+Documentation: https://viteplus.dev/guide/install
+
+
+> vp install # should install packages first
+VITE+ - The Unified Toolchain for the Web
+
+bun install v<semver> (af24e281)
+
++ test-vite-plus-package@<semver>
++ test-vite-plus-package-optional@<semver>
++ testnpm2@<semver>
+
+3 packages installed [<variable>ms]
+
+> vp why testnpm2 # should show why package is installed
+testnpm2@<semver>
+  └─ command-why-bun (requires <semver>)
+

--- a/packages/cli/snap-tests-global/command-why-bun/steps.json
+++ b/packages/cli/snap-tests-global/command-why-bun/steps.json
@@ -1,0 +1,8 @@
+{
+  "ignoredPlatforms": ["win32"],
+  "commands": [
+    "vp why --help # should show help",
+    "vp install # should install packages first",
+    "vp why testnpm2 # should show why package is installed"
+  ]
+}

--- a/packages/cli/snap-tests-global/new-check/snap.txt
+++ b/packages/cli/snap-tests-global/new-check/snap.txt
@@ -13,15 +13,16 @@ Arguments:
             - Local: @company/generator-*, ./tools/create-ui-component
 
 Options:
-  --directory DIR   Target directory for the generated project.
-  --agent NAME      Create an agent instructions file for the specified agent.
-  --editor NAME     Write editor config files for the specified editor.
-  --hooks           Set up pre-commit hooks (default in non-interactive mode)
-  --no-hooks        Skip pre-commit hooks setup
-  --verbose         Show detailed scaffolding output
-  --no-interactive  Run in non-interactive mode
-  --list            List all available templates
-  -h, --help        Show this help message
+  --directory DIR         Target directory for the generated project.
+  --agent NAME            Create an agent instructions file for the specified agent.
+  --editor NAME           Write editor config files for the specified editor.
+  --hooks                 Set up pre-commit hooks (default in non-interactive mode)
+  --no-hooks              Skip pre-commit hooks setup
+  --package-manager NAME  Use specified package manager (pnpm, npm, yarn, bun)
+  --verbose               Show detailed scaffolding output
+  --no-interactive        Run in non-interactive mode
+  --list                  List all available templates
+  -h, --help              Show this help message
 
 Template Options:
   Any arguments after -- are passed directly to the template.

--- a/packages/cli/snap-tests-global/new-vite-monorepo-bun/snap.txt
+++ b/packages/cli/snap-tests-global/new-vite-monorepo-bun/snap.txt
@@ -1,0 +1,73 @@
+> vp create vite:monorepo --no-interactive --package-manager bun # create monorepo with bun
+> ls vite-plus-monorepo | LC_ALL=C sort # check files created
+AGENTS.md
+README.md
+apps
+package.json
+packages
+tsconfig.json
+vite.config.ts
+
+> cat vite-plus-monorepo/package.json # check package.json with catalog
+{
+  "name": "vite-plus-monorepo",
+  "version": "0.0.0",
+  "private": true,
+  "workspaces": [
+    "packages/*",
+    "apps/*",
+    "tools/*"
+  ],
+  "type": "module",
+  "scripts": {
+    "ready": "vp fmt && vp lint && vp run -r test && vp run -r build",
+    "dev": "vp run website#dev",
+    "prepare": "vp config"
+  },
+  "devDependencies": {
+    "vite-plus": "catalog:"
+  },
+  "overrides": {
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=22.12.0"
+  },
+  "packageManager": "bun@<semver>",
+  "catalog": {
+    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
+    "vitest": "npm:@voidzero-dev/vite-plus-test@latest",
+    "vite-plus": "latest"
+  }
+}
+
+> test ! -f vite-plus-monorepo/pnpm-workspace.yaml && echo 'No pnpm-workspace.yaml' || echo 'ERROR: pnpm-workspace.yaml exists' # verify no pnpm config
+No pnpm-workspace.yaml
+
+> test ! -f vite-plus-monorepo/.yarnrc.yml && echo 'No .yarnrc.yml' || echo 'ERROR: .yarnrc.yml exists' # verify no yarn config
+No .yarnrc.yml
+
+> test -d vite-plus-monorepo/.git && echo 'Git initialized' || echo 'No git' # check git init
+Git initialized
+
+> ls vite-plus-monorepo/apps # check apps directory
+website
+
+> cat vite-plus-monorepo/apps/website/package.json # check website uses catalog:
+{
+  "name": "website",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vp dev",
+    "build": "tsc && vp build",
+    "preview": "vp preview"
+  },
+  "devDependencies": {
+    "typescript": "~5.9.3",
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
+  }
+}

--- a/packages/cli/snap-tests-global/new-vite-monorepo-bun/steps.json
+++ b/packages/cli/snap-tests-global/new-vite-monorepo-bun/steps.json
@@ -1,0 +1,16 @@
+{
+  "ignoredPlatforms": ["win32"],
+  "commands": [
+    {
+      "command": "vp create vite:monorepo --no-interactive --package-manager bun # create monorepo with bun",
+      "ignoreOutput": true
+    },
+    "ls vite-plus-monorepo | LC_ALL=C sort # check files created",
+    "cat vite-plus-monorepo/package.json # check package.json with catalog",
+    "test ! -f vite-plus-monorepo/pnpm-workspace.yaml && echo 'No pnpm-workspace.yaml' || echo 'ERROR: pnpm-workspace.yaml exists' # verify no pnpm config",
+    "test ! -f vite-plus-monorepo/.yarnrc.yml && echo 'No .yarnrc.yml' || echo 'ERROR: .yarnrc.yml exists' # verify no yarn config",
+    "test -d vite-plus-monorepo/.git && echo 'Git initialized' || echo 'No git' # check git init",
+    "ls vite-plus-monorepo/apps # check apps directory",
+    "cat vite-plus-monorepo/apps/website/package.json # check website uses catalog:"
+  ]
+}

--- a/packages/cli/src/create/bin.ts
+++ b/packages/cli/src/create/bin.ts
@@ -11,7 +11,7 @@ import {
   rewriteMonorepoProject,
   rewriteStandaloneProject,
 } from '../migration/migrator.js';
-import { DependencyType, type WorkspaceInfo } from '../types/index.js';
+import { DependencyType, PackageManager, type WorkspaceInfo } from '../types/index.js';
 import {
   detectExistingAgentTargetPaths,
   selectAgentTargetPaths,
@@ -91,6 +91,10 @@ const helpMessage = renderCliDoc({
           description: 'Set up pre-commit hooks (default in non-interactive mode)',
         },
         { label: '--no-hooks', description: 'Skip pre-commit hooks setup' },
+        {
+          label: '--package-manager NAME',
+          description: 'Use specified package manager (pnpm, npm, yarn, bun)',
+        },
         { label: '--verbose', description: 'Show detailed scaffolding output' },
         { label: '--no-interactive', description: 'Run in non-interactive mode' },
         { label: '--list', description: 'List all available templates' },
@@ -185,6 +189,7 @@ export interface Options {
   agent?: string | string[] | false;
   editor?: string;
   hooks?: boolean;
+  packageManager?: string;
 }
 
 // Parse CLI arguments: split on '--' separator
@@ -207,10 +212,11 @@ function parseArgs() {
     agent?: string | string[] | false;
     editor?: string;
     hooks?: boolean;
+    'package-manager'?: string;
   }>(viteArgs, {
     alias: { h: 'help' },
     boolean: ['help', 'list', 'all', 'interactive', 'hooks', 'verbose'],
-    string: ['directory', 'agent', 'editor'],
+    string: ['directory', 'agent', 'editor', 'package-manager'],
     default: { interactive: defaultInteractive() },
   });
 
@@ -227,6 +233,7 @@ function parseArgs() {
       agent: parsed.agent,
       editor: parsed.editor,
       hooks: parsed.hooks,
+      packageManager: parsed['package-manager'],
     } as Options,
     templateArgs,
   };
@@ -624,9 +631,20 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
     }
   }
 
-  // Prompt for package manager or use default
+  // Resolve package manager: workspace detection > CLI flag > interactive prompt/default
+  if (
+    options.packageManager &&
+    !Object.values(PackageManager).includes(options.packageManager as PackageManager)
+  ) {
+    const valid = Object.values(PackageManager).join(', ');
+    prompts.log.error(
+      `Invalid package manager: ${options.packageManager}. Must be one of: ${valid}`,
+    );
+    cancelAndExit('Invalid --package-manager value', 1);
+  }
   const packageManager =
     workspaceInfoOptional.packageManager ??
+    (options.packageManager as PackageManager | undefined) ??
     (await selectPackageManager(options.interactive, compactOutput));
   const shouldSilencePackageManagerInstallLog =
     compactOutput || (isMonorepo && workspaceInfoOptional.packageManager !== undefined);

--- a/packages/cli/src/create/command.ts
+++ b/packages/cli/src/create/command.ts
@@ -153,6 +153,8 @@ export function getPackageRunner(workspaceInfo: WorkspaceInfo) {
         command: 'yarn',
         args: ['dlx'],
       };
+    case 'bun':
+      return { command: 'bun', args: ['x'] };
     case 'npm':
     default:
       return { command: 'npx', args: [] };
@@ -166,7 +168,7 @@ export function formatDlxCommand(
   workspaceInfo: WorkspaceInfo,
 ) {
   const runner = getPackageRunner(workspaceInfo);
-  const dlxArgs = runner.command === 'npm' ? ['--', ...args] : args;
+  const dlxArgs = runner.command === 'npx' ? ['--', ...args] : args;
   return {
     command: runner.command,
     args: [...runner.args, packageName, ...dlxArgs],

--- a/packages/cli/src/create/templates/monorepo.ts
+++ b/packages/cli/src/create/templates/monorepo.ts
@@ -89,7 +89,7 @@ export async function executeMonorepoTemplate(
       fs.unlinkSync(pnpmWorkspacePath);
     }
   } else {
-    // npm
+    // npm or bun: both use package.json workspaces field
     // remove pnpm field
     editJsonFile(path.join(fullPath, 'package.json'), (pkg) => {
       pkg.pnpm = undefined;

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -779,7 +779,10 @@ async function executeMigrationPlan(
   // 11. Reinstall after migration
   // npm needs --force to re-resolve packages with newly added overrides,
   // otherwise the stale lockfile prevents override resolution.
-  const installArgs = plan.packageManager === PackageManager.npm ? ['--force'] : undefined;
+  const installArgs =
+    plan.packageManager === PackageManager.npm || plan.packageManager === PackageManager.bun
+      ? ['--force']
+      : undefined;
   updateMigrationProgress('Installing dependencies');
   const finalInstallSummary = await runViteInstall(
     workspaceInfo.rootDir,

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -680,7 +680,7 @@ export function rewriteStandaloneProject(
         ...pkg.resolutions,
         ...VITE_PLUS_OVERRIDE_PACKAGES,
       };
-    } else if (packageManager === PackageManager.npm) {
+    } else if (packageManager === PackageManager.npm || packageManager === PackageManager.bun) {
       pkg.overrides = {
         ...pkg.overrides,
         ...VITE_PLUS_OVERRIDE_PACKAGES,
@@ -749,6 +749,8 @@ export function rewriteMonorepo(
     rewritePnpmWorkspaceYaml(workspaceInfo.rootDir);
   } else if (workspaceInfo.packageManager === PackageManager.yarn) {
     rewriteYarnrcYml(workspaceInfo.rootDir);
+  } else if (workspaceInfo.packageManager === PackageManager.bun) {
+    rewriteBunCatalog(workspaceInfo.rootDir);
   }
   rewriteRootWorkspacePackageJson(
     workspaceInfo.rootDir,
@@ -951,6 +953,52 @@ function rewriteCatalog(doc: YamlDocument): void {
 }
 
 /**
+ * Write catalog entries to root package.json for bun.
+ * Bun stores catalogs in package.json under the `catalog` key,
+ * unlike pnpm which uses pnpm-workspace.yaml.
+ * @see https://bun.sh/docs/pm/catalogs
+ */
+function rewriteBunCatalog(projectPath: string): void {
+  const packageJsonPath = path.join(projectPath, 'package.json');
+  if (!fs.existsSync(packageJsonPath)) {
+    return;
+  }
+
+  editJsonFile<{
+    catalog?: Record<string, string>;
+    overrides?: Record<string, string>;
+  }>(packageJsonPath, (pkg) => {
+    const catalog: Record<string, string> = { ...pkg.catalog };
+
+    // Add vite-plus managed packages to catalog
+    for (const [key, value] of Object.entries(VITE_PLUS_OVERRIDE_PACKAGES)) {
+      if (!value.startsWith('file:')) {
+        catalog[key] = value;
+      }
+    }
+    if (!VITE_PLUS_VERSION.startsWith('file:')) {
+      catalog[VITE_PLUS_NAME] = VITE_PLUS_VERSION;
+    }
+
+    // Remove replaced packages from catalog
+    for (const name of REMOVE_PACKAGES) {
+      delete catalog[name];
+    }
+
+    pkg.catalog = catalog;
+
+    // bun overrides support catalog: references
+    const overrides: Record<string, string> = { ...pkg.overrides };
+    for (const key of Object.keys(VITE_PLUS_OVERRIDE_PACKAGES)) {
+      overrides[key] = 'catalog:';
+    }
+    pkg.overrides = overrides;
+
+    return pkg;
+  });
+}
+
+/**
  * Rewrite root workspace package.json to add vite-plus dependencies
  * @param projectPath - The path to the project
  */
@@ -984,6 +1032,8 @@ function rewriteRootWorkspacePackageJson(
         ...pkg.overrides,
         ...VITE_PLUS_OVERRIDE_PACKAGES,
       };
+    } else if (packageManager === PackageManager.bun) {
+      // bun overrides are handled in rewriteBunCatalog() with catalog: references
     } else if (packageManager === PackageManager.pnpm) {
       if (isForceOverrideMode()) {
         // In force-override mode, keep overrides in package.json pnpm.overrides

--- a/packages/cli/src/resolve-lint.ts
+++ b/packages/cli/src/resolve-lint.ts
@@ -42,18 +42,16 @@ export async function lint(): Promise<{
   const binPath = join(oxlintPackageRoot, 'bin', 'oxlint');
   let oxlintTsgolintPath = resolve('oxlint-tsgolint/bin/tsgolint');
   if (process.platform === 'win32') {
-    // If on Windows, resolve the tsgolint binary from the local node_modules
-    oxlintTsgolintPath = join(
-      dirname(fileURLToPath(import.meta.url)),
-      '..',
-      'node_modules',
-      '.bin',
-      'tsgolint.cmd',
-    );
-    if (!existsSync(oxlintTsgolintPath)) {
-      // Fallback to the cwd node_modules
-      oxlintTsgolintPath = join(process.cwd(), 'node_modules', '.bin', 'tsgolint.cmd');
-    }
+    // On Windows, try .exe first (bun creates .exe), then .cmd (npm/pnpm/yarn create .cmd)
+    const localBinDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'node_modules', '.bin');
+    const cwdBinDir = join(process.cwd(), 'node_modules', '.bin');
+    oxlintTsgolintPath =
+      [
+        join(localBinDir, 'tsgolint.exe'),
+        join(localBinDir, 'tsgolint.cmd'),
+        join(cwdBinDir, 'tsgolint.exe'),
+        join(cwdBinDir, 'tsgolint.cmd'),
+      ].find((p) => existsSync(p)) ?? join(cwdBinDir, 'tsgolint.cmd');
     const relativePath = relative(process.cwd(), oxlintTsgolintPath);
     // Only prepend .\ if it's actually a relative path (not an absolute path returned by relative())
     oxlintTsgolintPath = /^[a-zA-Z]:/.test(relativePath) ? relativePath : `.\\${relativePath}`;

--- a/packages/cli/src/types/package.ts
+++ b/packages/cli/src/types/package.ts
@@ -2,6 +2,7 @@ export const PackageManager = {
   pnpm: 'pnpm',
   npm: 'npm',
   yarn: 'yarn',
+  bun: 'bun',
 } as const;
 export type PackageManager = (typeof PackageManager)[keyof typeof PackageManager];
 

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -24,6 +24,7 @@ export async function selectPackageManager(interactive?: boolean, silent = false
         { value: PackageManager.pnpm, hint: 'recommended' },
         { value: PackageManager.yarn },
         { value: PackageManager.npm },
+        { value: PackageManager.bun },
       ],
       initialValue: PackageManager.pnpm,
     });

--- a/packages/tools/src/utils.ts
+++ b/packages/tools/src/utils.ts
@@ -83,6 +83,12 @@ export function replaceUnstableOutput(output: string, cwd?: string) {
       .replaceAll(/\++\n/g, '+<repeat>\n')
       // ignore pnpm registry request error warning log
       .replaceAll(/ ?WARN\s+GET\s+https:\/\/registry\..+?\n/g, '')
+      // ignore bun resolution progress (appears intermittently depending on cache state)
+      .replaceAll(/Resolving dependencies\n/g, '')
+      .replaceAll(/Resolved, downloaded and extracted \[\d+\]\n/g, '')
+      .replaceAll(/Resolving\.\.\. /g, '')
+      .replaceAll(/Saved lockfile\n/g, '')
+      .replaceAll(/ \(v\d+\.\d+\.\d+ available\)/g, '')
       // ignore yarn YN0013, because it's unstable output, only exists on CI environment
       // ➤ YN0013: │ A package was added to the project (+ 0.7 KiB).
       .replaceAll(/➤ YN0013:[^\n]+\n/g, '')

--- a/rfcs/add-remove-package-commands.md
+++ b/rfcs/add-remove-package-commands.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Add `vp add` and `vp remove` commands that automatically adapt to the detected package manager (pnpm/yarn/npm) for adding and removing packages, with support for multiple packages, common flags, and workspace-aware operations based on pnpm's API design.
+Add `vp add` and `vp remove` commands that automatically adapt to the detected package manager (pnpm/yarn/npm/bun) for adding and removing packages, with support for multiple packages, common flags, and workspace-aware operations based on pnpm's API design.
 
 ## Motivation
 
@@ -12,6 +12,7 @@ Currently, developers must manually use package manager-specific commands:
 pnpm add react
 yarn add react
 npm install react
+bun add react
 ```
 
 This creates friction in monorepo workflows and requires remembering different syntaxes. A unified interface would:
@@ -28,11 +29,13 @@ This creates friction in monorepo workflows and requires remembering different s
 pnpm add -D typescript  # pnpm project
 yarn add --dev typescript  # yarn project
 npm install --save-dev typescript  # npm project
+bun add --dev typescript  # bun project
 
 # Different remove commands
 pnpm remove lodash
 yarn remove lodash
 npm uninstall lodash
+bun remove lodash
 ```
 
 ### Proposed Solution
@@ -102,7 +105,7 @@ vp install <PACKAGES>... [OPTIONS]
 
 ##### Install global packages with npm cli only
 
-For global packages, we will use npm cli only.
+For global packages, we will use npm cli only (except for bun, which natively supports `bun add -g`).
 
 > Because yarn do not support global packages install on [version>=2.x](https://yarnpkg.com/migration/guide#use-yarn-dlx-instead-of-yarn-global), and pnpm global install has some bugs like `wrong bin file` issues.
 
@@ -145,22 +148,23 @@ vp remove -g typescript                # Remove global package
 - https://pnpm.io/cli/add#options
 - https://yarnpkg.com/cli/add#options
 - https://docs.npmjs.com/cli/v11/commands/npm-install#description
+- https://bun.sh/docs/cli/add
 
-| Vite+ Flag                           | pnpm                     | yarn                                            | npm                             | Description                                             |
-| ------------------------------------ | ------------------------ | ----------------------------------------------- | ------------------------------- | ------------------------------------------------------- |
-| `<packages>`                         | `add <packages>`         | `add <packages>`                                | `install <packages>`            | Add packages                                            |
-| `--filter <pattern>`                 | `--filter <pattern> add` | `workspaces foreach -A --include <pattern> add` | `install --workspace <pattern>` | Target specific workspace package(s)                    |
-| `-w, --workspace-root`               | `-w`                     | `-W` for v1, v2+ N/A                            | `--include-workspace-root`      | Add to workspace root (ignore-workspace-root-check)     |
-| `--workspace`                        | `--workspace`            | N/A                                             | N/A                             | Only add if package exists in workspace (pnpm-specific) |
-| `-P, --save-prod`                    | `--save-prod` / `-P`     | N/A                                             | `--save-prod` / `-P`            | Save to `dependencies`. The default behavior            |
-| `-D, --save-dev`                     | `-D`                     | `--dev` / `-D`                                  | `--save-dev` / `-D`             | Save to `devDependencies`                               |
-| `--save-peer`                        | `--save-peer`            | `--peer` / `-P`                                 | `--save-peer`                   | Save to `peerDependencies` and `devDependencies`        |
-| `-O, --save-optional`                | `-O`                     | `--optional` / `-O`                             | `--save-optional` / `-O`        | Save to `optionalDependencies`                          |
-| `-E, --save-exact`                   | `-E`                     | `--exact` / `-E`                                | `--save-exact` / `-E`           | Save exact version                                      |
-| `-g, --global`                       | `-g`                     | `global add`                                    | `--global` / `-g`               | Install globally                                        |
-| `--save-catalog`                     | pnpm@10+ only            | N/A                                             | N/A                             | Save the new dependency to the default catalog          |
-| `--save-catalog-name <catalog_name>` | pnpm@10+ only            | N/A                                             | N/A                             | Save the new dependency to the specified catalog        |
-| `--allow-build <names>`              | pnpm@10+ only            | N/A                                             | N/A                             | A list of package names allowed to run postinstall      |
+| Vite+ Flag                           | pnpm                     | yarn                                            | npm                             | bun               | Description                                             |
+| ------------------------------------ | ------------------------ | ----------------------------------------------- | ------------------------------- | ----------------- | ------------------------------------------------------- |
+| `<packages>`                         | `add <packages>`         | `add <packages>`                                | `install <packages>`            | `add <packages>`  | Add packages                                            |
+| `--filter <pattern>`                 | `--filter <pattern> add` | `workspaces foreach -A --include <pattern> add` | `install --workspace <pattern>` | N/A               | Target specific workspace package(s)                    |
+| `-w, --workspace-root`               | `-w`                     | `-W` for v1, v2+ N/A                            | `--include-workspace-root`      | N/A               | Add to workspace root (ignore-workspace-root-check)     |
+| `--workspace`                        | `--workspace`            | N/A                                             | N/A                             | N/A               | Only add if package exists in workspace (pnpm-specific) |
+| `-P, --save-prod`                    | `--save-prod` / `-P`     | N/A                                             | `--save-prod` / `-P`            | N/A               | Save to `dependencies`. The default behavior            |
+| `-D, --save-dev`                     | `-D`                     | `--dev` / `-D`                                  | `--save-dev` / `-D`             | `--dev` / `-d`    | Save to `devDependencies`                               |
+| `--save-peer`                        | `--save-peer`            | `--peer` / `-P`                                 | `--save-peer`                   | `--peer`          | Save to `peerDependencies` and `devDependencies`        |
+| `-O, --save-optional`                | `-O`                     | `--optional` / `-O`                             | `--save-optional` / `-O`        | `--optional`      | Save to `optionalDependencies`                          |
+| `-E, --save-exact`                   | `-E`                     | `--exact` / `-E`                                | `--save-exact` / `-E`           | `--exact` / `-E`  | Save exact version                                      |
+| `-g, --global`                       | `-g`                     | `global add`                                    | `--global` / `-g`               | `--global` / `-g` | Install globally                                        |
+| `--save-catalog`                     | pnpm@10+ only            | N/A                                             | N/A                             | N/A               | Save the new dependency to the default catalog          |
+| `--save-catalog-name <catalog_name>` | pnpm@10+ only            | N/A                                             | N/A                             | N/A               | Save the new dependency to the specified catalog        |
+| `--allow-build <names>`              | pnpm@10+ only            | N/A                                             | N/A                             | N/A               | A list of package names allowed to run postinstall      |
 
 **Note**: For pnpm, `--filter` must come before the command (e.g., `pnpm --filter app add react`). For yarn/npm, it's integrated into the command structure.
 
@@ -169,17 +173,18 @@ vp remove -g typescript                # Remove global package
 - https://pnpm.io/cli/remove#options
 - https://yarnpkg.com/cli/remove#options
 - https://docs.npmjs.com/cli/v11/commands/npm-uninstall#description
+- https://bun.sh/docs/cli/remove
 
-| Vite+ Flag             | pnpm                        | yarn                                               | npm                               | Description                                    |
-| ---------------------- | --------------------------- | -------------------------------------------------- | --------------------------------- | ---------------------------------------------- |
-| `<packages>`           | `remove <packages>`         | `remove <packages>`                                | `uninstall <packages>`            | Remove packages                                |
-| `-D, --save-dev`       | `-D`                        | N/A                                                | `--save-dev` / `-D`               | Only remove from `devDependencies`             |
-| `-O, --save-optional`  | `-O`                        | N/A                                                | `--save-optional` / `-O`          | Only remove from `optionalDependencies`        |
-| `-P, --save-prod`      | `-P`                        | N/A                                                | `--save-prod` / `-P`              | Only remove from `dependencies`                |
-| `--filter <pattern>`   | `--filter <pattern> remove` | `workspaces foreach -A --include <pattern> remove` | `uninstall --workspace <pattern>` | Target specific workspace package(s)           |
-| `-w, --workspace-root` | `-w`                        | N/A                                                | `--include-workspace-root`        | Remove from workspace root                     |
-| `-r, --recursive`      | `-r, --recursive`           | `-A, --all`                                        | `--workspaces`                    | Remove recursively from all workspace packages |
-| `-g, --global`         | `-g`                        | N/A                                                | `--global` / `-g`                 | Remove global packages                         |
+| Vite+ Flag             | pnpm                        | yarn                                               | npm                               | bun                 | Description                                    |
+| ---------------------- | --------------------------- | -------------------------------------------------- | --------------------------------- | ------------------- | ---------------------------------------------- |
+| `<packages>`           | `remove <packages>`         | `remove <packages>`                                | `uninstall <packages>`            | `remove <packages>` | Remove packages                                |
+| `-D, --save-dev`       | `-D`                        | N/A                                                | `--save-dev` / `-D`               | N/A                 | Only remove from `devDependencies`             |
+| `-O, --save-optional`  | `-O`                        | N/A                                                | `--save-optional` / `-O`          | N/A                 | Only remove from `optionalDependencies`        |
+| `-P, --save-prod`      | `-P`                        | N/A                                                | `--save-prod` / `-P`              | N/A                 | Only remove from `dependencies`                |
+| `--filter <pattern>`   | `--filter <pattern> remove` | `workspaces foreach -A --include <pattern> remove` | `uninstall --workspace <pattern>` | N/A                 | Target specific workspace package(s)           |
+| `-w, --workspace-root` | `-w`                        | N/A                                                | `--include-workspace-root`        | N/A                 | Remove from workspace root                     |
+| `-r, --recursive`      | `-r, --recursive`           | `-A, --all`                                        | `--workspaces`                    | N/A                 | Remove recursively from all workspace packages |
+| `-g, --global`         | `-g`                        | N/A                                                | `--global` / `-g`                 | `--global` / `-g`   | Remove global packages                         |
 
 **Note**: Similar to add, `--filter` must precede the command for pnpm.
 
@@ -221,6 +226,7 @@ vp add react --allow-build=react,napi -- --use-stderr
 -> pnpm add --allow-build=react,napi --use-stderr react
 -> yarn add --use-stderr react
 -> npm install --use-stderr react
+-> bun add --use-stderr react
 ```
 
 ### Implementation Architecture
@@ -294,6 +300,7 @@ impl PackageManager {
             PackageManagerType::Pnpm => "add",
             PackageManagerType::Yarn => "add",
             PackageManagerType::Npm => "install",
+            PackageManagerType::Bun => "add",
         }
     }
 
@@ -303,6 +310,7 @@ impl PackageManager {
             PackageManagerType::Pnpm => "remove",
             PackageManagerType::Yarn => "remove",
             PackageManagerType::Npm => "uninstall",
+            PackageManagerType::Bun => "remove",
         }
     }
 
@@ -365,6 +373,12 @@ impl PackageManager {
                 }
                 args.extend_from_slice(extra_args);
             }
+            PackageManagerType::Bun => {
+                // bun: simple add command, no workspace filter support
+                args.push("add".to_string());
+                args.extend_from_slice(packages);
+                args.extend_from_slice(extra_args);
+            }
         }
 
         args
@@ -412,6 +426,12 @@ impl PackageManager {
                     }
                 }
                 args.push("uninstall".to_string());
+                args.extend_from_slice(packages);
+                args.extend_from_slice(extra_args);
+            }
+            PackageManagerType::Bun => {
+                // bun: simple remove command, no workspace filter support
+                args.push("remove".to_string());
                 args.extend_from_slice(packages);
                 args.extend_from_slice(extra_args);
             }
@@ -541,7 +561,7 @@ impl RemoveCommand {
 Yarn requires different command structure for global operations:
 
 ```rust
-// pnpm/npm: <bin> add -g <package>
+// pnpm/npm/bun: <bin> add -g <package>
 // yarn: <bin> global add <package>
 
 fn handle_global_flag(args: &[String], pm_type: PackageManagerType) -> (Vec<String>, bool) {
@@ -599,6 +619,12 @@ fn build_workspace_command(
             }
             args
         }
+        PackageManagerType::Bun => {
+            // bun: no workspace filter support
+            let mut args = vec![operation.to_string()];
+            args.extend_from_slice(packages);
+            args
+        }
     }
 }
 ```
@@ -652,6 +678,7 @@ vp add react --save-exact
 # → pnpm add react --save-exact
 # → yarn add react --save-exact
 # → npm install react --save-exact
+# → bun add react --exact
 ```
 
 ### 3. Common Flags Only
@@ -661,7 +688,7 @@ vp add react --save-exact
 **Common Flags**:
 
 - `-D, --save-dev` - universally supported
-- `-g, --global` - needs special handling for yarn
+- `-g, --global` - needs special handling for yarn; bun uses `--global` / `-g`
 - `-E, --save-exact` - universally supported
 - `-P, --save-peer` - universally supported
 - `-O, --save-optional` - universally supported
@@ -765,6 +792,7 @@ vp add react --dev
 # → pnpm add react -D
 # → yarn add react --dev
 # → npm install react --save-dev
+# → bun add react --dev
 ```
 
 **Rejected because**:
@@ -780,6 +808,7 @@ vp add react --dev
 vp pnpm:add react
 vp yarn:add react
 vp npm:install react
+vp bun:add react
 ```
 
 **Rejected because**:
@@ -841,6 +870,7 @@ $ vp add
 - yarn@4.x
 - npm@10.x
 - npm@11.x [WIP]
+- bun@1.x
 
 ### Unit Tests
 
@@ -852,6 +882,9 @@ fn test_add_command_resolution() {
 
     let pm = PackageManager::mock(PackageManagerType::Npm);
     assert_eq!(pm.resolve_add_command(), "install");
+
+    let pm = PackageManager::mock(PackageManagerType::Bun);
+    assert_eq!(pm.resolve_add_command(), "add");
 }
 
 #[test]
@@ -861,6 +894,9 @@ fn test_remove_command_resolution() {
 
     let pm = PackageManager::mock(PackageManagerType::Npm);
     assert_eq!(pm.resolve_remove_command(), "uninstall");
+
+    let pm = PackageManager::mock(PackageManagerType::Bun);
+    assert_eq!(pm.resolve_remove_command(), "remove");
 }
 
 #[test]
@@ -1050,8 +1086,11 @@ This is a new feature with no breaking changes:
 Users can start using immediately:
 
 ```bash
-# Old way
+# Old way (package manager specific)
 pnpm add react
+yarn add react
+npm install react
+bun add react
 
 # New way (works with any package manager)
 vp add react
@@ -1080,7 +1119,7 @@ vp add <packages>... [OPTIONS]
 ```
 ````
 
-Automatically uses the detected package manager (pnpm/yarn/npm).
+Automatically uses the detected package manager (pnpm/yarn/npm/bun).
 
 **Basic Examples:**
 
@@ -1137,13 +1176,13 @@ Aliases: `rm`, `un`, `uninstall`
 
 Document flag support matrix:
 
-| Flag | pnpm | yarn | npm |
-|------|------|------|-----|
-| `-D` | ✅ | ✅ | ✅ |
-| `-E` | ✅ | ✅ | ✅ |
-| `-P` | ✅ | ✅ | ✅ |
-| `-O` | ✅ | ✅ | ✅ |
-| `-g` | ✅ | ⚠️ (use global) | ✅ |
+| Flag | pnpm | yarn | npm | bun |
+|------|------|------|-----|-----|
+| `-D` | ✅ | ✅ | ✅ | ✅ |
+| `-E` | ✅ | ✅ | ✅ | ✅ |
+| `-P` | ✅ | ✅ | ✅ | ✅ |
+| `-O` | ✅ | ✅ | ✅ | ✅ |
+| `-g` | ✅ | ⚠️ (use global) | ✅ | ✅ |
 
 ## Workspace Operations Deep Dive
 
@@ -1210,6 +1249,7 @@ vp add -D typescript -w
 # → pnpm add -D typescript -w  (pnpm)
 # → yarn add -D typescript -W  (yarn)
 # → npm install -D typescript -w  (npm)
+# → bun add --dev typescript  (bun, no workspace root flag)
 ```
 
 **Why needed**: By default, package managers prevent adding to workspace root to encourage proper package structure.
@@ -1231,31 +1271,32 @@ vp add "@myorg/utils@workspace:^" --filter app
 
 ### Package Manager Compatibility
 
-| Feature                    | pnpm               | yarn                  | npm                     | Notes                    |
-| -------------------------- | ------------------ | --------------------- | ----------------------- | ------------------------ |
-| `--filter <pattern>`       | ✅ Native          | ⚠️ `workspace <name>` | ⚠️ `--workspace <name>` | Syntax differs           |
-| Multiple filters           | ✅ Repeatable flag | ❌ Single only        | ⚠️ Limited              | pnpm most flexible       |
-| Wildcard patterns          | ✅ Full support    | ⚠️ Limited            | ❌ No wildcards         | pnpm best                |
-| Exclusion `!`              | ✅ Supported       | ❌ Not supported      | ❌ Not supported        | pnpm only                |
-| Dependency selectors `...` | ✅ Supported       | ❌ Not supported      | ❌ Not supported        | pnpm only                |
-| `-w` (root)                | ✅ `-w`            | ✅ `-W`               | ✅ `-w`                 | Slightly different flags |
-| `--workspace` protocol     | ✅ Supported       | ❌ Manual             | ❌ Manual               | pnpm feature             |
+| Feature                    | pnpm               | yarn                  | npm                     | bun              | Notes                    |
+| -------------------------- | ------------------ | --------------------- | ----------------------- | ---------------- | ------------------------ |
+| `--filter <pattern>`       | ✅ Native          | ⚠️ `workspace <name>` | ⚠️ `--workspace <name>` | ❌ Not supported | Syntax differs           |
+| Multiple filters           | ✅ Repeatable flag | ❌ Single only        | ⚠️ Limited              | ❌ Not supported | pnpm most flexible       |
+| Wildcard patterns          | ✅ Full support    | ⚠️ Limited            | ❌ No wildcards         | ❌ Not supported | pnpm best                |
+| Exclusion `!`              | ✅ Supported       | ❌ Not supported      | ❌ Not supported        | ❌ Not supported | pnpm only                |
+| Dependency selectors `...` | ✅ Supported       | ❌ Not supported      | ❌ Not supported        | ❌ Not supported | pnpm only                |
+| `-w` (root)                | ✅ `-w`            | ✅ `-W`               | ✅ `-w`                 | ❌ Not supported | Slightly different flags |
+| `--workspace` protocol     | ✅ Supported       | ❌ Manual             | ❌ Manual               | ❌ Not supported | pnpm feature             |
 
 **Graceful Degradation**:
 
-- Advanced pnpm features (wildcard, exclusion, selectors) will error on yarn/npm with helpful message
+- Advanced pnpm features (wildcard, exclusion, selectors) will error on yarn/npm/bun with helpful message
 - Basic `--filter <exact-name>` works across all package managers
 
 ## Future Enhancements
 
-### 1. Enhanced Filter Support for yarn/npm
+### 1. Enhanced Filter Support for yarn/npm/bun
 
-Implement wildcard translation for yarn/npm:
+Implement wildcard translation for yarn/npm/bun:
 
 ```bash
 vp add react --filter "app*"
 # → For yarn: Run `yarn workspace app add react` for each matching package
 # → For npm: Run `npm install react --workspace app` for each matching package
+# → For bun: Run `bun add react` in each matching package directory
 ```
 
 ### 2. Interactive Mode

--- a/rfcs/dedupe-package-command.md
+++ b/rfcs/dedupe-package-command.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Add `vp dedupe` command that automatically adapts to the detected package manager (pnpm/npm/yarn) for optimizing dependency trees by removing duplicate packages and upgrading older dependencies to newer compatible versions in the lockfile. This helps reduce redundancy and improve project efficiency.
+Add `vp dedupe` command that automatically adapts to the detected package manager (pnpm/npm/yarn/bun) for optimizing dependency trees by removing duplicate packages and upgrading older dependencies to newer compatible versions in the lockfile. This helps reduce redundancy and improve project efficiency.
 
 ## Motivation
 
@@ -84,15 +84,16 @@ vp dedupe --check
 - https://yarnpkg.com/cli/dedupe (yarn@2+)
 - Note: yarn@2+ has a dedicated `yarn dedupe` command with `--check` mode support
 
-| Vite+ Flag  | pnpm          | npm          | yarn@2+       | Description                  |
-| ----------- | ------------- | ------------ | ------------- | ---------------------------- |
-| `vp dedupe` | `pnpm dedupe` | `npm dedupe` | `yarn dedupe` | Deduplicate dependencies     |
-| `--check`   | `--check`     | `--dry-run`  | `--check`     | Check if changes would occur |
+| Vite+ Flag  | pnpm          | npm          | yarn@2+       | bun | Description                  |
+| ----------- | ------------- | ------------ | ------------- | --- | ---------------------------- |
+| `vp dedupe` | `pnpm dedupe` | `npm dedupe` | `yarn dedupe` | N/A | Deduplicate dependencies     |
+| `--check`   | `--check`     | `--dry-run`  | `--check`     | N/A | Check if changes would occur |
 
 **Note**:
 
 - pnpm uses `--check` for dry-run, npm uses `--dry-run`, yarn@2+ uses `--check`
 - yarn@1 does not have dedupe command and is not supported
+- bun does not currently support a dedupe command
 
 ### Dedupe Behavior Differences Across Package Managers
 
@@ -561,6 +562,7 @@ vp dedupe:run
 - yarn@4.x (yarn@2+)
 - npm@10.x
 - npm@11.x (WIP)
+- bun@1.x (N/A - bun does not support dedupe)
 
 ### Unit Tests
 
@@ -764,13 +766,13 @@ vp test
 
 ## Package Manager Compatibility
 
-| Feature       | pnpm         | npm            | yarn@2+      | Notes                                     |
-| ------------- | ------------ | -------------- | ------------ | ----------------------------------------- |
-| Basic dedupe  | ✅ `dedupe`  | ✅ `dedupe`    | ✅ `dedupe`  | All use native dedupe command             |
-| Check/Dry-run | ✅ `--check` | ✅ `--dry-run` | ✅ `--check` | npm uses different flag name              |
-| Exit codes    | ✅ Supported | ✅ Supported   | ✅ Supported | All return non-zero on check with changes |
+| Feature       | pnpm         | npm            | yarn@2+      | bun              | Notes                                     |
+| ------------- | ------------ | -------------- | ------------ | ---------------- | ----------------------------------------- |
+| Basic dedupe  | ✅ `dedupe`  | ✅ `dedupe`    | ✅ `dedupe`  | ❌ Not supported | bun has no dedupe command                 |
+| Check/Dry-run | ✅ `--check` | ✅ `--dry-run` | ✅ `--check` | ❌ Not supported | npm uses different flag name              |
+| Exit codes    | ✅ Supported | ✅ Supported   | ✅ Supported | ❌ Not supported | All return non-zero on check with changes |
 
-**Note**: yarn@1 does not have a dedupe command and is not supported
+**Note**: yarn@1 does not have a dedupe command and is not supported. bun does not currently support a dedupe command.
 
 ## Future Enhancements
 
@@ -870,7 +872,7 @@ Recommendation: All can use lodash@4.17.21
 
 ## Conclusion
 
-This RFC proposes adding `vp dedupe` command to provide a unified interface for dependency deduplication across pnpm/npm/yarn@2+. The design:
+This RFC proposes adding `vp dedupe` command to provide a unified interface for dependency deduplication across pnpm/npm/yarn@2+/bun. The design:
 
 - ✅ Automatically adapts to detected package manager
 - ✅ Supports check mode for validation (maps to --check for pnpm/yarn@2+, --dry-run for npm)

--- a/rfcs/dlx-command.md
+++ b/rfcs/dlx-command.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Add `vp dlx` command that fetches a package from the registry without installing it as a dependency, hotloads it, and runs whatever default command binary it exposes. This provides a unified interface across pnpm, npm, and yarn for executing remote packages temporarily.
+Add `vp dlx` command that fetches a package from the registry without installing it as a dependency, hotloads it, and runs whatever default command binary it exposes. This provides a unified interface across pnpm, npm, yarn, and bun for executing remote packages temporarily.
 
 ## Motivation
 
@@ -104,13 +104,14 @@ vp dlx -p typescript -p @types/node -c 'tsc --init && node -e "console.log(123)"
 - pnpm: https://pnpm.io/cli/dlx
 - npm: https://docs.npmjs.com/cli/v10/commands/npm-exec
 - yarn: https://yarnpkg.com/cli/dlx
+- bun: https://bun.sh/docs/pm/bunx
 
-| Vite+ Flag                      | pnpm               | npm                 | yarn@1      | yarn@2+          | Description                |
-| ------------------------------- | ------------------ | ------------------- | ----------- | ---------------- | -------------------------- |
-| `vp dlx <pkg>`                  | `pnpm dlx <pkg>`   | `npm exec <pkg>`    | `npx <pkg>` | `yarn dlx <pkg>` | Execute package binary     |
-| `--package <name>`, `-p <name>` | `--package <name>` | `--package=<name>`  | N/A         | `-p <name>`      | Specify package to install |
-| `--shell-mode`, `-c`            | `-c`               | `-c`                | N/A         | N/A              | Execute in shell           |
-| `--silent`, `-s`                | `--silent`         | `--loglevel silent` | `--quiet`   | `--quiet`        | Suppress output            |
+| Vite+ Flag                      | pnpm               | npm                 | yarn@1      | yarn@2+          | bun                | Description                |
+| ------------------------------- | ------------------ | ------------------- | ----------- | ---------------- | ------------------ | -------------------------- |
+| `vp dlx <pkg>`                  | `pnpm dlx <pkg>`   | `npm exec <pkg>`    | `npx <pkg>` | `yarn dlx <pkg>` | `bun x <pkg>`      | Execute package binary     |
+| `--package <name>`, `-p <name>` | `--package <name>` | `--package=<name>`  | N/A         | `-p <name>`      | `--package <name>` | Specify package to install |
+| `--shell-mode`, `-c`            | `-c`               | `-c`                | N/A         | N/A              | N/A                | Execute in shell           |
+| `--silent`, `-s`                | `--silent`         | `--loglevel silent` | `--quiet`   | `--quiet`        | N/A                | Suppress output            |
 
 **Notes:**
 
@@ -119,6 +120,7 @@ vp dlx -p typescript -p @types/node -c 'tsc --init && node -e "console.log(123)"
 - **Shell mode**: Yarn 2+ does not support shell mode (`-c`), command will print a warning and try to execute anyway.
 - **--package flag position**: For pnpm, `--package` comes before `dlx`. For npm, `--package` can be anywhere. For yarn, `-p` comes after `dlx`.
 - **Auto-confirm prompts**: For npm and npx (yarn@1 fallback), `--yes` is automatically added to align with pnpm's behavior which doesn't require confirmation.
+- **bun**: Uses `bun x` subcommand (preferred over the `bunx` standalone binary for better cross-platform compatibility). It supports `--package` but does not support `--shell-mode` or `--silent` flags. The `--package` flag must come before the package spec.
 
 ### Argument Handling
 
@@ -719,7 +721,7 @@ Error: yarn@1.22.19 does not support dlx command
 
 - Frustrating user experience
 - npx fallback works well and is available
-- Other tools (like bunx) also provide fallbacks
+- Other tools (like `bun x`) also provide fallbacks
 - Users shouldn't need to switch package managers for dlx
 
 ## Implementation Plan
@@ -888,14 +890,14 @@ Examples:
 
 ## Package Manager Compatibility
 
-| Feature           | pnpm    | npm     | yarn@1  | yarn@2+ | Notes                    |
-| ----------------- | ------- | ------- | ------- | ------- | ------------------------ |
-| Basic execution   | ✅ Full | ✅ Full | ⚠️ npx  | ✅ Full | yarn@1 uses npx fallback |
-| Version specifier | ✅ Full | ✅ Full | ⚠️ npx  | ✅ Full |                          |
-| --package flag    | ✅ Full | ✅ Full | ⚠️ npx  | ✅ Full |                          |
-| Shell mode (-c)   | ✅ Full | ✅ Full | ⚠️ npx  | ❌ N/A  | yarn@2+ doesn't support  |
-| Silent mode       | ✅ Full | ✅ Full | ⚠️ npx  | ✅ Full |                          |
-| Auto-confirm      | ✅ N/A  | ✅ Auto | ⚠️ Auto | ✅ N/A  | --yes added for npm/npx  |
+| Feature           | pnpm    | npm     | yarn@1  | yarn@2+ | bun        | Notes                     |
+| ----------------- | ------- | ------- | ------- | ------- | ---------- | ------------------------- |
+| Basic execution   | ✅ Full | ✅ Full | ⚠️ npx  | ✅ Full | ✅ `bun x` | yarn@1 uses npx fallback  |
+| Version specifier | ✅ Full | ✅ Full | ⚠️ npx  | ✅ Full | ✅ Full    |                           |
+| --package flag    | ✅ Full | ✅ Full | ⚠️ npx  | ✅ Full | ✅ Full    |                           |
+| Shell mode (-c)   | ✅ Full | ✅ Full | ⚠️ npx  | ❌ N/A  | ❌ N/A     | yarn@2+/bun don't support |
+| Silent mode       | ✅ Full | ✅ Full | ⚠️ npx  | ✅ Full | ❌ N/A     | `bun x` doesn't support   |
+| Auto-confirm      | ✅ N/A  | ✅ Auto | ⚠️ Auto | ✅ N/A  | ✅ N/A     | --yes added for npm/npx   |
 
 ## Security Considerations
 
@@ -1026,7 +1028,7 @@ vp dlx madge --image deps.svg src/
 
 ## Conclusion
 
-This RFC proposes adding `vp dlx` command to provide unified remote package execution across pnpm/npm/yarn. The design:
+This RFC proposes adding `vp dlx` command to provide unified remote package execution across pnpm/npm/yarn/bun. The design:
 
 - ✅ Unified interface for all package managers
 - ✅ Intelligent fallback for yarn@1

--- a/rfcs/exec-command.md
+++ b/rfcs/exec-command.md
@@ -2,15 +2,17 @@
 
 ## Summary
 
-Add `vp exec` as a subcommand that prepends `./node_modules/.bin` to PATH and executes a command. This is the equivalent of `pnpm exec`.
+Add `vp exec` as a subcommand that prepends `./node_modules/.bin` to PATH and executes a command. This is the equivalent of `pnpm exec` or direct execution with `bun`.
 
 The command completes the execution story alongside existing commands:
 
-| Command       | Behavior                                                       | Analogy         |
-| ------------- | -------------------------------------------------------------- | --------------- |
-| `vp dlx`      | Always downloads from remote                                   | `pnpm dlx`      |
-| `vpx`         | Local → global → PATH → remote fallback                        | `npx`           |
-| **`vp exec`** | **Prepend `node_modules/.bin` to PATH, then execute normally** | **`pnpm exec`** |
+| Command       | Behavior                                                       | Analogy                     |
+| ------------- | -------------------------------------------------------------- | --------------------------- |
+| `vp dlx`      | Always downloads from remote                                   | `pnpm dlx` / `bun x`        |
+| `vpx`         | Local → global → PATH → remote fallback                        | `npx`                       |
+| **`vp exec`** | **Prepend `node_modules/.bin` to PATH, then execute normally** | **`pnpm exec`** / **`bun`** |
+
+**Note:** bun natively resolves binaries from local `node_modules/.bin`, so `bun <cmd>` or `bun x <cmd>` can serve a similar purpose to `vp exec`.
 
 ## Motivation
 

--- a/rfcs/install-command.md
+++ b/rfcs/install-command.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Add `vp install` command (alias: `vp i`) that automatically adapts to the detected package manager (pnpm/yarn/npm) for installing all dependencies in a project, with support for common flags and workspace-aware operations based on pnpm's API design.
+Add `vp install` command (alias: `vp i`) that automatically adapts to the detected package manager (pnpm/yarn/npm/bun) for installing all dependencies in a project, with support for common flags and workspace-aware operations based on pnpm's API design.
 
 ## Motivation
 
@@ -28,6 +28,7 @@ This creates friction in monorepo workflows and requires remembering different s
 pnpm install --frozen-lockfile  # pnpm project
 yarn install --frozen-lockfile  # yarn project (v1) or --immutable (v2+)
 npm ci                          # npm project (clean install)
+bun install --frozen-lockfile   # bun project
 
 # Different flags for production install
 pnpm install --prod
@@ -120,27 +121,28 @@ vp install --filter app              # Install for specific package
 - https://yarnpkg.com/cli/install
 - https://classic.yarnpkg.com/en/docs/cli/install
 - https://docs.npmjs.com/cli/v11/commands/npm-install
+- https://bun.sh/docs/cli/install
 
-| Vite+ Flag             | pnpm                   | yarn@1                 | yarn@2+                                     | npm                         | Description                          |
-| ---------------------- | ---------------------- | ---------------------- | ------------------------------------------- | --------------------------- | ------------------------------------ |
-| `vp install`           | `pnpm install`         | `yarn install`         | `yarn install`                              | `npm install`               | Install all dependencies             |
-| `--prod, -P`           | `--prod`               | `--production`         | N/A (use `.yarnrc.yml`)                     | `--omit=dev`                | Skip devDependencies                 |
-| `--dev, -D`            | `--dev`                | N/A                    | N/A                                         | `--include=dev --omit=prod` | Only devDependencies                 |
-| `--no-optional`        | `--no-optional`        | `--ignore-optional`    | N/A                                         | `--omit=optional`           | Skip optionalDependencies            |
-| `--frozen-lockfile`    | `--frozen-lockfile`    | `--frozen-lockfile`    | `--immutable`                               | `ci` (use `npm ci`)         | Fail if lockfile outdated            |
-| `--no-frozen-lockfile` | `--no-frozen-lockfile` | `--no-frozen-lockfile` | `--no-immutable`                            | `install` (not `ci`)        | Allow lockfile updates               |
-| `--lockfile-only`      | `--lockfile-only`      | N/A                    | `--mode update-lockfile`                    | `--package-lock-only`       | Only update lockfile                 |
-| `--prefer-offline`     | `--prefer-offline`     | `--prefer-offline`     | N/A                                         | `--prefer-offline`          | Prefer cached packages               |
-| `--offline`            | `--offline`            | `--offline`            | N/A                                         | `--offline`                 | Only use cache                       |
-| `--force, -f`          | `--force`              | `--force`              | N/A                                         | `--force`                   | Force reinstall                      |
-| `--ignore-scripts`     | `--ignore-scripts`     | `--ignore-scripts`     | `--mode skip-build`                         | `--ignore-scripts`          | Skip lifecycle scripts               |
-| `--no-lockfile`        | `--no-lockfile`        | `--no-lockfile`        | N/A                                         | `--no-package-lock`         | Skip lockfile                        |
-| `--fix-lockfile`       | `--fix-lockfile`       | N/A                    | `--refresh-lockfile`                        | N/A                         | Fix broken lockfile entries          |
-| `--shamefully-hoist`   | `--shamefully-hoist`   | N/A                    | N/A                                         | N/A                         | Flat node_modules (pnpm)             |
-| `--resolution-only`    | `--resolution-only`    | N/A                    | N/A                                         | N/A                         | Re-run resolution only (pnpm)        |
-| `--silent`             | `--silent`             | `--silent`             | N/A (use env var)                           | `--loglevel silent`         | Suppress output                      |
-| `--filter <pattern>`   | `--filter <pattern>`   | N/A                    | `workspaces foreach -A --include <pattern>` | `--workspace <pattern>`     | Target specific workspace package(s) |
-| `-w, --workspace-root` | `-w`                   | `-W`                   | N/A                                         | `--include-workspace-root`  | Install in root only                 |
+| Vite+ Flag             | pnpm                   | yarn@1                 | yarn@2+                                     | npm                         | bun                      | Description                          |
+| ---------------------- | ---------------------- | ---------------------- | ------------------------------------------- | --------------------------- | ------------------------ | ------------------------------------ |
+| `vp install`           | `pnpm install`         | `yarn install`         | `yarn install`                              | `npm install`               | `bun install`            | Install all dependencies             |
+| `--prod, -P`           | `--prod`               | `--production`         | N/A (use `.yarnrc.yml`)                     | `--omit=dev`                | `--production`           | Skip devDependencies                 |
+| `--dev, -D`            | `--dev`                | N/A                    | N/A                                         | `--include=dev --omit=prod` | N/A                      | Only devDependencies                 |
+| `--no-optional`        | `--no-optional`        | `--ignore-optional`    | N/A                                         | `--omit=optional`           | `--omit optional`        | Skip optionalDependencies            |
+| `--frozen-lockfile`    | `--frozen-lockfile`    | `--frozen-lockfile`    | `--immutable`                               | `ci` (use `npm ci`)         | `--frozen-lockfile`      | Fail if lockfile outdated            |
+| `--no-frozen-lockfile` | `--no-frozen-lockfile` | `--no-frozen-lockfile` | `--no-immutable`                            | `install` (not `ci`)        | `--no-frozen-lockfile`   | Allow lockfile updates               |
+| `--lockfile-only`      | `--lockfile-only`      | N/A                    | `--mode update-lockfile`                    | `--package-lock-only`       | `--lockfile-only`        | Only update lockfile                 |
+| `--prefer-offline`     | `--prefer-offline`     | `--prefer-offline`     | N/A                                         | `--prefer-offline`          | N/A                      | Prefer cached packages               |
+| `--offline`            | `--offline`            | `--offline`            | N/A                                         | `--offline`                 | N/A                      | Only use cache                       |
+| `--force, -f`          | `--force`              | `--force`              | N/A                                         | `--force`                   | `--force`                | Force reinstall                      |
+| `--ignore-scripts`     | `--ignore-scripts`     | `--ignore-scripts`     | `--mode skip-build`                         | `--ignore-scripts`          | `--ignore-scripts`       | Skip lifecycle scripts               |
+| `--no-lockfile`        | `--no-lockfile`        | `--no-lockfile`        | N/A                                         | `--no-package-lock`         | N/A                      | Skip lockfile                        |
+| `--fix-lockfile`       | `--fix-lockfile`       | N/A                    | `--refresh-lockfile`                        | N/A                         | N/A                      | Fix broken lockfile entries          |
+| `--shamefully-hoist`   | `--shamefully-hoist`   | N/A                    | N/A                                         | N/A                         | N/A (hoisted by default) | Flat node_modules (pnpm)             |
+| `--resolution-only`    | `--resolution-only`    | N/A                    | N/A                                         | N/A                         | N/A                      | Re-run resolution only (pnpm)        |
+| `--silent`             | `--silent`             | `--silent`             | N/A (use env var)                           | `--loglevel silent`         | `--silent`               | Suppress output                      |
+| `--filter <pattern>`   | `--filter <pattern>`   | N/A                    | `workspaces foreach -A --include <pattern>` | `--workspace <pattern>`     | `--filter <pattern>`     | Target specific workspace package(s) |
+| `-w, --workspace-root` | `-w`                   | `-W`                   | N/A                                         | `--include-workspace-root`  | N/A                      | Install in root only                 |
 
 **Notes:**
 
@@ -151,6 +153,7 @@ vp install --filter app              # Install for specific package
 - `--fix-lockfile`: Automatically fixes broken lockfile entries (pnpm and yarn@2+ only, npm does not support)
 - `--resolution-only`: Re-runs dependency resolution without installing packages. Useful for peer dependency analysis (pnpm only)
 - `--shamefully-hoist`: pnpm-specific, creates flat node_modules like npm/yarn
+- `--ignore-scripts`: For bun, use `--ignore-scripts` to skip lifecycle scripts.
 - `--silent`: Suppresses output. For yarn@2+, use `YARN_ENABLE_PROGRESS=false` environment variable instead. For npm, maps to `--loglevel silent`
 
 **Add Package Mode:**
@@ -801,6 +804,7 @@ VITE_PM=pnpm vp install
 - yarn@4.x
 - npm@10.x
 - npm@11.x
+- bun@1.x
 
 ### Unit Tests
 
@@ -1002,25 +1006,25 @@ This is a new feature with no breaking changes:
 
 ## Package Manager Compatibility Matrix
 
-| Feature                | pnpm | yarn@1 | yarn@2+                 | npm             | Notes                     |
-| ---------------------- | ---- | ------ | ----------------------- | --------------- | ------------------------- |
-| Basic install          | ✅   | ✅     | ✅                      | ✅              | All supported             |
-| `--prod`               | ✅   | ✅     | ⚠️                      | ✅              | yarn@2+ needs .yarnrc.yml |
-| `--dev`                | ✅   | ❌     | ❌                      | ✅              | Limited support           |
-| `--no-optional`        | ✅   | ✅     | ⚠️                      | ✅              | yarn@2+ needs .yarnrc.yml |
-| `--frozen-lockfile`    | ✅   | ✅     | ✅ `--immutable`        | ✅ `ci`         | npm uses `npm ci`         |
-| `--no-frozen-lockfile` | ✅   | ✅     | ✅ `--no-immutable`     | ✅ `install`    | Pass through to PM        |
-| `--lockfile-only`      | ✅   | ❌     | ✅                      | ✅              | yarn@1 not supported      |
-| `--prefer-offline`     | ✅   | ✅     | ❌                      | ✅              | yarn@2+ not supported     |
-| `--offline`            | ✅   | ✅     | ❌                      | ✅              | yarn@2+ not supported     |
-| `--force`              | ✅   | ✅     | ❌                      | ✅              | yarn@2+ not supported     |
-| `--ignore-scripts`     | ✅   | ✅     | ✅ `--mode skip-build`  | ✅              | All supported             |
-| `--no-lockfile`        | ✅   | ✅     | ❌                      | ✅              | yarn@2+ not supported     |
-| `--fix-lockfile`       | ✅   | ❌     | ✅ `--refresh-lockfile` | ❌              | pnpm and yarn@2+ only     |
-| `--shamefully-hoist`   | ✅   | ❌     | ❌                      | ❌              | pnpm only                 |
-| `--resolution-only`    | ✅   | ❌     | ❌                      | ❌              | pnpm only                 |
-| `--silent`             | ✅   | ✅     | ⚠️ (use env var)        | ✅ `--loglevel` | yarn@2+ use env var       |
-| `--filter`             | ✅   | ❌     | ✅ `workspaces foreach` | ✅              | yarn@1 not supported      |
+| Feature                | pnpm | yarn@1 | yarn@2+                 | npm             | bun                     | Notes                      |
+| ---------------------- | ---- | ------ | ----------------------- | --------------- | ----------------------- | -------------------------- |
+| Basic install          | ✅   | ✅     | ✅                      | ✅              | ✅                      | All supported              |
+| `--prod`               | ✅   | ✅     | ⚠️                      | ✅              | ✅                      | yarn@2+ needs .yarnrc.yml  |
+| `--dev`                | ✅   | ❌     | ❌                      | ✅              | ❌                      | Limited support            |
+| `--no-optional`        | ✅   | ✅     | ⚠️                      | ✅              | ✅                      | yarn@2+ needs .yarnrc.yml  |
+| `--frozen-lockfile`    | ✅   | ✅     | ✅ `--immutable`        | ✅ `ci`         | ✅                      | npm uses `npm ci`          |
+| `--no-frozen-lockfile` | ✅   | ✅     | ✅ `--no-immutable`     | ✅ `install`    | ✅                      | Pass through to PM         |
+| `--lockfile-only`      | ✅   | ❌     | ✅                      | ✅              | ✅                      | yarn@1 not supported       |
+| `--prefer-offline`     | ✅   | ✅     | ❌                      | ✅              | ❌                      | yarn@2+, bun not supported |
+| `--offline`            | ✅   | ✅     | ❌                      | ✅              | ❌                      | yarn@2+, bun not supported |
+| `--force`              | ✅   | ✅     | ❌                      | ✅              | ✅                      | yarn@2+ not supported      |
+| `--ignore-scripts`     | ✅   | ✅     | ✅ `--mode skip-build`  | ✅              | ✅                      |                            |
+| `--no-lockfile`        | ✅   | ✅     | ❌                      | ✅              | ❌                      | yarn@2+, bun not supported |
+| `--fix-lockfile`       | ✅   | ❌     | ✅ `--refresh-lockfile` | ❌              | ❌                      | pnpm and yarn@2+ only      |
+| `--shamefully-hoist`   | ✅   | ❌     | ❌                      | ❌              | ❌ (hoisted by default) | pnpm only                  |
+| `--resolution-only`    | ✅   | ❌     | ❌                      | ❌              | ❌                      | pnpm only                  |
+| `--silent`             | ✅   | ✅     | ⚠️ (use env var)        | ✅ `--loglevel` | ✅                      | yarn@2+ use env var        |
+| `--filter`             | ✅   | ❌     | ✅ `workspaces foreach` | ✅              | ✅                      | yarn@1 not supported       |
 
 ## Future Enhancements
 
@@ -1139,7 +1143,7 @@ vp install --offline
 
 ## Conclusion
 
-This RFC proposes adding `vp install` command to provide a unified interface for installing dependencies across pnpm/yarn/npm. The design:
+This RFC proposes adding `vp install` command to provide a unified interface for installing dependencies across pnpm/yarn/npm/bun. The design:
 
 - ✅ Automatically adapts to detected package manager
 - ✅ Supports common installation flags

--- a/rfcs/link-unlink-package-commands.md
+++ b/rfcs/link-unlink-package-commands.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Add `vp link` (alias: `vp ln`) and `vp unlink` commands that automatically adapt to the detected package manager (pnpm/yarn/npm) for creating and removing symlinks to local packages, making them accessible system-wide or in other locations. This enables local package development and testing workflows.
+Add `vp link` (alias: `vp ln`) and `vp unlink` commands that automatically adapt to the detected package manager (pnpm/yarn/npm/bun) for creating and removing symlinks to local packages, making them accessible system-wide or in other locations. This enables local package development and testing workflows.
 
 ## Motivation
 
@@ -139,11 +139,16 @@ vp unlink -r
 - https://docs.npmjs.com/cli/v11/commands/npm-link
 - npm link creates symlinks between packages
 
-| Vite+ Command   | pnpm              | yarn@1            | yarn@2+           | npm              | Description                                             |
-| --------------- | ----------------- | ----------------- | ----------------- | ---------------- | ------------------------------------------------------- |
-| `vp link`       | `pnpm link`       | `yarn link`       | `yarn link`       | `npm link`       | Register current package or link to local directory     |
-| `vp link <pkg>` | `pnpm link <pkg>` | `yarn link <pkg>` | `yarn link <pkg>` | `npm link <pkg>` | Links package to current project                        |
-| `vp link <dir>` | `pnpm link <dir>` | `yarn link <dir>` | `yarn link <dir>` | `npm link <dir>` | Links package from `<dir>` directory to current project |
+**bun references:**
+
+- https://bun.sh/docs/cli/link
+- bun link creates symlinks for local packages
+
+| Vite+ Command   | pnpm              | yarn@1            | yarn@2+           | npm              | bun              | Description                                             |
+| --------------- | ----------------- | ----------------- | ----------------- | ---------------- | ---------------- | ------------------------------------------------------- |
+| `vp link`       | `pnpm link`       | `yarn link`       | `yarn link`       | `npm link`       | `bun link`       | Register current package or link to local directory     |
+| `vp link <pkg>` | `pnpm link <pkg>` | `yarn link <pkg>` | `yarn link <pkg>` | `npm link <pkg>` | `bun link <pkg>` | Links package to current project                        |
+| `vp link <dir>` | `pnpm link <dir>` | `yarn link <dir>` | `yarn link <dir>` | `npm link <dir>` | `bun link <dir>` | Links package from `<dir>` directory to current project |
 
 #### Unlink Command Mapping
 
@@ -163,11 +168,11 @@ vp unlink -r
 - https://docs.npmjs.com/cli/v11/commands/npm-uninstall
 - npm unlink removes symlinks
 
-| Vite+ Command           | pnpm                      | yarn@1              | yarn@2+             | npm                | Description                        |
-| ----------------------- | ------------------------- | ------------------- | ------------------- | ------------------ | ---------------------------------- |
-| `vp unlink`             | `pnpm unlink`             | `yarn unlink`       | `yarn unlink`       | `npm unlink`       | Unlinks current package            |
-| `vp unlink <pkg>`       | `pnpm unlink <pkg>`       | `yarn unlink <pkg>` | `yarn unlink <pkg>` | `npm unlink <pkg>` | Unlinks specific package           |
-| `vp unlink --recursive` | `pnpm unlink --recursive` | N/A                 | `yarn unlink --all` | N/A                | Unlinks in every workspace package |
+| Vite+ Command           | pnpm                      | yarn@1              | yarn@2+             | npm                | bun          | Description                        |
+| ----------------------- | ------------------------- | ------------------- | ------------------- | ------------------ | ------------ | ---------------------------------- |
+| `vp unlink`             | `pnpm unlink`             | `yarn unlink`       | `yarn unlink`       | `npm unlink`       | `bun unlink` | Unlinks current package            |
+| `vp unlink <pkg>`       | `pnpm unlink <pkg>`       | `yarn unlink <pkg>` | `yarn unlink <pkg>` | `npm unlink <pkg>` | `bun unlink` | Unlinks specific package           |
+| `vp unlink --recursive` | `pnpm unlink --recursive` | N/A                 | `yarn unlink --all` | N/A                | N/A          | Unlinks in every workspace package |
 
 ### Link/Unlink Behavior Differences Across Package Managers
 
@@ -216,6 +221,18 @@ vp unlink -r
 
 - `npm unlink`: Removes global symlink for current package
 - `npm unlink <pkg>`: Removes package from current project
+
+#### bun
+
+**Link behavior:**
+
+- `bun link`: Registers current package as a linkable package
+- `bun link <pkg>`: Links a registered package to current project
+- `--save`: Adds `link:` prefix to package.json dependency entry
+
+**Unlink behavior:**
+
+- `bun unlink`: Unlinks current package
 
 ### Implementation Architecture
 
@@ -740,6 +757,7 @@ $ vp link
 - yarn@4.x
 - npm@10.x
 - npm@11.x
+- bun@1.x [WIP]
 
 ### Unit Tests
 
@@ -992,13 +1010,14 @@ npm install my-lib@latest
 
 ## Package Manager Compatibility
 
-| Feature              | pnpm                    | yarn@1           | yarn@2+           | npm              | Notes            |
-| -------------------- | ----------------------- | ---------------- | ----------------- | ---------------- | ---------------- |
-| Link package/dir     | `link`                  | `link`           | `link`            | `link`           | All supported    |
-| Link with package    | `link <pkg>`            | `link <pkg>`     | `link <pkg>`      | `link <pkg>`     | All supported    |
-| Link local directory | `link <dir>`            | `link <dir>`     | `link <dir>`      | `link <dir>`     | All supported    |
-| Unlink               | `unlink`                | `unlink`         | `unlink`          | `unlink`         | All supported    |
-| Recursive unlink     | ✅ `unlink --recursive` | ❌ Not supported | ✅ `unlink --all` | ❌ Not supported | pnpm and yarn@2+ |
+| Feature              | pnpm                    | yarn@1           | yarn@2+           | npm              | bun              | Notes            |
+| -------------------- | ----------------------- | ---------------- | ----------------- | ---------------- | ---------------- | ---------------- |
+| Link package/dir     | `link`                  | `link`           | `link`            | `link`           | `link`           | All supported    |
+| Link with package    | `link <pkg>`            | `link <pkg>`     | `link <pkg>`      | `link <pkg>`     | `link <pkg>`     | All supported    |
+| Link local directory | `link <dir>`            | `link <dir>`     | `link <dir>`      | `link <dir>`     | `link <dir>`     | All supported    |
+| Save to package.json | N/A                     | N/A              | N/A               | N/A              | `--save`         | bun-specific     |
+| Unlink               | `unlink`                | `unlink`         | `unlink`          | `unlink`         | `unlink`         | All supported    |
+| Recursive unlink     | ✅ `unlink --recursive` | ❌ Not supported | ✅ `unlink --all` | ❌ Not supported | ❌ Not supported | pnpm and yarn@2+ |
 
 ## Future Enhancements
 
@@ -1090,7 +1109,7 @@ vp link --verify
 
 ## Conclusion
 
-This RFC proposes adding `vp link` and `vp unlink` commands to provide a unified interface for local package development across pnpm/yarn/npm. The design:
+This RFC proposes adding `vp link` and `vp unlink` commands to provide a unified interface for local package development across pnpm/yarn/npm/bun. The design:
 
 - ✅ Automatically adapts to detected package manager
 - ✅ Supports both package and local directory linking

--- a/rfcs/outdated-package-command.md
+++ b/rfcs/outdated-package-command.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Add `vite outdated` command that automatically adapts to the detected package manager (pnpm/npm/yarn) for checking outdated packages. This helps developers identify packages that have newer versions available, maintain up-to-date dependencies, and manage security vulnerabilities by showing which packages can be updated.
+Add `vite outdated` command that automatically adapts to the detected package manager (pnpm/npm/yarn/bun) for checking outdated packages. This helps developers identify packages that have newer versions available, maintain up-to-date dependencies, and manage security vulnerabilities by showing which packages can be updated.
 
 ## Motivation
 
@@ -147,21 +147,26 @@ vite outdated -g                      # Check globally installed packages
 - https://yarnpkg.com/cli/upgrade-interactive (yarn@2+)
 - Checks for outdated package dependencies
 
-| Vite+ Flag             | pnpm                   | npm                                 | yarn@1          | yarn@2+                    | Description                                   |
-| ---------------------- | ---------------------- | ----------------------------------- | --------------- | -------------------------- | --------------------------------------------- |
-| `vite outdated`        | `pnpm outdated`        | `npm outdated`                      | `yarn outdated` | `yarn upgrade-interactive` | Check for outdated packages                   |
-| `<pattern>...`         | `<pattern>...`         | `[[@scope/]<pkg>]`                  | `[<package>]`   | N/A                        | Package patterns to check                     |
-| `--long`               | `--long`               | `--long`                            | N/A             | N/A                        | Extended output format                        |
-| `--format <format>`    | `--format <format>`    | json: `--json`/ list: `--parseable` | `--json`        | N/A                        | Output format (table/list/json)               |
-| `-r, --recursive`      | `-r, --recursive`      | `--all`                             | N/A             | N/A                        | Check across all workspaces                   |
-| `--filter <pattern>`   | `--filter <pattern>`   | `--workspace <pattern>`             | N/A             | N/A                        | Target specific workspace                     |
-| `-w, --workspace-root` | `-w, --workspace-root` | `--include-workspace-root`          | N/A             | N/A                        | Include workspace root                        |
-| `-P, --prod`           | `-P, --prod`           | N/A                                 | N/A             | N/A                        | Only production dependencies (pnpm-specific)  |
-| `-D, --dev`            | `-D, --dev`            | N/A                                 | N/A             | N/A                        | Only dev dependencies (pnpm-specific)         |
-| `--no-optional`        | `--no-optional`        | N/A                                 | N/A             | N/A                        | Exclude optional dependencies (pnpm-specific) |
-| `--compatible`         | `--compatible`         | N/A                                 | N/A             | N/A                        | Only show compatible versions (pnpm-specific) |
-| `--sort-by <field>`    | `--sort-by <field>`    | N/A                                 | N/A             | N/A                        | Sort results by field (pnpm-specific)         |
-| `-g, --global`         | `-g, --global`         | `-g, --global`                      | N/A             | N/A                        | Check globally installed packages             |
+**bun references:**
+
+- https://bun.sh/docs/cli/outdated
+- Checks for outdated packages in the current project
+
+| Vite+ Flag             | pnpm                   | npm                                 | yarn@1          | yarn@2+                    | bun                  | Description                                   |
+| ---------------------- | ---------------------- | ----------------------------------- | --------------- | -------------------------- | -------------------- | --------------------------------------------- |
+| `vite outdated`        | `pnpm outdated`        | `npm outdated`                      | `yarn outdated` | `yarn upgrade-interactive` | `bun outdated`       | Check for outdated packages                   |
+| `<pattern>...`         | `<pattern>...`         | `[[@scope/]<pkg>]`                  | `[<package>]`   | N/A                        | N/A                  | Package patterns to check                     |
+| `--long`               | `--long`               | `--long`                            | N/A             | N/A                        | N/A                  | Extended output format                        |
+| `--format <format>`    | `--format <format>`    | json: `--json`/ list: `--parseable` | `--json`        | N/A                        | N/A                  | Output format (table/list/json)               |
+| `-r, --recursive`      | `-r, --recursive`      | `--all`                             | N/A             | N/A                        | `-r` / `--recursive` | Check across all workspaces                   |
+| `--filter <pattern>`   | `--filter <pattern>`   | `--workspace <pattern>`             | N/A             | N/A                        | `--filter` / `-F`    | Target specific workspace                     |
+| `-w, --workspace-root` | `-w, --workspace-root` | `--include-workspace-root`          | N/A             | N/A                        | N/A                  | Include workspace root                        |
+| `-P, --prod`           | `-P, --prod`           | N/A                                 | N/A             | N/A                        | `--production`       | Only production dependencies                  |
+| `-D, --dev`            | `-D, --dev`            | N/A                                 | N/A             | N/A                        | N/A                  | Only dev dependencies (pnpm-specific)         |
+| `--no-optional`        | `--no-optional`        | N/A                                 | N/A             | N/A                        | `--omit optional`    | Exclude optional dependencies                 |
+| `--compatible`         | `--compatible`         | N/A                                 | N/A             | N/A                        | N/A                  | Only show compatible versions (pnpm-specific) |
+| `--sort-by <field>`    | `--sort-by <field>`    | N/A                                 | N/A             | N/A                        | N/A                  | Sort results by field (pnpm-specific)         |
+| `-g, --global`         | `-g, --global`         | `-g, --global`                      | N/A             | N/A                        | N/A                  | Check globally installed packages             |
 
 **Note:**
 
@@ -170,6 +175,8 @@ vite outdated -g                      # Check globally installed packages
 - yarn@1 accepts package names but limited filtering options
 - yarn@2+ uses interactive mode (`upgrade-interactive`) instead of traditional `outdated`
 - pnpm has the most comprehensive filtering and output options
+- bun supports `--filter` / `-F` for workspace filtering, `-r` / `--recursive` for checking across all workspaces, `--production` for production-only, and `--omit optional` for excluding optional dependencies
+- bun does not support JSON output format (`--format json`)
 
 ### Outdated Behavior Differences Across Package Managers
 
@@ -1002,6 +1009,7 @@ vp outdated --update
 - yarn@4.x
 - npm@10.x
 - npm@11.x
+- bun@1.x [WIP]
 
 ### Unit Tests
 
@@ -1286,21 +1294,21 @@ vite outdated -g typescript
 
 ## Package Manager Compatibility
 
-| Feature             | pnpm               | npm                           | yarn@1           | yarn@2+             | Notes                    |
-| ------------------- | ------------------ | ----------------------------- | ---------------- | ------------------- | ------------------------ |
-| Basic command       | ✅ `outdated`      | ✅ `outdated`                 | ✅ `outdated`    | ⚠️ `upgrade-int...` | yarn@2+ uses interactive |
-| Pattern matching    | ✅ Glob patterns   | ⚠️ Package names              | ⚠️ Package names | ❌ Not supported    | pnpm supports globs      |
-| JSON output         | ✅ `--format json` | ✅ `--json`                   | ❌ Not supported | ❌ Not supported    | Different flags          |
-| Long output         | ✅ `--long`        | ✅ `--long`                   | ❌ Not supported | ❌ Not supported    | pnpm and npm only        |
-| Parseable           | ❌ Not supported   | ✅ `--parseable`              | ❌ Not supported | ❌ Not supported    | npm only                 |
-| Recursive           | ✅ `-r`            | ❌ Not supported              | ❌ Not supported | ❌ Not supported    | pnpm only                |
-| Workspace filter    | ✅ `--filter`      | ✅ `--workspace`              | ❌ Not supported | ❌ Not supported    | Different flags          |
-| Workspace root      | ✅ `-w`            | ✅ `--include-workspace-root` | ❌ Not supported | ❌ Not supported    | Different flags          |
-| Dep type filter     | ✅ `--prod/--dev`  | ❌ Not supported              | ❌ Not supported | ❌ Not supported    | pnpm only                |
-| Compatible only     | ✅ `--compatible`  | ❌ Not supported              | ❌ Not supported | ❌ Not supported    | pnpm only                |
-| Sort results        | ✅ `--sort-by`     | ❌ Not supported              | ❌ Not supported | ❌ Not supported    | pnpm only                |
-| Global check        | ✅ `-g`            | ✅ `-g`                       | ❌ Not supported | ❌ Not supported    | pnpm and npm             |
-| Show all transitive | ⚠️ Use `-r`        | ✅ `--all`                    | ❌ Not supported | ❌ Not supported    | Different approaches     |
+| Feature             | pnpm               | npm                           | yarn@1           | yarn@2+             | bun                  | Notes                    |
+| ------------------- | ------------------ | ----------------------------- | ---------------- | ------------------- | -------------------- | ------------------------ |
+| Basic command       | ✅ `outdated`      | ✅ `outdated`                 | ✅ `outdated`    | ⚠️ `upgrade-int...` | ✅ `outdated`        | yarn@2+ uses interactive |
+| Pattern matching    | ✅ Glob patterns   | ⚠️ Package names              | ⚠️ Package names | ❌ Not supported    | ❌ Not supported     | pnpm supports globs      |
+| JSON output         | ✅ `--format json` | ✅ `--json`                   | ❌ Not supported | ❌ Not supported    | ❌ Not supported     | Different flags          |
+| Long output         | ✅ `--long`        | ✅ `--long`                   | ❌ Not supported | ❌ Not supported    | ❌ Not supported     | pnpm and npm only        |
+| Parseable           | ❌ Not supported   | ✅ `--parseable`              | ❌ Not supported | ❌ Not supported    | ❌ Not supported     | npm only                 |
+| Recursive           | ✅ `-r`            | ❌ Not supported              | ❌ Not supported | ❌ Not supported    | ✅ `-r`              | pnpm and bun             |
+| Workspace filter    | ✅ `--filter`      | ✅ `--workspace`              | ❌ Not supported | ❌ Not supported    | ✅ `--filter` / `-F` | Different flags          |
+| Workspace root      | ✅ `-w`            | ✅ `--include-workspace-root` | ❌ Not supported | ❌ Not supported    | ❌ Not supported     | Different flags          |
+| Dep type filter     | ✅ `--prod/--dev`  | ❌ Not supported              | ❌ Not supported | ❌ Not supported    | ❌ Not supported     | pnpm only                |
+| Compatible only     | ✅ `--compatible`  | ❌ Not supported              | ❌ Not supported | ❌ Not supported    | ❌ Not supported     | pnpm only                |
+| Sort results        | ✅ `--sort-by`     | ❌ Not supported              | ❌ Not supported | ❌ Not supported    | ❌ Not supported     | pnpm only                |
+| Global check        | ✅ `-g`            | ✅ `-g`                       | ❌ Not supported | ❌ Not supported    | ❌ Not supported     | pnpm and npm             |
+| Show all transitive | ⚠️ Use `-r`        | ✅ `--all`                    | ❌ Not supported | ❌ Not supported    | ❌ Not supported     | Different approaches     |
 
 ## Future Enhancements
 
@@ -1415,7 +1423,7 @@ Changes:
 
 ## Conclusion
 
-This RFC proposes adding `vite outdated` command to provide a unified interface for checking outdated packages across pnpm/npm/yarn. The design:
+This RFC proposes adding `vite outdated` command to provide a unified interface for checking outdated packages across pnpm/npm/yarn/bun. The design:
 
 - ✅ Automatically adapts to detected package manager
 - ✅ Supports pattern matching (pnpm) with graceful degradation

--- a/rfcs/pack-command.md
+++ b/rfcs/pack-command.md
@@ -232,10 +232,12 @@ Node.js version v22.22.0 does not support `exe` option. Please upgrade to Node.j
 
 These are distinct commands:
 
-| Command      | Purpose                       | Output              |
-| ------------ | ----------------------------- | ------------------- |
-| `vp pack`    | Library bundling via tsdown   | `dist/` directory   |
-| `vp pm pack` | Tarball creation via npm/pnpm | `.tgz` package file |
+| Command      | Purpose                           | Output              |
+| ------------ | --------------------------------- | ------------------- |
+| `vp pack`    | Library bundling via tsdown       | `dist/` directory   |
+| `vp pm pack` | Tarball creation via npm/pnpm/bun | `.tgz` package file |
+
+**Note:** For tarball creation, bun uses `bun pm pack` (not `bun pack`). It supports `--destination` and `--dry-run` flags. See the [pm-command-group RFC](./pm-command-group.md) for the full command mapping.
 
 ## Design Decisions
 

--- a/rfcs/package-manager-detection.md
+++ b/rfcs/package-manager-detection.md
@@ -1,0 +1,223 @@
+# RFC: Package Manager Detection
+
+## Summary
+
+Document how Vite+ determines which package manager (pnpm/yarn/npm/bun) a project uses. This detection runs automatically before any package management command (`vp install`, `vp add`, `vp remove`, etc.) and drives all PM-specific behavior including command translation, lockfile handling, and workspace configuration.
+
+## Detection Algorithm
+
+Vite+ uses a strict priority-ordered algorithm to detect the package manager. The first match wins.
+
+### Priority 1: `packageManager` field in `package.json`
+
+The highest-priority signal. If the root `package.json` contains a `packageManager` field, it is used unconditionally.
+
+```json
+{
+  "packageManager": "pnpm@10.19.0"
+}
+```
+
+**Format**: `<name>@<semver>[+<hash>]`
+
+- `name` must be one of: `pnpm`, `yarn`, `npm`, `bun`
+- `semver` must be valid (e.g., `10.19.0`, `4.0.0`)
+- Optional hash suffix: `pnpm@10.0.0+sha512.abc123...`
+
+**Errors**:
+
+- Invalid semver → `PackageManagerVersionInvalid` error
+- Unknown name → `UnsupportedPackageManager` error
+
+**Reference**: [Node.js Corepack packageManager field](https://nodejs.org/api/packages.html#packagemanager)
+
+### Priority 2: Lockfiles
+
+If no `packageManager` field is found, Vite+ checks for lockfiles in the workspace root. Checked in this order:
+
+| File                  | Detected PM | Notes                            |
+| --------------------- | ----------- | -------------------------------- |
+| `pnpm-workspace.yaml` | pnpm        | Workspace definition file        |
+| `pnpm-lock.yaml`      | pnpm        | Lockfile                         |
+| `yarn.lock`           | yarn        | Lockfile                         |
+| `.yarnrc.yml`         | yarn        | Yarn Berry (v2+) configuration   |
+| `package-lock.json`   | npm         | Lockfile                         |
+| `bun.lock`            | bun         | Text-format lockfile (preferred) |
+| `bun.lockb`           | bun         | Binary-format lockfile (legacy)  |
+
+When detected from lockfiles, version is set to `"latest"` (resolved during download).
+
+### Priority 3: Configuration files
+
+Lower-priority config files that indicate a package manager:
+
+| File              | Detected PM | Notes                                       |
+| ----------------- | ----------- | ------------------------------------------- |
+| `.pnpmfile.cjs`   | pnpm        | [pnpm hooks](https://pnpm.io/pnpmfile)      |
+| `pnpmfile.cjs`    | pnpm        | Legacy format (pnpm v5.x)                   |
+| `bunfig.toml`     | bun         | [Bun configuration](https://bun.sh/docs/pm) |
+| `yarn.config.cjs` | yarn        | Yarn Berry (v2+) configuration              |
+
+### Priority 4: Explicit default
+
+If a caller provides a default package manager type (used internally by some code paths), that default is used with version `"latest"`.
+
+### Priority 5: Interactive selection
+
+If no signals are detected and no default is provided, the behavior depends on the environment:
+
+#### CI environment
+
+Checks for common CI environment variables:
+
+- `CI`, `CONTINUOUS_INTEGRATION`, `GITHUB_ACTIONS`, `GITLAB_CI`, `CIRCLECI`, `TRAVIS`, `JENKINS_URL`, `BUILDKITE`, `DRONE`, `CODEBUILD_BUILD_ID` (AWS CodeBuild), `TF_BUILD` (Azure Pipelines)
+
+**Result**: Auto-selects `pnpm` without prompting.
+
+#### Non-interactive terminal
+
+If stdin is not a TTY (piped input, non-interactive shell):
+
+**Result**: Auto-selects `pnpm` without prompting.
+
+#### Interactive terminal
+
+Displays a keyboard-navigable menu:
+
+```
+No package manager detected. Please select one:
+   Use ↑↓ arrows to navigate, Enter to select, 1-4 for quick selection
+
+  ▶ [1] pnpm (recommended) ←
+    [2] npm
+    [3] yarn
+    [4] bun
+```
+
+If the interactive menu fails (terminal compatibility issues), falls back to a simple text prompt:
+
+```
+No package manager detected. Please select one:
+────────────────────────────────────────────────
+  [1] pnpm (recommended)
+  [2] npm
+  [3] yarn
+  [4] bun
+
+Enter your choice (1-4) [default: 1]:
+```
+
+## CLI Flag: `--package-manager`
+
+The `vp create` command supports a `--package-manager` flag for explicitly specifying the package manager:
+
+```bash
+vp create vite:monorepo --no-interactive --package-manager bun
+```
+
+**Resolution priority for `vp create`**:
+
+1. Detected workspace `packageManager` field (existing monorepo takes precedence)
+2. `--package-manager` CLI flag
+3. Interactive prompt / auto-default (pnpm)
+
+This ensures monorepo consistency: if you run `vp create` inside an existing workspace that already has a `packageManager` field, the workspace setting wins over the CLI flag.
+
+## Auto-Update Behavior
+
+After detection and download, Vite+ automatically writes the resolved package manager version to the `packageManager` field in `package.json`. This ensures:
+
+- Future runs use the exact version (Priority 1 match)
+- Team members get consistent versions
+- CI environments use deterministic versions
+
+## Version Resolution
+
+| Detection method          | Version used                                                     |
+| ------------------------- | ---------------------------------------------------------------- |
+| `packageManager` field    | Exact version from field (e.g., `10.19.0`)                       |
+| Lockfile/config detection | `"latest"` — resolved to latest stable version from npm registry |
+| Interactive selection     | `"latest"` — resolved to latest stable version from npm registry |
+
+**Special cases**:
+
+- **yarn ≥ 2.0.0**: Downloads from `@yarnpkg/cli-dist` instead of `yarn` npm package
+- **bun**: Downloads platform-specific native binary from `@oven/bun-{os}-{arch}` (including musl variants for Alpine Linux)
+
+## Workspace and Monorepo Detection
+
+Workspace detection determines `is_monorepo` based on:
+
+- `pnpm-workspace.yaml` → monorepo (pnpm)
+- `package.json` with `workspaces` field → monorepo (npm/yarn/bun)
+
+The package manager type and monorepo status together drive:
+
+- Which lockfile patterns to watch for cache invalidation
+- Whether catalog support is available (pnpm, yarn, bun — not npm)
+- How workspace filters (`--filter`) are translated
+
+## Detection Signals Summary
+
+### Per package manager
+
+| Package Manager | Lockfiles               | Config Files                                           | Field            |
+| --------------- | ----------------------- | ------------------------------------------------------ | ---------------- |
+| pnpm            | `pnpm-lock.yaml`        | `pnpm-workspace.yaml`, `.pnpmfile.cjs`, `pnpmfile.cjs` | `packageManager` |
+| yarn            | `yarn.lock`             | `.yarnrc.yml`, `.yarnrc`, `yarn.config.cjs`            | `packageManager` |
+| npm             | `package-lock.json`     | —                                                      | `packageManager` |
+| bun             | `bun.lock`, `bun.lockb` | `bunfig.toml`                                          | `packageManager` |
+
+### Cache invalidation (fingerprint ignores)
+
+Each package manager has specific files that trigger cache invalidation when changed:
+
+| Package Manager | Watched Files                                                                        |
+| --------------- | ------------------------------------------------------------------------------------ |
+| pnpm            | `pnpm-workspace.yaml`, `pnpm-lock.yaml`, `.pnpmfile.cjs`, `pnpmfile.cjs`, `.pnp.cjs` |
+| yarn            | `.yarnrc`, `.yarnrc.yml`, `yarn.config.cjs`, `yarn.lock`, `.yarn/**/*`, `.pnp.cjs`   |
+| npm             | `package-lock.json`, `npm-shrinkwrap.json`                                           |
+| bun             | `bun.lock`, `bun.lockb`, `bunfig.toml`                                               |
+| All             | `**/package.json`, `.npmrc`                                                          |
+
+## Implementation
+
+### Rust (core detection)
+
+- **File**: `crates/vite_install/src/package_manager.rs`
+- **Function**: `get_package_manager_type_and_version()` — priority-ordered detection
+- **Function**: `prompt_package_manager_selection()` — CI/TTY/interactive fallback
+- **Enum**: `PackageManagerType` — `Pnpm`, `Yarn`, `Npm`, `Bun`
+
+### TypeScript (CLI integration)
+
+- **File**: `packages/cli/src/utils/workspace.ts` — `detectWorkspace()` wraps NAPI binding
+- **File**: `packages/cli/src/utils/prompts.ts` — `selectPackageManager()` for non-interactive default
+- **File**: `packages/cli/src/create/bin.ts` — `--package-manager` flag handling
+
+### NAPI binding (bridge)
+
+- **File**: `packages/cli/binding/src/package_manager.rs` — `detectWorkspace()` exports to JS
+
+## Future Enhancements
+
+### `devEngines.packageManager` field
+
+Support the [Node.js `devEngines` field](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#devengines) for package manager constraints:
+
+```json
+{
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": ">=10.0.0"
+    }
+  }
+}
+```
+
+This would be checked between Priority 1 (`packageManager` field) and Priority 2 (lockfiles). It specifies a constraint rather than an exact version, so it would be combined with other signals.
+
+### Multiple lockfile conflict resolution
+
+Currently, if multiple lockfiles exist (e.g., both `pnpm-lock.yaml` and `package-lock.json`), the first one found in priority order wins silently. A future enhancement could warn about conflicting lockfiles and suggest cleanup.

--- a/rfcs/pm-command-group.md
+++ b/rfcs/pm-command-group.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Add `vp pm` command group that provides a set of utilities for working with package managers. The `pm` command group offers direct access to package manager utilities like cache management, package publishing, configuration, and more. These are pass-through commands that delegate to the detected package manager (pnpm/npm/yarn) with minimal processing, providing a unified interface across different package managers.
+Add `vp pm` command group that provides a set of utilities for working with package managers. The `pm` command group offers direct access to package manager utilities like cache management, package publishing, configuration, and more. These are pass-through commands that delegate to the detected package manager (pnpm/npm/yarn/bun) with minimal processing, providing a unified interface across different package managers.
 
 ## Motivation
 
@@ -730,6 +730,22 @@ vp pm ping --registry https://custom-registry.com
 
 - `--registry <url>`: Registry URL to ping
 
+### Bun-Specific Subcommands
+
+Bun provides several `bun pm` subcommands that may not have direct equivalents in other package managers:
+
+- `bun pm ls` / `bun list` - List installed packages
+- `bun pm bin` - Show the bin directory for installed binaries
+- `bun pm cache` / `bun pm cache rm` - Cache management (show cache path / remove cached packages)
+- `bun pm whoami` - Show the currently logged-in npm registry username
+- `bun pm pack` - Create a tarball of the package (supports `--destination`, `--dry-run`)
+- `bun pm trust` / `bun pm untrusted` - Manage trusted dependencies (allow lifecycle scripts)
+- `bun pm version` - Show the installed version of bun
+- `bun pm pkg` - Manage package.json fields programmatically
+- `bun publish` - Publish package to the npm registry (direct subcommand, not `bun pm publish`)
+
+**Note:** Many npm registry operations (login, logout, owner, dist-tag, deprecate, search, fund, ping, token) do not have native bun equivalents and delegate to `npm` when using bun as the package manager.
+
 ### Command Mapping
 
 #### Prune Command
@@ -747,16 +763,17 @@ vp pm ping --registry https://custom-registry.com
 - https://classic.yarnpkg.com/en/docs/cli/prune
 - The prune command isn't necessary. yarn install will prune extraneous packages.
 
-| Vite+ Flag      | pnpm            | npm               | yarn | Description                 |
-| --------------- | --------------- | ----------------- | ---- | --------------------------- |
-| `vp pm prune`   | `pnpm prune`    | `npm prune`       | N/A  | Remove unnecessary packages |
-| `--prod`        | `--prod`        | `--omit=dev`      | N/A  | Remove devDependencies      |
-| `--no-optional` | `--no-optional` | `--omit=optional` | N/A  | Remove optional deps        |
+| Vite+ Flag      | pnpm            | npm               | yarn | bun | Description                 |
+| --------------- | --------------- | ----------------- | ---- | --- | --------------------------- |
+| `vp pm prune`   | `pnpm prune`    | `npm prune`       | N/A  | N/A | Remove unnecessary packages |
+| `--prod`        | `--prod`        | `--omit=dev`      | N/A  | N/A | Remove devDependencies      |
+| `--no-optional` | `--no-optional` | `--omit=optional` | N/A  | N/A | Remove optional deps        |
 
 **Note:**
 
 - npm supports prune with `--omit=dev` (for prod) and `--omit=optional` (for no-optional)
 - yarn doesn't have a prune command (automatic during install)
+- bun doesn't have a prune command
 
 #### Pack Command
 
@@ -774,15 +791,16 @@ vp pm ping --registry https://custom-registry.com
 - https://yarnpkg.com/cli/pack
 - https://yarnpkg.com/cli/workspaces/foreach (for yarn@2+ recursive packing)
 
-| Vite+ Flag                  | pnpm                 | npm                  | yarn@1       | yarn@2+                                       | Description                       |
-| --------------------------- | -------------------- | -------------------- | ------------ | --------------------------------------------- | --------------------------------- |
-| `vp pm pack`                | `pnpm pack`          | `npm pack`           | `yarn pack`  | `yarn pack`                                   | Create package tarball            |
-| `-r, --recursive`           | `--recursive`        | `--workspaces`       | N/A          | `workspaces foreach --all pack`               | Pack all workspace packages       |
-| `--filter <pattern>`        | `--filter`           | `--workspace`        | N/A          | `workspaces foreach --include <pattern> pack` | Filter packages to pack           |
-| `--out <path>`              | `--out`              | N/A                  | `--filename` | `--out`                                       | Output file path (supports %s/%v) |
-| `--pack-destination <dir>`  | `--pack-destination` | `--pack-destination` | N/A          | N/A                                           | Output directory                  |
-| `--pack-gzip-level <level>` | `--pack-gzip-level`  | N/A                  | N/A          | N/A                                           | Gzip compression level (0-9)      |
-| `--json`                    | `--json`             | `--json`             | `--json`     | `--json`                                      | JSON output                       |
+| Vite+ Flag                  | pnpm                 | npm                  | yarn@1       | yarn@2+                                       | bun             | Description                       |
+| --------------------------- | -------------------- | -------------------- | ------------ | --------------------------------------------- | --------------- | --------------------------------- |
+| `vp pm pack`                | `pnpm pack`          | `npm pack`           | `yarn pack`  | `yarn pack`                                   | `bun pm pack`   | Create package tarball            |
+| `-r, --recursive`           | `--recursive`        | `--workspaces`       | N/A          | `workspaces foreach --all pack`               | N/A             | Pack all workspace packages       |
+| `--filter <pattern>`        | `--filter`           | `--workspace`        | N/A          | `workspaces foreach --include <pattern> pack` | N/A             | Filter packages to pack           |
+| `--out <path>`              | `--out`              | N/A                  | `--filename` | `--out`                                       | `--filename`    | Output file path (supports %s/%v) |
+| `--pack-destination <dir>`  | `--pack-destination` | `--pack-destination` | N/A          | N/A                                           | `--destination` | Output directory                  |
+| `--pack-gzip-level <level>` | `--pack-gzip-level`  | N/A                  | N/A          | N/A                                           | `--gzip-level`  | Gzip compression level (0-9)      |
+| `--json`                    | `--json`             | `--json`             | `--json`     | `--json`                                      | N/A             | JSON output                       |
+| `--dry-run`                 | N/A                  | `--dry-run`          | N/A          | N/A                                           | `--dry-run`     | Preview without creating tarball  |
 
 **Note:**
 
@@ -804,8 +822,9 @@ vp pm ping --registry https://custom-registry.com
   - Supported by pnpm and npm
   - yarn does not support this option (prints warning and ignores)
 - `--pack-gzip-level <level>`: Gzip compression level (0-9)
-  - Only supported by pnpm
+  - Supported by pnpm and bun (bun uses `--gzip-level`)
   - npm and yarn do not support this option (prints warning and ignores)
+- bun uses `bun pm pack` (not `bun pack`), supports `--destination` and `--dry-run` flags
 
 #### List Command
 
@@ -821,22 +840,22 @@ vp pm ping --registry https://custom-registry.com
 
 - https://classic.yarnpkg.com/en/docs/cli/list
 
-| Vite+ Flag           | pnpm              | npm                             | yarn@1        | yarn@2+       | Description                                   |
-| -------------------- | ----------------- | ------------------------------- | ------------- | ------------- | --------------------------------------------- |
-| `vp pm list`         | `pnpm list`       | `npm list`                      | `yarn list`   | N/A           | List installed packages                       |
-| `--depth <n>`        | `--depth <n>`     | `--depth <n>`                   | `--depth <n>` | N/A           | Limit tree depth                              |
-| `--json`             | `--json`          | `--json`                        | `--json`      | N/A           | JSON output                                   |
-| `--long`             | `--long`          | `--long`                        | N/A           | N/A           | Extended info                                 |
-| `--parseable`        | `--parseable`     | `--parseable`                   | N/A           | N/A           | Parseable format                              |
-| `-P, --prod`         | `--prod`          | `--include prod --include peer` | N/A           | N/A           | Production deps only                          |
-| `-D, --dev`          | `--dev`           | `--include dev`                 | N/A           | N/A           | Dev deps only                                 |
-| `--no-optional`      | `--no-optional`   | `--omit optional`               | N/A           | N/A           | Exclude optional deps                         |
-| `--exclude-peers`    | `--exclude-peers` | `--omit peer`                   | N/A           | N/A           | Exclude peer deps                             |
-| `--only-projects`    | `--only-projects` | N/A                             | N/A           | N/A           | Show only project packages (pnpm)             |
-| `--find-by <name>`   | `--find-by`       | N/A                             | N/A           | N/A           | Use finder function from .pnpmfile.cjs (pnpm) |
-| `-r, --recursive`    | `--recursive`     | `--workspaces`                  | N/A           | N/A           | List across workspaces                        |
-| `--filter <pattern>` | `--filter`        | `--workspace`                   | N/A           | N/A           | Filter workspace                              |
-| `-g, --global`       | `npm list -g`     | `npm list -g`                   | `npm list -g` | `npm list -g` | List global packages                          |
+| Vite+ Flag           | pnpm              | npm                             | yarn@1        | yarn@2+       | bun           | Description                                   |
+| -------------------- | ----------------- | ------------------------------- | ------------- | ------------- | ------------- | --------------------------------------------- |
+| `vp pm list`         | `pnpm list`       | `npm list`                      | `yarn list`   | N/A           | `bun pm ls`   | List installed packages                       |
+| `--depth <n>`        | `--depth <n>`     | `--depth <n>`                   | `--depth <n>` | N/A           | N/A           | Limit tree depth                              |
+| `--json`             | `--json`          | `--json`                        | `--json`      | N/A           | N/A           | JSON output                                   |
+| `--long`             | `--long`          | `--long`                        | N/A           | N/A           | N/A           | Extended info                                 |
+| `--parseable`        | `--parseable`     | `--parseable`                   | N/A           | N/A           | N/A           | Parseable format                              |
+| `-P, --prod`         | `--prod`          | `--include prod --include peer` | N/A           | N/A           | N/A           | Production deps only                          |
+| `-D, --dev`          | `--dev`           | `--include dev`                 | N/A           | N/A           | N/A           | Dev deps only                                 |
+| `--no-optional`      | `--no-optional`   | `--omit optional`               | N/A           | N/A           | N/A           | Exclude optional deps                         |
+| `--exclude-peers`    | `--exclude-peers` | `--omit peer`                   | N/A           | N/A           | N/A           | Exclude peer deps                             |
+| `--only-projects`    | `--only-projects` | N/A                             | N/A           | N/A           | N/A           | Show only project packages (pnpm)             |
+| `--find-by <name>`   | `--find-by`       | N/A                             | N/A           | N/A           | N/A           | Use finder function from .pnpmfile.cjs (pnpm) |
+| `-r, --recursive`    | `--recursive`     | `--workspaces`                  | N/A           | N/A           | N/A           | List across workspaces                        |
+| `--filter <pattern>` | `--filter`        | `--workspace`                   | N/A           | N/A           | N/A           | Filter workspace                              |
+| `-g, --global`       | `npm list -g`     | `npm list -g`                   | `npm list -g` | `npm list -g` | `npm list -g` | List global packages                          |
 
 **Note:**
 
@@ -900,15 +919,15 @@ vp pm ping --registry https://custom-registry.com
 - https://classic.yarnpkg.com/en/docs/cli/info (delegates to npm view)
 - https://yarnpkg.com/cli/npm/info (delegates to npm view)
 
-| Vite+ Flag   | pnpm       | npm        | yarn@1     | yarn@2+    | Description       |
-| ------------ | ---------- | ---------- | ---------- | ---------- | ----------------- |
-| `vp pm view` | `npm view` | `npm view` | `npm view` | `npm view` | View package info |
-| `--json`     | `--json`   | `--json`   | `--json`   | `--json`   | JSON output       |
+| Vite+ Flag   | pnpm       | npm        | yarn@1     | yarn@2+    | bun        | Description       |
+| ------------ | ---------- | ---------- | ---------- | ---------- | ---------- | ----------------- |
+| `vp pm view` | `npm view` | `npm view` | `npm view` | `npm view` | `bun info` | View package info |
+| `--json`     | `--json`   | `--json`   | `--json`   | `--json`   | `--json`   | JSON output       |
 
 **Note:**
 
-- All package managers delegate to `npm view` for viewing package information
-- pnpm and yarn both use npm's view/info functionality internally
+- pnpm and yarn delegate to `npm view` for viewing package information
+- bun has a native `bun info` command for viewing package information
 - Aliases: `vp pm info` and `vp pm show` work the same as `vp pm view`
 
 #### Publish Command
@@ -926,20 +945,20 @@ vp pm ping --registry https://custom-registry.com
 - https://classic.yarnpkg.com/en/docs/cli/publish (delegates to npm publish)
 - https://yarnpkg.com/cli/npm/publish (delegates to npm publish)
 
-| Vite+ Flag                  | pnpm               | npm                | yarn@1             | yarn@2+            | Description                 |
-| --------------------------- | ------------------ | ------------------ | ------------------ | ------------------ | --------------------------- |
-| `vp pm publish`             | `pnpm publish`     | `npm publish`      | `npm publish`      | `npm publish`      | Publish package             |
-| `--dry-run`                 | `--dry-run`        | `--dry-run`        | `--dry-run`        | `--dry-run`        | Preview without publishing  |
-| `--tag <tag>`               | `--tag <tag>`      | `--tag <tag>`      | `--tag <tag>`      | `--tag <tag>`      | Publish tag                 |
-| `--access <level>`          | `--access <level>` | `--access <level>` | `--access <level>` | `--access <level>` | Public/restricted           |
-| `--otp <otp>`               | `--otp`            | `--otp`            | `--otp`            | `--otp`            | One-time password           |
-| `--no-git-checks`           | `--no-git-checks`  | N/A                | N/A                | N/A                | Skip git checks (pnpm)      |
-| `--publish-branch <branch>` | `--publish-branch` | N/A                | N/A                | N/A                | Set publish branch (pnpm)   |
-| `--report-summary`          | `--report-summary` | N/A                | N/A                | N/A                | Save publish summary (pnpm) |
-| `--force`                   | `--force`          | `--force`          | `--force`          | `--force`          | Force publish               |
-| `--json`                    | `--json`           | N/A                | N/A                | N/A                | JSON output (pnpm)          |
-| `-r, --recursive`           | `--recursive`      | `--workspaces`     | N/A                | N/A                | Publish workspaces          |
-| `--filter <pattern>`        | `--filter`         | `--workspace`      | N/A                | N/A                | Filter workspace            |
+| Vite+ Flag                  | pnpm               | npm                | yarn@1             | yarn@2+            | bun           | Description                 |
+| --------------------------- | ------------------ | ------------------ | ------------------ | ------------------ | ------------- | --------------------------- |
+| `vp pm publish`             | `pnpm publish`     | `npm publish`      | `npm publish`      | `npm publish`      | `bun publish` | Publish package             |
+| `--dry-run`                 | `--dry-run`        | `--dry-run`        | `--dry-run`        | `--dry-run`        | `--dry-run`   | Preview without publishing  |
+| `--tag <tag>`               | `--tag <tag>`      | `--tag <tag>`      | `--tag <tag>`      | `--tag <tag>`      | `--tag <tag>` | Publish tag                 |
+| `--access <level>`          | `--access <level>` | `--access <level>` | `--access <level>` | `--access <level>` | `--access`    | Public/restricted           |
+| `--otp <otp>`               | `--otp`            | `--otp`            | `--otp`            | `--otp`            | N/A           | One-time password           |
+| `--no-git-checks`           | `--no-git-checks`  | N/A                | N/A                | N/A                | N/A           | Skip git checks (pnpm)      |
+| `--publish-branch <branch>` | `--publish-branch` | N/A                | N/A                | N/A                | N/A           | Set publish branch (pnpm)   |
+| `--report-summary`          | `--report-summary` | N/A                | N/A                | N/A                | N/A           | Save publish summary (pnpm) |
+| `--force`                   | `--force`          | `--force`          | `--force`          | `--force`          | N/A           | Force publish               |
+| `--json`                    | `--json`           | N/A                | N/A                | N/A                | N/A           | JSON output (pnpm)          |
+| `-r, --recursive`           | `--recursive`      | `--workspaces`     | N/A                | N/A                | N/A           | Publish workspaces          |
+| `--filter <pattern>`        | `--filter`         | `--workspace`      | N/A                | N/A                | N/A           | Filter workspace            |
 
 **Note:**
 
@@ -986,12 +1005,12 @@ vp pm ping --registry https://custom-registry.com
 - https://classic.yarnpkg.com/en/docs/cli/owner (delegates to npm owner)
 - https://yarnpkg.com/cli/npm/owner (delegates to npm owner)
 
-| Vite+ Flag                | pnpm             | npm              | yarn@1           | yarn@2+          | Description         |
-| ------------------------- | ---------------- | ---------------- | ---------------- | ---------------- | ------------------- |
-| `vp pm owner list <pkg>`  | `npm owner list` | `npm owner list` | `npm owner list` | `npm owner list` | List package owners |
-| `vp pm owner add <u> <p>` | `npm owner add`  | `npm owner add`  | `npm owner add`  | `npm owner add`  | Add owner           |
-| `vp pm owner rm <u> <p>`  | `npm owner rm`   | `npm owner rm`   | `npm owner rm`   | `npm owner rm`   | Remove owner        |
-| `--otp <otp>`             | `--otp`          | `--otp`          | `--otp`          | `--otp`          | One-time password   |
+| Vite+ Flag                | pnpm             | npm              | yarn@1           | yarn@2+          | bun              | Description         |
+| ------------------------- | ---------------- | ---------------- | ---------------- | ---------------- | ---------------- | ------------------- |
+| `vp pm owner list <pkg>`  | `npm owner list` | `npm owner list` | `npm owner list` | `npm owner list` | `npm owner list` | List package owners |
+| `vp pm owner add <u> <p>` | `npm owner add`  | `npm owner add`  | `npm owner add`  | `npm owner add`  | `npm owner add`  | Add owner           |
+| `vp pm owner rm <u> <p>`  | `npm owner rm`   | `npm owner rm`   | `npm owner rm`   | `npm owner rm`   | `npm owner rm`   | Remove owner        |
+| `--otp <otp>`             | `--otp`          | `--otp`          | `--otp`          | `--otp`          | `--otp`          | One-time password   |
 
 **Note:**
 
@@ -1014,11 +1033,11 @@ vp pm ping --registry https://custom-registry.com
 - https://classic.yarnpkg.com/en/docs/cli/cache
 - https://yarnpkg.com/cli/cache
 
-| Vite+ Flag          | pnpm               | npm                    | yarn@1             | yarn@2+                       | Description          |
-| ------------------- | ------------------ | ---------------------- | ------------------ | ----------------------------- | -------------------- |
-| `vp pm cache dir`   | `pnpm store path`  | `npm config get cache` | `yarn cache dir`   | `yarn config get cacheFolder` | Show cache directory |
-| `vp pm cache path`  | Alias for `dir`    | Alias for `dir`        | Alias for `dir`    | Alias for `dir`               | Alias for dir        |
-| `vp pm cache clean` | `pnpm store prune` | `npm cache clean`      | `yarn cache clean` | `yarn cache clean`            | Clean cache          |
+| Vite+ Flag          | pnpm               | npm                    | yarn@1             | yarn@2+                       | bun               | Description          |
+| ------------------- | ------------------ | ---------------------- | ------------------ | ----------------------------- | ----------------- | -------------------- |
+| `vp pm cache dir`   | `pnpm store path`  | `npm config get cache` | `yarn cache dir`   | `yarn config get cacheFolder` | `bun pm cache`    | Show cache directory |
+| `vp pm cache path`  | Alias for `dir`    | Alias for `dir`        | Alias for `dir`    | Alias for `dir`               | Alias for `dir`   | Alias for dir        |
+| `vp pm cache clean` | `pnpm store prune` | `npm cache clean`      | `yarn cache clean` | `yarn cache clean`            | `bun pm cache rm` | Clean cache          |
 
 **Note:**
 
@@ -1044,15 +1063,15 @@ vp pm ping --registry https://custom-registry.com
 - https://classic.yarnpkg.com/en/docs/cli/config
 - https://yarnpkg.com/cli/config
 
-| Vite+ Flag                  | pnpm                 | npm                 | yarn@1               | yarn@2+                     | Description        |
-| --------------------------- | -------------------- | ------------------- | -------------------- | --------------------------- | ------------------ |
-| `vp pm config list`         | `pnpm config list`   | `npm config list`   | `yarn config list`   | `yarn config`               | List configuration |
-| `vp pm config get <key>`    | `pnpm config get`    | `npm config get`    | `yarn config get`    | `yarn config get`           | Get config value   |
-| `vp pm config set <k> <v>`  | `pnpm config set`    | `npm config set`    | `yarn config set`    | `yarn config set`           | Set config value   |
-| `vp pm config delete <key>` | `pnpm config delete` | `npm config delete` | `yarn config delete` | `yarn config unset`         | Delete config key  |
-| `--json`                    | `--json`             | `--json`            | `--json`             | `--json`                    | JSON output        |
-| `-g, --global`              | `--global`           | `--global`          | `--global`           | `--home`                    | Global config      |
-| `--location <location>`     | `--location`         | `--location`        | N/A                  | Maps to `--home` for global | Config location    |
+| Vite+ Flag                  | pnpm                 | npm                 | yarn@1               | yarn@2+                     | bun | Description        |
+| --------------------------- | -------------------- | ------------------- | -------------------- | --------------------------- | --- | ------------------ |
+| `vp pm config list`         | `pnpm config list`   | `npm config list`   | `yarn config list`   | `yarn config`               | N/A | List configuration |
+| `vp pm config get <key>`    | `pnpm config get`    | `npm config get`    | `yarn config get`    | `yarn config get`           | N/A | Get config value   |
+| `vp pm config set <k> <v>`  | `pnpm config set`    | `npm config set`    | `yarn config set`    | `yarn config set`           | N/A | Set config value   |
+| `vp pm config delete <key>` | `pnpm config delete` | `npm config delete` | `yarn config delete` | `yarn config unset`         | N/A | Delete config key  |
+| `--json`                    | `--json`             | `--json`            | `--json`             | `--json`                    | N/A | JSON output        |
+| `-g, --global`              | `--global`           | `--global`          | `--global`           | `--home`                    | N/A | Global config      |
+| `--location <location>`     | `--location`         | `--location`        | N/A                  | Maps to `--home` for global | N/A | Config location    |
 
 **Note:**
 
@@ -1087,11 +1106,11 @@ vp pm ping --registry https://custom-registry.com
 - https://classic.yarnpkg.com/en/docs/cli/login
 - https://yarnpkg.com/cli/npm/login
 
-| Vite+ Flag         | pnpm         | npm          | yarn@1       | yarn@2+          | Description          |
-| ------------------ | ------------ | ------------ | ------------ | ---------------- | -------------------- |
-| `vp pm login`      | `npm login`  | `npm login`  | `yarn login` | `yarn npm login` | Log in to registry   |
-| `--registry <url>` | `--registry` | `--registry` | `--registry` | `--registry`     | Registry URL         |
-| `--scope <scope>`  | `--scope`    | `--scope`    | `--scope`    | `--scope`        | Associate with scope |
+| Vite+ Flag         | pnpm         | npm          | yarn@1       | yarn@2+          | bun          | Description          |
+| ------------------ | ------------ | ------------ | ------------ | ---------------- | ------------ | -------------------- |
+| `vp pm login`      | `npm login`  | `npm login`  | `yarn login` | `yarn npm login` | `npm login`  | Log in to registry   |
+| `--registry <url>` | `--registry` | `--registry` | `--registry` | `--registry`     | `--registry` | Registry URL         |
+| `--scope <scope>`  | `--scope`    | `--scope`    | `--scope`    | `--scope`        | `--scope`    | Associate with scope |
 
 **Note:**
 
@@ -1114,11 +1133,11 @@ vp pm ping --registry https://custom-registry.com
 - https://classic.yarnpkg.com/en/docs/cli/logout
 - https://yarnpkg.com/cli/npm/logout
 
-| Vite+ Flag         | pnpm         | npm          | yarn@1        | yarn@2+           | Description           |
-| ------------------ | ------------ | ------------ | ------------- | ----------------- | --------------------- |
-| `vp pm logout`     | `npm logout` | `npm logout` | `yarn logout` | `yarn npm logout` | Log out from registry |
-| `--registry <url>` | `--registry` | `--registry` | `--registry`  | `--registry`      | Registry URL          |
-| `--scope <scope>`  | `--scope`    | `--scope`    | `--scope`     | `--scope`         | Scoped registry       |
+| Vite+ Flag         | pnpm         | npm          | yarn@1        | yarn@2+           | bun          | Description           |
+| ------------------ | ------------ | ------------ | ------------- | ----------------- | ------------ | --------------------- |
+| `vp pm logout`     | `npm logout` | `npm logout` | `yarn logout` | `yarn npm logout` | `npm logout` | Log out from registry |
+| `--registry <url>` | `--registry` | `--registry` | `--registry`  | `--registry`      | `--registry` | Registry URL          |
+| `--scope <scope>`  | `--scope`    | `--scope`    | `--scope`     | `--scope`         | `--scope`    | Scoped registry       |
 
 **Note:**
 
@@ -1140,10 +1159,10 @@ vp pm ping --registry https://custom-registry.com
 
 - https://yarnpkg.com/cli/npm/whoami
 
-| Vite+ Flag         | pnpm         | npm          | yarn@1     | yarn@2+           | Description         |
-| ------------------ | ------------ | ------------ | ---------- | ----------------- | ------------------- |
-| `vp pm whoami`     | `npm whoami` | `npm whoami` | N/A (warn) | `yarn npm whoami` | Show logged-in user |
-| `--registry <url>` | `--registry` | `--registry` | N/A        | `--registry`      | Registry URL        |
+| Vite+ Flag         | pnpm         | npm          | yarn@1     | yarn@2+           | bun             | Description         |
+| ------------------ | ------------ | ------------ | ---------- | ----------------- | --------------- | ------------------- |
+| `vp pm whoami`     | `npm whoami` | `npm whoami` | N/A (warn) | `yarn npm whoami` | `bun pm whoami` | Show logged-in user |
+| `--registry <url>` | `--registry` | `--registry` | N/A        | `--registry`      | N/A             | Registry URL        |
 
 **Note:**
 
@@ -1157,13 +1176,13 @@ vp pm ping --registry https://custom-registry.com
 
 - https://docs.npmjs.com/cli/v11/commands/npm-token
 
-| Vite+ Flag           | pnpm               | npm                | yarn@1     | yarn@2+    | Description      |
-| -------------------- | ------------------ | ------------------ | ---------- | ---------- | ---------------- |
-| `vp pm token list`   | `npm token list`   | `npm token list`   | N/A (warn) | N/A (warn) | List tokens      |
-| `vp pm token create` | `npm token create` | `npm token create` | N/A (warn) | N/A (warn) | Create token     |
-| `vp pm token revoke` | `npm token revoke` | `npm token revoke` | N/A (warn) | N/A (warn) | Revoke token     |
-| `--read-only`        | `--read-only`      | `--read-only`      | N/A        | N/A        | Read-only token  |
-| `--cidr <cidr>`      | `--cidr`           | `--cidr`           | N/A        | N/A        | CIDR restriction |
+| Vite+ Flag           | pnpm               | npm                | yarn@1     | yarn@2+    | bun        | Description      |
+| -------------------- | ------------------ | ------------------ | ---------- | ---------- | ---------- | ---------------- |
+| `vp pm token list`   | `npm token list`   | `npm token list`   | N/A (warn) | N/A (warn) | N/A (warn) | List tokens      |
+| `vp pm token create` | `npm token create` | `npm token create` | N/A (warn) | N/A (warn) | N/A (warn) | Create token     |
+| `vp pm token revoke` | `npm token revoke` | `npm token revoke` | N/A (warn) | N/A (warn) | N/A (warn) | Revoke token     |
+| `--read-only`        | `--read-only`      | `--read-only`      | N/A        | N/A        | N/A        | Read-only token  |
+| `--cidr <cidr>`      | `--cidr`           | `--cidr`           | N/A        | N/A        | N/A        | CIDR restriction |
 
 **Note:**
 
@@ -1185,13 +1204,13 @@ vp pm ping --registry https://custom-registry.com
 - https://classic.yarnpkg.com/en/docs/cli/audit
 - https://yarnpkg.com/cli/npm/audit
 
-| Vite+ Flag              | pnpm            | npm             | yarn@1          | yarn@2+                    | Description        |
-| ----------------------- | --------------- | --------------- | --------------- | -------------------------- | ------------------ |
-| `vp pm audit`           | `pnpm audit`    | `npm audit`     | `yarn audit`    | `yarn npm audit`           | Run security audit |
-| `--json`                | `--json`        | `--json`        | `--json`        | `--json`                   | JSON output        |
-| `--prod`                | `--prod`        | `--omit=dev`    | `--groups prod` | `--environment production` | Production only    |
-| `--audit-level <level>` | `--audit-level` | `--audit-level` | `--level`       | `--severity`               | Minimum severity   |
-| `fix`                   | `--fix`         | `npm audit fix` | N/A             | N/A                        | Auto-fix           |
+| Vite+ Flag              | pnpm            | npm             | yarn@1          | yarn@2+                    | bun             | Description        |
+| ----------------------- | --------------- | --------------- | --------------- | -------------------------- | --------------- | ------------------ |
+| `vp pm audit`           | `pnpm audit`    | `npm audit`     | `yarn audit`    | `yarn npm audit`           | `bun audit`     | Run security audit |
+| `--json`                | `--json`        | `--json`        | `--json`        | `--json`                   | `--json`        | JSON output        |
+| `--prod`                | `--prod`        | `--omit=dev`    | `--groups prod` | `--environment production` | N/A             | Production only    |
+| `--audit-level <level>` | `--audit-level` | `--audit-level` | `--level`       | `--severity`               | `--audit-level` | Minimum severity   |
+| `fix`                   | `--fix`         | `npm audit fix` | N/A             | N/A                        | N/A             | Auto-fix           |
 
 **Note:**
 
@@ -1213,12 +1232,12 @@ vp pm ping --registry https://custom-registry.com
 - https://classic.yarnpkg.com/en/docs/cli/tag
 - https://yarnpkg.com/cli/npm/tag
 
-| Vite+ Flag                       | pnpm                | npm                 | yarn@1          | yarn@2+             | Description       |
-| -------------------------------- | ------------------- | ------------------- | --------------- | ------------------- | ----------------- |
-| `vp pm dist-tag list <pkg>`      | `npm dist-tag list` | `npm dist-tag list` | `yarn tag list` | `yarn npm tag list` | List tags         |
-| `vp pm dist-tag add <pkg> <tag>` | `npm dist-tag add`  | `npm dist-tag add`  | `yarn tag add`  | `yarn npm tag add`  | Add tag           |
-| `vp pm dist-tag rm <pkg> <tag>`  | `npm dist-tag rm`   | `npm dist-tag rm`   | `yarn tag rm`   | `yarn npm tag rm`   | Remove tag        |
-| `--otp <otp>`                    | `--otp`             | `--otp`             | `--otp`         | `--otp`             | One-time password |
+| Vite+ Flag                       | pnpm                | npm                 | yarn@1          | yarn@2+             | bun                 | Description       |
+| -------------------------------- | ------------------- | ------------------- | --------------- | ------------------- | ------------------- | ----------------- |
+| `vp pm dist-tag list <pkg>`      | `npm dist-tag list` | `npm dist-tag list` | `yarn tag list` | `yarn npm tag list` | `npm dist-tag list` | List tags         |
+| `vp pm dist-tag add <pkg> <tag>` | `npm dist-tag add`  | `npm dist-tag add`  | `yarn tag add`  | `yarn npm tag add`  | `npm dist-tag add`  | Add tag           |
+| `vp pm dist-tag rm <pkg> <tag>`  | `npm dist-tag rm`   | `npm dist-tag rm`   | `yarn tag rm`   | `yarn npm tag rm`   | `npm dist-tag rm`   | Remove tag        |
+| `--otp <otp>`                    | `--otp`             | `--otp`             | `--otp`         | `--otp`             | `--otp`             | One-time password |
 
 **Note:**
 
@@ -1233,11 +1252,11 @@ vp pm ping --registry https://custom-registry.com
 
 - https://docs.npmjs.com/cli/v11/commands/npm-deprecate
 
-| Vite+ Flag                    | pnpm            | npm             | yarn@1          | yarn@2+         | Description         |
-| ----------------------------- | --------------- | --------------- | --------------- | --------------- | ------------------- |
-| `vp pm deprecate <pkg> <msg>` | `npm deprecate` | `npm deprecate` | `npm deprecate` | `npm deprecate` | Deprecate a package |
-| `--otp <otp>`                 | `--otp`         | `--otp`         | `--otp`         | `--otp`         | One-time password   |
-| `--registry <url>`            | `--registry`    | `--registry`    | `--registry`    | `--registry`    | Registry URL        |
+| Vite+ Flag                    | pnpm            | npm             | yarn@1          | yarn@2+         | bun             | Description         |
+| ----------------------------- | --------------- | --------------- | --------------- | --------------- | --------------- | ------------------- |
+| `vp pm deprecate <pkg> <msg>` | `npm deprecate` | `npm deprecate` | `npm deprecate` | `npm deprecate` | `npm deprecate` | Deprecate a package |
+| `--otp <otp>`                 | `--otp`         | `--otp`         | `--otp`         | `--otp`         | `--otp`         | One-time password   |
+| `--registry <url>`            | `--registry`    | `--registry`    | `--registry`    | `--registry`    | `--registry`    | Registry URL        |
 
 **Note:**
 
@@ -1250,12 +1269,12 @@ vp pm ping --registry https://custom-registry.com
 
 - https://docs.npmjs.com/cli/v11/commands/npm-search
 
-| Vite+ Flag             | pnpm            | npm             | yarn@1          | yarn@2+         | Description         |
-| ---------------------- | --------------- | --------------- | --------------- | --------------- | ------------------- |
-| `vp pm search <terms>` | `npm search`    | `npm search`    | `npm search`    | `npm search`    | Search for packages |
-| `--json`               | `--json`        | `--json`        | `--json`        | `--json`        | JSON output         |
-| `--long`               | `--long`        | `--long`        | `--long`        | `--long`        | Extended info       |
-| `--searchlimit <n>`    | `--searchlimit` | `--searchlimit` | `--searchlimit` | `--searchlimit` | Limit results       |
+| Vite+ Flag             | pnpm            | npm             | yarn@1          | yarn@2+         | bun             | Description         |
+| ---------------------- | --------------- | --------------- | --------------- | --------------- | --------------- | ------------------- |
+| `vp pm search <terms>` | `npm search`    | `npm search`    | `npm search`    | `npm search`    | `npm search`    | Search for packages |
+| `--json`               | `--json`        | `--json`        | `--json`        | `--json`        | `--json`        | JSON output         |
+| `--long`               | `--long`        | `--long`        | `--long`        | `--long`        | `--long`        | Extended info       |
+| `--searchlimit <n>`    | `--searchlimit` | `--searchlimit` | `--searchlimit` | `--searchlimit` | `--searchlimit` | Limit results       |
 
 **Note:**
 
@@ -1271,10 +1290,10 @@ vp pm ping --registry https://custom-registry.com
 
 - https://docs.npmjs.com/cli/v11/commands/npm-rebuild
 
-| Vite+ Flag               | pnpm                 | npm                 | yarn@1     | yarn@2+    | Description           |
-| ------------------------ | -------------------- | ------------------- | ---------- | ---------- | --------------------- |
-| `vp pm rebuild`          | `pnpm rebuild`       | `npm rebuild`       | N/A (warn) | N/A (warn) | Rebuild native addons |
-| `vp pm rebuild <pkg...>` | `pnpm rebuild <pkg>` | `npm rebuild <pkg>` | N/A (warn) | N/A (warn) | Rebuild specific pkgs |
+| Vite+ Flag               | pnpm                 | npm                 | yarn@1     | yarn@2+    | bun        | Description           |
+| ------------------------ | -------------------- | ------------------- | ---------- | ---------- | ---------- | --------------------- |
+| `vp pm rebuild`          | `pnpm rebuild`       | `npm rebuild`       | N/A (warn) | N/A (warn) | N/A (warn) | Rebuild native addons |
+| `vp pm rebuild <pkg...>` | `pnpm rebuild <pkg>` | `npm rebuild <pkg>` | N/A (warn) | N/A (warn) | N/A (warn) | Rebuild specific pkgs |
 
 **Note:**
 
@@ -1290,12 +1309,12 @@ vp pm ping --registry https://custom-registry.com
 
 - https://docs.npmjs.com/cli/v11/commands/npm-fund
 
-| Vite+ Flag         | pnpm       | npm        | yarn@1     | yarn@2+    | Description           |
-| ------------------ | ---------- | ---------- | ---------- | ---------- | --------------------- |
-| `vp pm fund`       | `npm fund` | `npm fund` | N/A (warn) | N/A (warn) | Show funding info     |
-| `vp pm fund <pkg>` | `npm fund` | `npm fund` | N/A (warn) | N/A (warn) | Fund for specific pkg |
-| `--json`           | `--json`   | `--json`   | N/A        | N/A        | JSON output           |
-| `--depth <n>`      | `--depth`  | `--depth`  | N/A        | N/A        | Limit depth           |
+| Vite+ Flag         | pnpm       | npm        | yarn@1     | yarn@2+    | bun        | Description           |
+| ------------------ | ---------- | ---------- | ---------- | ---------- | ---------- | --------------------- |
+| `vp pm fund`       | `npm fund` | `npm fund` | N/A (warn) | N/A (warn) | N/A (warn) | Show funding info     |
+| `vp pm fund <pkg>` | `npm fund` | `npm fund` | N/A (warn) | N/A (warn) | N/A (warn) | Fund for specific pkg |
+| `--json`           | `--json`   | `--json`   | N/A        | N/A        | N/A        | JSON output           |
+| `--depth <n>`      | `--depth`  | `--depth`  | N/A        | N/A        | N/A        | Limit depth           |
 
 **Note:**
 
@@ -1309,10 +1328,10 @@ vp pm ping --registry https://custom-registry.com
 
 - https://docs.npmjs.com/cli/v11/commands/npm-ping
 
-| Vite+ Flag         | pnpm         | npm          | yarn@1       | yarn@2+      | Description   |
-| ------------------ | ------------ | ------------ | ------------ | ------------ | ------------- |
-| `vp pm ping`       | `npm ping`   | `npm ping`   | `npm ping`   | `npm ping`   | Ping registry |
-| `--registry <url>` | `--registry` | `--registry` | `--registry` | `--registry` | Registry URL  |
+| Vite+ Flag         | pnpm         | npm          | yarn@1       | yarn@2+      | bun          | Description   |
+| ------------------ | ------------ | ------------ | ------------ | ------------ | ------------ | ------------- |
+| `vp pm ping`       | `npm ping`   | `npm ping`   | `npm ping`   | `npm ping`   | `npm ping`   | Ping registry |
+| `--registry <url>` | `--registry` | `--registry` | `--registry` | `--registry` | `--registry` | Registry URL  |
 
 **Note:**
 
@@ -2176,27 +2195,27 @@ Examples:
 
 ## Package Manager Compatibility
 
-| Subcommand | pnpm       | npm     | yarn@1     | yarn@2+          | Notes                                   |
-| ---------- | ---------- | ------- | ---------- | ---------------- | --------------------------------------- |
-| prune      | ✅ Full    | ✅ Full | ❌ N/A     | ❌ N/A           | npm uses --omit flags, yarn auto-prunes |
-| pack       | ✅ Full    | ✅ Full | ✅ Full    | ✅ Full          | All supported                           |
-| list/ls    | ✅ Full    | ✅ Full | ⚠️ Limited | ❌ N/A           | yarn@1 no -r, yarn@2+ not supported     |
-| view       | ✅ Full    | ✅ Full | ⚠️ `info`  | ⚠️ `info`        | yarn uses different name                |
-| publish    | ✅ Full    | ✅ Full | ✅ Full    | ⚠️ `npm publish` | yarn@2+ uses npm plugin                 |
-| owner      | ✅ Full    | ✅ Full | ✅ Full    | ⚠️ `npm owner`   | yarn@2+ uses npm plugin                 |
-| cache      | ⚠️ `store` | ✅ Full | ✅ Full    | ✅ Full          | pnpm uses different command             |
-| config     | ✅ Full    | ✅ Full | ✅ Full    | ⚠️ Different     | yarn@2+ has different API               |
-| login      | ✅ `npm`   | ✅ Full | ✅ Full    | ⚠️ `npm login`   | pnpm delegates to npm                   |
-| logout     | ✅ `npm`   | ✅ Full | ✅ Full    | ⚠️ `npm logout`  | pnpm delegates to npm                   |
-| whoami     | ✅ `npm`   | ✅ Full | ❌ N/A     | ⚠️ `npm whoami`  | yarn@1 not supported                    |
-| token      | ✅ `npm`   | ✅ Full | ❌ N/A     | ❌ N/A           | Always delegates to npm                 |
-| audit      | ✅ Full    | ✅ Full | ✅ Full    | ⚠️ `npm audit`   | yarn@2+ uses npm plugin                 |
-| dist-tag   | ✅ `npm`   | ✅ Full | ⚠️ `tag`   | ⚠️ `npm tag`     | Different command names                 |
-| deprecate  | ✅ `npm`   | ✅ Full | ✅ `npm`   | ✅ `npm`         | Always delegates to npm                 |
-| search     | ✅ `npm`   | ✅ Full | ✅ `npm`   | ✅ `npm`         | Always delegates to npm                 |
-| rebuild    | ✅ Full    | ✅ Full | ❌ N/A     | ❌ N/A           | yarn does not support                   |
-| fund       | ✅ `npm`   | ✅ Full | ❌ N/A     | ❌ N/A           | Always delegates to npm                 |
-| ping       | ✅ `npm`   | ✅ Full | ✅ `npm`   | ✅ `npm`         | Always delegates to npm                 |
+| Subcommand | pnpm       | npm     | yarn@1     | yarn@2+          | bun                | Notes                                   |
+| ---------- | ---------- | ------- | ---------- | ---------------- | ------------------ | --------------------------------------- |
+| prune      | ✅ Full    | ✅ Full | ❌ N/A     | ❌ N/A           | ❌ N/A             | npm uses --omit flags, yarn auto-prunes |
+| pack       | ✅ Full    | ✅ Full | ✅ Full    | ✅ Full          | ✅ `bun pm pack`   | bun uses `bun pm pack`                  |
+| list/ls    | ✅ Full    | ✅ Full | ⚠️ Limited | ❌ N/A           | ⚠️ `bun pm ls`     | bun has basic list support              |
+| view       | ✅ Full    | ✅ Full | ⚠️ `info`  | ⚠️ `info`        | ✅ `npm view`      | delegates to npm                        |
+| publish    | ✅ Full    | ✅ Full | ✅ Full    | ⚠️ `npm publish` | ✅ `bun publish`   | bun has native publish                  |
+| owner      | ✅ Full    | ✅ Full | ✅ Full    | ⚠️ `npm owner`   | ✅ `npm owner`     | delegates to npm                        |
+| cache      | ⚠️ `store` | ✅ Full | ✅ Full    | ✅ Full          | ⚠️ `bun pm cache`  | bun uses `bun pm cache`                 |
+| config     | ✅ Full    | ✅ Full | ✅ Full    | ⚠️ Different     | ❌ N/A             | bun has no config command               |
+| login      | ✅ `npm`   | ✅ Full | ✅ Full    | ⚠️ `npm login`   | ✅ `npm login`     | delegates to npm                        |
+| logout     | ✅ `npm`   | ✅ Full | ✅ Full    | ⚠️ `npm logout`  | ✅ `npm logout`    | delegates to npm                        |
+| whoami     | ✅ `npm`   | ✅ Full | ❌ N/A     | ⚠️ `npm whoami`  | ✅ `bun pm whoami` | bun has native whoami                   |
+| token      | ✅ `npm`   | ✅ Full | ❌ N/A     | ❌ N/A           | ❌ N/A             | Always delegates to npm                 |
+| audit      | ✅ Full    | ✅ Full | ✅ Full    | ⚠️ `npm audit`   | ✅ `bun audit`     | bun has native audit support            |
+| dist-tag   | ✅ `npm`   | ✅ Full | ⚠️ `tag`   | ⚠️ `npm tag`     | ✅ `npm dist-tag`  | delegates to npm                        |
+| deprecate  | ✅ `npm`   | ✅ Full | ✅ `npm`   | ✅ `npm`         | ✅ `npm deprecate` | Always delegates to npm                 |
+| search     | ✅ `npm`   | ✅ Full | ✅ `npm`   | ✅ `npm`         | ✅ `npm search`    | Always delegates to npm                 |
+| rebuild    | ✅ Full    | ✅ Full | ❌ N/A     | ❌ N/A           | ❌ N/A             | bun has no rebuild command              |
+| fund       | ✅ `npm`   | ✅ Full | ❌ N/A     | ❌ N/A           | ❌ N/A             | Always delegates to npm                 |
+| ping       | ✅ `npm`   | ✅ Full | ✅ `npm`   | ✅ `npm`         | ✅ `npm ping`      | Always delegates to npm                 |
 
 ## Future Enhancements
 
@@ -2308,7 +2327,7 @@ vp pm list --filter app
 
 ## Conclusion
 
-This RFC proposes adding `vp pm` command group to provide unified access to package manager utilities across pnpm/npm/yarn. The design:
+This RFC proposes adding `vp pm` command group to provide unified access to package manager utilities across pnpm/npm/yarn/bun. The design:
 
 - ✅ Pass-through architecture for maximum flexibility
 - ✅ Command name translation for common operations

--- a/rfcs/update-package-command.md
+++ b/rfcs/update-package-command.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Add `vp update` (alias: `vp up`) command that automatically adapts to the detected package manager (pnpm/yarn/npm) for updating packages to their latest versions within the specified semver range, with support for updating to absolute latest versions, workspace-aware operations, and interactive mode.
+Add `vp update` (alias: `vp up`) command that automatically adapts to the detected package manager (pnpm/yarn/npm/bun) for updating packages to their latest versions within the specified semver range, with support for updating to absolute latest versions, workspace-aware operations, and interactive mode.
 
 ## Motivation
 
@@ -106,21 +106,22 @@ vp update react --latest --no-save        # Test latest version without saving
 - https://yarnpkg.com/cli/up (yarn@2+)
 - https://classic.yarnpkg.com/en/docs/cli/upgrade (yarn@1)
 - https://docs.npmjs.com/cli/v11/commands/npm-update
+- https://bun.sh/docs/cli/update
 
-| Vite+ Flag             | pnpm                        | yarn@1               | yarn@2+                                     | npm                            | Description                                                |
-| ---------------------- | --------------------------- | -------------------- | ------------------------------------------- | ------------------------------ | ---------------------------------------------------------- |
-| `[packages]`           | `update [packages]`         | `upgrade [packages]` | `up [packages]`                             | `update [packages]`            | Update specific packages (or all if omitted)               |
-| `-L, --latest`         | `--latest` / `-L`           | `--latest`           | N/A (default behavior)                      | N/A                            | Update to latest version (ignore semver range)             |
-| `-g, --global`         | N/A                         | N/A                  | N/A                                         | `--global` / `-g`              | Update global packages                                     |
-| `-r, --recursive`      | `-r, --recursive`           | N/A                  | `--recursive` / `-R`                        | `--workspaces`                 | Update recursively in all workspace packages               |
-| `--filter <pattern>`   | `--filter <pattern> update` | N/A                  | `workspaces foreach --include <pattern> up` | `update --workspace <pattern>` | Target specific workspace package(s)                       |
-| `-w, --workspace-root` | `-w`                        | N/A                  | N/A                                         | `--include-workspace-root`     | Include workspace root                                     |
-| `-D, --dev`            | `--dev` / `-D`              | N/A                  | N/A                                         | `--include=dev`                | Update only devDependencies                                |
-| `-P, --prod`           | `--prod` / `-P`             | N/A                  | N/A                                         | `--include=prod`               | Update only dependencies and optionalDependencies          |
-| `-i, --interactive`    | `--interactive` / `-i`      | N/A                  | `--interactive` / `-i`                      | N/A                            | Show outdated packages and choose which to update          |
-| `--no-optional`        | `--no-optional`             | N/A                  | N/A                                         | `--no-optional`                | Don't update optionalDependencies                          |
-| `--no-save`            | `--no-save`                 | N/A                  | N/A                                         | `--no-save`                    | Update lockfile only, don't modify package.json            |
-| `--workspace`          | `--workspace`               | N/A                  | N/A                                         | N/A                            | Only update if package exists in workspace (pnpm-specific) |
+| Vite+ Flag             | pnpm                        | yarn@1               | yarn@2+                                     | npm                            | bun                    | Description                                                |
+| ---------------------- | --------------------------- | -------------------- | ------------------------------------------- | ------------------------------ | ---------------------- | ---------------------------------------------------------- |
+| `[packages]`           | `update [packages]`         | `upgrade [packages]` | `up [packages]`                             | `update [packages]`            | `update [packages]`    | Update specific packages (or all if omitted)               |
+| `-L, --latest`         | `--latest` / `-L`           | `--latest`           | N/A (default behavior)                      | N/A                            | `--latest`             | Update to latest version (ignore semver range)             |
+| `-g, --global`         | N/A                         | N/A                  | N/A                                         | `--global` / `-g`              | N/A                    | Update global packages                                     |
+| `-r, --recursive`      | `-r, --recursive`           | N/A                  | `--recursive` / `-R`                        | `--workspaces`                 | `--recursive` / `-r`   | Update recursively in all workspace packages               |
+| `--filter <pattern>`   | `--filter <pattern> update` | N/A                  | `workspaces foreach --include <pattern> up` | `update --workspace <pattern>` | N/A                    | Target specific workspace package(s)                       |
+| `-w, --workspace-root` | `-w`                        | N/A                  | N/A                                         | `--include-workspace-root`     | N/A                    | Include workspace root                                     |
+| `-D, --dev`            | `--dev` / `-D`              | N/A                  | N/A                                         | `--include=dev`                | N/A                    | Update only devDependencies                                |
+| `-P, --prod`           | `--prod` / `-P`             | N/A                  | N/A                                         | `--include=prod`               | `--production`         | Update only dependencies and optionalDependencies          |
+| `-i, --interactive`    | `--interactive` / `-i`      | N/A                  | `--interactive` / `-i`                      | N/A                            | `--interactive` / `-i` | Show outdated packages and choose which to update          |
+| `--no-optional`        | `--no-optional`             | N/A                  | N/A                                         | `--no-optional`                | `--omit optional`      | Don't update optionalDependencies                          |
+| `--no-save`            | `--no-save`                 | N/A                  | N/A                                         | `--no-save`                    | `--no-save`            | Update lockfile only, don't modify package.json            |
+| `--workspace`          | `--workspace`               | N/A                  | N/A                                         | N/A                            | N/A                    | Only update if package exists in workspace (pnpm-specific) |
 
 **Note**:
 
@@ -128,8 +129,9 @@ vp update react --latest --no-save        # Test latest version without saving
 - Yarn@2+ uses `up` or `upgrade` command, and updates to latest by default
 - Yarn@1 uses `upgrade` command
 - npm doesn't support `--latest` flag, it always updates within semver range
-- `--no-optional` skips updating optional dependencies (pnpm/npm only)
-- `--no-save` updates lockfile without modifying package.json (pnpm/npm only)
+- `--no-optional` skips updating optional dependencies (pnpm/npm/bun)
+- `--no-save` updates lockfile without modifying package.json (pnpm/npm/bun)
+- bun supports `--recursive`, `--latest`, `--interactive`, `--production`, `--omit optional`, and `--no-save` flags
 
 **Aliases:**
 
@@ -648,6 +650,7 @@ vp update react --range # Updates within semver range
 - yarn@4.x
 - npm@10.x
 - npm@11.x [WIP]
+- bun@1.x [WIP]
 
 ### Unit Tests
 
@@ -777,17 +780,17 @@ vp update --no-optional
 
 ## Package Manager Compatibility
 
-| Feature          | pnpm               | yarn@1           | yarn@2+          | npm              | Notes                      |
-| ---------------- | ------------------ | ---------------- | ---------------- | ---------------- | -------------------------- |
-| Update command   | `update`           | `upgrade`        | `up`             | `update`         | Different command names    |
-| Latest flag      | `--latest` / `-L`  | `--latest`       | N/A (default)    | ❌ Not supported | npm only updates in range  |
-| Interactive      | `--interactive`    | ❌ Not supported | `--interactive`  | ❌ Not supported | Limited support            |
-| Workspace filter | `--filter`         | ⚠️ Limited       | ⚠️ Limited       | `--workspace`    | pnpm most flexible         |
-| Recursive        | `--recursive`      | ❌ Not supported | `--recursive`    | `--workspaces`   | Different flags            |
-| Dev/Prod filter  | `--dev` / `--prod` | ❌ Not supported | ❌ Not supported | ❌ Not supported | pnpm only                  |
-| Global           | `-g`               | `global upgrade` | ❌ Not supported | `-g`             | Use npm for global         |
-| No optional      | `--no-optional`    | ❌ Not supported | ❌ Not supported | `--no-optional`  | Skip optional dependencies |
-| No save          | `--no-save`        | ❌ Not supported | ❌ Not supported | `--no-save`      | Lockfile only updates      |
+| Feature          | pnpm               | yarn@1           | yarn@2+          | npm              | bun                    | Notes                      |
+| ---------------- | ------------------ | ---------------- | ---------------- | ---------------- | ---------------------- | -------------------------- |
+| Update command   | `update`           | `upgrade`        | `up`             | `update`         | `update`               | Different command names    |
+| Latest flag      | `--latest` / `-L`  | `--latest`       | N/A (default)    | ❌ Not supported | `--latest`             | npm only updates in range  |
+| Interactive      | `--interactive`    | ❌ Not supported | `--interactive`  | ❌ Not supported | `--interactive` / `-i` | Limited support            |
+| Workspace filter | `--filter`         | ⚠️ Limited       | ⚠️ Limited       | `--workspace`    | N/A                    | pnpm most flexible         |
+| Recursive        | `--recursive`      | ❌ Not supported | `--recursive`    | `--workspaces`   | `--recursive` / `-r`   | bun supports --recursive   |
+| Dev/Prod filter  | `--dev` / `--prod` | ❌ Not supported | ❌ Not supported | ❌ Not supported | ❌ Not supported       | pnpm only                  |
+| Global           | `-g`               | `global upgrade` | ❌ Not supported | `-g`             | ❌ Not supported       | Use npm for global         |
+| No optional      | `--no-optional`    | ❌ Not supported | ❌ Not supported | `--no-optional`  | `--omit optional`      | Skip optional dependencies |
+| No save          | `--no-save`        | ❌ Not supported | ❌ Not supported | `--no-save`      | `--no-save`            | Lockfile only updates      |
 
 ## Future Enhancements
 
@@ -838,7 +841,7 @@ Continue? (Y/n)
 
 ## Conclusion
 
-This RFC proposes adding `vp update` command to provide a unified interface for updating packages across pnpm/yarn/npm. The design:
+This RFC proposes adding `vp update` command to provide a unified interface for updating packages across pnpm/yarn/npm/bun. The design:
 
 - ✅ Automatically adapts to detected package manager
 - ✅ Supports updating specific packages or all packages

--- a/rfcs/why-package-command.md
+++ b/rfcs/why-package-command.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Add `vp why` (alias: `vp explain`) command that automatically adapts to the detected package manager (pnpm/npm/yarn) for showing all packages that depend on a specified package. This helps developers understand dependency relationships, audit package usage, and debug dependency tree issues.
+Add `vp why` (alias: `vp explain`) command that automatically adapts to the detected package manager (pnpm/npm/yarn/bun) for showing all packages that depend on a specified package. This helps developers understand dependency relationships, audit package usage, and debug dependency tree issues.
 
 ## Motivation
 
@@ -138,22 +138,22 @@ vp why typescript -g            # Check globally installed packages
 - https://yarnpkg.com/cli/why (yarn@2+)
 - Identifies why a package has been installed
 
-| Vite+ Flag                | pnpm                      | npm                     | yarn@1              | yarn@2+                  | Description                                                     |
-| ------------------------- | ------------------------- | ----------------------- | ------------------- | ------------------------ | --------------------------------------------------------------- |
-| `vp why <pkg>`            | `pnpm why <pkg>`          | `npm explain <pkg>`     | `yarn why <pkg>`    | `yarn why <pkg> --peers` | Show why package is installed                                   |
-| `--json`                  | `--json`                  | `--json`                | `--json`            | `--json`                 | JSON output format                                              |
-| `--long`                  | `--long`                  | N/A                     | N/A                 | N/A                      | Verbose output (pnpm only)                                      |
-| `--parseable`             | `--parseable`             | N/A                     | N/A                 | N/A                      | Parseable format (pnpm only)                                    |
-| `-r, --recursive`         | `-r, --recursive`         | N/A                     | N/A                 | `--recursive`            | Check across all workspaces                                     |
-| `--filter <pattern>`      | `--filter <pattern>`      | `--workspace <pattern>` | N/A                 | N/A                      | Target specific workspace (pnpm/npm)                            |
-| `-w, --workspace-root`    | `-w`                      | N/A                     | N/A                 | N/A                      | Check in workspace root (pnpm-specific)                         |
-| `-P, --prod`              | `-P, --prod`              | N/A                     | N/A                 | N/A                      | Only production dependencies (pnpm only)                        |
-| `-D, --dev`               | `-D, --dev`               | N/A                     | N/A                 | N/A                      | Only dev dependencies (pnpm only)                               |
-| `--depth <number>`        | `--depth <number>`        | N/A                     | N/A                 | N/A                      | Limit tree depth (pnpm only)                                    |
-| `--no-optional`           | `--no-optional`           | N/A                     | `--ignore-optional` | N/A                      | Exclude optional dependencies (pnpm only)                       |
-| `-g, --global`            | `-g, --global`            | N/A                     | N/A                 | N/A                      | Check globally installed packages                               |
-| `--exclude-peers`         | `--exclude-peers`         | N/A                     | N/A                 | Removes `--peers` flag   | Exclude peer dependencies (yarn@2+ defaults to including peers) |
-| `--find-by <finder_name>` | `--find-by <finder_name>` | N/A                     | N/A                 | N/A                      | Use finder function from .pnpmfile.cjs                          |
+| Vite+ Flag                | pnpm                      | npm                     | yarn@1              | yarn@2+                  | bun             | Description                                                     |
+| ------------------------- | ------------------------- | ----------------------- | ------------------- | ------------------------ | --------------- | --------------------------------------------------------------- |
+| `vp why <pkg>`            | `pnpm why <pkg>`          | `npm explain <pkg>`     | `yarn why <pkg>`    | `yarn why <pkg> --peers` | `bun why <pkg>` | Show why package is installed                                   |
+| `--json`                  | `--json`                  | `--json`                | `--json`            | `--json`                 | N/A             | JSON output format                                              |
+| `--long`                  | `--long`                  | N/A                     | N/A                 | N/A                      | N/A             | Verbose output (pnpm only)                                      |
+| `--parseable`             | `--parseable`             | N/A                     | N/A                 | N/A                      | N/A             | Parseable format (pnpm only)                                    |
+| `-r, --recursive`         | `-r, --recursive`         | N/A                     | N/A                 | `--recursive`            | N/A             | Check across all workspaces                                     |
+| `--filter <pattern>`      | `--filter <pattern>`      | `--workspace <pattern>` | N/A                 | N/A                      | N/A             | Target specific workspace (pnpm/npm)                            |
+| `-w, --workspace-root`    | `-w`                      | N/A                     | N/A                 | N/A                      | N/A             | Check in workspace root (pnpm-specific)                         |
+| `-P, --prod`              | `-P, --prod`              | N/A                     | N/A                 | N/A                      | N/A             | Only production dependencies (pnpm only)                        |
+| `-D, --dev`               | `-D, --dev`               | N/A                     | N/A                 | N/A                      | N/A             | Only dev dependencies (pnpm only)                               |
+| `--depth <number>`        | `--depth <number>`        | N/A                     | N/A                 | N/A                      | `--depth`       | Limit tree depth (pnpm/bun)                                     |
+| `--no-optional`           | `--no-optional`           | N/A                     | `--ignore-optional` | N/A                      | N/A             | Exclude optional dependencies (pnpm only)                       |
+| `-g, --global`            | `-g, --global`            | N/A                     | N/A                 | N/A                      | N/A             | Check globally installed packages                               |
+| `--exclude-peers`         | `--exclude-peers`         | N/A                     | N/A                 | Removes `--peers` flag   | N/A             | Exclude peer dependencies (yarn@2+ defaults to including peers) |
+| `--find-by <finder_name>` | `--find-by <finder_name>` | N/A                     | N/A                 | N/A                      | N/A             | Use finder function from .pnpmfile.cjs                          |
 
 **Note:**
 
@@ -162,6 +162,7 @@ vp why typescript -g            # Check globally installed packages
 - yarn has `why` command in both v1 and v2+, but different output formats, only supports single package
 - pnpm has the most comprehensive filtering and output options
 - npm has simpler output focused on the dependency path
+- bun uses `bun why <pkg>` as a direct subcommand (not `bun pm why`); it provides a tree visualization of dependency relationships
 
 **Aliases:**
 
@@ -989,6 +990,7 @@ vp why react --json  # On yarn
 - yarn@4.x
 - npm@10.x
 - npm@11.x
+- bun@1.x [WIP]
 
 ### Unit Tests
 
@@ -1253,19 +1255,20 @@ vp why package --prod --json
 
 ## Package Manager Compatibility
 
-| Feature          | pnpm              | npm              | yarn@1           | yarn@2+          | Notes                   |
-| ---------------- | ----------------- | ---------------- | ---------------- | ---------------- | ----------------------- |
-| Basic command    | `why`             | `explain`        | `why`            | `why`            | npm uses different name |
-| Multiple pkgs    | ✅ Supported      | ✅ Supported     | ❌ Single only   | ❌ Single only   | pnpm and npm            |
-| Glob patterns    | ✅ Supported      | ❌ Not supported | ❌ Not supported | ❌ Not supported | pnpm only               |
-| JSON output      | ✅ `--json`       | ✅ `--json`      | ❌ Not supported | ❌ Not supported | pnpm and npm only       |
-| Long output      | ✅ `--long`       | ❌ Not supported | ❌ Not supported | ❌ Not supported | pnpm only               |
-| Parseable        | ✅ `--parseable`  | ❌ Not supported | ❌ Not supported | ❌ Not supported | pnpm only               |
-| Recursive        | ✅ `-r`           | ❌ Not supported | ❌ Not supported | ✅ `--recursive` | pnpm and yarn@2+        |
-| Workspace filter | ✅ `--filter`     | ✅ `--workspace` | ❌ Not supported | ❌ Not supported | pnpm and npm            |
-| Dep type filter  | ✅ `--prod/--dev` | ❌ Not supported | ❌ Not supported | ❌ Not supported | pnpm only               |
-| Depth limit      | ✅ `--depth`      | ❌ Not supported | ❌ Not supported | ❌ Not supported | pnpm only               |
-| Global check     | ✅ `-g`           | ❌ Not supported | ❌ Not supported | ❌ Not supported | pnpm only               |
+| Feature          | pnpm              | npm              | yarn@1           | yarn@2+          | bun              | Notes                   |
+| ---------------- | ----------------- | ---------------- | ---------------- | ---------------- | ---------------- | ----------------------- |
+| Basic command    | `why`             | `explain`        | `why`            | `why`            | `why`            | npm uses different name |
+| Multiple pkgs    | ✅ Supported      | ✅ Supported     | ❌ Single only   | ❌ Single only   | ❌ Single only   | pnpm and npm            |
+| Glob patterns    | ✅ Supported      | ❌ Not supported | ❌ Not supported | ❌ Not supported | ❌ Not supported | pnpm only               |
+| JSON output      | ✅ `--json`       | ✅ `--json`      | ❌ Not supported | ❌ Not supported | ❌ Not supported | pnpm and npm only       |
+| Long output      | ✅ `--long`       | ❌ Not supported | ❌ Not supported | ❌ Not supported | ❌ Not supported | pnpm only               |
+| Parseable        | ✅ `--parseable`  | ❌ Not supported | ❌ Not supported | ❌ Not supported | ❌ Not supported | pnpm only               |
+| Recursive        | ✅ `-r`           | ❌ Not supported | ❌ Not supported | ✅ `--recursive` | ❌ Not supported | pnpm and yarn@2+        |
+| Workspace filter | ✅ `--filter`     | ✅ `--workspace` | ❌ Not supported | ❌ Not supported | ❌ Not supported | pnpm and npm            |
+| Dep type filter  | ✅ `--prod/--dev` | ❌ Not supported | ❌ Not supported | ❌ Not supported | ❌ Not supported | pnpm only               |
+| Depth limit      | ✅ `--depth`      | ❌ Not supported | ❌ Not supported | ❌ Not supported | ✅ `--depth`     | pnpm and bun            |
+| Global check     | ✅ `-g`           | ❌ Not supported | ❌ Not supported | ❌ Not supported | ❌ Not supported | pnpm only               |
+| Tree view        | ❌ Not supported  | ❌ Not supported | ❌ Not supported | ❌ Not supported | ✅ Built-in      | bun shows tree view     |
 
 ## Future Enhancements
 
@@ -1365,7 +1368,7 @@ Total impact: 23.3MB
 
 ## Conclusion
 
-This RFC proposes adding `vp why` command to provide a unified interface for understanding dependency relationships across pnpm/npm/yarn. The design:
+This RFC proposes adding `vp why` command to provide a unified interface for understanding dependency relationships across pnpm/npm/yarn/bun. The design:
 
 - ✅ Automatically adapts to detected package manager
 - ✅ Supports multiple packages (pnpm) with graceful degradation


### PR DESCRIPTION
## Summary

Add bun as the 4th supported package manager alongside pnpm, npm, and yarn. Bun is added only as a package manager and runtime support is not planned.

Closes #557

## Changes

### Rust Core

- Add `Bun` variant to `PackageManagerType` enum
- Detect bun via `packageManager` field, `bun.lock`, `bun.lockb`, `bunfig.toml`
- Download platform-specific native binary from `@oven/bun-{os}-{arch}` npm packages (including musl variants)
- Add native binary shim support (non-Node.js wrappers for sh/cmd/ps1)
- Add `PackageManagerType::Bun` arms to all 30 command files with correct flag mappings
- Add bun to interactive package manager selection menu

### Command Mappings

- `bun install` with `--frozen-lockfile`, `--production`, `--ignore-scripts`, `--lockfile-only`, `--omit optional`, `--filter`
- `bun add` with `--dev`, `--peer`, `--optional`, `--exact`, `--global`
- `bun remove`, `bun update` (with `--latest`, `--interactive`, `--recursive`, `--production`)
- `bun outdated` (with `--filter`, `--recursive`, `--production`, `--omit optional`)
- `bun why` (with `--depth`), `bun x` (with `--package`), `bun audit` (with `--audit-level`)
- `bun pm pack` (with `--filename`, `--gzip-level`), `bun pm ls`, `bun pm cache`, `bun pm whoami`
- `bun info` for package view, `bun publish` for publishing
- Unsupported commands (deprecate, fund, owner, ping, search, token) fall back to npm silently

### Global CLI & NAPI

- Add `"bun"` to `PACKAGE_MANAGER_TOOLS` in shim dispatch
- Add `"bun" => PackageManagerType::Bun` in NAPI binding

### TypeScript

- Add `bun` to `PackageManager` type and selection prompt
- Add `--package-manager` flag to `vp create` for easier testing
- Handle bun in monorepo templates (uses `package.json` workspaces, not pnpm-workspace.yaml)
- Bun catalog support: write catalog entries to root `package.json` with `catalog:` references in both dependencies and overrides
- Migration: bun uses `overrides` with `catalog:` references (not raw versions)
- Use `bun x` instead of `bunx` for DLX commands (better cross-platform compatibility)

### Snap Tests & Output Sanitizer

- 10 bun command snap tests (add, remove, update, outdated, why, dlx, list, publish, view, cache)
- 1 bun monorepo creation snap test (`new-vite-monorepo-bun`) verifying catalog support
- Filter unstable bun output: `Resolving dependencies`, `Resolved, downloaded and extracted`, `Resolving...`, `Saved lockfile`, `(vX.Y.Z available)`

### RFCs

- Update all 11 package-manager RFCs with bun command mapping tables

### Ecosystem CI

- Add `bun-vite-template` (React + Mantine) test case

## Test plan

- [x] `cargo test -p vite_install` — 455 tests pass (18 new bun tests)
- [x] `cargo test -p vite_global_cli` — 311 tests pass
- [x] `pnpm -F vite-plus snap-test-global bun` — all 10 bun snap tests pass
- [x] `pnpm -F vite-plus snap-test-global new-vite-monorepo-bun` — catalog test passes
- [x] `pnpm -F vite-plus snap-test-global new-vite-monorepo` — existing pnpm test unaffected
- [x] Ecosystem CI clone verified locally for `bun-vite-template`
- [x] Windows native cmd shim tested (no command echo)
- [x] musl Linux binary detection tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)