### PR TITLE
refactor(migration): move pnpm config into pnpm-workspace.yaml

### DIFF
--- a/packages/cli/snap-tests-global/migration-add-git-hooks/snap.txt
+++ b/packages/cli/snap-tests-global/migration-add-git-hooks/snap.txt
@@ -11,30 +11,30 @@ VITE+ - The Unified Toolchain for the Web
 {
   "name": "migration-add-git-hooks",
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>",
   "scripts": {
     "prepare": "vp config"
   }
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > cat .vite-hooks/pre-commit # check pre-commit hook
 vp staged

--- a/packages/cli/snap-tests-global/migration-add-git-hooks/steps.json
+++ b/packages/cli/snap-tests-global/migration-add-git-hooks/steps.json
@@ -1,8 +1,12 @@
 {
   "commands": [
-    { "command": "git init", "ignoreOutput": true },
+    {
+      "command": "git init",
+      "ignoreOutput": true
+    },
     "vp migrate --no-interactive # migration should add git hooks setup",
     "cat package.json # check package.json has prepare script and lint-staged config",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "cat .vite-hooks/pre-commit # check pre-commit hook",
     "test -d .vite-hooks/_ && echo 'hook shims exist' || echo 'no hook shims' # check vp config ran",
     "git config --local core.hooksPath # should be set to .vite-hooks/_",

--- a/packages/cli/snap-tests-global/migration-auto-create-vite-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-auto-create-vite-config/snap.txt
@@ -35,26 +35,26 @@ export default defineConfig({
 > cat package.json # check package.json
 {
   "devDependencies": {
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>",
   "scripts": {
     "prepare": "vp config"
   }
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'

--- a/packages/cli/snap-tests-global/migration-auto-create-vite-config/steps.json
+++ b/packages/cli/snap-tests-global/migration-auto-create-vite-config/steps.json
@@ -4,6 +4,7 @@
     "cat vite.config.ts # check vite.config.ts",
     "test ! -f .oxlintrc.json # check .oxlintrc.json is removed",
     "test ! -f .oxfmtrc.json # check .oxfmtrc.json is removed",
-    "cat package.json # check package.json"
+    "cat package.json # check package.json",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-baseurl-tsconfig/snap.txt
+++ b/packages/cli/snap-tests-global/migration-baseurl-tsconfig/snap.txt
@@ -28,26 +28,26 @@ export default defineConfig({
 > cat package.json # check package.json
 {
   "devDependencies": {
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>",
   "scripts": {
     "prepare": "vp config"
   }
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'

--- a/packages/cli/snap-tests-global/migration-baseurl-tsconfig/steps.json
+++ b/packages/cli/snap-tests-global/migration-baseurl-tsconfig/steps.json
@@ -1,8 +1,9 @@
 {
   "commands": [
     "vp migrate --no-interactive # migration should skip typeAware/typeCheck when tsconfig has baseUrl",
-    "cat vite.config.ts # check vite.config.ts — should NOT have typeAware or typeCheck",
+    "cat vite.config.ts # check vite.config.ts \u2014 should NOT have typeAware or typeCheck",
     "test ! -f .oxlintrc.json # check .oxlintrc.json is removed",
-    "cat package.json # check package.json"
+    "cat package.json # check package.json",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-chained-lint-staged-pre-commit/snap.txt
+++ b/packages/cli/snap-tests-global/migration-chained-lint-staged-pre-commit/snap.txt
@@ -14,27 +14,27 @@ VITE+ - The Unified Toolchain for the Web
     "prepare": "vp config"
   },
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > cat vite.config.ts # check staged config migrated to vite.config.ts
 import { defineConfig } from 'vite-plus';

--- a/packages/cli/snap-tests-global/migration-chained-lint-staged-pre-commit/steps.json
+++ b/packages/cli/snap-tests-global/migration-chained-lint-staged-pre-commit/steps.json
@@ -1,8 +1,12 @@
 {
   "commands": [
-    { "command": "git init", "ignoreOutput": true },
+    {
+      "command": "git init",
+      "ignoreOutput": true
+    },
     "vp migrate --no-interactive # migration should preserve chained commands after lint-staged",
     "cat package.json # check prepare rewritten and husky/lint-staged removed",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "cat vite.config.ts # check staged config migrated to vite.config.ts",
     "cat .vite-hooks/pre-commit # check npx lint-staged replaced but --diff HEAD~1 && npm test preserved"
   ]

--- a/packages/cli/snap-tests-global/migration-composed-husky-custom-dir/snap.txt
+++ b/packages/cli/snap-tests-global/migration-composed-husky-custom-dir/snap.txt
@@ -14,27 +14,27 @@ VITE+ - The Unified Toolchain for the Web
     "prepare": "npm run build && vp config --hooks-dir .config/husky"
   },
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > cat .config/husky/pre-commit # pre-commit hook should be in custom dir
 vp staged

--- a/packages/cli/snap-tests-global/migration-composed-husky-custom-dir/steps.json
+++ b/packages/cli/snap-tests-global/migration-composed-husky-custom-dir/steps.json
@@ -1,8 +1,12 @@
 {
   "commands": [
-    { "command": "git init", "ignoreOutput": true },
+    {
+      "command": "git init",
+      "ignoreOutput": true
+    },
     "vp migrate --no-interactive # migration should preserve custom husky dir in composed prepare",
     "cat package.json # prepare should be 'vp config --hooks-dir .config/husky && npm run build'",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "cat .config/husky/pre-commit # pre-commit hook should be in custom dir",
     "cat .config/husky/_/h # hook dispatcher should resolve repo root correctly for nested dirs"
   ]

--- a/packages/cli/snap-tests-global/migration-composed-husky-prepare/snap.txt
+++ b/packages/cli/snap-tests-global/migration-composed-husky-prepare/snap.txt
@@ -14,24 +14,24 @@ VITE+ - The Unified Toolchain for the Web
     "prepare": "vp config && npm run build"
   },
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'

--- a/packages/cli/snap-tests-global/migration-composed-husky-prepare/steps.json
+++ b/packages/cli/snap-tests-global/migration-composed-husky-prepare/steps.json
@@ -1,7 +1,11 @@
 {
   "commands": [
-    { "command": "git init", "ignoreOutput": true },
+    {
+      "command": "git init",
+      "ignoreOutput": true
+    },
     "vp migrate --no-interactive # migration should replace husky in composed prepare script",
-    "cat package.json # check prepare becomes 'vp config --hooks-dir .husky && npm run build' without leftover husky"
+    "cat package.json # check prepare becomes 'vp config --hooks-dir .husky && npm run build' without leftover husky",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-env-prefix-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-env-prefix-lint-staged/snap.txt
@@ -14,27 +14,27 @@ VITE+ - The Unified Toolchain for the Web
     "prepare": "vp config"
   },
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > cat vite.config.ts # check staged config migrated to vite.config.ts
 import { defineConfig } from 'vite-plus';

--- a/packages/cli/snap-tests-global/migration-env-prefix-lint-staged/steps.json
+++ b/packages/cli/snap-tests-global/migration-env-prefix-lint-staged/steps.json
@@ -1,8 +1,12 @@
 {
   "commands": [
-    { "command": "git init", "ignoreOutput": true },
+    {
+      "command": "git init",
+      "ignoreOutput": true
+    },
     "vp migrate --no-interactive # migration should replace env-prefixed lint-staged in pre-commit",
     "cat package.json # check husky/lint-staged removed, staged config in vite.config.ts",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "cat vite.config.ts # check staged config migrated to vite.config.ts",
     "cat .vite-hooks/pre-commit # check env prefix preserved with vp staged"
   ]

--- a/packages/cli/snap-tests-global/migration-eslint-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-lint-staged/snap.txt
@@ -14,27 +14,27 @@ VITE+ - The Unified Toolchain for the Web
     "prepare": "vp config"
   },
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
-  "packageManager": "pnpm@<semver>",
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
-  }
+  "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > cat vite.config.ts # check oxlint config and staged config merged into vite.config.ts
 import { defineConfig } from 'vite-plus';

--- a/packages/cli/snap-tests-global/migration-eslint-lint-staged/steps.json
+++ b/packages/cli/snap-tests-global/migration-eslint-lint-staged/steps.json
@@ -2,6 +2,7 @@
   "commands": [
     "vp migrate --no-interactive # migration should detect eslint and auto-migrate including lint-staged",
     "cat package.json # check eslint removed, scripts rewritten, lint-staged rewritten",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "cat vite.config.ts # check oxlint config and staged config merged into vite.config.ts"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-eslint-lintstagedrc/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-lintstagedrc/snap.txt
@@ -14,27 +14,27 @@ VITE+ - The Unified Toolchain for the Web
     "prepare": "vp config"
   },
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
-  "packageManager": "pnpm@<semver>",
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
-  }
+  "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > test ! -f .lintstagedrc.json # check lintstagedrc.json is removed
 > cat vite.config.ts # check oxlint config merged into vite.config.ts

--- a/packages/cli/snap-tests-global/migration-eslint-lintstagedrc/steps.json
+++ b/packages/cli/snap-tests-global/migration-eslint-lintstagedrc/steps.json
@@ -2,6 +2,7 @@
   "commands": [
     "vp migrate --no-interactive # migration should detect eslint and auto-migrate including lintstagedrc",
     "cat package.json # check eslint removed and scripts rewritten",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "test ! -f .lintstagedrc.json # check lintstagedrc.json is removed",
     "cat vite.config.ts # check oxlint config merged into vite.config.ts"
   ]

--- a/packages/cli/snap-tests-global/migration-eslint-npx-wrapper/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-npx-wrapper/snap.txt
@@ -19,26 +19,26 @@ VITE+ - The Unified Toolchain for the Web
     "prepare": "vp config"
   },
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
-  "packageManager": "pnpm@<semver>",
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
-  }
+  "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > test ! -f eslint.config.mjs # check eslint config is removed

--- a/packages/cli/snap-tests-global/migration-eslint-npx-wrapper/steps.json
+++ b/packages/cli/snap-tests-global/migration-eslint-npx-wrapper/steps.json
@@ -2,6 +2,7 @@
   "commands": [
     "vp migrate --no-interactive # migration should rewrite bare eslint but leave npx wrappers unchanged",
     "cat package.json # check eslint removed, bare eslint rewritten, npx/pnpm exec/bunx wrappers unchanged",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "test ! -f eslint.config.mjs # check eslint config is removed"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-eslint/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint/snap.txt
@@ -17,27 +17,27 @@ VITE+ - The Unified Toolchain for the Web
     "prepare": "vp config"
   },
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
-  "packageManager": "pnpm@<semver>",
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
-  }
+  "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > test ! -f eslint.config.mjs # check eslint config is removed
 > cat vite.config.ts # check oxlint config merged into vite.config.ts

--- a/packages/cli/snap-tests-global/migration-eslint/steps.json
+++ b/packages/cli/snap-tests-global/migration-eslint/steps.json
@@ -2,6 +2,7 @@
   "commands": [
     "vp migrate --no-interactive # migration should detect eslint and auto-migrate",
     "cat package.json # check eslint removed and scripts rewritten",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "test ! -f eslint.config.mjs # check eslint config is removed",
     "cat vite.config.ts # check oxlint config merged into vite.config.ts"
   ]

--- a/packages/cli/snap-tests-global/migration-existing-husky-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-husky-lint-staged/snap.txt
@@ -14,27 +14,27 @@ VITE+ - The Unified Toolchain for the Web
     "prepare": "vp config"
   },
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > cat vite.config.ts # check staged config migrated to vite.config.ts
 import { defineConfig } from 'vite-plus';

--- a/packages/cli/snap-tests-global/migration-existing-husky-lint-staged/steps.json
+++ b/packages/cli/snap-tests-global/migration-existing-husky-lint-staged/steps.json
@@ -1,8 +1,12 @@
 {
   "commands": [
-    { "command": "git init", "ignoreOutput": true },
+    {
+      "command": "git init",
+      "ignoreOutput": true
+    },
     "vp migrate --no-interactive # migration should rewrite husky and lint-staged",
     "cat package.json # check prepare rewritten, lint-staged removed, both removed from devDeps",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "cat vite.config.ts # check staged config migrated to vite.config.ts",
     "cat .vite-hooks/pre-commit # check pre-commit hook rewritten"
   ]

--- a/packages/cli/snap-tests-global/migration-existing-husky-v8-hooks/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-husky-v8-hooks/snap.txt
@@ -17,27 +17,27 @@ VITE+ - The Unified Toolchain for the Web
   "devDependencies": {
     "husky": "^8.0.0",
     "lint-staged": "^15.0.0",
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > cat .husky/pre-commit # hook file should be unchanged (still has bootstrap)
 . "$(dirname -- "$0")/_/husky.sh"

--- a/packages/cli/snap-tests-global/migration-existing-husky-v8-hooks/steps.json
+++ b/packages/cli/snap-tests-global/migration-existing-husky-v8-hooks/steps.json
@@ -1,8 +1,12 @@
 {
   "commands": [
-    { "command": "git init", "ignoreOutput": true },
+    {
+      "command": "git init",
+      "ignoreOutput": true
+    },
     "vp migrate --no-interactive # should warn about husky v8 and skip hooks setup",
     "cat package.json # husky/lint-staged should remain in devDeps, prepare should stay as husky",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "cat .husky/pre-commit # hook file should be unchanged (still has bootstrap)"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-existing-husky-v8-multi-hooks/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-husky-v8-multi-hooks/snap.txt
@@ -17,27 +17,27 @@ VITE+ - The Unified Toolchain for the Web
   "devDependencies": {
     "husky": "^8.0.0",
     "lint-staged": "^15.0.0",
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > cat .husky/pre-commit # hook file should be unchanged (still has bootstrap)
 . "$(dirname -- "$0")/_/husky.sh"

--- a/packages/cli/snap-tests-global/migration-existing-husky-v8-multi-hooks/steps.json
+++ b/packages/cli/snap-tests-global/migration-existing-husky-v8-multi-hooks/steps.json
@@ -1,8 +1,12 @@
 {
   "commands": [
-    { "command": "git init", "ignoreOutput": true },
+    {
+      "command": "git init",
+      "ignoreOutput": true
+    },
     "vp migrate --no-interactive # should warn about husky v8 and skip hooks setup",
     "cat package.json # husky/lint-staged should remain in devDeps, prepare should stay as husky",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "cat .husky/pre-commit # hook file should be unchanged (still has bootstrap)",
     "cat .husky/commit-msg # hook file should be unchanged (still has bootstrap)"
   ]

--- a/packages/cli/snap-tests-global/migration-existing-husky/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-husky/snap.txt
@@ -14,27 +14,27 @@ VITE+ - The Unified Toolchain for the Web
     "prepare": "vp config"
   },
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > cat .vite-hooks/pre-commit # check pre-commit hook rewritten to vp staged
 vp staged

--- a/packages/cli/snap-tests-global/migration-existing-husky/steps.json
+++ b/packages/cli/snap-tests-global/migration-existing-husky/steps.json
@@ -1,8 +1,12 @@
 {
   "commands": [
-    { "command": "git init", "ignoreOutput": true },
+    {
+      "command": "git init",
+      "ignoreOutput": true
+    },
     "vp migrate --no-interactive # migration should rewrite husky to vp config",
     "cat package.json # check prepare script rewritten and husky removed from devDeps",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "cat .vite-hooks/pre-commit # check pre-commit hook rewritten to vp staged"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-existing-lint-staged-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-lint-staged-config/snap.txt
@@ -11,30 +11,30 @@ VITE+ - The Unified Toolchain for the Web
 {
   "name": "migration-existing-lint-staged-config",
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>",
   "scripts": {
     "prepare": "vp config"
   }
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > test ! -f .lintstagedrc.json # check lintstagedrc.json (should be deleted after inlining to vite.config.ts)
 > cat vite.config.ts # check staged config migrated to vite.config.ts

--- a/packages/cli/snap-tests-global/migration-existing-lint-staged-config/steps.json
+++ b/packages/cli/snap-tests-global/migration-existing-lint-staged-config/steps.json
@@ -1,8 +1,12 @@
 {
   "commands": [
-    { "command": "git init", "ignoreOutput": true },
+    {
+      "command": "git init",
+      "ignoreOutput": true
+    },
     "vp migrate --no-interactive # migration should add prepare script, remove lint-staged from devDeps",
     "cat package.json # check prepare script added, lint-staged removed from devDeps",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "test ! -f .lintstagedrc.json # check lintstagedrc.json (should be deleted after inlining to vite.config.ts)",
     "cat vite.config.ts # check staged config migrated to vite.config.ts",
     "cat .vite-hooks/pre-commit # check pre-commit hook created"

--- a/packages/cli/snap-tests-global/migration-existing-pnpm-exec-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-pnpm-exec-lint-staged/snap.txt
@@ -14,27 +14,27 @@ VITE+ - The Unified Toolchain for the Web
     "prepare": "vp config"
   },
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > cat vite.config.ts # check staged config migrated to vite.config.ts
 import { defineConfig } from 'vite-plus';

--- a/packages/cli/snap-tests-global/migration-existing-pnpm-exec-lint-staged/steps.json
+++ b/packages/cli/snap-tests-global/migration-existing-pnpm-exec-lint-staged/steps.json
@@ -1,8 +1,12 @@
 {
   "commands": [
-    { "command": "git init", "ignoreOutput": true },
+    {
+      "command": "git init",
+      "ignoreOutput": true
+    },
     "vp migrate --no-interactive # migration should strip pnpm exec lint-staged and add vp staged",
     "cat package.json # check prepare rewritten and husky/lint-staged removed",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "cat vite.config.ts # check staged config migrated to vite.config.ts",
     "cat .vite-hooks/pre-commit # check pnpm exec lint-staged replaced with vp staged"
   ]

--- a/packages/cli/snap-tests-global/migration-existing-prepare-script/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-prepare-script/snap.txt
@@ -15,27 +15,27 @@ VITE+ - The Unified Toolchain for the Web
     "prepare": "vp config && npm run build"
   },
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > cat .vite-hooks/pre-commit # check pre-commit hook
 vp staged

--- a/packages/cli/snap-tests-global/migration-existing-prepare-script/steps.json
+++ b/packages/cli/snap-tests-global/migration-existing-prepare-script/steps.json
@@ -1,8 +1,12 @@
 {
   "commands": [
-    { "command": "git init", "ignoreOutput": true },
+    {
+      "command": "git init",
+      "ignoreOutput": true
+    },
     "vp migrate --no-interactive # migration should compose vp config with existing prepare script",
     "cat package.json # check prepare script is composed: vp config && npm run build",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "cat .vite-hooks/pre-commit # check pre-commit hook"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-from-tsdown-json-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-from-tsdown-json-config/snap.txt
@@ -39,27 +39,27 @@ export default defineConfig({
     "prepare": "vp config"
   },
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > vp migrate --no-interactive # run migration again to check if it is idempotent
 VITE+ - The Unified Toolchain for the Web
@@ -100,24 +100,8 @@ export default defineConfig({
     "prepare": "vp config"
   },
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }

--- a/packages/cli/snap-tests-global/migration-from-tsdown-json-config/steps.json
+++ b/packages/cli/snap-tests-global/migration-from-tsdown-json-config/steps.json
@@ -4,6 +4,7 @@
     "test ! -f tsdown.config.json # check tsdown.config.json should be removed",
     "cat vite.config.ts # check vite.config.ts",
     "cat package.json # check package.json",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "vp migrate --no-interactive # run migration again to check if it is idempotent",
     "cat vite.config.ts # check vite.config.ts",
     "cat package.json # check package.json"

--- a/packages/cli/snap-tests-global/migration-from-tsdown/snap.txt
+++ b/packages/cli/snap-tests-global/migration-from-tsdown/snap.txt
@@ -41,27 +41,27 @@ export default defineConfig({
     "prepare": "vp config"
   },
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > vp migrate --no-interactive # run migration again to check if it is idempotent
 VITE+ - The Unified Toolchain for the Web
@@ -103,24 +103,8 @@ export default defineConfig({
     "prepare": "vp config"
   },
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }

--- a/packages/cli/snap-tests-global/migration-from-tsdown/steps.json
+++ b/packages/cli/snap-tests-global/migration-from-tsdown/steps.json
@@ -4,6 +4,7 @@
     "cat tsdown.config.ts # check tsdown.config.ts",
     "cat vite.config.ts # check vite.config.ts",
     "cat package.json # check package.json",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "vp migrate --no-interactive # run migration again to check if it is idempotent",
     "cat tsdown.config.ts # check tsdown.config.ts",
     "cat vite.config.ts # check vite.config.ts",

--- a/packages/cli/snap-tests-global/migration-from-vitest-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-from-vitest-config/snap.txt
@@ -42,26 +42,26 @@ export default defineConfig({
     "prepare": "vp config"
   },
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vitest": "npm:@voidzero-dev/vite-plus-test@latest",
+    "vite": "catalog:",
+    "vitest": "catalog:",
     "playwright": "*",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'

--- a/packages/cli/snap-tests-global/migration-from-vitest-config/steps.json
+++ b/packages/cli/snap-tests-global/migration-from-vitest-config/steps.json
@@ -2,6 +2,7 @@
   "commands": [
     "vp migrate --no-interactive # migration should rewrite imports to vite-plus",
     "cat vitest.config.ts # check vitest.config.ts",
-    "cat package.json # check package.json"
+    "cat package.json # check package.json",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-from-vitest-files/snap.txt
+++ b/packages/cli/snap-tests-global/migration-from-vitest-files/snap.txt
@@ -17,29 +17,29 @@ VITE+ - The Unified Toolchain for the Web
     "prepare": "vp config"
   },
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vitest": "npm:@voidzero-dev/vite-plus-test@latest",
+    "vite": "catalog:",
+    "vitest": "catalog:",
     "playwright": "*",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > cat test/hello.ts # check test/hello.ts
 import { server } from 'vite-plus/test/browser-playwright/context';

--- a/packages/cli/snap-tests-global/migration-from-vitest-files/steps.json
+++ b/packages/cli/snap-tests-global/migration-from-vitest-files/steps.json
@@ -2,6 +2,7 @@
   "commands": [
     "vp migrate --no-interactive # migration should rewrite imports to vite-plus",
     "cat package.json # check package.json",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "cat test/hello.ts # check test/hello.ts"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-hooks-skip-on-existing-hookspath/snap.txt
+++ b/packages/cli/snap-tests-global/migration-hooks-skip-on-existing-hookspath/snap.txt
@@ -17,27 +17,27 @@ VITE+ - The Unified Toolchain for the Web
   },
   "devDependencies": {
     "husky": "^9.1.7",
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > git config --local core.hooksPath # should still be .custom-hooks
 .custom-hooks

--- a/packages/cli/snap-tests-global/migration-hooks-skip-on-existing-hookspath/steps.json
+++ b/packages/cli/snap-tests-global/migration-hooks-skip-on-existing-hookspath/steps.json
@@ -1,9 +1,16 @@
 {
   "commands": [
-    { "command": "git init", "ignoreOutput": true },
-    { "command": "git config core.hooksPath .custom-hooks", "ignoreOutput": true },
+    {
+      "command": "git init",
+      "ignoreOutput": true
+    },
+    {
+      "command": "git config core.hooksPath .custom-hooks",
+      "ignoreOutput": true
+    },
     "vp migrate --no-interactive # should skip hooks because core.hooksPath is already set",
     "cat package.json # prepare should stay 'husky' and husky must remain in devDependencies",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "git config --local core.hooksPath # should still be .custom-hooks"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-husky-latest-dist-tag-v9-installed/snap.txt
+++ b/packages/cli/snap-tests-global/migration-husky-latest-dist-tag-v9-installed/snap.txt
@@ -14,24 +14,24 @@ VITE+ - The Unified Toolchain for the Web
     "prepare": "vp config"
   },
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'

--- a/packages/cli/snap-tests-global/migration-husky-latest-dist-tag-v9-installed/steps.json
+++ b/packages/cli/snap-tests-global/migration-husky-latest-dist-tag-v9-installed/steps.json
@@ -1,7 +1,11 @@
 {
   "commands": [
-    { "command": "git init", "ignoreOutput": true },
+    {
+      "command": "git init",
+      "ignoreOutput": true
+    },
     "vp migrate --no-interactive # should resolve husky v9 from node_modules, no warning",
-    "cat package.json # husky and lint-staged should be removed"
+    "cat package.json # husky and lint-staged should be removed",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-husky-latest-dist-tag/snap.txt
+++ b/packages/cli/snap-tests-global/migration-husky-latest-dist-tag/snap.txt
@@ -16,24 +16,24 @@ VITE+ - The Unified Toolchain for the Web
   },
   "devDependencies": {
     "husky": "latest",
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'

--- a/packages/cli/snap-tests-global/migration-husky-latest-dist-tag/steps.json
+++ b/packages/cli/snap-tests-global/migration-husky-latest-dist-tag/steps.json
@@ -1,7 +1,11 @@
 {
   "commands": [
-    { "command": "git init", "ignoreOutput": true },
+    {
+      "command": "git init",
+      "ignoreOutput": true
+    },
     "vp migrate --no-interactive # should warn about uncoercible husky version",
-    "cat package.json # husky should still be in devDeps"
+    "cat package.json # husky should still be in devDeps",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-husky-or-prepare/snap.txt
+++ b/packages/cli/snap-tests-global/migration-husky-or-prepare/snap.txt
@@ -14,24 +14,24 @@ VITE+ - The Unified Toolchain for the Web
     "prepare": "vp config || true"
   },
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'

--- a/packages/cli/snap-tests-global/migration-husky-or-prepare/steps.json
+++ b/packages/cli/snap-tests-global/migration-husky-or-prepare/steps.json
@@ -1,7 +1,11 @@
 {
   "commands": [
-    { "command": "git init", "ignoreOutput": true },
+    {
+      "command": "git init",
+      "ignoreOutput": true
+    },
     "vp migrate --no-interactive # migration should preserve || fallback semantics",
-    "cat package.json # check prepare script preserves || true fallback"
+    "cat package.json # check prepare script preserves || true fallback",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-husky-semicolon-prepare/snap.txt
+++ b/packages/cli/snap-tests-global/migration-husky-semicolon-prepare/snap.txt
@@ -14,24 +14,24 @@ VITE+ - The Unified Toolchain for the Web
     "prepare": "npm run build; vp config"
   },
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'

--- a/packages/cli/snap-tests-global/migration-husky-semicolon-prepare/steps.json
+++ b/packages/cli/snap-tests-global/migration-husky-semicolon-prepare/steps.json
@@ -1,7 +1,11 @@
 {
   "commands": [
-    { "command": "git init", "ignoreOutput": true },
+    {
+      "command": "git init",
+      "ignoreOutput": true
+    },
     "vp migrate --no-interactive # migration should strip husky from semicolon-composed prepare script",
-    "cat package.json # check husky removed from prepare script, not left as broken command"
+    "cat package.json # check husky removed from prepare script, not left as broken command",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-husky-v8-preserves-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-husky-v8-preserves-lint-staged/snap.txt
@@ -17,27 +17,27 @@ VITE+ - The Unified Toolchain for the Web
   "devDependencies": {
     "husky": "^8.0.0",
     "lint-staged": "^15.0.0",
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "lint-staged": {
     "*.{js,ts}": "eslint --fix"
   },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
-  },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'

--- a/packages/cli/snap-tests-global/migration-husky-v8-preserves-lint-staged/steps.json
+++ b/packages/cli/snap-tests-global/migration-husky-v8-preserves-lint-staged/steps.json
@@ -1,7 +1,11 @@
 {
   "commands": [
-    { "command": "git init", "ignoreOutput": true },
+    {
+      "command": "git init",
+      "ignoreOutput": true
+    },
     "vp migrate --no-interactive # should warn about husky v8, preserve lint-staged config",
-    "cat package.json # lint-staged config should still be in package.json"
+    "cat package.json # lint-staged config should still be in package.json",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-lint-staged-in-scripts/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lint-staged-in-scripts/snap.txt
@@ -15,27 +15,27 @@ VITE+ - The Unified Toolchain for the Web
     "check-staged": "vp staged --diff HEAD~1"
   },
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > cat vite.config.ts # check staged config migrated to vite.config.ts
 import { defineConfig } from 'vite-plus';

--- a/packages/cli/snap-tests-global/migration-lint-staged-in-scripts/steps.json
+++ b/packages/cli/snap-tests-global/migration-lint-staged-in-scripts/steps.json
@@ -1,8 +1,12 @@
 {
   "commands": [
-    { "command": "git init", "ignoreOutput": true },
+    {
+      "command": "git init",
+      "ignoreOutput": true
+    },
     "vp migrate --no-interactive # migration should rewrite lint-staged commands in scripts",
     "cat package.json # check-staged script should use vp staged, lint-staged removed from devDeps",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "cat vite.config.ts # check staged config migrated to vite.config.ts"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-lint-staged-merge-fail/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lint-staged-merge-fail/snap.txt
@@ -17,33 +17,33 @@ Please add staged config to vite.config.ts manually, see https://viteplus.dev/gu
   "name": "migration-lint-staged-merge-fail",
   "devDependencies": {
     "lint-staged": "^16.2.6",
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "lint-staged": {
     "*.css": "stylelint --fix"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
   },
   "packageManager": "pnpm@<semver>",
   "scripts": {
     "prepare": "vp config"
   }
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > cat vite.config.ts # vite config should be unchanged (merge failed)
 const config = { plugins: [] };

--- a/packages/cli/snap-tests-global/migration-lint-staged-merge-fail/steps.json
+++ b/packages/cli/snap-tests-global/migration-lint-staged-merge-fail/steps.json
@@ -1,8 +1,12 @@
 {
   "commands": [
-    { "command": "git init", "ignoreOutput": true },
+    {
+      "command": "git init",
+      "ignoreOutput": true
+    },
     "vp migrate --no-interactive # should handle merge failure gracefully",
     "cat package.json # lint-staged config should be preserved when merge fails",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "cat vite.config.ts # vite config should be unchanged (merge failed)",
     "test -f .vite-hooks/pre-commit && echo 'pre-commit hook exists' || echo 'no pre-commit hook' # should NOT exist when merge fails"
   ]

--- a/packages/cli/snap-tests-global/migration-lint-staged-ts-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lint-staged-ts-config/snap.txt
@@ -18,27 +18,27 @@ VITE+ - The Unified Toolchain for the Web
   "devDependencies": {
     "husky": "^9.1.7",
     "lint-staged": "^16.2.6",
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > cat lint-staged.config.ts # check TS config is not modified
 export default {

--- a/packages/cli/snap-tests-global/migration-lint-staged-ts-config/steps.json
+++ b/packages/cli/snap-tests-global/migration-lint-staged-ts-config/steps.json
@@ -1,8 +1,12 @@
 {
   "commands": [
-    { "command": "git init", "ignoreOutput": true },
+    {
+      "command": "git init",
+      "ignoreOutput": true
+    },
     "vp migrate --no-interactive # migration should warn about unsupported TS lint-staged config",
     "cat package.json # check lint-staged NOT added to package.json, husky/lint-staged removed from devDependencies",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "cat lint-staged.config.ts # check TS config is not modified"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-json/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-json/snap.txt
@@ -85,30 +85,30 @@ VITE+ - The Unified Toolchain for the Web
 > cat package.json # check package.json
 {
   "name": "migration-lintstagedrc",
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
-  },
   "devDependencies": {
-    "vite-plus": "latest"
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>",
   "scripts": {
     "prepare": "vp config"
   }
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > cat vite.config.ts # check staged config migrated to vite.config.ts
 import { defineConfig } from 'vite-plus';

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-json/steps.json
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-json/steps.json
@@ -4,6 +4,7 @@
     "vp migrate --no-interactive # migration work with lintstagedrc.json",
     "cat .lintstagedrc.json # check lintstagedrc.json (should be deleted after inlining)",
     "cat package.json # check package.json",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "cat vite.config.ts # check staged config migrated to vite.config.ts"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-merge-fail/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-merge-fail/snap.txt
@@ -17,30 +17,30 @@ Please add staged config to vite.config.ts manually, see https://viteplus.dev/gu
   "name": "migration-lintstagedrc-merge-fail",
   "devDependencies": {
     "lint-staged": "^16.2.6",
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>",
   "scripts": {
     "prepare": "vp config"
   }
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > cat .lintstagedrc.json # config file should be preserved when merge fails
 {

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-merge-fail/steps.json
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-merge-fail/steps.json
@@ -1,8 +1,12 @@
 {
   "commands": [
-    { "command": "git init", "ignoreOutput": true },
+    {
+      "command": "git init",
+      "ignoreOutput": true
+    },
     "vp migrate --no-interactive # should handle merge failure gracefully",
     "cat package.json # check package.json",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "cat .lintstagedrc.json # config file should be preserved when merge fails",
     "cat vite.config.ts # vite config should be unchanged (merge failed)",
     "test -f .vite-hooks/pre-commit && echo 'pre-commit hook exists' || echo 'no pre-commit hook' # should NOT exist when merge fails"

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-not-support/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-not-support/snap.txt
@@ -32,23 +32,23 @@ export default {
   "devDependencies": {
     "husky": "^9.1.7",
     "lint-staged": "^16.2.6",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-not-support/steps.json
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-not-support/steps.json
@@ -1,10 +1,14 @@
 {
   "commands": [
-    { "command": "git init", "ignoreOutput": true },
+    {
+      "command": "git init",
+      "ignoreOutput": true
+    },
     "vp migrate --no-interactive # migration should not support non-json format lintstagedrc",
     "cat .lintstagedrc # check .lintstagedrc is not updated",
     "cat .lintstagedrc.yaml # check .lintstagedrc.yaml is not updated",
     "cat lint-staged.config.mjs # check lint-staged.config.mjs is not updated",
-    "cat package.json # check hooks setup skipped but husky/lint-staged removed from devDependencies"
+    "cat package.json # check hooks setup skipped but husky/lint-staged removed from devDependencies",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-staged-exists/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-staged-exists/snap.txt
@@ -12,30 +12,30 @@ VITE+ - The Unified Toolchain for the Web
 {
   "name": "migration-lintstagedrc-staged-exists",
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>",
   "scripts": {
     "prepare": "vp config"
   }
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > test -f .lintstagedrc.json && echo 'lintstagedrc.json still exists' || echo 'lintstagedrc.json was deleted' # should still exist
 lintstagedrc.json still exists

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-staged-exists/steps.json
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-staged-exists/steps.json
@@ -1,8 +1,12 @@
 {
   "commands": [
-    { "command": "git init", "ignoreOutput": true },
+    {
+      "command": "git init",
+      "ignoreOutput": true
+    },
     "vp migrate --no-interactive # should warn when staged already exists in vite.config.ts",
     "cat package.json # check package.json",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "test -f .lintstagedrc.json && echo 'lintstagedrc.json still exists' || echo 'lintstagedrc.json was deleted' # should still exist",
     "cat vite.config.ts # vite config should be unchanged"
   ]

--- a/packages/cli/snap-tests-global/migration-merge-vite-config-js/snap.txt
+++ b/packages/cli/snap-tests-global/migration-merge-vite-config-js/snap.txt
@@ -36,24 +36,24 @@ export default {
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.0",
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'

--- a/packages/cli/snap-tests-global/migration-merge-vite-config-js/steps.json
+++ b/packages/cli/snap-tests-global/migration-merge-vite-config-js/steps.json
@@ -3,6 +3,7 @@
     "vp migrate --no-interactive # migration should merge vite.config.js and remove oxlintrc",
     "cat vite.config.js # check vite.config.js",
     "test ! -f .oxlintrc.json # check .oxlintrc.json is removed",
-    "cat package.json # check package.json"
+    "cat package.json # check package.json",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-merge-vite-config-ts/snap.txt
+++ b/packages/cli/snap-tests-global/migration-merge-vite-config-ts/snap.txt
@@ -68,26 +68,26 @@ export default defineConfig({
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.0",
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vitest": "npm:@voidzero-dev/vite-plus-test@latest",
+    "vite": "catalog:",
+    "vitest": "catalog:",
     "playwright": "*",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'

--- a/packages/cli/snap-tests-global/migration-merge-vite-config-ts/steps.json
+++ b/packages/cli/snap-tests-global/migration-merge-vite-config-ts/steps.json
@@ -4,6 +4,7 @@
     "cat vite.config.ts # check vite.config.ts",
     "test ! -f .oxlintrc.json # check .oxlintrc.json is removed",
     "test ! -f .oxfmtrc.json # check .oxfmtrc.json is removed",
-    "cat package.json # check package.json"
+    "cat package.json # check package.json",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-monorepo-pnpm-overrides-dependency-selector/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-pnpm-overrides-dependency-selector/snap.txt
@@ -31,13 +31,7 @@ export default defineConfig({
     "vite": "catalog:",
     "vite-plus": "catalog:"
   },
-  "packageManager": "pnpm@<semver>+sha512.cf9998222162dd85864d0a8102e7892e7ba4ceadebbf5a31f9c2fce48dfce317a9c53b9f6464d1ef9042cba2e02ae02a9f7c143a2b438cd93c91840f0192b9dd",
-  "pnpm": {
-    "overrides": {
-      "react-click-away-listener>react": "0.0.0-experimental-7dc903cd-20251203",
-      "supertest>superagent": "9.0.2"
-    }
-  }
+  "packageManager": "pnpm@<semver>+sha512.cf9998222162dd85864d0a8102e7892e7ba4ceadebbf5a31f9c2fce48dfce317a9c53b9f6464d1ef9042cba2e02ae02a9f7c143a2b438cd93c91840f0192b9dd"
 }
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml
@@ -51,9 +45,10 @@ catalog:
 
 overrides:
   '@vitejs/plugin-react>vite': 'npm:vite@<semver>'
-  'supertest>superagent': '9.0.2'
+  'supertest>superagent': <semver>
   vite: 'catalog:'
   vitest: 'catalog:'
+  react-click-away-listener>react: <semver>
 peerDependencyRules:
   allowAny:
     - vite

--- a/packages/cli/snap-tests-global/migration-no-git-repo/snap.txt
+++ b/packages/cli/snap-tests-global/migration-no-git-repo/snap.txt
@@ -9,30 +9,30 @@ VITE+ - The Unified Toolchain for the Web
 {
   "name": "migration-no-git-repo",
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>",
   "scripts": {
     "prepare": "vp config"
   }
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > test -d .vite-hooks && echo 'hooks dir exists' || echo 'no hooks dir'
 hooks dir exists

--- a/packages/cli/snap-tests-global/migration-no-git-repo/steps.json
+++ b/packages/cli/snap-tests-global/migration-no-git-repo/steps.json
@@ -2,6 +2,7 @@
   "commands": [
     "vp migrate --no-interactive # migration should create .vite-hooks/pre-commit even without .git",
     "cat package.json # check package.json has prepare script and lint-staged config",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "test -d .vite-hooks && echo 'hooks dir exists' || echo 'no hooks dir'",
     "cat .vite-hooks/pre-commit # pre-commit hook should exist even without .git"
   ]

--- a/packages/cli/snap-tests-global/migration-no-hooks-with-husky/snap.txt
+++ b/packages/cli/snap-tests-global/migration-no-hooks-with-husky/snap.txt
@@ -16,30 +16,30 @@ VITE+ - The Unified Toolchain for the Web
   "devDependencies": {
     "husky": "^9.1.7",
     "lint-staged": "^16.2.6",
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "lint-staged": {
     "*.ts": "eslint --fix"
   },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
-  },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > test -d .husky && echo '.husky directory exists' || echo 'No .husky directory' # verify no .husky directory
 No .husky directory

--- a/packages/cli/snap-tests-global/migration-no-hooks-with-husky/steps.json
+++ b/packages/cli/snap-tests-global/migration-no-hooks-with-husky/steps.json
@@ -1,8 +1,12 @@
 {
   "commands": [
-    { "command": "git init", "ignoreOutput": true },
+    {
+      "command": "git init",
+      "ignoreOutput": true
+    },
     "vp migrate --no-hooks --no-interactive # --no-hooks should keep husky/lint-staged and preserve config",
     "cat package.json # prepare script, lint-staged config, check-staged script, and deps should all be preserved",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "test -d .husky && echo '.husky directory exists' || echo 'No .husky directory' # verify no .husky directory"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-no-hooks/snap.txt
+++ b/packages/cli/snap-tests-global/migration-no-hooks/snap.txt
@@ -10,27 +10,27 @@ VITE+ - The Unified Toolchain for the Web
 {
   "name": "migration-no-hooks",
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > test -d .vite-hooks && echo '.vite-hooks directory exists' || echo 'No .vite-hooks directory' # verify no .vite-hooks directory
 No .vite-hooks directory

--- a/packages/cli/snap-tests-global/migration-no-hooks/steps.json
+++ b/packages/cli/snap-tests-global/migration-no-hooks/steps.json
@@ -1,8 +1,12 @@
 {
   "commands": [
-    { "command": "git init", "ignoreOutput": true },
+    {
+      "command": "git init",
+      "ignoreOutput": true
+    },
     "vp migrate --no-hooks --no-interactive # migration with --no-hooks should skip hooks setup",
     "cat package.json # check package.json has no prepare script and no lint-staged config",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "test -d .vite-hooks && echo '.vite-hooks directory exists' || echo 'No .vite-hooks directory' # verify no .vite-hooks directory"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-other-hook-tool/snap.txt
+++ b/packages/cli/snap-tests-global/migration-other-hook-tool/snap.txt
@@ -16,8 +16,8 @@ VITE+ - The Unified Toolchain for the Web
   "devDependencies": {
     "lint-staged": "^16.2.6",
     "simple-git-hooks": "^2.11.1",
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "simple-git-hooks": {
     "pre-commit": "npx lint-staged"
@@ -25,21 +25,21 @@ VITE+ - The Unified Toolchain for the Web
   "lint-staged": {
     "*.ts": "eslint --fix"
   },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
-  },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'

--- a/packages/cli/snap-tests-global/migration-other-hook-tool/steps.json
+++ b/packages/cli/snap-tests-global/migration-other-hook-tool/steps.json
@@ -1,6 +1,7 @@
 {
   "commands": [
     "vp migrate --no-interactive # hooks should be skipped due to simple-git-hooks",
-    "cat package.json # lint-staged config, scripts, and simple-git-hooks config should all be preserved"
+    "cat package.json # lint-staged config, scripts, and simple-git-hooks config should all be preserved",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-oxlintrc-json-with-comments/snap.txt
+++ b/packages/cli/snap-tests-global/migration-oxlintrc-json-with-comments/snap.txt
@@ -33,26 +33,26 @@ export default defineConfig({
 > cat package.json # check package.json
 {
   "devDependencies": {
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>",
   "scripts": {
     "prepare": "vp config"
   }
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'

--- a/packages/cli/snap-tests-global/migration-oxlintrc-json-with-comments/steps.json
+++ b/packages/cli/snap-tests-global/migration-oxlintrc-json-with-comments/steps.json
@@ -3,6 +3,7 @@
     "vp migrate --no-interactive 2>&1 # migration should handle .oxlintrc.json with JSONC comments",
     "cat vite.config.ts # check vite.config.ts",
     "test ! -f .oxlintrc.json # check .oxlintrc.json is removed",
-    "cat package.json # check package.json"
+    "cat package.json # check package.json",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-oxlintrc-jsonc/snap.txt
+++ b/packages/cli/snap-tests-global/migration-oxlintrc-jsonc/snap.txt
@@ -35,26 +35,26 @@ export default defineConfig({
 > cat package.json # check package.json
 {
   "devDependencies": {
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>",
   "scripts": {
     "prepare": "vp config"
   }
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'

--- a/packages/cli/snap-tests-global/migration-oxlintrc-jsonc/steps.json
+++ b/packages/cli/snap-tests-global/migration-oxlintrc-jsonc/steps.json
@@ -4,6 +4,7 @@
     "cat vite.config.ts # check vite.config.ts",
     "test ! -f .oxlintrc.jsonc # check .oxlintrc.jsonc is removed",
     "test ! -f .oxfmtrc.jsonc # check .oxfmtrc.jsonc is removed",
-    "cat package.json # check package.json"
+    "cat package.json # check package.json",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-partially-migrated-pre-commit/snap.txt
+++ b/packages/cli/snap-tests-global/migration-partially-migrated-pre-commit/snap.txt
@@ -17,27 +17,27 @@ VITE+ - The Unified Toolchain for the Web
   "devDependencies": {
     "husky": "^8.0.0",
     "lint-staged": "^15.0.0",
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > cat .husky/pre-commit # hook file should be unchanged (still has bootstrap)
 . "$(dirname -- "$0")/_/husky.sh"

--- a/packages/cli/snap-tests-global/migration-partially-migrated-pre-commit/steps.json
+++ b/packages/cli/snap-tests-global/migration-partially-migrated-pre-commit/steps.json
@@ -1,8 +1,12 @@
 {
   "commands": [
-    { "command": "git init", "ignoreOutput": true },
+    {
+      "command": "git init",
+      "ignoreOutput": true
+    },
     "vp migrate --no-interactive # should warn about husky v8 and skip hooks setup",
     "cat package.json # husky/lint-staged should remain in devDeps, prepare should stay as husky",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "cat .husky/pre-commit # hook file should be unchanged (still has bootstrap)"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-prettier-eslint-combo/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier-eslint-combo/snap.txt
@@ -21,27 +21,27 @@ Prettier configuration detected. Auto-migrating to Oxfmt...
     "prepare": "vp config"
   },
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
-  "packageManager": "pnpm@<semver>",
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
-  }
+  "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > test ! -f eslint.config.mjs # check eslint config is removed
 > test ! -f .prettierrc.json # check prettier config is removed

--- a/packages/cli/snap-tests-global/migration-prettier-eslint-combo/steps.json
+++ b/packages/cli/snap-tests-global/migration-prettier-eslint-combo/steps.json
@@ -2,6 +2,7 @@
   "commands": [
     "vp migrate --no-interactive # migration should detect both eslint and prettier and auto-migrate",
     "cat package.json # check eslint and prettier removed, scripts rewritten",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "test ! -f eslint.config.mjs # check eslint config is removed",
     "test ! -f .prettierrc.json # check prettier config is removed",
     "cat vite.config.ts # check oxlint and oxfmt config merged into vite.config.ts"

--- a/packages/cli/snap-tests-global/migration-prettier-ignore-unknown/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier-ignore-unknown/snap.txt
@@ -19,26 +19,26 @@ Prettier configuration detected. Auto-migrating to Oxfmt...
     "prepare": "vp config"
   },
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > test ! -f .prettierrc.json # check prettier config is removed

--- a/packages/cli/snap-tests-global/migration-prettier-ignore-unknown/steps.json
+++ b/packages/cli/snap-tests-global/migration-prettier-ignore-unknown/steps.json
@@ -2,6 +2,7 @@
   "commands": [
     "vp migrate --no-interactive # migration should strip --ignore-unknown and -u flags",
     "cat package.json # check prettier removed and --ignore-unknown stripped from scripts",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "test ! -f .prettierrc.json # check prettier config is removed"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-prettier-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier-lint-staged/snap.txt
@@ -16,27 +16,27 @@ Prettier configuration detected. Auto-migrating to Oxfmt...
     "prepare": "vp config"
   },
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > cat vite.config.ts # check oxfmt config and staged config merged into vite.config.ts
 import { defineConfig } from "vite-plus";

--- a/packages/cli/snap-tests-global/migration-prettier-lint-staged/steps.json
+++ b/packages/cli/snap-tests-global/migration-prettier-lint-staged/steps.json
@@ -2,6 +2,7 @@
   "commands": [
     "vp migrate --no-interactive # migration should detect prettier and auto-migrate including lint-staged",
     "cat package.json # check prettier removed, scripts rewritten, lint-staged rewritten",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "cat vite.config.ts # check oxfmt config and staged config merged into vite.config.ts"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-prettier-pkg-json/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier-pkg-json/snap.txt
@@ -17,27 +17,27 @@ Prettier configuration detected. Auto-migrating to Oxfmt...
     "prepare": "vp config"
   },
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > cat vite.config.ts # check oxfmt config merged into vite.config.ts with semi/singleQuote settings
 import { defineConfig } from 'vite-plus';

--- a/packages/cli/snap-tests-global/migration-prettier-pkg-json/steps.json
+++ b/packages/cli/snap-tests-global/migration-prettier-pkg-json/steps.json
@@ -2,6 +2,7 @@
   "commands": [
     "vp migrate --no-interactive # migration should detect prettier in package.json and auto-migrate",
     "cat package.json # check prettier key removed, scripts rewritten, dep removed",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "cat vite.config.ts # check oxfmt config merged into vite.config.ts with semi/singleQuote settings"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-prettier/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier/snap.txt
@@ -19,27 +19,27 @@ Prettier configuration detected. Auto-migrating to Oxfmt...
     "prepare": "vp config"
   },
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > test ! -f .prettierrc.json # check prettier config is removed
 > cat vite.config.ts # check oxfmt config merged into vite.config.ts

--- a/packages/cli/snap-tests-global/migration-prettier/steps.json
+++ b/packages/cli/snap-tests-global/migration-prettier/steps.json
@@ -2,6 +2,7 @@
   "commands": [
     "vp migrate --no-interactive # migration should detect prettier and auto-migrate",
     "cat package.json # check prettier removed and scripts rewritten",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog",
     "test ! -f .prettierrc.json # check prettier config is removed",
     "cat vite.config.ts # check oxfmt config merged into vite.config.ts"
   ]

--- a/packages/cli/snap-tests-global/migration-rewrite-declare-module/snap.txt
+++ b/packages/cli/snap-tests-global/migration-rewrite-declare-module/snap.txt
@@ -39,27 +39,27 @@ declare module 'vite-plus' {
 > cat package.json # check package.json
 {
   "name": "migration-rewrite-declare-module",
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
-  },
   "devDependencies": {
-    "vite-plus": "latest"
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>",
   "scripts": {
     "prepare": "vp config"
   }
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'

--- a/packages/cli/snap-tests-global/migration-rewrite-declare-module/steps.json
+++ b/packages/cli/snap-tests-global/migration-rewrite-declare-module/steps.json
@@ -2,6 +2,7 @@
   "commands": [
     "vp migrate --no-interactive # migration should rewrite imports to vite-plus",
     "cat src/index.ts # check src/index.ts",
-    "cat package.json # check package.json"
+    "cat package.json # check package.json",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-skip-vite-dependency/snap.txt
+++ b/packages/cli/snap-tests-global/migration-skip-vite-dependency/snap.txt
@@ -32,29 +32,29 @@ export default defineConfig({
 {
   "name": "migration-skip-vite-dependency",
   "dependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:"
   },
   "devDependencies": {
-    "vite-plus": "latest"
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>",
   "scripts": {
     "prepare": "vp config"
   }
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'

--- a/packages/cli/snap-tests-global/migration-skip-vite-dependency/steps.json
+++ b/packages/cli/snap-tests-global/migration-skip-vite-dependency/steps.json
@@ -2,6 +2,7 @@
   "commands": [
     "vp migrate --no-interactive # migration should skip rewriting vite imports when vite is in dependencies",
     "cat src/index.ts # vite imports should NOT be rewritten, vitest imports SHOULD be rewritten",
-    "cat package.json # check package.json"
+    "cat package.json # check package.json",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-skip-vite-peer-dependency/snap.txt
+++ b/packages/cli/snap-tests-global/migration-skip-vite-peer-dependency/snap.txt
@@ -34,27 +34,27 @@ export default defineConfig({
   "peerDependencies": {
     "vite": "^6.0.0"
   },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
-  },
   "devDependencies": {
-    "vite-plus": "latest"
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>",
   "scripts": {
     "prepare": "vp config"
   }
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'

--- a/packages/cli/snap-tests-global/migration-skip-vite-peer-dependency/steps.json
+++ b/packages/cli/snap-tests-global/migration-skip-vite-peer-dependency/steps.json
@@ -2,6 +2,7 @@
   "commands": [
     "vp migrate --no-interactive # migration should skip rewriting vite imports when vite is in peerDependencies",
     "cat src/index.ts # vite imports should NOT be rewritten, vitest imports SHOULD be rewritten",
-    "cat package.json # check package.json"
+    "cat package.json # check package.json",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-standalone-pnpm/snap.txt
+++ b/packages/cli/snap-tests-global/migration-standalone-pnpm/snap.txt
@@ -1,4 +1,4 @@
-> vp migrate --no-interactive --no-hooks --package-manager pnpm # migration should work with pnpm, add overrides and peerDependencyRules
+> vp migrate --no-interactive --no-hooks --package-manager pnpm # migration should work with pnpm, write overrides and peerDependencyRules to pnpm-workspace.yaml
 VITE+ - The Unified Toolchain for the Web
 
 ◇ Migrated . to Vite+<repeat>
@@ -6,29 +6,29 @@ VITE+ - The Unified Toolchain for the Web
 ✓ Dependencies installed in <variable>ms
 • 1 config update applied
 
-> cat package.json # check package.json has pnpm.overrides and pnpm.peerDependencyRules
+> cat package.json # check package.json has no pnpm section
 {
   "name": "migration-standalone-pnpm",
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vitest": "npm:@voidzero-dev/vite-plus-test@latest",
-    "vite-plus": "latest"
+    "vite": "catalog:",
+    "vitest": "catalog:",
+    "vite-plus": "catalog:"
   },
-  "packageManager": "pnpm@<semver>",
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
-  }
+  "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides, peerDependencyRules, and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'

--- a/packages/cli/snap-tests-global/migration-standalone-pnpm/steps.json
+++ b/packages/cli/snap-tests-global/migration-standalone-pnpm/steps.json
@@ -6,7 +6,8 @@
     "VP_SKIP_INSTALL": ""
   },
   "commands": [
-    "vp migrate --no-interactive --no-hooks --package-manager pnpm # migration should work with pnpm, add overrides and peerDependencyRules",
-    "cat package.json # check package.json has pnpm.overrides and pnpm.peerDependencyRules"
+    "vp migrate --no-interactive --no-hooks --package-manager pnpm # migration should work with pnpm, write overrides and peerDependencyRules to pnpm-workspace.yaml",
+    "cat package.json # check package.json has no pnpm section",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides, peerDependencyRules, and catalog"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-subpath/snap.txt
+++ b/packages/cli/snap-tests-global/migration-subpath/snap.txt
@@ -20,24 +20,8 @@ VITE+ - The Unified Toolchain for the Web
       "oxlint --fix"
     ]
   },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
-  },
   "devDependencies": {
-    "vite-plus": "latest"
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
@@ -52,3 +36,19 @@ export default defineConfig({
 
 > git config --local core.hooksPath || echo 'core.hooksPath is not set' # should NOT be set
 core.hooksPath is not set
+
+> cat foo/pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'

--- a/packages/cli/snap-tests-global/migration-subpath/steps.json
+++ b/packages/cli/snap-tests-global/migration-subpath/steps.json
@@ -1,9 +1,13 @@
 {
   "commands": [
-    { "command": "git init", "ignoreOutput": true },
+    {
+      "command": "git init",
+      "ignoreOutput": true
+    },
     "vp migrate foo --no-interactive # migration work with subpath",
     "cat foo/package.json # check package.json",
     "cat foo/vite.config.ts # check vite.config.ts",
-    "git config --local core.hooksPath || echo 'core.hooksPath is not set' # should NOT be set"
+    "git config --local core.hooksPath || echo 'core.hooksPath is not set' # should NOT be set",
+    "cat foo/pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-tsconfig-esmoduleinterop/snap.txt
+++ b/packages/cli/snap-tests-global/migration-tsconfig-esmoduleinterop/snap.txt
@@ -31,27 +31,27 @@ export default defineConfig({
 > cat package.json # check package.json
 {
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>",
   "scripts": {
     "prepare": "vp config"
   }
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'

--- a/packages/cli/snap-tests-global/migration-tsconfig-esmoduleinterop/steps.json
+++ b/packages/cli/snap-tests-global/migration-tsconfig-esmoduleinterop/steps.json
@@ -3,6 +3,7 @@
     "vp migrate --no-interactive # should remove esModuleInterop: false from tsconfig.json",
     "cat tsconfig.json # verify esModuleInterop: false is removed",
     "cat vite.config.ts # check vite.config.ts",
-    "cat package.json # check package.json"
+    "cat package.json # check package.json",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-vite-version/snap.txt
+++ b/packages/cli/snap-tests-global/migration-vite-version/snap.txt
@@ -14,24 +14,24 @@ VITE+ - The Unified Toolchain for the Web
     "prepare": "vp config"
   },
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-    },
-    "peerDependencyRules": {
-      "allowAny": [
-        "vite",
-        "vitest"
-      ],
-      "allowedVersions": {
-        "vite": "*",
-        "vitest": "*"
-      }
-    }
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "packageManager": "pnpm@<semver>"
 }
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'

--- a/packages/cli/snap-tests-global/migration-vite-version/steps.json
+++ b/packages/cli/snap-tests-global/migration-vite-version/steps.json
@@ -1,6 +1,7 @@
 {
   "commands": [
     "vp migrate --no-interactive # migration should rewrite vite --version to vp --version",
-    "cat package.json # check package.json"
+    "cat package.json # check package.json",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog"
   ]
 }

--- a/packages/cli/src/migration/__tests__/migrator.spec.ts
+++ b/packages/cli/src/migration/__tests__/migrator.spec.ts
@@ -16,6 +16,7 @@ vi.mock('../../utils/constants.js', async (importOriginal) => {
 
 const {
   rewritePackageJson,
+  rewriteStandaloneProject,
   parseNvmrcVersion,
   detectNodeVersionManagerFile,
   migrateNodeVersionManagerFile,
@@ -288,5 +289,144 @@ describe('migrateNodeVersionManagerFile', () => {
     expect(ok).toBe(false);
     expect(report.warnings.length).toBe(1);
     expect(fs.existsSync(path.join(tmpDir, '.node-version'))).toBe(false);
+  });
+});
+
+function makeWorkspaceInfo(
+  rootDir: string,
+  packageManager: PackageManager,
+): import('../../types/index.js').WorkspaceInfo {
+  return {
+    rootDir,
+    isMonorepo: false,
+    monorepoScope: '',
+    workspacePatterns: [],
+    parentDirs: [],
+    packageManager,
+    packageManagerVersion: '10.33.0',
+    downloadPackageManager: {
+      name: 'pnpm',
+      installDir: '/tmp',
+      binPrefix: '/tmp/bin',
+      packageName: 'pnpm',
+      version: '10.33.0',
+    },
+    packages: [],
+  };
+}
+
+function readJson(filePath: string): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function readYaml(filePath: string): string {
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+describe('rewriteStandaloneProject pnpm workspace yaml', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vp-test-pnpm-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('creates pnpm-workspace.yaml when no existing pnpm config in package.json', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ name: 'test', devDependencies: { vite: '^7.0.0' } }),
+    );
+    rewriteStandaloneProject(tmpDir, makeWorkspaceInfo(tmpDir, PackageManager.pnpm), true, true);
+
+    // pnpm-workspace.yaml should be created
+    expect(fs.existsSync(path.join(tmpDir, 'pnpm-workspace.yaml'))).toBe(true);
+    const yaml = readYaml(path.join(tmpDir, 'pnpm-workspace.yaml'));
+    expect(yaml).toContain('overrides:');
+    expect(yaml).toContain('peerDependencyRules:');
+    expect(yaml).toContain('catalog:');
+
+    // package.json should not have pnpm section
+    const pkg = readJson(path.join(tmpDir, 'package.json'));
+    expect(pkg.pnpm).toBeUndefined();
+
+    // devDependencies should use catalog:
+    const devDeps = pkg.devDependencies as Record<string, string>;
+    expect(devDeps.vite).toBe('catalog:');
+    expect(devDeps['vite-plus']).toBe('catalog:');
+  });
+
+  it('keeps pnpm config in package.json when existing pnpm field present', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({
+        name: 'test',
+        devDependencies: { vite: '^7.0.0' },
+        pnpm: {
+          overrides: { 'some-pkg': '1.0.0' },
+          onlyBuiltDependencies: ['esbuild'],
+        },
+      }),
+    );
+    rewriteStandaloneProject(tmpDir, makeWorkspaceInfo(tmpDir, PackageManager.pnpm), true, true);
+
+    // pnpm-workspace.yaml should NOT be created
+    expect(fs.existsSync(path.join(tmpDir, 'pnpm-workspace.yaml'))).toBe(false);
+
+    // package.json should have pnpm.overrides with both existing and vite overrides
+    const pkg = readJson(path.join(tmpDir, 'package.json'));
+    const pnpm = pkg.pnpm as Record<string, unknown>;
+    expect(pnpm).toBeDefined();
+    const overrides = pnpm.overrides as Record<string, string>;
+    expect(overrides['some-pkg']).toBe('1.0.0');
+    expect(overrides.vite).toBeDefined();
+    expect(overrides.vitest).toBeDefined();
+
+    // peerDependencyRules should be present
+    expect(pnpm.peerDependencyRules).toBeDefined();
+    // onlyBuiltDependencies should be preserved
+    expect(pnpm.onlyBuiltDependencies).toEqual(['esbuild']);
+  });
+
+  it('preserves custom peerDependencyRules when migrating to pnpm-workspace.yaml', () => {
+    // Project has peerDependencyRules but no pnpm.overrides -- pnpm field is present
+    // so it should keep using package.json
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({
+        name: 'test',
+        devDependencies: { vite: '^7.0.0' },
+        pnpm: {
+          peerDependencyRules: {
+            allowAny: ['react', 'vite'],
+            allowedVersions: { react: '*', vite: '*' },
+            ignoreMissing: ['@types/node'],
+          },
+        },
+      }),
+    );
+    rewriteStandaloneProject(tmpDir, makeWorkspaceInfo(tmpDir, PackageManager.pnpm), true, true);
+
+    const pkg = readJson(path.join(tmpDir, 'package.json'));
+    const pnpm = pkg.pnpm as Record<string, unknown>;
+    const rules = pnpm.peerDependencyRules as Record<string, unknown>;
+    // Custom entries preserved, Vite entries merged
+    expect(rules.allowAny).toEqual(expect.arrayContaining(['react', 'vite', 'vitest']));
+    // ignoreMissing preserved
+    expect(rules.ignoreMissing).toEqual(['@types/node']);
+  });
+
+  it('writes vite overrides with catalog references to pnpm-workspace.yaml', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ name: 'test', devDependencies: { vite: '^7.0.0' } }),
+    );
+    rewriteStandaloneProject(tmpDir, makeWorkspaceInfo(tmpDir, PackageManager.pnpm), true, true);
+
+    const yaml = readYaml(path.join(tmpDir, 'pnpm-workspace.yaml'));
+    expect(yaml).toContain("vite: 'catalog:'");
+    expect(yaml).toContain("vitest: 'catalog:'");
   });
 });

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -697,6 +697,9 @@ export function rewriteStandaloneProject(
 
   const packageManager = workspaceInfo.packageManager;
   let extractedStagedConfig: Record<string, string | string[]> | null = null;
+  let remainingPnpmOverrides: Record<string, string> | undefined;
+  // Determined inside editJsonFile callback to avoid a redundant file read
+  let usePnpmWorkspaceYaml = false;
   editJsonFile<{
     overrides?: Record<string, string>;
     resolutions?: Record<string, string>;
@@ -722,24 +725,52 @@ export function rewriteStandaloneProject(
         ...VITE_PLUS_OVERRIDE_PACKAGES,
       };
     } else if (packageManager === PackageManager.pnpm) {
+      // If package.json already has a "pnpm" field, keep using it;
+      // otherwise use pnpm-workspace.yaml.
+      usePnpmWorkspaceYaml = !pkg.pnpm;
+      if (usePnpmWorkspaceYaml) {
+        rewritePnpmWorkspaceYaml(projectPath);
+        // In force-override mode, also override vite-plus itself so transitive
+        // deps resolve to the local tgz instead of the published version.
+        if (isForceOverrideMode()) {
+          migratePnpmOverridesToWorkspaceYaml(projectPath, {
+            [VITE_PLUS_NAME]: VITE_PLUS_VERSION,
+          });
+        }
+      }
       const overrideKeys = Object.keys(VITE_PLUS_OVERRIDE_PACKAGES);
-      pkg.pnpm = {
-        ...pkg.pnpm,
-        overrides: {
-          ...pkg.pnpm?.overrides,
-          ...VITE_PLUS_OVERRIDE_PACKAGES,
-          ...(isForceOverrideMode() ? { [VITE_PLUS_NAME]: VITE_PLUS_VERSION } : {}),
-        },
-        peerDependencyRules: {
-          allowAny: [
-            ...new Set([...(pkg.pnpm?.peerDependencyRules?.allowAny ?? []), ...overrideKeys]),
-          ],
-          allowedVersions: {
-            ...pkg.pnpm?.peerDependencyRules?.allowedVersions,
-            ...Object.fromEntries(overrideKeys.map((key) => [key, '*'])),
+      if (!usePnpmWorkspaceYaml) {
+        // Project already has pnpm config in package.json -- keep using it.
+        pkg.pnpm = {
+          ...pkg.pnpm,
+          overrides: {
+            ...pkg.pnpm?.overrides,
+            ...VITE_PLUS_OVERRIDE_PACKAGES,
+            ...(isForceOverrideMode() ? { [VITE_PLUS_NAME]: VITE_PLUS_VERSION } : {}),
           },
-        },
-      };
+          peerDependencyRules: {
+            ...pkg.pnpm?.peerDependencyRules,
+            allowAny: [
+              ...new Set([...(pkg.pnpm?.peerDependencyRules?.allowAny ?? []), ...overrideKeys]),
+            ],
+            allowedVersions: {
+              ...pkg.pnpm?.peerDependencyRules?.allowedVersions,
+              ...Object.fromEntries(overrideKeys.map((key) => [key, '*'])),
+            },
+          },
+        };
+      } else {
+        remainingPnpmOverrides = cleanupPnpmOverridesForWorkspaceYaml(pkg, overrideKeys);
+      }
+      // remove dependency selectors targeting vite (e.g. "vite-plugin-svgr>vite")
+      for (const key in pkg.pnpm?.overrides) {
+        if (key.includes('>')) {
+          const splits = key.split('>');
+          if (splits[splits.length - 1].trim() === 'vite') {
+            delete pkg.pnpm.overrides[key];
+          }
+        }
+      }
       // remove packages from `resolutions` field if they exist
       // https://pnpm.io/9.x/package_json#resolutions
       for (const key of [...overrideKeys, ...REMOVE_PACKAGES]) {
@@ -749,17 +780,31 @@ export function rewriteStandaloneProject(
       }
     }
 
-    extractedStagedConfig = rewritePackageJson(pkg, packageManager, false, skipStagedMigration);
+    extractedStagedConfig = rewritePackageJson(
+      pkg,
+      packageManager,
+      usePnpmWorkspaceYaml,
+      skipStagedMigration,
+    );
 
     // ensure vite-plus is in devDependencies
     if (!pkg.devDependencies?.[VITE_PLUS_NAME] || isForceOverrideMode()) {
+      const version =
+        usePnpmWorkspaceYaml && !VITE_PLUS_VERSION.startsWith('file:')
+          ? 'catalog:'
+          : VITE_PLUS_VERSION;
       pkg.devDependencies = {
         ...pkg.devDependencies,
-        [VITE_PLUS_NAME]: VITE_PLUS_VERSION,
+        [VITE_PLUS_NAME]: version,
       };
     }
     return pkg;
   });
+
+  // Move remaining non-Vite pnpm.overrides to pnpm-workspace.yaml
+  if (remainingPnpmOverrides) {
+    migratePnpmOverridesToWorkspaceYaml(projectPath, remainingPnpmOverrides);
+  }
 
   // Merge extracted staged config into vite.config.ts, then remove lint-staged from package.json
   if (extractedStagedConfig) {
@@ -961,6 +1006,102 @@ function rewritePnpmWorkspaceYaml(projectPath: string): void {
 }
 
 /**
+ * Clean up pnpm.overrides and peerDependencyRules from package.json when migrating
+ * to pnpm-workspace.yaml. Returns any remaining non-Vite overrides that need to be
+ * moved to pnpm-workspace.yaml.
+ */
+function cleanupPnpmOverridesForWorkspaceYaml(
+  pkg: {
+    pnpm?: {
+      overrides?: Record<string, string>;
+      peerDependencyRules?: { allowAny?: string[]; allowedVersions?: Record<string, string> };
+    };
+  },
+  overrideKeys: string[],
+): Record<string, string> | undefined {
+  // Remove Vite-managed keys from pnpm.overrides
+  for (const key of [...overrideKeys, ...REMOVE_PACKAGES]) {
+    if (pkg.pnpm?.overrides?.[key]) {
+      delete pkg.pnpm.overrides[key];
+    }
+  }
+  // Remove dependency selectors targeting vite
+  for (const key in pkg.pnpm?.overrides) {
+    if (key.includes('>')) {
+      const splits = key.split('>');
+      if (splits[splits.length - 1].trim() === 'vite') {
+        delete pkg.pnpm.overrides[key];
+      }
+    }
+  }
+  // Collect remaining overrides to move to pnpm-workspace.yaml then delete all
+  // (pnpm ignores workspace-level overrides when pnpm.overrides exists in package.json)
+  let remaining: Record<string, string> | undefined;
+  if (pkg.pnpm?.overrides && Object.keys(pkg.pnpm.overrides).length > 0) {
+    remaining = { ...pkg.pnpm.overrides };
+  }
+  delete pkg.pnpm?.overrides;
+  // Only remove Vite-managed peerDependencyRules entries, preserve custom ones
+  cleanupPeerDependencyRules(pkg.pnpm?.peerDependencyRules, overrideKeys);
+  if (pkg.pnpm?.peerDependencyRules && Object.keys(pkg.pnpm.peerDependencyRules).length === 0) {
+    delete pkg.pnpm.peerDependencyRules;
+  }
+  if (pkg.pnpm && Object.keys(pkg.pnpm).length === 0) {
+    delete pkg.pnpm;
+  }
+  return remaining;
+}
+
+/**
+ * Move remaining non-Vite pnpm.overrides from package.json to pnpm-workspace.yaml.
+ * pnpm ignores workspace-level overrides when pnpm.overrides exists in package.json,
+ * so all overrides must live in pnpm-workspace.yaml.
+ */
+function migratePnpmOverridesToWorkspaceYaml(
+  projectPath: string,
+  overrides: Record<string, string>,
+): void {
+  const pnpmWorkspaceYamlPath = path.join(projectPath, 'pnpm-workspace.yaml');
+  editYamlFile(pnpmWorkspaceYamlPath, (doc) => {
+    for (const [key, value] of Object.entries(overrides)) {
+      // Always overwrite: package.json value was the effective one before migration
+      // (pnpm ignores workspace overrides when pnpm.overrides exists in package.json)
+      doc.setIn(['overrides', scalarString(key)], scalarString(value));
+    }
+  });
+}
+
+/**
+ * Remove only Vite-managed entries from peerDependencyRules, preserving custom ones.
+ */
+function cleanupPeerDependencyRules(
+  peerDependencyRules:
+    | { allowAny?: string[]; allowedVersions?: Record<string, string> }
+    | undefined,
+  overrideKeys: string[],
+): void {
+  if (!peerDependencyRules) {
+    return;
+  }
+  if (Array.isArray(peerDependencyRules.allowAny)) {
+    peerDependencyRules.allowAny = peerDependencyRules.allowAny.filter(
+      (key) => !overrideKeys.includes(key),
+    );
+    if (peerDependencyRules.allowAny.length === 0) {
+      delete peerDependencyRules.allowAny;
+    }
+  }
+  if (peerDependencyRules.allowedVersions) {
+    for (const key of overrideKeys) {
+      delete peerDependencyRules.allowedVersions[key];
+    }
+    if (Object.keys(peerDependencyRules.allowedVersions).length === 0) {
+      delete peerDependencyRules.allowedVersions;
+    }
+  }
+}
+
+/**
  * Rewrite .yarnrc.yml to add vite-plus dependencies
  * @param projectPath - The path to the project
  */
@@ -1062,12 +1203,17 @@ function rewriteRootWorkspacePackageJson(
     return;
   }
 
+  let remainingPnpmOverrides: Record<string, string> | undefined;
   editJsonFile<{
     resolutions?: Record<string, string>;
     overrides?: Record<string, string>;
     devDependencies?: Record<string, string>;
     pnpm?: {
       overrides?: Record<string, string>;
+      peerDependencyRules?: {
+        allowAny?: string[];
+        allowedVersions?: Record<string, string>;
+      };
     };
   }>(packageJsonPath, (pkg) => {
     if (packageManager === PackageManager.yarn) {
@@ -1085,6 +1231,7 @@ function rewriteRootWorkspacePackageJson(
     } else if (packageManager === PackageManager.bun) {
       // bun overrides are handled in rewriteBunCatalog() with catalog: references
     } else if (packageManager === PackageManager.pnpm) {
+      const overrideKeys = Object.keys(VITE_PLUS_OVERRIDE_PACKAGES);
       if (isForceOverrideMode()) {
         // In force-override mode, keep overrides in package.json pnpm.overrides
         // because pnpm ignores pnpm-workspace.yaml overrides when pnpm.overrides
@@ -1098,20 +1245,14 @@ function rewriteRootWorkspacePackageJson(
           },
         };
       } else {
-        // pnpm use overrides field at pnpm-workspace.yaml
-        // so we don't need to set overrides field at package.json
-        // remove packages from `resolutions` field and `pnpm.overrides` field if they exist
-        // https://pnpm.io/9.x/package_json#resolutions
-        for (const key of [...Object.keys(VITE_PLUS_OVERRIDE_PACKAGES), ...REMOVE_PACKAGES]) {
-          if (pkg.pnpm?.overrides?.[key]) {
-            delete pkg.pnpm.overrides[key];
-          }
+        for (const key of [...overrideKeys, ...REMOVE_PACKAGES]) {
           if (pkg.resolutions?.[key]) {
             delete pkg.resolutions[key];
           }
         }
+        remainingPnpmOverrides = cleanupPnpmOverridesForWorkspaceYaml(pkg, overrideKeys);
       }
-      // remove dependency selector from vite, e.g. "vite-plugin-svgr>vite": "npm:vite@7.0.12"
+      // remove dependency selectors targeting vite (e.g. "vite-plugin-svgr>vite")
       for (const key in pkg.pnpm?.overrides) {
         if (key.includes('>')) {
           const splits = key.split('>');
@@ -1134,6 +1275,11 @@ function rewriteRootWorkspacePackageJson(
     }
     return pkg;
   });
+
+  // Move remaining non-Vite pnpm.overrides to pnpm-workspace.yaml
+  if (remainingPnpmOverrides) {
+    migratePnpmOverridesToWorkspaceYaml(projectPath, remainingPnpmOverrides);
+  }
 
   // rewrite package.json
   rewriteMonorepoProject(projectPath, packageManager, skipStagedMigration);

--- a/rfcs/migration-command.md
+++ b/rfcs/migration-command.md
@@ -32,8 +32,10 @@ When transitioning to Vite+, projects typically use standalone tools like vite, 
 
 - ✅ **Dependencies**: vite, vitest, oxlint, oxfmt → vite-plus
 - ✅ **Overrides**: Force vite → vite-plus (for all dependencies)
-  - npm/pnpm/bun: Adds `overrides.vite` mapping
-  - yarn: Adds `resolutions.vite` mapping
+  - pnpm (no existing `pnpm` config): Writes `overrides`, `peerDependencyRules`, and `catalog` to `pnpm-workspace.yaml`
+  - pnpm (existing `pnpm` config): Adds `pnpm.overrides` and `pnpm.peerDependencyRules` in `package.json`
+  - npm/bun: Adds `overrides.vite` mapping in `package.json`
+  - yarn: Adds `resolutions.vite` mapping in `package.json`
   - **Benefit**: Code keeps `import from 'vite'` - automatically resolves to vite-plus
 - ✅ **Configuration files**:
   - .oxlintrc → vite.config.ts (lint section)
@@ -191,7 +193,7 @@ Wrote agent instructions to AGENTS.md
 }
 ```
 
-**After:**
+**After (npm/bun) -- `package.json`:**
 
 ```json
 {
@@ -211,9 +213,73 @@ Wrote agent instructions to AGENTS.md
 }
 ```
 
+**After (pnpm, no existing `pnpm` config) -- `package.json`:**
+
+```json
+{
+  "name": "my-package",
+  "dependencies": {
+    "react": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "catalog:",
+    "vitest": "catalog:",
+    "@vitejs/plugin-react": "^4.2.0",
+    "vite-plus": "catalog:"
+  },
+  "packageManager": "pnpm@<semver>"
+}
+```
+
+**After (pnpm, no existing `pnpm` config) -- `pnpm-workspace.yaml`:**
+
+```yaml
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
+```
+
+**After (pnpm, existing `pnpm` config) -- `package.json`:**
+
+Projects that already have a `pnpm` field in `package.json` (e.g., with `overrides` or `onlyBuiltDependencies`) keep using `package.json` for pnpm config:
+
+```json
+{
+  "name": "my-package",
+  "devDependencies": {
+    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
+    "vitest": "npm:@voidzero-dev/vite-plus-test@latest",
+    "vite-plus": "latest"
+  },
+  "pnpm": {
+    "overrides": {
+      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
+      "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
+    },
+    "peerDependencyRules": {
+      "allowAny": ["vite", "vitest"],
+      "allowedVersions": { "vite": "*", "vitest": "*" }
+    }
+  }
+}
+```
+
 **Important**:
 
 - `overrides.vite` ensures any dependency requiring `vite` gets `vite-plus` instead
+- For pnpm without existing config, overrides and peerDependencyRules are written to `pnpm-workspace.yaml`
+- For pnpm with existing `pnpm` config in `package.json`, the existing location is respected
 - rewrite `import from 'vite'` to `import from 'vite-plus'`
 - rewrite `import from 'vite/{name}'` to `import from 'vite-plus/{name}'`, e.g.: `import from 'vite/module-runner'` to `import from 'vite-plus/module-runner'`
 - rewrite `import from 'vitest'` to `import from 'vite-plus/test'`
@@ -430,17 +496,18 @@ export default defineConfig({
 
 ### for pnpm
 
+For monorepo projects and standalone projects without existing `pnpm` config in `package.json`, overrides, peerDependencyRules, and catalog are written to `pnpm-workspace.yaml`. Projects with existing `pnpm` config in `package.json` keep using `package.json`.
+
 `pnpm-workspace.yaml`
 
 ```yaml
 catalog:
   vite: npm:@voidzero-dev/vite-plus-core@latest
   vitest: npm:@voidzero-dev/vite-plus-test@latest
-
+  vite-plus: latest
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'
-
 peerDependencyRules:
   allowAny:
     - vite


### PR DESCRIPTION
## Summary

- For standalone pnpm projects **without** existing `pnpm` config in `package.json`, write overrides, peerDependencyRules, and catalog to `pnpm-workspace.yaml` instead of `package.json`, and use `catalog:` references in devDependencies
- For projects **with** existing `pnpm` config in `package.json` (e.g., dify with `pnpm.overrides`), respect the existing location and keep config in `package.json`
- Move any remaining non-Vite `pnpm.overrides` from `package.json` to `pnpm-workspace.yaml` to prevent pnpm from ignoring workspace-level overrides
- Surgically remove only Vite-managed entries from `peerDependencyRules` instead of deleting the entire object, preserving custom rules
- Update migration RFC to document the pnpm-specific behavior

Closes #1233

## Test plan

- [x] `pnpm -F vite-plus snap-test-global` -- all 80+ snap tests pass
- [x] Standalone pnpm without existing `pnpm` field: creates `pnpm-workspace.yaml` with catalog/overrides/peerDependencyRules, devDependencies use `catalog:`
- [x] Standalone pnpm with existing `pnpm` field (dify): keeps config in `package.json`, no `pnpm-workspace.yaml` created, `vp install` succeeds
- [x] Monorepo pnpm tests unchanged
- [x] Monorepo with remaining non-Vite overrides: moves them to `pnpm-workspace.yaml`, removes `pnpm.overrides` from `package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)