### PR TITLE
fix(create): use bundler module resolution in monorepo template

### DIFF
--- a/packages/cli/templates/monorepo/tsconfig.json
+++ b/packages/cli/templates/monorepo/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "noEmit": true,
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
+    "module": "preserve",
+    "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "esModuleInterop": true
   }


### PR DESCRIPTION
The monorepo template's tsconfig used nodenext module resolution which
requires explicit .js extensions on relative imports and breaks Vite
config type autocomplete. Switch to module: preserve and
moduleResolution: bundler which is correct for Vite projects.

Closes #1029