### PR TITLE
fix(editor/zed): remove setting oxlint `configPath` option

### DIFF
--- a/packages/cli/src/utils/editor.ts
+++ b/packages/cli/src/utils/editor.ts
@@ -27,9 +27,7 @@ const ZED_SETTINGS = {
     oxlint: {
       initialization_options: {
         settings: {
-          configPath: './.oxlintrc.json',
           run: 'onType',
-          disableNestedConfig: false,
           fixKind: 'safe_fix',
           typeAware: true,
           unusedDisableDirectives: 'deny',


### PR DESCRIPTION
It doesn't make sense for this setting to be be here sine the lint config will be in vite.config.ts