### PR TITLE
fix(cache): add Package-scoped negative globs to prevent cache miss in monorepos

### DIFF
--- a/packages/cli/binding/src/cli.rs
+++ b/packages/cli/binding/src/cli.rs
@@ -332,13 +332,7 @@ impl SubcommandResolver {
                     cache_config: UserCacheConfig::with_config(EnabledCacheConfig {
                         env: Some(Box::new([Str::from("VITE_*")])),
                         untracked_env: None,
-                        input: Some(vec![
-                            UserInputEntry::Auto(AutoInput { auto: true }),
-                            UserInputEntry::GlobWithBase(GlobWithBase {
-                                pattern: Str::from("!node_modules/.vite-temp/**"),
-                                base: InputBase::Workspace,
-                            }),
-                        ]),
+                        input: Some(build_pack_cache_inputs()),
                     }),
                     envs: merge_resolved_envs_with_version(envs, resolved.envs),
                 })
@@ -366,7 +360,14 @@ impl SubcommandResolver {
                     cache_config: UserCacheConfig::with_config(EnabledCacheConfig {
                         env: None,
                         untracked_env: None,
-                        input: None,
+                        input: Some(vec![
+                            UserInputEntry::Auto(AutoInput { auto: true }),
+                            exclude_glob("!node_modules/.vite-temp/**", InputBase::Package),
+                            exclude_glob(
+                                "!node_modules/.vite/vitest/**/results.json",
+                                InputBase::Package,
+                            ),
+                        ]),
                     }),
                     envs: merge_resolved_envs_with_version(envs, resolved.envs),
                 })
@@ -390,13 +391,7 @@ impl SubcommandResolver {
                     cache_config: UserCacheConfig::with_config(EnabledCacheConfig {
                         env: None,
                         untracked_env: None,
-                        input: Some(vec![
-                            UserInputEntry::Auto(AutoInput { auto: true }),
-                            UserInputEntry::GlobWithBase(GlobWithBase {
-                                pattern: Str::from("!node_modules/.vite-temp/**"),
-                                base: InputBase::Workspace,
-                            }),
-                        ]),
+                        input: Some(build_pack_cache_inputs()),
                     }),
                     envs: merge_resolved_envs(envs, resolved.envs),
                 })
@@ -504,6 +499,24 @@ impl SubcommandResolver {
 
 /// Merge resolved environment variables from JS resolver into existing envs.
 /// Does not override existing entries.
+/// Create a negative glob entry to exclude a pattern from cache fingerprinting.
+fn exclude_glob(pattern: &str, base: InputBase) -> UserInputEntry {
+    UserInputEntry::GlobWithBase(GlobWithBase { pattern: Str::from(pattern), base })
+}
+
+/// Common cache input entries for build/pack commands.
+/// Excludes .vite-temp config files and dist output files that are both read and written.
+/// TODO: The hardcoded `!dist/**` exclusion is a temporary workaround. It will be replaced
+/// by a runner-aware approach that automatically excludes task output directories.
+fn build_pack_cache_inputs() -> Vec<UserInputEntry> {
+    vec![
+        UserInputEntry::Auto(AutoInput { auto: true }),
+        exclude_glob("!node_modules/.vite-temp/**", InputBase::Workspace),
+        exclude_glob("!node_modules/.vite-temp/**", InputBase::Package),
+        exclude_glob("!dist/**", InputBase::Package),
+    ]
+}
+
 fn merge_resolved_envs(
     envs: &Arc<FxHashMap<Arc<OsStr>, Arc<OsStr>>>,
     resolved_envs: Vec<(String, String)>,

--- a/packages/cli/snap-tests/build-vite-env/snap.txt
+++ b/packages/cli/snap-tests/build-vite-env/snap.txt
@@ -35,5 +35,3 @@ dist/assets/index-BnIqjoTZ.js  <variable> kB │ gzip: <variable> kB
 
 ✓ built in <variable>ms
 
----
-vp run: build-vite-env-test#build not cached because it modified its input. (Run `vp run --last-details` for full details)

--- a/packages/cli/snap-tests/vp-cache-monorepo-missing/package.json
+++ b/packages/cli/snap-tests/vp-cache-monorepo-missing/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "cache-monorepo-missing",
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ],
+  "scripts": {
+    "ready": "vp run -r build"
+  },
+  "packageManager": "pnpm@10.32.1"
+}

--- a/packages/cli/snap-tests/vp-cache-monorepo-missing/packages/lib/package.json
+++ b/packages/cli/snap-tests/vp-cache-monorepo-missing/packages/lib/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "lib",
+  "private": true,
+  "scripts": {
+    "build": "vp pack"
+  }
+}

--- a/packages/cli/snap-tests/vp-cache-monorepo-missing/packages/lib/src/index.ts
+++ b/packages/cli/snap-tests/vp-cache-monorepo-missing/packages/lib/src/index.ts
@@ -1,0 +1,3 @@
+export function add(a: number, b: number): number {
+  return a + b;
+}

--- a/packages/cli/snap-tests/vp-cache-monorepo-missing/packages/lib/vite.config.ts
+++ b/packages/cli/snap-tests/vp-cache-monorepo-missing/packages/lib/vite.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from 'vite-plus';
+
+export default defineConfig({});

--- a/packages/cli/snap-tests/vp-cache-monorepo-missing/snap.txt
+++ b/packages/cli/snap-tests/vp-cache-monorepo-missing/snap.txt
@@ -1,0 +1,4 @@
+> vp run --cache ready # first run
+> vp run --cache ready 2>&1 | grep -E 'cache hit|modified' # second run should all hit cache
+~/packages/lib$ vp pack ◉ cache hit, replaying
+vp run: cache hit, <variable>ms saved.

--- a/packages/cli/snap-tests/vp-cache-monorepo-missing/steps.json
+++ b/packages/cli/snap-tests/vp-cache-monorepo-missing/steps.json
@@ -1,0 +1,9 @@
+{
+  "commands": [
+    {
+      "command": "vp run --cache ready # first run",
+      "ignoreOutput": true
+    },
+    "vp run --cache ready 2>&1 | grep -E 'cache hit|modified' # second run should all hit cache"
+  ]
+}


### PR DESCRIPTION
In monorepos, each package has its own node_modules/. When vp build/test/pack
run, Vite creates .vite-temp/ config files and dist/ outputs that are both read
and written during execution. The existing !node_modules/.vite-temp/** glob at
Workspace scope only matched the workspace root, not package-level paths,
causing perpetual cache misses due to read-write overlap detection.

- Build: add Package-scoped !node_modules/.vite-temp/** and !dist/**
- Test: add Package-scoped !node_modules/.vite-temp/** and !node_modules/.vite/**/results.json
- Pack: add Package-scoped !node_modules/.vite-temp/** and !dist/**