### PR TITLE
fix: stop intercepting `vite` as `vp` and synthesize `vpr` in task scripts

### DIFF
--- a/packages/cli/binding/src/cli.rs
+++ b/packages/cli/binding/src/cli.rs
@@ -551,18 +551,18 @@ impl CommandHandler for VitePlusCommandHandler {
         &mut self,
         command: &mut ScriptCommand,
     ) -> anyhow::Result<HandledCommand> {
-        // Intercept both "vp" and "vite" commands in task scripts.
-        // "vp" is the conventional alias used in vite-plus task configs.
-        // "vite" must also be intercepted so that `vite test`, `vite build`, etc.
-        // in task scripts are synthesized in-session rather than spawning a new CLI process.
+        // Intercept "vp" and "vpr" commands in task scripts so that `vp test`, `vp build`,
+        // `vpr build`, etc. are synthesized in-session rather than spawning a new CLI process.
         let program = command.program.as_str();
-        if program != "vp" && program != "vite" {
+        if program != "vp" && program != "vpr" {
             return Ok(HandledCommand::Verbatim);
         }
-        // Parse "vp <args>" using CLIArgs — always use "vp" as the program name
-        // so clap shows "Usage: vp ..." even if the original command was "vite ..."
+        // "vpr <args>" is shorthand for "vp run <args>", so prepend "run" for parsing.
+        let is_vpr = program == "vpr";
         let cli_args = match CLIArgs::try_parse_from(
-            iter::once("vp").chain(command.args.iter().map(Str::as_str)),
+            iter::once("vp")
+                .chain(is_vpr.then_some("run"))
+                .chain(command.args.iter().map(Str::as_str)),
         ) {
             Ok(args) => args,
             Err(err) if err.kind() == ErrorKind::InvalidSubcommand => {

--- a/packages/cli/snap-tests-global/command-run-script-vite-program/package.json
+++ b/packages/cli/snap-tests-global/command-run-script-vite-program/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "command-run-script-vite-program",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "vite",
+    "dev-help": "vite -h",
+    "dev-version": "vite --version",
+    "hello": "echo hello from script",
+    "hello-vpr": "vpr hello",
+    "ready": "vpr hello-vpr && vpr dev-version"
+  },
+  "packageManager": "pnpm@10.19.0"
+}

--- a/packages/cli/snap-tests-global/command-run-script-vite-program/setup-bin.js
+++ b/packages/cli/snap-tests-global/command-run-script-vite-program/setup-bin.js
@@ -1,0 +1,8 @@
+const fs = require('fs');
+fs.mkdirSync('node_modules/.bin', { recursive: true });
+fs.writeFileSync(
+  'node_modules/.bin/vite',
+  '#!/usr/bin/env node\nconst args = process.argv.slice(2);\nconsole.log(args.length ? "vite " + args.join(" ") : "vite");\n',
+  { mode: 0o755 },
+);
+fs.writeFileSync('node_modules/.bin/vite.cmd', '@node "%~dp0\\vite" %*\n');

--- a/packages/cli/snap-tests-global/command-run-script-vite-program/snap.txt
+++ b/packages/cli/snap-tests-global/command-run-script-vite-program/snap.txt
@@ -1,0 +1,40 @@
+> node setup-bin.js
+> vp run dev # should run vite binary, not parse as vp subcommand
+VITE+ - The Unified Toolchain for the Web
+
+$ vite ⊘ cache disabled
+vite
+
+
+> vp run dev-help # should run vite -h, not parse as vp subcommand
+VITE+ - The Unified Toolchain for the Web
+
+$ vite -h ⊘ cache disabled
+vite -h
+
+
+> vp run dev-version # should run vite --version, not parse as vp subcommand
+VITE+ - The Unified Toolchain for the Web
+
+$ vite --version ⊘ cache disabled
+vite --version
+
+
+> vp run hello-vpr # vpr in script should be synthesized in-session
+VITE+ - The Unified Toolchain for the Web
+
+$ echo hello from script ⊘ cache disabled
+hello from script
+
+
+> vp run ready # chained vpr commands should both be synthesized
+VITE+ - The Unified Toolchain for the Web
+
+$ echo hello from script ⊘ cache disabled
+hello from script
+
+$ vite --version ⊘ cache disabled
+vite --version
+
+---
+vp run: 0/2 cache hit (0%). (Run `vp run --last-details` for full details)

--- a/packages/cli/snap-tests-global/command-run-script-vite-program/steps.json
+++ b/packages/cli/snap-tests-global/command-run-script-vite-program/steps.json
@@ -1,0 +1,10 @@
+{
+  "commands": [
+    { "command": "node setup-bin.js", "ignoreOutput": true },
+    "vp run dev # should run vite binary, not parse as vp subcommand",
+    "vp run dev-help # should run vite -h, not parse as vp subcommand",
+    "vp run dev-version # should run vite --version, not parse as vp subcommand",
+    "vp run hello-vpr # vpr in script should be synthesized in-session",
+    "vp run ready # chained vpr commands should both be synthesized"
+  ]
+}


### PR DESCRIPTION
## Summary

- **Fix**: `VitePlusCommandHandler` was intercepting both `vp` and `vite` program names in task scripts. This caused `vp run dev` to fail with "Invalid vite task command" when a package.json script used bare `vite` (e.g. `"dev": "vite"`), because `vite` is a separate tool, not a vp alias. Now only `vp` and `vpr` are intercepted; `vite` runs verbatim as an external process.
- **Feat**: `vpr` commands in task scripts (e.g. `"ready": "vpr hello && vpr dev"`) are now expanded to `vp run` and synthesized in-session, avoiding unnecessary process spawns.

## Test plan

- [x] Added snap test `command-run-script-vite-program` covering:
  - bare `vite`, `vite -h`, `vite --version` all run verbatim
  - `vpr hello` synthesized in-session
  - chained `vpr hello-vpr && vpr dev-version` both synthesized
- [x] All 254 global snap tests pass
- [x] All 22 Rust unit tests pass
- [x] Verified on real reproduction project (`vp run dev` starts Vite dev server)

Closes #1176