### PR TITLE
chore(ci): disable upgrade deps in fork

### DIFF
--- a/.github/workflows/upgrade-deps.yml
+++ b/.github/workflows/upgrade-deps.yml
@@ -9,6 +9,7 @@ permissions: {}
 
 jobs:
   upgrade:
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Otherwise, users will keep getting error notifications.

https://github.com/hyoban/vite-plus/actions/runs/23774678223