### PR TITLE
fix(cli): exit 0 when all fmt input files are excluded by ignorePatterns

### DIFF
--- a/packages/cli/binding/src/cli.rs
+++ b/packages/cli/binding/src/cli.rs
@@ -292,11 +292,23 @@ impl SubcommandResolver {
                     &owned_resolved_vite_config
                 };
 
-                if let (Some(_), Some(config_file)) =
+                if let (Some(fmt_config), Some(config_file)) =
                     (&resolved_vite_config.fmt, &resolved_vite_config.config_file)
                 {
                     args.insert(0, "-c".to_string());
                     args.insert(1, config_file.clone());
+
+                    // Avoid "Expected at least one target file" error when
+                    // ignorePatterns filters out all input files (e.g., `vp staged`
+                    // passes only package-lock.json which is then excluded).
+                    if fmt_config
+                        .get("ignorePatterns")
+                        .and_then(|v| v.as_array())
+                        .is_some_and(|arr| !arr.is_empty())
+                        && !has_flag_before_terminator(&args, "--no-error-on-unmatched-pattern")
+                    {
+                        args.push("--no-error-on-unmatched-pattern".to_string());
+                    }
                 }
 
                 Ok(ResolvedSubcommand {

--- a/packages/cli/snap-tests/fmt-ignore-patterns-all-excluded/package.json
+++ b/packages/cli/snap-tests/fmt-ignore-patterns-all-excluded/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@test/fmt-ignore-patterns-all-excluded",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}

--- a/packages/cli/snap-tests/fmt-ignore-patterns-all-excluded/snap.txt
+++ b/packages/cli/snap-tests/fmt-ignore-patterns-all-excluded/snap.txt
@@ -1,0 +1,2 @@
+> vp fmt src/ # Test that fmt exits 0 when all input files are excluded by ignorePatterns
+No files found matching the given patterns.

--- a/packages/cli/snap-tests/fmt-ignore-patterns-all-excluded/snap.txt
+++ b/packages/cli/snap-tests/fmt-ignore-patterns-all-excluded/snap.txt
@@ -1,2 +1,3 @@
 > vp fmt src/ # Test that fmt exits 0 when all input files are excluded by ignorePatterns
+Finished in <variable>ms on 0 files using <variable> threads.
 No files found matching the given patterns.

--- a/packages/cli/snap-tests/fmt-ignore-patterns-all-excluded/src/ignored.js
+++ b/packages/cli/snap-tests/fmt-ignore-patterns-all-excluded/src/ignored.js
@@ -1,0 +1,4 @@
+// This file is excluded by ignorePatterns
+function ignored() {
+  return 'hello';
+}

--- a/packages/cli/snap-tests/fmt-ignore-patterns-all-excluded/steps.json
+++ b/packages/cli/snap-tests/fmt-ignore-patterns-all-excluded/steps.json
@@ -1,0 +1,5 @@
+{
+  "commands": [
+    "vp fmt src/ # Test that fmt exits 0 when all input files are excluded by ignorePatterns"
+  ]
+}

--- a/packages/cli/snap-tests/fmt-ignore-patterns-all-excluded/vite.config.ts
+++ b/packages/cli/snap-tests/fmt-ignore-patterns-all-excluded/vite.config.ts
@@ -1,0 +1,5 @@
+export default {
+  fmt: {
+    ignorePatterns: ['src/**/*'],
+  },
+};


### PR DESCRIPTION
## Summary

When `vp staged` passes files to `vp fmt` that are all excluded by ignorePatterns in vite.config.ts (e.g., package-lock.json), oxfmt would error with "Expected at least one target file". Now `vp fmt` automatically adds `--no-error-on-unmatched-pattern` when the fmt config has ignorePatterns, so it exits 0 gracefully instead.

Closes #1210

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

- [x] ran vp check --fix before committing
- [x] ran pnpm bootstrap-cli && pnpm test && git status
- [x] commit is signed
- [x] snap test added & reviewed via git diff

