### PR TITLE
fix(create): add `.claude/worktrees/` to monorepo template gitignore

### DIFF
--- a/packages/cli/templates/monorepo/_gitignore
+++ b/packages/cli/templates/monorepo/_gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# AI agent worktrees
+.claude/worktrees/


### PR DESCRIPTION
## Summary

- Add `.claude/worktrees/` to the monorepo template's `_gitignore` so that projects created with `vp create` ignore Claude Code worktree files by default
- This prevents oxlint/oxfmt from reporting false warnings on worktree files, since both tools respect `.gitignore` via the `ignore` crate's `WalkBuilder`

Closes #1106