### PR TITLE
chore: Fix editor list.

### DIFF
--- a/packages/cli/src/utils/editor.ts
+++ b/packages/cli/src/utils/editor.ts
@@ -184,10 +184,7 @@ export async function selectEditor({
     };
     const selectedEditor = await prompts.select({
       message: 'Which editor are you using?',
-      options:
-        editorOptions.length > 0
-          ? [editorOptions[0], noneOption, ...editorOptions.slice(1)]
-          : [noneOption],
+      options: [...editorOptions, noneOption],
       initialValue: 'vscode',
     });
 


### PR DESCRIPTION
Right now it says "VSCode, None, Zed", which is odd. We should list editors at the top, and "None" at the bottom.