### PR TITLE
fix(deps): upgrade cac to v7 to fix sync-remote major version conflict

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ catalogs:
       specifier: ^0.20.0
       version: 0.20.0
     cac:
-      specifier: ^6.7.14
-      version: 6.7.14
+      specifier: ^7.0.0
+      version: 7.0.0
     chalk:
       specifier: ^5.3.0
       version: 5.6.2
@@ -339,7 +339,7 @@ importers:
         version: link:../test
       cac:
         specifier: 'catalog:'
-        version: 6.7.14
+        version: 7.0.0
       cross-spawn:
         specifier: 'catalog:'
         version: 7.0.6
@@ -929,7 +929,7 @@ importers:
         version: 0.20.0
       cac:
         specifier: 'catalog:'
-        version: 6.7.14
+        version: 7.0.0
       consola:
         specifier: 'catalog:'
         version: 3.4.2
@@ -5078,10 +5078,6 @@ packages:
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
-
-  cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
 
   cac@7.0.0:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
@@ -12046,8 +12042,6 @@ snapshots:
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
-
-  cac@6.7.14: {}
 
   cac@7.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -49,7 +49,7 @@ catalog:
   astring: ^1.9.0
   bingo: ^0.9.2
   buble: ^0.20.0
-  cac: ^6.7.14
+  cac: ^7.0.0
   chalk: ^5.3.0
   change-case: ^5.4.4
   connect: ^3.7.0
@@ -161,7 +161,7 @@ overrides:
   rolldown: workspace:rolldown@*
   vite: workspace:@voidzero-dev/vite-plus-core@*
   vitest: workspace:@voidzero-dev/vite-plus-test@*
-  vitest-dev: 'npm:vitest@^4.1.0'
+  vitest-dev: npm:vitest@^4.1.0
 packageExtensions:
   sass-embedded:
     peerDependencies:


### PR DESCRIPTION
Rolldown upgraded to cac ^7.0.0 while our catalog still had ^6.7.14,
causing `pnpm tool sync-remote` to fail on incompatible major versions.