### PR TITLE
feat(create): enable task cache by default in monorepo template

### DIFF
--- a/packages/cli/snap-tests-global/create-missing-typecheck/snap.txt
+++ b/packages/cli/snap-tests-global/create-missing-typecheck/snap.txt
@@ -20,6 +20,9 @@ export default defineConfig({
   },
   fmt: {},
   lint: { options: { typeAware: true, typeCheck: true } },
+  run: {
+    cache: true,
+  },
 });
 
 > test ! -f vite-plus-monorepo/apps/website/vite.config.ts # sub-app should NOT have typeAware/typeCheck

--- a/packages/cli/snap-tests-global/create-missing-typecheck/steps.json
+++ b/packages/cli/snap-tests-global/create-missing-typecheck/steps.json
@@ -1,5 +1,5 @@
 {
-  "ignoredPlatforms": ["darwin", "win32", { "os": "linux", "libc": "musl" }],
+  "ignoredPlatforms": ["win32", { "os": "linux", "libc": "musl" }],
   "commands": [
     {
       "command": "vp create vite:application --no-interactive # create standalone app",

--- a/packages/cli/snap-tests-global/new-vite-monorepo/snap.txt
+++ b/packages/cli/snap-tests-global/new-vite-monorepo/snap.txt
@@ -29,6 +29,20 @@ vite.config.ts
   "packageManager": "pnpm@<semver>"
 }
 
+> cat vite-plus-monorepo/vite.config.ts # check vite config has cache enabled
+import { defineConfig } from "vite-plus";
+
+export default defineConfig({
+  staged: {
+    "*": "vp check --fix",
+  },
+  fmt: {},
+  lint: { options: { typeAware: true, typeCheck: true } },
+  run: {
+    cache: true,
+  },
+});
+
 > cat vite-plus-monorepo/pnpm-workspace.yaml # check workspace config
 packages:
   - apps/*

--- a/packages/cli/snap-tests-global/new-vite-monorepo/steps.json
+++ b/packages/cli/snap-tests-global/new-vite-monorepo/steps.json
@@ -7,6 +7,7 @@
     },
     "ls vite-plus-monorepo | LC_ALL=C sort # check files created",
     "cat vite-plus-monorepo/package.json # check package.json",
+    "cat vite-plus-monorepo/vite.config.ts # check vite config has cache enabled",
     "cat vite-plus-monorepo/pnpm-workspace.yaml # check workspace config",
     "test -d vite-plus-monorepo/.git && echo 'Git initialized' || echo 'No git' # check git init",
     "ls vite-plus-monorepo/apps # check apps directory created",

--- a/packages/cli/templates/monorepo/vite.config.ts
+++ b/packages/cli/templates/monorepo/vite.config.ts
@@ -1,3 +1,7 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vite-plus';
 
-export default defineConfig({});
+export default defineConfig({
+  run: {
+    cache: true,
+  },
+});


### PR DESCRIPTION
New monorepos created via `vp create vite:monorepo` now have
`run: { cache: true }` in vite.config.ts, enabling caching for
both built-in commands and package.json scripts out of the box.