### PR TITLE
chore: use `matchDepNames` for vite-task crates in renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,14 +15,13 @@
       "enabled": false
     },
     {
-      "matchPackageNames": [
+      "matchDepNames": [
         "fspy",
         "vite_glob",
         "vite_path",
         "vite_str",
         "vite_task",
-        "vite_workspace",
-        "https://github.com/voidzero-dev/vite-task"
+        "vite_workspace"
       ],
       "enabled": false
     }


### PR DESCRIPTION
`matchPackageNames` matches against the git URL for Cargo git
dependencies, not the crate name. This caused the disable rule to
have no effect, resulting in unwanted update PRs.

Closes #1208
Closes #1203