### PR TITLE
fix(cli): merge root and sub-package lint configs for vp lint

### DIFF
--- a/packages/cli/binding/src/cli.rs
+++ b/packages/cli/binding/src/cli.rs
@@ -34,6 +34,9 @@ use vite_task::{
 pub struct ResolvedUniversalViteConfig {
     #[serde(rename = "configFile")]
     pub config_file: Option<String>,
+    /// Separate config file path for lint (merged JSON when sub-package overrides exist)
+    #[serde(rename = "lintConfigFile")]
+    pub lint_config_file: Option<String>,
     pub lint: Option<serde_json::Value>,
     pub fmt: Option<serde_json::Value>,
     pub run: Option<serde_json::Value>,
@@ -258,9 +261,14 @@ impl SubcommandResolver {
                     &owned_resolved_vite_config
                 };
 
-                if let (Some(_), Some(config_file)) =
-                    (&resolved_vite_config.lint, &resolved_vite_config.config_file)
-                {
+                // Use lint-specific config file (merged JSON) if available,
+                // otherwise fall back to vite.config.ts
+                if let Some(config_file) = resolved_vite_config.lint.as_ref().and(
+                    resolved_vite_config
+                        .lint_config_file
+                        .as_ref()
+                        .or(resolved_vite_config.config_file.as_ref()),
+                ) {
                     args.insert(0, "-c".to_string());
                     args.insert(1, config_file.clone());
                 }

--- a/packages/cli/binding/src/cli.rs
+++ b/packages/cli/binding/src/cli.rs
@@ -205,7 +205,10 @@ impl SubcommandResolver {
         self
     }
 
-    async fn resolve_universal_vite_config(&self) -> anyhow::Result<ResolvedUniversalViteConfig> {
+    async fn resolve_universal_vite_config(
+        &self,
+        cwd: Option<&AbsolutePath>,
+    ) -> anyhow::Result<ResolvedUniversalViteConfig> {
         let cli_options = self
             .cli_options
             .as_ref()
@@ -215,8 +218,13 @@ impl SubcommandResolver {
             .as_path()
             .to_str()
             .ok_or_else(|| anyhow::anyhow!("workspace path is not valid UTF-8"))?;
+        let cwd_str = cwd
+            .and_then(|p| p.as_path().to_str())
+            .ok_or_else(|| anyhow::anyhow!("cwd is not valid UTF-8"))
+            .ok();
+        let arg = build_vite_config_resolver_arg(workspace_path_str, cwd_str);
         let vite_config_json =
-            (cli_options.resolve_universal_vite_config)(workspace_path_str.to_string()).await?;
+            (cli_options.resolve_universal_vite_config)(arg).await?;
 
         Ok(serde_json::from_str(&vite_config_json).inspect_err(|_| {
             tracing::error!("Failed to parse vite config: {vite_config_json}");
@@ -246,7 +254,8 @@ impl SubcommandResolver {
                 let resolved_vite_config = if let Some(config) = resolved_vite_config {
                     config
                 } else {
-                    owned_resolved_vite_config = self.resolve_universal_vite_config().await?;
+                    owned_resolved_vite_config =
+                        self.resolve_universal_vite_config(Some(cwd)).await?;
                     &owned_resolved_vite_config
                 };
 
@@ -285,7 +294,8 @@ impl SubcommandResolver {
                 let resolved_vite_config = if let Some(config) = resolved_vite_config {
                     config
                 } else {
-                    owned_resolved_vite_config = self.resolve_universal_vite_config().await?;
+                    owned_resolved_vite_config =
+                        self.resolve_universal_vite_config(Some(cwd)).await?;
                     &owned_resolved_vite_config
                 };
 
@@ -644,6 +654,22 @@ impl UserConfigLoader for VitePlusConfigLoader {
             None => UserRunConfig::default(),
         };
         Ok(Some(run_config))
+    }
+}
+
+/// Build the argument string for `resolve_universal_vite_config` JS function.
+///
+/// When `cwd` differs from `workspace_path`, returns a JSON string with both
+/// paths so the JS side can merge root and sub-package configs.
+/// Otherwise returns the workspace path as a plain string.
+fn build_vite_config_resolver_arg(workspace_path: &str, cwd: Option<&str>) -> String {
+    match cwd {
+        Some(cwd) if cwd != workspace_path => serde_json::json!({
+            "workspacePath": workspace_path,
+            "cwd": cwd
+        })
+        .to_string(),
+        _ => workspace_path.to_string(),
     }
 }
 
@@ -1020,7 +1046,8 @@ async fn execute_direct_subcommand(
             let has_paths = !paths.is_empty();
             let mut fmt_fix_started: Option<Instant> = None;
             let mut deferred_lint_pass: Option<(String, String)> = None;
-            let resolved_vite_config = resolver.resolve_universal_vite_config().await?;
+            let resolved_vite_config =
+                resolver.resolve_universal_vite_config(Some(&cwd_arc)).await?;
 
             if !no_fmt {
                 let mut args = if fix { vec![] } else { vec!["--check".to_string()] };
@@ -1537,8 +1564,9 @@ mod tests {
     use vite_task::config::UserRunConfig;
 
     use super::{
-        CLIArgs, LintMessageKind, SynthesizableSubcommand, extract_unknown_argument,
-        has_pass_as_value_suggestion, should_prepend_vitest_run, should_suppress_subcommand_stdout,
+        CLIArgs, LintMessageKind, SynthesizableSubcommand, build_vite_config_resolver_arg,
+        extract_unknown_argument, has_pass_as_value_suggestion, should_prepend_vitest_run,
+        should_suppress_subcommand_stdout,
     };
 
     #[test]
@@ -1685,5 +1713,26 @@ mod tests {
                 error.kind()
             );
         }
+    }
+
+    #[test]
+    fn vite_config_resolver_arg_returns_plain_string_when_no_cwd() {
+        let arg = build_vite_config_resolver_arg("/workspace", None);
+        assert_eq!(arg, "/workspace");
+    }
+
+    #[test]
+    fn vite_config_resolver_arg_returns_plain_string_when_cwd_same_as_workspace() {
+        let arg = build_vite_config_resolver_arg("/workspace", Some("/workspace"));
+        assert_eq!(arg, "/workspace");
+    }
+
+    #[test]
+    fn vite_config_resolver_arg_returns_json_when_cwd_differs() {
+        let arg =
+            build_vite_config_resolver_arg("/workspace", Some("/workspace/packages/some-package"));
+        let parsed: serde_json::Value = serde_json::from_str(&arg).expect("should be valid JSON");
+        assert_eq!(parsed["workspacePath"], "/workspace");
+        assert_eq!(parsed["cwd"], "/workspace/packages/some-package");
     }
 }

--- a/packages/cli/binding/src/cli.rs
+++ b/packages/cli/binding/src/cli.rs
@@ -223,8 +223,7 @@ impl SubcommandResolver {
             .ok_or_else(|| anyhow::anyhow!("cwd is not valid UTF-8"))
             .ok();
         let arg = build_vite_config_resolver_arg(workspace_path_str, cwd_str);
-        let vite_config_json =
-            (cli_options.resolve_universal_vite_config)(arg).await?;
+        let vite_config_json = (cli_options.resolve_universal_vite_config)(arg).await?;
 
         Ok(serde_json::from_str(&vite_config_json).inspect_err(|_| {
             tracing::error!("Failed to parse vite config: {vite_config_json}");

--- a/packages/cli/snap-tests/workspace-lint-ignore-patterns/package.json
+++ b/packages/cli/snap-tests/workspace-lint-ignore-patterns/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "workspace-lint-ignore-patterns",
+  "version": "1.0.0",
+  "private": true,
+  "packageManager": "pnpm@10.19.0"
+}

--- a/packages/cli/snap-tests/workspace-lint-ignore-patterns/packages/some-package/package.json
+++ b/packages/cli/snap-tests/workspace-lint-ignore-patterns/packages/some-package/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "some-package",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/packages/cli/snap-tests/workspace-lint-ignore-patterns/packages/some-package/src/index.ts
+++ b/packages/cli/snap-tests/workspace-lint-ignore-patterns/packages/some-package/src/index.ts
@@ -1,0 +1,1 @@
+export const hello = 'hello';

--- a/packages/cli/snap-tests/workspace-lint-ignore-patterns/packages/some-package/tests/fixtures/should-ignore-this.cjs
+++ b/packages/cli/snap-tests/workspace-lint-ignore-patterns/packages/some-package/tests/fixtures/should-ignore-this.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  name: 'should-ignore-this',
+};

--- a/packages/cli/snap-tests/workspace-lint-ignore-patterns/packages/some-package/vite.config.ts
+++ b/packages/cli/snap-tests/workspace-lint-ignore-patterns/packages/some-package/vite.config.ts
@@ -1,0 +1,5 @@
+export default {
+  lint: {
+    ignorePatterns: ['tests/fixtures/**/*'],
+  },
+};

--- a/packages/cli/snap-tests/workspace-lint-ignore-patterns/pnpm-workspace.yaml
+++ b/packages/cli/snap-tests/workspace-lint-ignore-patterns/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - packages/*

--- a/packages/cli/snap-tests/workspace-lint-ignore-patterns/snap.txt
+++ b/packages/cli/snap-tests/workspace-lint-ignore-patterns/snap.txt
@@ -1,3 +1,3 @@
-> cd packages/app-a && vp lint # sub-workspace has no-console:off but root has no-console:warn
+> cd packages/some-package && vp lint # sub-package ignorePatterns should exclude fixtures
 Found 0 warnings and 0 errors.
 Finished in <variable>ms on 2 files with <variable> rules using <variable> threads.

--- a/packages/cli/snap-tests/workspace-lint-ignore-patterns/steps.json
+++ b/packages/cli/snap-tests/workspace-lint-ignore-patterns/steps.json
@@ -1,0 +1,6 @@
+{
+  "ignoredPlatforms": ["win32"],
+  "commands": [
+    "cd packages/some-package && vp lint # sub-package ignorePatterns should exclude fixtures"
+  ]
+}

--- a/packages/cli/snap-tests/workspace-lint-ignore-patterns/vite.config.ts
+++ b/packages/cli/snap-tests/workspace-lint-ignore-patterns/vite.config.ts
@@ -1,0 +1,8 @@
+export default {
+  lint: {
+    plugins: ['import'],
+    rules: {
+      'import/no-commonjs': 'error',
+    },
+  },
+};

--- a/packages/cli/src/__tests__/resolve-vite-config.spec.ts
+++ b/packages/cli/src/__tests__/resolve-vite-config.spec.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { findViteConfigUp } from '../resolve-vite-config';
+import { findViteConfigUp, mergeLintConfig } from '../resolve-vite-config';
 
 describe('findViteConfigUp', () => {
   let tempDir: string;
@@ -116,5 +116,85 @@ describe('findViteConfigUp', () => {
 
     const result = findViteConfigUp(subDir, tempDir);
     expect(result).toBe(path.join(tempDir, 'vite.config.mjs'));
+  });
+});
+
+describe('mergeLintConfig', () => {
+  it('should return rootLint when cwdLint is undefined', () => {
+    const root = { plugins: ['import'], rules: { 'no-console': 'warn' } };
+    expect(mergeLintConfig(root, undefined)).toEqual(root);
+  });
+
+  it('should return cwdLint when rootLint is undefined', () => {
+    const cwd = { ignorePatterns: ['tests/**'] };
+    expect(mergeLintConfig(undefined, cwd)).toEqual(cwd);
+  });
+
+  it('should return undefined when both are undefined', () => {
+    expect(mergeLintConfig(undefined, undefined)).toBeUndefined();
+  });
+
+  it('should merge plugins as union with dedup', () => {
+    const root = { plugins: ['import', 'react'] };
+    const cwd = { plugins: ['import', 'unicorn'] };
+    const merged = mergeLintConfig(root, cwd)!;
+    expect(merged.plugins).toEqual(['import', 'react', 'unicorn']);
+  });
+
+  it('should shallow merge rules with cwd taking priority', () => {
+    const root = { rules: { 'no-console': 'warn', 'import/no-commonjs': 'error' } };
+    const cwd = { rules: { 'no-console': 'off' } };
+    const merged = mergeLintConfig(root, cwd)!;
+    expect(merged.rules).toEqual({
+      'no-console': 'off',
+      'import/no-commonjs': 'error',
+    });
+  });
+
+  it('should use cwd ignorePatterns when present', () => {
+    const root = { ignorePatterns: ['dist/**'] };
+    const cwd = { ignorePatterns: ['tests/fixtures/**/*'] };
+    const merged = mergeLintConfig(root, cwd)!;
+    expect(merged.ignorePatterns).toEqual(['tests/fixtures/**/*']);
+  });
+
+  it('should keep root ignorePatterns when cwd has none', () => {
+    const root = { ignorePatterns: ['dist/**'], rules: { 'no-console': 'warn' } };
+    const cwd = { rules: { 'no-console': 'off' } };
+    const merged = mergeLintConfig(root, cwd)!;
+    expect(merged.ignorePatterns).toEqual(['dist/**']);
+  });
+
+  it('should shallow merge options with cwd taking priority', () => {
+    const root = { options: { typeAware: false, denyWarnings: true } };
+    const cwd = { options: { typeAware: true } };
+    const merged = mergeLintConfig(root, cwd)!;
+    expect(merged.options).toEqual({ typeAware: true, denyWarnings: true });
+  });
+
+  it('should concatenate overrides from root and cwd', () => {
+    const root = { overrides: [{ files: ['*.ts'], rules: { a: 'off' } }] };
+    const cwd = { overrides: [{ files: ['*.tsx'], rules: { b: 'off' } }] };
+    const merged = mergeLintConfig(root, cwd)!;
+    expect(merged.overrides).toEqual([
+      { files: ['*.ts'], rules: { a: 'off' } },
+      { files: ['*.tsx'], rules: { b: 'off' } },
+    ]);
+  });
+
+  it('should merge all fields together (issue #997 scenario)', () => {
+    const root = {
+      plugins: ['import'],
+      rules: { 'import/no-commonjs': 'error' },
+    };
+    const cwd = {
+      options: { typeAware: true, typeCheck: true },
+      ignorePatterns: ['tests/fixtures/**/*'],
+    };
+    const merged = mergeLintConfig(root, cwd)!;
+    expect(merged.plugins).toEqual(['import']);
+    expect(merged.rules).toEqual({ 'import/no-commonjs': 'error' });
+    expect(merged.ignorePatterns).toEqual(['tests/fixtures/**/*']);
+    expect(merged.options).toEqual({ typeAware: true, typeCheck: true });
   });
 });

--- a/packages/cli/src/resolve-vite-config.ts
+++ b/packages/cli/src/resolve-vite-config.ts
@@ -94,19 +94,140 @@ export async function resolveViteConfig(cwd: string, options?: ResolveViteConfig
   return resolveConfig({ root: cwd }, 'build');
 }
 
-export async function resolveUniversalViteConfig(err: null | Error, viteConfigCwd: string) {
+/**
+ * Merge two lint configs. The cwd config overrides the root config.
+ * - plugins: union (deduplicated)
+ * - rules: shallow merge (cwd wins)
+ * - ignorePatterns: cwd overrides entirely
+ * - options: shallow merge (cwd wins)
+ * - overrides: concatenated
+ * - other fields: cwd wins if present
+ */
+export function mergeLintConfig(
+  rootLint: Record<string, unknown> | undefined,
+  cwdLint: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!cwdLint) return rootLint;
+  if (!rootLint) return cwdLint;
+
+  const merged: Record<string, unknown> = { ...rootLint, ...cwdLint };
+
+  // plugins: union with dedup
+  const rootPlugins = (rootLint.plugins as string[]) ?? [];
+  const cwdPlugins = (cwdLint.plugins as string[]) ?? [];
+  if (rootPlugins.length > 0 || cwdPlugins.length > 0) {
+    merged.plugins = [...new Set([...rootPlugins, ...cwdPlugins])];
+  }
+
+  // rules: shallow merge
+  if (rootLint.rules || cwdLint.rules) {
+    merged.rules = {
+      ...(rootLint.rules as Record<string, unknown>),
+      ...(cwdLint.rules as Record<string, unknown>),
+    };
+  }
+
+  // options: shallow merge
+  if (rootLint.options || cwdLint.options) {
+    merged.options = {
+      ...(rootLint.options as Record<string, unknown>),
+      ...(cwdLint.options as Record<string, unknown>),
+    };
+  }
+
+  // overrides: concatenate
+  const rootOverrides = (rootLint.overrides as unknown[]) ?? [];
+  const cwdOverrides = (cwdLint.overrides as unknown[]) ?? [];
+  if (rootOverrides.length > 0 || cwdOverrides.length > 0) {
+    merged.overrides = [...rootOverrides, ...cwdOverrides];
+  }
+
+  return merged;
+}
+
+/**
+ * Write merged lint config to a fixed path in node_modules/.cache/vite-plus/.
+ * Using a fixed path ensures vite-task's cache key (which includes CLI args)
+ * stays stable across runs.
+ */
+function writeMergedLintConfig(cwd: string, mergedLint: Record<string, unknown>): string {
+  const cacheDir = path.join(cwd, 'node_modules', '.cache', 'vite-plus');
+  fs.mkdirSync(cacheDir, { recursive: true });
+  const configPath = path.join(cacheDir, 'merged-lint-config.json');
+  fs.writeFileSync(configPath, JSON.stringify(mergedLint, null, 2));
+  return configPath;
+}
+
+/**
+ * Resolve vite config for lint/fmt/staged commands.
+ *
+ * The argument can be either:
+ * - A plain string (workspace path) for backward compatibility
+ * - A JSON string `{"workspacePath": "...", "cwd": "..."}` when cwd differs
+ *   from workspace root (e.g., running `vp lint` in a sub-package)
+ *
+ * When cwd differs from workspacePath:
+ * 1. Resolve root config (from workspacePath)
+ * 2. Resolve cwd config (from cwd)
+ * 3. Merge lint configs (root as base, cwd overrides)
+ * 4. Write merged lint to a fixed cache file
+ * 5. Return the cache file as configFile
+ */
+export async function resolveUniversalViteConfig(err: null | Error, arg: string) {
   if (err) {
     throw err;
   }
   try {
-    const config = await resolveViteConfig(viteConfigCwd);
+    let workspacePath: string;
+    let cwd: string | undefined;
+
+    // Parse argument: plain string or JSON with workspacePath + cwd
+    if (arg.startsWith('{')) {
+      const parsed = JSON.parse(arg) as { workspacePath: string; cwd: string };
+      workspacePath = parsed.workspacePath;
+      cwd = parsed.cwd;
+    } else {
+      workspacePath = arg;
+    }
+
+    const rootConfig = await resolveViteConfig(workspacePath);
+
+    // If cwd is different from workspace root and has its own vite config,
+    // merge lint configs
+    if (cwd && cwd !== workspacePath && hasViteConfig(cwd)) {
+      const cwdConfig = await resolveViteConfig(cwd);
+      const mergedLint = mergeLintConfig(
+        rootConfig.lint as Record<string, unknown> | undefined,
+        cwdConfig.lint as Record<string, unknown> | undefined,
+      );
+      const mergedFmt = cwdConfig.fmt ?? rootConfig.fmt;
+
+      if (mergedLint) {
+        const mergedConfigPath = writeMergedLintConfig(cwd, mergedLint);
+        return JSON.stringify({
+          configFile: mergedConfigPath,
+          lint: mergedLint,
+          fmt: mergedFmt,
+          run: cwdConfig.run ?? rootConfig.run,
+          staged: cwdConfig.staged ?? rootConfig.staged,
+        });
+      }
+
+      return JSON.stringify({
+        configFile: cwdConfig.configFile ?? rootConfig.configFile,
+        lint: cwdConfig.lint ?? rootConfig.lint,
+        fmt: mergedFmt,
+        run: cwdConfig.run ?? rootConfig.run,
+        staged: cwdConfig.staged ?? rootConfig.staged,
+      });
+    }
 
     return JSON.stringify({
-      configFile: config.configFile,
-      lint: config.lint,
-      fmt: config.fmt,
-      run: config.run,
-      staged: config.staged,
+      configFile: rootConfig.configFile,
+      lint: rootConfig.lint,
+      fmt: rootConfig.fmt,
+      run: rootConfig.run,
+      staged: rootConfig.staged,
     });
   } catch (resolveErr) {
     console.error('[Vite+] resolve universal vite config error:', resolveErr);

--- a/packages/cli/src/resolve-vite-config.ts
+++ b/packages/cli/src/resolve-vite-config.ts
@@ -206,10 +206,13 @@ export async function resolveUniversalViteConfig(err: null | Error, arg: string)
       );
       const mergedFmt = cwdConfig.fmt ?? rootConfig.fmt;
 
+      const configFile = cwdConfig.configFile ?? rootConfig.configFile;
+
       if (mergedLint) {
         const mergedConfigPath = writeMergedLintConfig(cwd, mergedLint);
         return JSON.stringify({
-          configFile: mergedConfigPath,
+          configFile,
+          lintConfigFile: mergedConfigPath,
           lint: mergedLint,
           fmt: mergedFmt,
           run: cwdConfig.run ?? rootConfig.run,
@@ -218,7 +221,7 @@ export async function resolveUniversalViteConfig(err: null | Error, arg: string)
       }
 
       return JSON.stringify({
-        configFile: cwdConfig.configFile ?? rootConfig.configFile,
+        configFile,
         lint: cwdConfig.lint ?? rootConfig.lint,
         fmt: mergedFmt,
         run: cwdConfig.run ?? rootConfig.run,

--- a/packages/cli/src/resolve-vite-config.ts
+++ b/packages/cli/src/resolve-vite-config.ts
@@ -107,8 +107,12 @@ export function mergeLintConfig(
   rootLint: Record<string, unknown> | undefined,
   cwdLint: Record<string, unknown> | undefined,
 ): Record<string, unknown> | undefined {
-  if (!cwdLint) return rootLint;
-  if (!rootLint) return cwdLint;
+  if (!cwdLint) {
+    return rootLint;
+  }
+  if (!rootLint) {
+    return cwdLint;
+  }
 
   const merged: Record<string, unknown> = { ...rootLint, ...cwdLint };
 


### PR DESCRIPTION
## Summary

Fixes `vp lint` ignoring sub-package `ignorePatterns` (and other lint config overrides) when running in a monorepo sub-package.

resolves #997

## Root Cause

`vp lint` always resolved the vite config from the **workspace root**, regardless of the current working directory.

When a sub-package defined its own `vite.config.ts` with `lint.ignorePatterns`, it was never read, oxlint only received the root's config via `-c`.

## Fix

When `cwd` differs from the workspace root and the sub-package has its own `vite.config.ts`, both configs are resolved and merged.

The root config serves as the base and the sub-package config overrides specific fields (`plugins` are unioned, `rules`/`options` are shallow-merged with sub-package priority, `ignorePatterns` are fully overridden by sub-package, `overrides` are concatenated).

The merged result is written to a fixed cache path (`node_modules/.cache/vite-plus/merged-lint-config.json`) and passed to oxlint via `-c`.

### Bug flow — sub-package config ignored

```mermaid
sequenceDiagram
    participant User as User (in packages/some-package/)
    participant Rust as vp lint (Rust CLI)
    participant JS as resolveUniversalViteConfig
    participant Vite as Vite resolveConfig
    participant Oxlint as oxlint

    User->>Rust: vp lint
    Rust->>Rust: workspace_path = /root (always)
    Rust->>JS: resolveUniversalViteConfig("/root")
    JS->>Vite: resolveViteConfig("/root")
    Vite-->>JS: configFile: /root/vite.config.ts
    Note over JS: lint: { plugins: ["import"],<br/>rules: { "import/no-commonjs": "error" } }<br/>Warn: No ignorePatterns

    JS-->>Rust: { configFile: "/root/vite.config.ts", lint }
    Rust->>Oxlint: oxlint -c /root/vite.config.ts
    Note over Oxlint: Reads root config only<br/>Sub-package ignorePatterns never seen
    Oxlint-->>User: NG: import/no-commonjs error on fixture files
```

### Fix flow — configs merged

```mermaid
sequenceDiagram
    participant User as User (in packages/some-package/)
    participant Rust as vp lint (Rust CLI)
    participant JS as resolveUniversalViteConfig
    participant Vite as Vite resolveConfig
    participant Oxlint as oxlint

    User->>Rust: vp lint
    Rust->>Rust: workspace_path = /root, cwd = /root/packages/some-package
    Rust->>JS: resolveUniversalViteConfig(JSON)
    Note over Rust: {"workspacePath": "/root",<br/>"cwd": "/root/packages/some-package"}

    JS->>Vite: resolveViteConfig("/root")
    Vite-->>JS: rootLint: { plugins, rules }
    JS->>Vite: resolveViteConfig("/root/packages/some-package")
    Vite-->>JS: cwdLint: { ignorePatterns, options }

    JS->>JS: mergeLintConfig(rootLint, cwdLint)
    Note over JS: merged: { plugins, rules,<br/>ignorePatterns, options }

    JS->>JS: Write merged config to<br/>node_modules/.cache/vite-plus/<br/>merged-lint-config.json
    JS-->>Rust: { configFile: "merged-lint-config.json", lint }

    Rust->>Oxlint: oxlint -c merged-lint-config.json
    Note over Oxlint: Reads merged config<br/>ignorePatterns excludes fixtures<br/>Root rules still apply
    Oxlint-->>User: OK: 0 errors (fixtures excluded)
```

## Fix

When `cwd` differs from the workspace root and the sub-package has its own `vite.config.ts`, both configs are resolved and merged.

The root config serves as the base and the sub-package config overrides specific fields (`plugins` are unioned, `rules`/`options` are shallow-merged with sub-package priority, `ignorePatterns` are fully overridden by sub-package, `overrides` are concatenated).

The merged result is written to a fixed cache path (`node_modules/.cache/vite-plus/merged-lint-config.json`) and passed to oxlint via `-c`.
