### PR TITLE
fix(create): inject default `fmt: {}` config and rebrand oxfmt messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7193,6 +7193,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "clap",
+ "cow-utils",
  "fspy",
  "napi",
  "napi-build",

--- a/crates/vite_migration/src/vite_config.rs
+++ b/crates/vite_migration/src/vite_config.rs
@@ -1013,6 +1013,27 @@ export default defineConfig({
     }
 
     #[test]
+    fn test_merge_json_config_content_empty_object() {
+        let vite_config = r#"import { defineConfig } from 'vite-plus';
+
+export default defineConfig({
+  lint: { options: { typeAware: true, typeCheck: true } },
+});"#;
+
+        let result = merge_json_config_content(vite_config, "{}", "fmt").unwrap();
+        assert!(result.updated);
+        assert_eq!(
+            result.content,
+            r#"import { defineConfig } from 'vite-plus';
+
+export default defineConfig({
+  fmt: {},
+  lint: { options: { typeAware: true, typeCheck: true } },
+});"#
+        );
+    }
+
+    #[test]
     fn test_merge_tsdown_config_content_simple() {
         let vite_config = r#"import { defineConfig } from 'vite-plus';
 

--- a/packages/cli/binding/Cargo.toml
+++ b/packages/cli/binding/Cargo.toml
@@ -10,6 +10,7 @@ rolldown = ["dep:rolldown_binding"]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
+cow-utils = { workspace = true }
 fspy = { workspace = true }
 rustc-hash = { workspace = true }
 napi = { workspace = true }

--- a/packages/cli/binding/src/cli.rs
+++ b/packages/cli/binding/src/cli.rs
@@ -12,6 +12,7 @@ use clap::{
     Parser, Subcommand,
     error::{ContextKind, ContextValue, ErrorKind},
 };
+use cow_utils::CowUtils;
 use owo_colors::OwoColorize;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
@@ -743,6 +744,33 @@ async fn resolve_and_execute_with_stdout_filter(
     Ok(ExitStatus(output.status.code().unwrap_or(1) as u8))
 }
 
+/// Like `resolve_and_execute`, but captures stderr, applies a text filter,
+/// and writes the result to real stderr. Stdout remains inherited (streaming).
+async fn resolve_and_execute_with_stderr_filter(
+    resolver: &SubcommandResolver,
+    subcommand: SynthesizableSubcommand,
+    resolved_vite_config: Option<&ResolvedUniversalViteConfig>,
+    envs: &Arc<FxHashMap<Arc<OsStr>, Arc<OsStr>>>,
+    cwd: &AbsolutePathBuf,
+    cwd_arc: &Arc<AbsolutePath>,
+    filter: impl Fn(&str) -> Cow<'_, str>,
+) -> Result<ExitStatus, Error> {
+    let mut cmd =
+        resolve_and_build_command(resolver, subcommand, resolved_vite_config, envs, cwd, cwd_arc)
+            .await?;
+    cmd.stderr(Stdio::piped());
+
+    let child = cmd.spawn().map_err(|e| Error::Anyhow(e.into()))?;
+    let output = child.wait_with_output().await.map_err(|e| Error::Anyhow(e.into()))?;
+
+    use std::io::Write;
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let filtered = filter(&stderr);
+    let _ = std::io::stderr().lock().write_all(filtered.as_bytes());
+
+    Ok(ExitStatus(output.status.code().unwrap_or(1) as u8))
+}
+
 struct CapturedCommandOutput {
     status: ExitStatus,
     stdout: String,
@@ -1256,6 +1284,17 @@ async fn execute_direct_subcommand(
                     cwd,
                     &cwd_arc,
                     |_| Cow::Borrowed(""),
+                )
+                .await?
+            } else if matches!(&other, SynthesizableSubcommand::Fmt { .. }) {
+                resolve_and_execute_with_stderr_filter(
+                    &resolver,
+                    other,
+                    None,
+                    &envs,
+                    cwd,
+                    &cwd_arc,
+                    |s| s.cow_replace("oxfmt --init", "vp fmt --init"),
                 )
                 .await?
             } else {

--- a/packages/cli/snap-tests-global/create-missing-typecheck/snap.txt
+++ b/packages/cli/snap-tests-global/create-missing-typecheck/snap.txt
@@ -6,6 +6,7 @@ export default defineConfig({
   staged: {
     "*": "vp check --fix",
   },
+  fmt: {},
   lint: { options: { typeAware: true, typeCheck: true } },
 });
 
@@ -17,6 +18,7 @@ export default defineConfig({
   staged: {
     "*": "vp check --fix",
   },
+  fmt: {},
   lint: { options: { typeAware: true, typeCheck: true } },
 });
 

--- a/packages/cli/snap-tests-global/migration-baseurl-tsconfig/snap.txt
+++ b/packages/cli/snap-tests-global/migration-baseurl-tsconfig/snap.txt
@@ -15,6 +15,7 @@ export default defineConfig({
   staged: {
     "*": "vp check --fix"
   },
+  fmt: {},
   lint: {
     "rules": {
       "no-unused-vars": "error"

--- a/packages/cli/snap-tests-global/migration-chained-lint-staged-pre-commit/snap.txt
+++ b/packages/cli/snap-tests-global/migration-chained-lint-staged-pre-commit/snap.txt
@@ -30,6 +30,7 @@ VITE+ - The Unified Toolchain for the Web
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({
+  fmt: {},
   lint: {"options":{"typeAware":true,"typeCheck":true}},
   staged: {
     "*.js": "vp lint --fix"

--- a/packages/cli/snap-tests-global/migration-env-prefix-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-env-prefix-lint-staged/snap.txt
@@ -30,6 +30,7 @@ VITE+ - The Unified Toolchain for the Web
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({
+  fmt: {},
   lint: {"options":{"typeAware":true,"typeCheck":true}},
   staged: {
     "*.js": "vp lint --fix"

--- a/packages/cli/snap-tests-global/migration-eslint-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-lint-staged/snap.txt
@@ -30,6 +30,7 @@ VITE+ - The Unified Toolchain for the Web
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({
+  fmt: {},
   lint: {
     "plugins": [
       "oxc",

--- a/packages/cli/snap-tests-global/migration-eslint-lintstagedrc/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-lintstagedrc/snap.txt
@@ -31,6 +31,7 @@ VITE+ - The Unified Toolchain for the Web
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({
+  fmt: {},
   lint: {
     "plugins": [
       "oxc",

--- a/packages/cli/snap-tests-global/migration-eslint/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint/snap.txt
@@ -37,6 +37,7 @@ export default defineConfig({
   staged: {
     "*": "vp check --fix"
   },
+  fmt: {},
   lint: {
     "plugins": [
       "oxc",

--- a/packages/cli/snap-tests-global/migration-existing-husky-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-husky-lint-staged/snap.txt
@@ -30,6 +30,7 @@ VITE+ - The Unified Toolchain for the Web
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({
+  fmt: {},
   lint: {"options":{"typeAware":true,"typeCheck":true}},
   staged: {
     "*.js": "vp lint --fix"

--- a/packages/cli/snap-tests-global/migration-existing-lint-staged-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-lint-staged-config/snap.txt
@@ -31,6 +31,7 @@ VITE+ - The Unified Toolchain for the Web
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({
+  fmt: {},
   lint: {"options":{"typeAware":true,"typeCheck":true}},
   staged: {
     "*.ts": "vp lint --fix"

--- a/packages/cli/snap-tests-global/migration-existing-pnpm-exec-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-pnpm-exec-lint-staged/snap.txt
@@ -30,6 +30,7 @@ VITE+ - The Unified Toolchain for the Web
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({
+  fmt: {},
   lint: {"options":{"typeAware":true,"typeCheck":true}},
   staged: {
     "*.js": "vp lint --fix"

--- a/packages/cli/snap-tests-global/migration-from-tsdown-json-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-from-tsdown-json-config/snap.txt
@@ -22,6 +22,7 @@ export default defineConfig({
       "cwd": "./src"
     }
   },
+  fmt: {},
   lint: {"options":{"typeAware":true,"typeCheck":true}},
   server: {
     port: 3000,
@@ -72,6 +73,7 @@ export default defineConfig({
       "cwd": "./src"
     }
   },
+  fmt: {},
   lint: {"options":{"typeAware":true,"typeCheck":true}},
   server: {
     port: 3000,

--- a/packages/cli/snap-tests-global/migration-from-tsdown/snap.txt
+++ b/packages/cli/snap-tests-global/migration-from-tsdown/snap.txt
@@ -27,6 +27,7 @@ export default defineConfig({
     "*": "vp check --fix"
   },
   pack: tsdownConfig,
+  fmt: {},
   lint: {"options":{"typeAware":true,"typeCheck":true}},
 });
 
@@ -78,6 +79,7 @@ export default defineConfig({
     "*": "vp check --fix"
   },
   pack: tsdownConfig,
+  fmt: {},
   lint: {"options":{"typeAware":true,"typeCheck":true}},
 });
 

--- a/packages/cli/snap-tests-global/migration-lint-staged-in-scripts/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lint-staged-in-scripts/snap.txt
@@ -31,6 +31,7 @@ VITE+ - The Unified Toolchain for the Web
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({
+  fmt: {},
   lint: {"options":{"typeAware":true,"typeCheck":true}},
   staged: {
     "*.js": "vp lint --fix"

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-json/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-json/snap.txt
@@ -104,6 +104,7 @@ VITE+ - The Unified Toolchain for the Web
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({
+  fmt: {},
   lint: {"options":{"typeAware":true,"typeCheck":true}},
   staged: {
     "*.@(js|ts|tsx|yml|yaml|md|json|html|toml)": [

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-staged-exists/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-staged-exists/snap.txt
@@ -34,6 +34,7 @@ lintstagedrc.json still exists
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({
+  fmt: {},
   lint: {"options":{"typeAware":true,"typeCheck":true}},
   staged: {
     '*.js': 'vp check --fix',

--- a/packages/cli/snap-tests-global/migration-merge-vite-config-js/snap.txt
+++ b/packages/cli/snap-tests-global/migration-merge-vite-config-js/snap.txt
@@ -12,6 +12,7 @@ export default {
   staged: {
     "*": "vp check --fix"
   },
+  fmt: {},
   lint: {
     "rules": {
       "no-unused-vars": "error"

--- a/packages/cli/snap-tests-global/migration-monorepo-pnpm-overrides-dependency-selector/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-pnpm-overrides-dependency-selector/snap.txt
@@ -13,6 +13,7 @@ export default defineConfig({
   staged: {
     "*": "vp check --fix"
   },
+  fmt: {},
   lint: {"options":{"typeAware":true,"typeCheck":true}},
   plugins: [react()],
 });

--- a/packages/cli/snap-tests-global/migration-monorepo-yarn4/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-yarn4/snap.txt
@@ -15,6 +15,7 @@ export default defineConfig({
   staged: {
     "*": "vp check --fix"
   },
+  fmt: {},
   lint: {
     "rules": {
       "no-unused-vars": "error"

--- a/packages/cli/snap-tests-global/migration-subpath/snap.txt
+++ b/packages/cli/snap-tests-global/migration-subpath/snap.txt
@@ -36,8 +36,8 @@ VITE+ - The Unified Toolchain for the Web
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({
+  fmt: {},
   lint: {"options":{"typeAware":true,"typeCheck":true}},
-  
 });
 
 > git config --local core.hooksPath || echo 'core.hooksPath is not set' # should NOT be set

--- a/packages/cli/snap-tests/fmt-no-config-message/package.json
+++ b/packages/cli/snap-tests/fmt-no-config-message/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@test/fmt-no-config-message",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/packages/cli/snap-tests/fmt-no-config-message/snap.txt
+++ b/packages/cli/snap-tests/fmt-no-config-message/snap.txt
@@ -1,0 +1,16 @@
+> vp fmt 2>&1 # should show 'vp fmt --init' instead of 'oxfmt --init'
+Finished in <variable>ms on 4 files using <variable> threads.
+No config found, using defaults. Please add a config file or try `vp fmt --init` if needed.
+
+> vp fmt --init
+Added 'fmt' to 'vite.config.ts'.
+
+> cat vite.config.ts # should have fmt config
+export default {
+  fmt: {
+    ignorePatterns: [],
+  },
+};
+
+> vp fmt 2>&1 # should no longer show 'No config found' message
+Finished in <variable>ms on 4 files using <variable> threads.

--- a/packages/cli/snap-tests/fmt-no-config-message/src/index.js
+++ b/packages/cli/snap-tests/fmt-no-config-message/src/index.js
@@ -1,0 +1,5 @@
+function hello() {
+  return 'world';
+}
+
+export { hello };

--- a/packages/cli/snap-tests/fmt-no-config-message/steps.json
+++ b/packages/cli/snap-tests/fmt-no-config-message/steps.json
@@ -1,0 +1,8 @@
+{
+  "commands": [
+    "vp fmt 2>&1 # should show 'vp fmt --init' instead of 'oxfmt --init'",
+    "vp fmt --init",
+    "cat vite.config.ts # should have fmt config",
+    "vp fmt 2>&1 # should no longer show 'No config found' message"
+  ]
+}

--- a/packages/cli/snap-tests/fmt-no-config-message/vite.config.ts
+++ b/packages/cli/snap-tests/fmt-no-config-message/vite.config.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -726,6 +726,7 @@ export function rewriteStandaloneProject(
   }
   mergeViteConfigFiles(projectPath, silent, report);
   injectLintTypeCheckDefaults(projectPath, silent, report);
+  injectFmtDefaults(projectPath, silent, report);
   mergeTsdownConfigFile(projectPath, silent, report);
   // rewrite imports in all TypeScript/JavaScript files
   rewriteAllImports(projectPath, silent, report);
@@ -771,6 +772,7 @@ export function rewriteMonorepo(
   }
   mergeViteConfigFiles(workspaceInfo.rootDir, silent, report);
   injectLintTypeCheckDefaults(workspaceInfo.rootDir, silent, report);
+  injectFmtDefaults(workspaceInfo.rootDir, silent, report);
   mergeTsdownConfigFile(workspaceInfo.rootDir, silent, report);
   // rewrite imports in all TypeScript/JavaScript files
   rewriteAllImports(workspaceInfo.rootDir, silent, report);
@@ -1335,6 +1337,21 @@ export function injectLintTypeCheckDefaults(
     'lint',
     '.vite-plus-lint-init.oxlintrc.json',
     JSON.stringify({ options: { typeAware: true, typeCheck: true } }),
+    silent,
+    report,
+  );
+}
+
+export function injectFmtDefaults(
+  projectPath: string,
+  silent = false,
+  report?: MigrationReport,
+): void {
+  injectConfigDefaults(
+    projectPath,
+    'fmt',
+    '.vite-plus-fmt-init.oxfmtrc.json',
+    JSON.stringify({}),
     silent,
     report,
   );


### PR DESCRIPTION
Projects created by `vp create` or migrated via `vp migrate` now get
`fmt: {}` in vite.config.ts, preventing the "No config found" message
when running `vp fmt`.

For projects that genuinely lack fmt config, the stderr message now
suggests `vp fmt --init` instead of `oxfmt --init`.