### PR TITLE
fix(install): support JFrog registry metadata JSON format

### DIFF
--- a/packages/cli/install.ps1
+++ b/packages/cli/install.ps1
@@ -74,7 +74,7 @@ function Get-PackageMetadata {
                 try {
                     $errorJson = $errorMsg | ConvertFrom-Json
                     if ($errorJson.error) {
-                        Write-Error-Exit "Failed to fetch version '${versionPath}': $($errorJson.error)"
+                        Write-Error-Exit "Failed to fetch version '${versionPath}': $($errorJson.error)`n  URL: $metadataUrl"
                     }
                 } catch {
                     # JSON parsing failed, fall through to generic error
@@ -85,11 +85,17 @@ function Get-PackageMetadata {
         # Check for error in successful response
         # npm can return {"error":"..."} object or a plain string like "version not found: test"
         if ($script:PackageMetadata -is [string]) {
-            # Plain string response means error
-            Write-Error-Exit "Failed to fetch version '${versionPath}': $script:PackageMetadata"
+            # Some registries (e.g. JFrog) may return JSON with a non-JSON content type,
+            # causing Invoke-RestMethod to return a raw string. Try parsing it as JSON first.
+            try {
+                $script:PackageMetadata = $script:PackageMetadata | ConvertFrom-Json
+            } catch {
+                # Not valid JSON - treat as plain string error
+                Write-Error-Exit "Failed to fetch version '${versionPath}': $script:PackageMetadata`n  URL: $metadataUrl"
+            }
         }
         if ($script:PackageMetadata.error) {
-            Write-Error-Exit "Failed to fetch version '${versionPath}': $($script:PackageMetadata.error)"
+            Write-Error-Exit "Failed to fetch version '${versionPath}': $($script:PackageMetadata.error)`n  URL: $metadataUrl"
         }
     }
     return $script:PackageMetadata

--- a/packages/cli/install.sh
+++ b/packages/cli/install.sh
@@ -245,16 +245,16 @@ fetch_package_metadata() {
     # npm can return either {"error":"..."} or a plain JSON string like "version not found: test"
     if echo "$PACKAGE_METADATA" | grep -q '"error"'; then
       local error_msg
-      error_msg=$(echo "$PACKAGE_METADATA" | grep -o '"error":"[^"]*"' | cut -d'"' -f4)
-      error "Failed to fetch version '${version_path}': ${error_msg:-unknown error}"
+      error_msg=$(echo "$PACKAGE_METADATA" | grep -o '"error" *: *"[^"]*"' | cut -d'"' -f4)
+      error "Failed to fetch version '${version_path}': ${error_msg:-unknown error}\n  URL: $metadata_url"
     fi
     # Check if response is a plain error string (not a valid package object)
     # Use '"version":' to match JSON property, not just the word "version"
-    if ! echo "$PACKAGE_METADATA" | grep -q '"version":'; then
+    if ! echo "$PACKAGE_METADATA" | grep -q '"version" *:'; then
       # Remove surrounding quotes from the error message if present
       local error_msg
       error_msg=$(echo "$PACKAGE_METADATA" | sed 's/^"//;s/"$//')
-      error "Failed to fetch version '${version_path}': ${error_msg:-unknown error}"
+      error "Failed to fetch version '${version_path}': ${error_msg:-unknown error}\n  URL: $metadata_url"
     fi
   fi
   # PACKAGE_METADATA is set as a global variable, no need to echo
@@ -266,7 +266,7 @@ get_version_from_metadata() {
   # Call fetch_package_metadata to populate PACKAGE_METADATA global
   # Don't use command substitution as it would swallow the exit from error()
   fetch_package_metadata
-  RESOLVED_VERSION=$(echo "$PACKAGE_METADATA" | grep -o '"version":"[^"]*"' | head -1 | cut -d'"' -f4)
+  RESOLVED_VERSION=$(echo "$PACKAGE_METADATA" | grep -o '"version" *: *"[^"]*"' | head -1 | cut -d'"' -f4)
   if [ -z "$RESOLVED_VERSION" ]; then
     error "Failed to extract version from package metadata"
   fi


### PR DESCRIPTION
JFrog npm registries return package metadata with spaces around colons
(e.g. `"version" : "0.1.12"`) which caused version extraction to fail.
Relax grep patterns to allow optional spaces and add ConvertFrom-Json
fallback in install.ps1 for registries returning non-JSON content types.
Also include the metadata URL in error messages for easier debugging.

Closes #962