### PR TITLE
fix(config): use `OxfmtConfig` instead of `FormatOptions` for fmt types

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,8 +1,8 @@
 import { type Plugin as VitestPlugin } from '@voidzero-dev/vite-plus-test/config';
+import type { OxfmtConfig } from 'oxfmt';
 import type { OxlintConfig } from 'oxlint';
 
 import { defineConfig } from './define-config.js';
-import type { FormatOptions } from './oxfmt-config';
 import type { PackUserConfig } from './pack';
 import type { RunConfig } from './run-config';
 import type { StagedConfig } from './staged-config';
@@ -14,7 +14,7 @@ declare module '@voidzero-dev/vite-plus-core' {
      */
     lint?: OxlintConfig;
 
-    fmt?: FormatOptions;
+    fmt?: OxfmtConfig;
 
     pack?: PackUserConfig | PackUserConfig[];
 

--- a/packages/cli/src/oxfmt-config.ts
+++ b/packages/cli/src/oxfmt-config.ts
@@ -1,1 +1,0 @@
-export type { FormatOptions, SortImportsOptions, TailwindcssOptions } from 'oxfmt';


### PR DESCRIPTION
fixes #1073

<img width="635" height="201" alt="Screenshot 2026-03-20 at 18 33 00" src="https://github.com/user-attachments/assets/8071661e-ec27-4ea4-a3e0-f014314bec32" />
