### PR TITLE
fix!: update `vp run` argument order for flags-before-task breaking change

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,9 +13,9 @@ vp test                            # Run Vitest (dedicated command)
 vp lint                            # Run oxlint (dedicated command)
 
 # Run tasks across packages (explicit mode)
-vp run build -r                    # recursive with topological ordering
+vp run -r build                    # recursive with topological ordering
 vp run app#build web#build         # specific packages
-vp run build -r --no-topological   # recursive without implicit deps
+vp run -r --no-topological build   # recursive without implicit deps
 
 # Run task in current package (implicit mode - for non-built-in tasks)
 vp run dev                         # runs dev script from package.json

--- a/packages/cli/snap-tests-global/new-vite-monorepo/snap.txt
+++ b/packages/cli/snap-tests-global/new-vite-monorepo/snap.txt
@@ -16,7 +16,7 @@ vite.config.ts
   "private": true,
   "type": "module",
   "scripts": {
-    "ready": "vp fmt && vp lint && vp run test -r && vp run build -r",
+    "ready": "vp fmt && vp lint && vp run -r test && vp run -r build",
     "dev": "vp run website#dev",
     "prepare": "vp config"
   },
@@ -126,7 +126,7 @@ vite.config.ts
   "private": true,
   "type": "module",
   "scripts": {
-    "ready": "vp fmt && vp lint && vp run test -r && vp run build -r",
+    "ready": "vp fmt && vp lint && vp run -r test && vp run -r build",
     "dev": "vp run website#dev",
     "prepare": "vp config"
   },

--- a/packages/cli/snap-tests/command-run-argument-order/package.json
+++ b/packages/cli/snap-tests/command-run-argument-order/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "run-argument-order",
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/packages/cli/snap-tests/command-run-argument-order/packages/app-a/package.json
+++ b/packages/cli/snap-tests/command-run-argument-order/packages/app-a/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "app-a",
+  "scripts": {
+    "hello": "echo hello from app-a"
+  },
+  "dependencies": {
+    "lib-b": "workspace:*"
+  }
+}

--- a/packages/cli/snap-tests/command-run-argument-order/packages/lib-b/package.json
+++ b/packages/cli/snap-tests/command-run-argument-order/packages/lib-b/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "lib-b",
+  "scripts": {
+    "hello": "echo hello from lib-b"
+  }
+}

--- a/packages/cli/snap-tests/command-run-argument-order/snap.txt
+++ b/packages/cli/snap-tests/command-run-argument-order/snap.txt
@@ -1,0 +1,14 @@
+> vp run -r hello # new syntax: -r before task, runs recursively
+~/packages/lib-b$ echo hello from lib-b ⊘ cache disabled
+hello from lib-b
+
+~/packages/app-a$ echo hello from app-a ⊘ cache disabled
+hello from app-a
+
+---
+vp run: 0/2 cache hit (0%). (Run `vp run --last-details` for full details)
+
+[1]> vp run hello -r # old syntax: -r after task, passed through as arg
+Task "hello" not found. Did you mean:
+  app-a#hello: echo hello from app-a
+  lib-b#hello: echo hello from lib-b

--- a/packages/cli/snap-tests/command-run-argument-order/steps.json
+++ b/packages/cli/snap-tests/command-run-argument-order/steps.json
@@ -1,0 +1,10 @@
+{
+  "ignoredPlatforms": ["win32"],
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": [
+    "vp run -r hello # new syntax: -r before task, runs recursively",
+    "vp run hello -r # old syntax: -r after task, passed through as arg"
+  ]
+}

--- a/packages/cli/templates/monorepo/README.md
+++ b/packages/cli/templates/monorepo/README.md
@@ -13,13 +13,13 @@ vp run ready
 - Run the tests:
 
 ```bash
-vp run test -r
+vp run -r test
 ```
 
 - Build the monorepo:
 
 ```bash
-vp run build -r
+vp run -r build
 ```
 
 - Run the development server:

--- a/packages/cli/templates/monorepo/package.json
+++ b/packages/cli/templates/monorepo/package.json
@@ -9,7 +9,7 @@
   ],
   "type": "module",
   "scripts": {
-    "ready": "vp fmt && vp lint && vp run test -r && vp run build -r",
+    "ready": "vp fmt && vp lint && vp run -r test && vp run -r build",
     "dev": "vp run website#dev"
   },
   "engines": {

--- a/rfcs/check-command.md
+++ b/rfcs/check-command.md
@@ -10,7 +10,7 @@ Currently, running a full code quality check requires chaining multiple commands
 
 ```bash
 # From the monorepo template's "ready" script:
-vp fmt && vp lint --type-aware && vp run test -r && vp run build -r
+vp fmt && vp lint --type-aware && vp run -r test && vp run -r build
 ```
 
 Pain points:
@@ -221,7 +221,7 @@ Options:
 With `vp check`, the monorepo template's "ready" script simplifies to:
 
 ```json
-"ready": "vp check && vp run test -r && vp run build -r"
+"ready": "vp check && vp run -r test && vp run -r build"
 ```
 
 ## Comparison with Other Tools

--- a/rfcs/run-without-vite-plus-dependency.md
+++ b/rfcs/run-without-vite-plus-dependency.md
@@ -46,7 +46,7 @@ $ vp run dev
 # Executes: pnpm run dev (or npm/yarn depending on project)
 
 # With vite-plus as a dependency, uses full task runner
-$ vp run build -r
+$ vp run -r build
 # Executes via vite-plus task runner with recursive + topological ordering
 ```
 
@@ -80,7 +80,7 @@ When falling back to PM run, all arguments are passed through as-is:
 | ------------------------ | -------------------------- | ------------------------ |
 | `vp run dev`             | `pnpm run dev`             | Basic script execution   |
 | `vp run dev --port 3000` | `pnpm run dev --port 3000` | Args passed through      |
-| `vp run build -r`        | `pnpm run build -r`        | PM ignores unknown flags |
+| `vp run -r build`        | `pnpm run -r build`        | PM ignores unknown flags |
 | `vp run app#build`       | `pnpm run app#build`       | PM treats as script name |
 
 vite-plus specific flags (`-r`, `--recursive`, `--topological`, `package#task` syntax) are only meaningful when vite-plus is installed. When falling back, these are passed verbatim to the PM which will naturally error with "Missing script" -- this is correct behavior since these features require vite-plus.
@@ -346,7 +346,7 @@ $ vp run dev
 
 ```bash
 # package.json has vite-plus in devDependencies
-$ vp run build -r
+$ vp run -r build
 # Delegates to local vite-plus CLI
 # Uses task runner with recursive + topological ordering
   my-lib  build  done in 1.2s


### PR DESCRIPTION
vite-task PR https://github.com/voidzero-dev/vite-task/pull/286 and
https://github.com/voidzero-dev/vite-task/pull/290 changed trailing_var_arg
to the command level, meaning flags like `-r` must now appear before the
task name. Tokens after the task name are passed through verbatim to the
task process.

- `vp run -r test` (correct) — `-r` is the recursive flag
- `vp run test -r` (broken) — `-r` is passed through to the task

Add snap test `command-run-argument-order` verifying both behaviors.
Update monorepo template, docs, and RFCs to use the new syntax.