### PR TITLE
ci: migrate runner to namespace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,11 +72,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: namespace-profile-linux-x64-default
             target: x86_64-unknown-linux-gnu
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-          - os: macos-latest
+          - os: namespace-profile-mac-default
             target: aarch64-apple-darwin
     runs-on: ${{ matrix.os }}
     steps:
@@ -100,7 +100,7 @@ jobs:
           target-dir: ${{ runner.os == 'Windows' && format('{0}/target', env.DEV_DRIVE) || '' }}
 
       - run: rustup target add x86_64-unknown-linux-musl
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
 
       - run: cargo check --all-targets --all-features
         env:
@@ -114,7 +114,7 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.code-changed == 'true'
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/clone
@@ -146,7 +146,7 @@ jobs:
 
   run:
     name: Run task
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     needs:
       - download-previous-rolldown-binaries
     steps:
@@ -194,8 +194,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
-          - os: macos-latest
+          - os: namespace-profile-linux-x64-default
+          - os: namespace-profile-mac-default
           - os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:
@@ -232,10 +232,10 @@ jobs:
       - name: Build with upstream
         uses: ./.github/actions/build-upstream
         with:
-          target: ${{ matrix.os == 'ubuntu-latest' && 'x86_64-unknown-linux-gnu' ||  matrix.os == 'windows-latest' && 'x86_64-pc-windows-msvc' || 'aarch64-apple-darwin' }}
+          target: ${{ matrix.os == 'namespace-profile-linux-x64-default' && 'x86_64-unknown-linux-gnu' ||  matrix.os == 'windows-latest' && 'x86_64-pc-windows-msvc' || 'aarch64-apple-darwin' }}
 
       - name: Check TypeScript types
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'namespace-profile-linux-x64-default' }}
         run: pnpm tsgo
 
       - name: Install Global CLI vp
@@ -577,7 +577,7 @@ jobs:
     name: Local CLI `vp install` E2E test
     needs:
       - download-previous-rolldown-binaries
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
     # Run if: not a PR, OR PR has 'test: install-e2e' label
     if: >-
       github.event_name != 'pull_request' ||

--- a/README.md
+++ b/README.md
@@ -204,3 +204,7 @@ Or, if you are using Yarn:
   "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
 }
 ```
+
+## Sponsors
+
+Thanks to [namespace.so](https://namespace.so) for powering our CI/CD pipelines with fast, free macOS and Linux runners.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -202,3 +202,7 @@ Or, if you are using Yarn:
   "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
 }
 ```
+
+## Sponsors
+
+Thanks to [namespace.so](https://namespace.so) for powering our CI/CD pipelines with fast, free macOS and Linux runners.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> CI execution environment changes (runner images/labels and some OS-based conditionals), which can cause unexpected build/test differences or job routing issues. No production code or security-sensitive logic is modified.
> 
> **Overview**
> **CI now runs on Namespace-provided runners.** The workflow swaps `ubuntu-latest`/`macos-latest` for `namespace-profile-linux-x64-default` and `namespace-profile-mac-default` across `test`, `lint`, `run`, `cli-e2e-test`, and `install-e2e-test`.
> 
> It also adjusts a few conditionals to match the new matrix (e.g., using `matrix.target` for the Linux MUSL target install and updating the `build-upstream` target selection / TypeScript type-check gating).
> 
> Adds a **Sponsors** section to `README.md` and `packages/cli/README.md` crediting `namespace.so` for CI runners.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79985c4f67e73473215822d2256fbbdd681ebe3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->