### PR TITLE
test(e2e): update dify to latest hash and add forceFreshMigration

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -246,6 +246,7 @@ jobs:
             command: |
               vp run type-check:tsgo
               vp run build
+              vp run build:vinext
               vp run test navigation-utils.test.ts real-browser-flicker.test.tsx workflow-parallel-limit.test.tsx
           - name: viteplus-ws-repro
             node-version: 24

--- a/ecosystem-ci/repo.json
+++ b/ecosystem-ci/repo.json
@@ -2,8 +2,9 @@
   "dify": {
     "repository": "https://github.com/langgenius/dify.git",
     "branch": "main",
-    "hash": "356a156f365a3c762f29303176defb28cbed3710",
-    "directory": "web"
+    "hash": "11e17871008f237d725960eafce7d3ecfe239ec4",
+    "directory": "web",
+    "forceFreshMigration": true
   },
   "skeleton": {
     "repository": "https://github.com/skeletonlabs/skeleton.git",


### PR DESCRIPTION
Dify has upgraded to vite-plus natively, so forceFreshMigration is now
needed. Also adds build:vinext (vinext build) to the test commands.