### PR TITLE
fix(deps): use native OS certificate store for TLS on non-Windows platforms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2302,11 +2302,11 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -4882,6 +4882,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4899,7 +4900,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -5854,6 +5854,18 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -7765,15 +7777,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/crates/vite_error/Cargo.toml
+++ b/crates/vite_error/Cargo.toml
@@ -29,7 +29,7 @@ wax = { workspace = true }
 reqwest = { workspace = true, features = ["stream", "native-tls-vendored", "json"] }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
-reqwest = { workspace = true, features = ["stream", "rustls-tls", "json"] }
+reqwest = { workspace = true, features = ["stream", "rustls-tls-native-roots", "json"] }
 
 [lib]
 test = false

--- a/crates/vite_install/Cargo.toml
+++ b/crates/vite_install/Cargo.toml
@@ -37,7 +37,7 @@ vite_workspace = { workspace = true }
 reqwest = { workspace = true, features = ["stream", "native-tls-vendored", "json"] }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
-reqwest = { workspace = true, features = ["stream", "rustls-tls", "json"] }
+reqwest = { workspace = true, features = ["stream", "rustls-tls-native-roots", "json"] }
 
 [dev-dependencies]
 httpmock = { workspace = true }

--- a/crates/vite_js_runtime/Cargo.toml
+++ b/crates/vite_js_runtime/Cargo.toml
@@ -32,7 +32,7 @@ zip = { workspace = true }
 reqwest = { workspace = true, features = ["stream", "native-tls-vendored"] }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
-reqwest = { workspace = true, features = ["stream", "rustls-tls"] }
+reqwest = { workspace = true, features = ["stream", "rustls-tls-native-roots"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }


### PR DESCRIPTION
> description below is written by opus; i've reviewed, verified, and approved the fix myself. the key is migrating to `rustls-tls-native-roots` to make `vp` usable in corporate vpn / self-signed CA / complex network conditions beyond simple / personal / home-use scenarios. 

## Description

The `vp` binary fails all HTTPS requests (downloads, registry lookups, upgrade checks) when running behind a TLS-intercepting proxy or firewall that re-signs certificates with a private CA.

**Root cause**: On non-Windows platforms, reqwest is configured with the `rustls-tls` feature, which bundles Mozilla's root CA store (`webpki-roots`) at compile time. This hardcoded CA set ignores any additional certificates installed in the operating system's trust store. When a network appliance re-signs TLS certificates with a private CA (common in corporate and enterprise environments), `vp` cannot verify any HTTPS connection.

**Fix**: Switch from `rustls-tls` to `rustls-tls-native-roots` in the three crates that depend on reqwest (`vite_error`, `vite_install`, `vite_js_runtime`). This replaces `webpki-roots` with `rustls-native-certs`, which loads certificates from the platform's native trust store at runtime:

- **macOS**: Security.framework (System Keychain)
- **Linux**: OpenSSL-compatible certificate directories (`/etc/ssl/certs`, etc.)
- **Windows**: No change — already uses `native-tls-vendored` (SChannel)

### Switching from `rustls-tls` to `rustls-tls-native-roots` 

| | `rustls-tls` | `rustls-tls-native-roots` |
|---|---|---|
| CA source | Bundled Mozilla root CAs (compile-time) | OS native trust store (runtime) |
| Custom/private CAs | Not supported | Loaded from OS keychain/cert dirs |
| TLS-intercepting proxies | Always fails | Works if proxy CA is in OS trust store |
| TLS library | rustls (unchanged) | rustls (unchanged) |
| Crypto backend | ring/aws-lc (unchanged) | ring/aws-lc (unchanged) |
| OS cert store dependency | None | `security-framework` (macOS), `openssl-probe` (Linux) |

The underlying TLS library (rustls) and cryptographic backend remain identical — only the source of trusted root certificates changes.

## Reproduction

1. Run `vp` on any machine where HTTPS traffic is intercepted by a TLS proxy that re-signs certificates with a non-Mozilla CA
2. Any command that makes HTTPS requests fails:
   ```
   $ vp upgrade --check
   error: Upgrade error: Failed to fetch package metadata from
   https://registry.npmjs.org/vite-plus/latest: error sending request for url
   (https://registry.npmjs.org/vite-plus/latest)

   $ vp env install lts
   error: Failed to download Node.js runtime: Failed to download from
   https://nodejs.org/dist/index.json: error sending request for url
   (https://nodejs.org/dist/index.json)
   ```
3. The same URLs work fine with `curl`, `node`, `git`, and other tools that use the OS certificate store or respect `SSL_CERT_FILE`

### Verify the issue in the binary

```bash
# Current binary uses bundled webpki-roots:
strings $(which vp) | grep -c 'webpki_roots'  # > 0

# After this fix, uses OS-native certs:
strings $(which vp) | grep -c 'webpki_roots'     # 0
strings $(which vp) | grep -c 'security-framework' # > 0 (macOS)
```

## Changes

- `crates/vite_error/Cargo.toml`: `rustls-tls` → `rustls-tls-native-roots`
- `crates/vite_install/Cargo.toml`: `rustls-tls` → `rustls-tls-native-roots`
- `crates/vite_js_runtime/Cargo.toml`: `rustls-tls` → `rustls-tls-native-roots`
- `Cargo.lock`: replaces `webpki-roots` with `rustls-native-certs` (+ transitive deps `security-framework`, `openssl-probe`)

No Rust source code changes required.
