### PR TITLE
fix(cli/lint): Remove `defineConfig` export from `oxlint`

### DIFF
--- a/packages/cli/src/lint.ts
+++ b/packages/cli/src/lint.ts
@@ -1,13 +1,4 @@
-export {
-  type AllowWarnDeny,
-  type DummyRule,
-  type DummyRuleMap,
-  type ExternalPluginEntry,
-  type ExternalPluginsConfig,
-  type OxlintConfig,
-  type OxlintEnv,
-  type OxlintGlobals,
-  type OxlintOverride,
-  type RuleCategories,
-  defineConfig,
-} from 'oxlint';
+// For now, `defineConfig()` is the only non-type exports from `oxlint`,
+// but in Vite+, users should use `defineConfig()` from 'vite-plus`.
+
+export type * from 'oxlint';


### PR DESCRIPTION
Historically, it appears to have been added in #710.

However, since this code no longer exists, there are no practical use cases for it. Furthermore, its use is not recommended for general users.