### PR TITLE
fix(install): support non-interactive installation for devcontainers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,8 @@
         }
       }
     }
-  }
+  },
+  "postCreateCommand": "curl -fsSL https://vite.plus | bash"
   // Use 'mounts' to make the cargo cache persistent in a Docker Volume.
   // "mounts": [
   // 	{

--- a/packages/cli/install.ps1
+++ b/packages/cli/install.ps1
@@ -205,6 +205,14 @@ function Setup-NodeManager {
 
     $binPath = "$InstallDir\bin"
 
+    # Explicit override via environment variable
+    if ($env:VITE_PLUS_NODE_MANAGER -eq "yes") {
+        Refresh-Shims -BinDir $BinDir
+        return "true"
+    } elseif ($env:VITE_PLUS_NODE_MANAGER -eq "no") {
+        return "false"
+    }
+
     # Check if Vite+ is already managing Node.js (bin\node.exe exists)
     if (Test-Path "$binPath\node.exe") {
         # Already managing Node.js, just refresh shims
@@ -212,8 +220,12 @@ function Setup-NodeManager {
         return "already"
     }
 
-    # Auto-enable on CI environment
-    if ($env:CI) {
+    # Auto-enable on CI or devcontainer environments
+    # CI: standard CI environment variable (GitHub Actions, Travis, CircleCI, etc.)
+    # CODESPACES: set by GitHub Codespaces (https://docs.github.com/en/codespaces)
+    # REMOTE_CONTAINERS: set by VS Code Dev Containers extension
+    # DEVPOD: set by DevPod (https://devpod.sh)
+    if ($env:CI -or $env:CODESPACES -or $env:REMOTE_CONTAINERS -or $env:DEVPOD) {
         Refresh-Shims -BinDir $BinDir
         return "true"
     }

--- a/packages/cli/install.sh
+++ b/packages/cli/install.sh
@@ -9,6 +9,7 @@
 #   VITE_PLUS_VERSION - Version to install (default: latest)
 #   VITE_PLUS_HOME - Installation directory (default: ~/.vite-plus)
 #   NPM_CONFIG_REGISTRY - Custom npm registry URL (default: https://registry.npmjs.org)
+#   VITE_PLUS_NODE_MANAGER - Set to "yes" or "no" to skip interactive prompt (for CI/devcontainers)
 #   VITE_PLUS_LOCAL_TGZ - Path to local vite-plus.tgz (for development/testing)
 
 set -e
@@ -442,6 +443,16 @@ setup_node_manager() {
     vp_bin="$bin_dir/vp.exe"
   fi
 
+  # Explicit override via environment variable
+  if [ "$VITE_PLUS_NODE_MANAGER" = "yes" ]; then
+    refresh_shims "$vp_bin"
+    NODE_MANAGER_ENABLED="true"
+    return 0
+  elif [ "$VITE_PLUS_NODE_MANAGER" = "no" ]; then
+    NODE_MANAGER_ENABLED="false"
+    return 0
+  fi
+
   # Check if Vite+ is already managing Node.js (bin/node or bin/node.exe exists)
   if [ -e "$bin_path/node" ] || [ -e "$bin_path/node.exe" ]; then
     refresh_shims "$vp_bin"
@@ -449,8 +460,12 @@ setup_node_manager() {
     return 0
   fi
 
-  # Auto-enable on CI environment
-  if [ -n "$CI" ]; then
+  # Auto-enable on CI or devcontainer environments
+  # CI: standard CI environment variable (GitHub Actions, Travis, CircleCI, etc.)
+  # CODESPACES: set by GitHub Codespaces (https://docs.github.com/en/codespaces)
+  # REMOTE_CONTAINERS: set by VS Code Dev Containers extension
+  # DEVPOD: set by DevPod (https://devpod.sh)
+  if [ -n "$CI" ] || [ -n "$CODESPACES" ] || [ -n "$REMOTE_CONTAINERS" ] || [ -n "$DEVPOD" ]; then
     refresh_shims "$vp_bin"
     NODE_MANAGER_ENABLED="true"
     return 0


### PR DESCRIPTION
Auto-detect devcontainer environments (GitHub Codespaces, VS Code Remote
Containers, DevPod) alongside CI to skip the interactive Node.js manager
prompt. Add VITE_PLUS_NODE_MANAGER env var for explicit override in other
non-interactive contexts. Add postCreateCommand to devcontainer.json.

Closes #1079