### PR TITLE
fix(create): show helpful error for unknown vite: templates

### DIFF
--- a/packages/cli/src/create/bin.ts
+++ b/packages/cli/src/create/bin.ts
@@ -447,6 +447,19 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
     selectedTemplateName = template;
   }
 
+  // Validate builtin template names
+  if (selectedTemplateName.startsWith('vite:')) {
+    const validBuiltins = Object.values(BuiltinTemplate);
+    if (!validBuiltins.includes(selectedTemplateName as BuiltinTemplate)) {
+      const validNames = validBuiltins.join(', ');
+      prompts.log.error(
+        `Unknown builtin template "${selectedTemplateName}". Valid builtin templates are: ${validNames}`,
+      );
+      prompts.log.info(`Run \`${accent('vp create --list')}\` to see all available templates.`);
+      cancelAndExit('', 1);
+    }
+  }
+
   const isBuiltinTemplate = selectedTemplateName.startsWith('vite:');
 
   // Remote templates (e.g., @tanstack/create-start, custom templates) run their own


### PR DESCRIPTION
Fixes issue #1128 where 'vp create vite:<unknown>' crashes with ENOENT.

Added validation for builtin template names in the create command. When an unknown 'vite:' prefixed template is provided, the CLI now displays a clear error message listing the valid builtin templates instead of crashing with an ENOENT error.

Valid builtin templates are:
- vite:monorepo
- vite:application
- vite:library
- vite:generator