### PR TITLE
docs: add manual package-manager install path for vp

### DIFF
--- a/docs/guide/implode.md
+++ b/docs/guide/implode.md
@@ -6,6 +6,13 @@ Use `vp implode` to remove `vp` and all related Vite+ data from your machine.
 
 `vp implode` is the cleanup command for removing a Vite+ installation and its managed data. Use it if you no longer want Vite+ to manage your runtime, package manager, and related local tooling state.
 
+If you installed `vite-plus` globally with npm or pnpm, `vp implode` does not remove that package-manager installation. In that case, uninstall it with the same package manager you used to install it:
+
+```bash
+npm uninstall -g vite-plus
+pnpm remove -g vite-plus
+```
+
 ::: info
 If you decide Vite+ is not for you, please [share your feedback with us](https://discord.gg/cAnsqHh5PX).
 :::

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -24,6 +24,27 @@ After installation, open a new shell and run:
 vp help
 ```
 
+### Install with npm or pnpm
+
+If you prefer not to pipe a remote script into your shell, you can install the published `vite-plus` package globally with a package manager instead:
+
+```bash
+npm install -g vite-plus
+# or
+pnpm add -g vite-plus
+```
+
+After installing, open a new shell and run `vp help`.
+
+If your shell cannot find `vp`, make sure your package manager's global bin directory is on your `PATH`. For `pnpm`, you may need to run `pnpm setup` first.
+
+This installation path is more manual than the install script:
+
+- It does not modify your shell profile for you.
+- It does not automatically create the `node`, `npm`, and `npx` shims in `VITE_PLUS_HOME/bin`.
+- If you want Vite+ to manage those shims after installing, run `vp env setup`.
+- If you want to keep your system Node.js first, run `vp env off`.
+
 ::: info
 Vite+ will manage your global Node.js runtime and package manager. If you'd like to opt out of this behavior, run `vp env off`. If you realize Vite+ is not for you, type `vp implode`, but please [share your feedback with us](https://discord.gg/cAnsqHh5PX).
 :::

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -41,9 +41,8 @@ If your shell cannot find `vp`, make sure your package manager's global bin dire
 This installation path is more manual than the install script:
 
 - It does not modify your shell profile for you.
-- It does not automatically create the `node`, `npm`, and `npx` shims in `VITE_PLUS_HOME/bin`.
-- If you want Vite+ to manage those shims after installing, run `vp env setup`.
-- If you want to keep your system Node.js first, run `vp env off`.
+- It does not create the Vite+-managed installation layout under `VITE_PLUS_HOME` that the install script uses.
+- `vp implode` does not uninstall npm/pnpm global installs. Use `npm uninstall -g vite-plus` or `pnpm remove -g vite-plus` if you installed it this way.
 
 ::: info
 Vite+ will manage your global Node.js runtime and package manager. If you'd like to opt out of this behavior, run `vp env off`. If you realize Vite+ is not for you, type `vp implode`, but please [share your feedback with us](https://discord.gg/cAnsqHh5PX).

--- a/docs/guide/upgrade.md
+++ b/docs/guide/upgrade.md
@@ -17,6 +17,13 @@ You can upgrade both of them independently.
 vp upgrade
 ```
 
+If you installed `vite-plus` globally with npm or pnpm instead of the install script, update it with the same package manager:
+
+```bash
+npm install -g vite-plus@latest
+pnpm add -g vite-plus@latest
+```
+
 ## Local `vite-plus`
 
 Update the project dependency with the package manager commands in Vite+:


### PR DESCRIPTION
## Summary

Add a manual package-manager-based installation path for `vp` to the docs.

## Changes

- add `npm install -g vite-plus` and `pnpm add -g vite-plus` to `/guide/`
- add follow-up notes for `PATH`, `pnpm setup`, `vp env setup`, and `vp env off`
- add matching npm/pnpm upgrade commands to `/guide/upgrade`

## Verification

- verified the docs gap still exists on current `main`
- tested `npm install -g vite-plus` in an isolated temp prefix
- tested `pnpm add -g vite-plus` in an isolated temp global environment
- tested upgrade with:
  - `npm install -g vite-plus@latest`
  - `pnpm add -g vite-plus@latest`
- ran `cd docs && pnpm install && pnpm build`
