### PR TITLE
fix(pm): allow registry commands to work outside a project

### DIFF
--- a/crates/vite_global_cli/src/commands/mod.rs
+++ b/crates/vite_global_cli/src/commands/mod.rs
@@ -25,7 +25,7 @@
 
 use std::{collections::HashMap, io::BufReader};
 
-use vite_install::package_manager::PackageManager;
+use vite_install::package_manager::{PackageManager, PackageManagerType};
 use vite_path::AbsolutePath;
 use vite_shared::{PrependOptions, prepend_to_path_env};
 
@@ -115,6 +115,37 @@ pub async fn build_package_manager(cwd: &AbsolutePath) -> Result<PackageManager,
             Err(Error::UserMessage("No package.json found.".into()))
         }
         Err(e) => Err(e.into()),
+    }
+}
+
+/// Build a PackageManager, falling back to a default npm instance when no
+/// package.json is found. Uses `build()` instead of `build_with_default()`
+/// to skip the interactive package manager selection prompt on the fallback path.
+///
+/// Requires `prepend_js_runtime_to_path_env` to be called first so npm is on PATH.
+pub async fn build_package_manager_or_npm_default(
+    cwd: &AbsolutePath,
+) -> Result<PackageManager, Error> {
+    match PackageManager::builder(cwd).build().await {
+        Ok(pm) => Ok(pm),
+        Err(vite_error::Error::WorkspaceError(vite_workspace::Error::PackageJsonNotFound(_)))
+        | Err(vite_error::Error::UnrecognizedPackageManager) => {
+            Ok(default_npm_package_manager(cwd))
+        }
+        Err(e) => Err(e.into()),
+    }
+}
+
+fn default_npm_package_manager(cwd: &AbsolutePath) -> PackageManager {
+    PackageManager {
+        client: PackageManagerType::Npm,
+        package_name: "npm".into(),
+        version: "latest".into(),
+        hash: None,
+        bin_name: "npm".into(),
+        workspace_root: cwd.to_absolute_path_buf(),
+        is_monorepo: false,
+        install_dir: cwd.to_absolute_path_buf(),
     }
 }
 

--- a/crates/vite_global_cli/src/commands/pm.rs
+++ b/crates/vite_global_cli/src/commands/pm.rs
@@ -29,7 +29,9 @@ use vite_install::commands::{
 };
 use vite_path::AbsolutePathBuf;
 
-use super::{build_package_manager, prepend_js_runtime_to_path_env};
+use super::{
+    build_package_manager, build_package_manager_or_npm_default, prepend_js_runtime_to_path_env,
+};
 use crate::{
     cli::{ConfigCommands, DistTagCommands, OwnerCommands, PmCommands, TokenCommands},
     error::Error,
@@ -45,7 +47,7 @@ pub async fn execute_info(
 ) -> Result<ExitStatus, Error> {
     prepend_js_runtime_to_path_env(&cwd).await?;
 
-    let package_manager = build_package_manager(&cwd).await?;
+    let package_manager = build_package_manager_or_npm_default(&cwd).await?;
 
     let options = ViewCommandOptions { package, field, json, pass_through_args };
 
@@ -64,7 +66,23 @@ pub async fn execute_pm_subcommand(
 
     prepend_js_runtime_to_path_env(&cwd).await?;
 
-    let package_manager = build_package_manager(&cwd).await?;
+    // Project-dependent commands require package.json; standalone ones fall back to npm.
+    let needs_project = matches!(
+        command,
+        PmCommands::Prune { .. }
+            | PmCommands::Pack { .. }
+            | PmCommands::List { .. }
+            | PmCommands::Publish { .. }
+            | PmCommands::Rebuild { .. }
+            | PmCommands::Fund { .. }
+            | PmCommands::Audit { .. }
+    );
+
+    let package_manager = if needs_project {
+        build_package_manager(&cwd).await?
+    } else {
+        build_package_manager_or_npm_default(&cwd).await?
+    };
 
     match command {
         PmCommands::Prune { prod, no_optional, pass_through_args } => {

--- a/packages/cli/snap-tests-global/command-info-no-package-json/snap.txt
+++ b/packages/cli/snap-tests-global/command-info-no-package-json/snap.txt
@@ -1,0 +1,5 @@
+> vp info vite@2.0.0 version # should work without package.json
+2.0.0
+
+> vp pm view vite@2.0.0 version # should work without package.json
+2.0.0

--- a/packages/cli/snap-tests-global/command-info-no-package-json/steps.json
+++ b/packages/cli/snap-tests-global/command-info-no-package-json/steps.json
@@ -1,0 +1,6 @@
+{
+  "commands": [
+    "vp info vite@2.0.0 version # should work without package.json",
+    "vp pm view vite@2.0.0 version # should work without package.json"
+  ]
+}


### PR DESCRIPTION
Commands like `vp info`, `vp pm search`, `vp pm ping`, and other
registry/auth operations no longer require a package.json. When no
project is found, these standalone commands fall back to a default
npm package manager instance.

Project-dependent commands (prune, pack, list, publish, rebuild,
fund, audit) still require a package.json and show the existing
"No package.json found." error.

Closes #1108