### PR TITLE
fix(ci): retry failed snap test cases instead of skipping flaky tests

### DIFF
--- a/.github/scripts/retry-failed-snap-tests.sh
+++ b/.github/scripts/retry-failed-snap-tests.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Retry only the snap test cases whose snap.txt changed, up to max_retries times.
+# Usage: retry-failed-snap-tests.sh [max_retries]
+set -euo pipefail
+
+max_retries=${1:-2}
+
+for retry in $(seq 1 "$max_retries"); do
+  changed=$(git diff --name-only -- 'packages/cli/snap-tests*/*/snap.txt')
+  if [ -z "$changed" ]; then
+    exit 0
+  fi
+
+  echo "::warning::Snapshot diff detected, retry $retry/$max_retries for failed cases..."
+  git diff --stat -- 'packages/cli/snap-tests*/*/snap.txt'
+
+  failed_local=$(echo "$changed" | grep -v 'snap-tests-global/' | sed -E 's|packages/cli/snap-tests/([^/]+)/.*|\1|' | sort -u || true)
+  failed_global=$(echo "$changed" | grep 'snap-tests-global/' | sed -E 's|packages/cli/snap-tests-global/([^/]+)/.*|\1|' | sort -u || true)
+
+  echo "$changed" | xargs git checkout --
+
+  for name in $failed_local; do
+    echo "Retrying local snap test: $name"
+    RUST_BACKTRACE=1 pnpm -F ./packages/cli snap-test-local "$name"
+  done
+  for name in $failed_global; do
+    echo "Retrying global snap test: $name"
+    RUST_BACKTRACE=1 pnpm -F ./packages/cli snap-test-global "$name"
+  done
+done
+
+# Final check after all retries
+if ! git diff --quiet -- 'packages/cli/snap-tests*/*/snap.txt'; then
+  echo "::error::Snapshot diff detected after $max_retries retries. Run 'pnpm -F vite-plus snap-test' locally and commit the updated snap.txt files."
+  git diff --stat
+  git diff
+  exit 1
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -656,12 +656,7 @@ jobs:
         run: |
           RUST_BACKTRACE=1 pnpm -F ./packages/cli snap-test-local --shard=${{ matrix.shard }}/${{ matrix.shardTotal }}
           RUST_BACKTRACE=1 pnpm -F ./packages/cli snap-test-global --shard=${{ matrix.shard }}/${{ matrix.shardTotal }}
-          if ! git diff --quiet; then
-            echo "::error::Snapshot diff detected. Run 'pnpm -F vite-plus snap-test' locally and commit the updated snap.txt files."
-            git diff --stat
-            git diff
-            exit 1
-          fi
+          bash .github/scripts/retry-failed-snap-tests.sh
         env:
           RUST_MIN_STACK: 8388608
 
@@ -735,15 +730,9 @@ jobs:
               tsc --version
               vp uninstall -g typescript
 
-              # Run snap tests
               git config --global --add safe.directory /workspace
               RUST_BACKTRACE=1 pnpm test
-              if ! git diff --quiet; then
-                echo '::error::Snapshot diff detected. Run pnpm -F vite-plus snap-test locally and commit the updated snap.txt files.'
-                git diff --stat
-                git diff
-                exit 1
-              fi
+              bash .github/scripts/retry-failed-snap-tests.sh
             "
 
   install-e2e-test:


### PR DESCRIPTION
## Summary

- Revert the `ignoredPlatforms` skip on `create-next-command-library` so it runs on all platforms again
- Add `.github/scripts/retry-failed-snap-tests.sh` that retries only the specific snap test cases whose `snap.txt` changed, up to 2 times
- Both `cli-snap-test` and `cli-e2e-test-musl` jobs use the shared script

## Test plan

- [x] CI passes on all platforms (Linux, macOS, Windows)
- [x] `create-next-command-library` snap test runs on macOS and Windows
- [x] If a snap test is flaky, CI retries only that specific case instead of failing immediately