### PR TITLE
fix(workspace): support Bun object-form workspaces in package.json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -122,7 +122,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1444,7 +1444,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1611,7 +1611,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1794,7 +1794,7 @@ dependencies = [
 [[package]]
 name = "fspy"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=1ef4e2f6bd783472ffdaa1cae874d142e2f56322#1ef4e2f6bd783472ffdaa1cae874d142e2f56322"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1830,7 +1830,7 @@ dependencies = [
 [[package]]
 name = "fspy_detours_sys"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=1ef4e2f6bd783472ffdaa1cae874d142e2f56322#1ef4e2f6bd783472ffdaa1cae874d142e2f56322"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
 dependencies = [
  "cc",
  "winapi",
@@ -1839,7 +1839,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=1ef4e2f6bd783472ffdaa1cae874d142e2f56322#1ef4e2f6bd783472ffdaa1cae874d142e2f56322"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1854,7 +1854,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_windows"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=1ef4e2f6bd783472ffdaa1cae874d142e2f56322#1ef4e2f6bd783472ffdaa1cae874d142e2f56322"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
 dependencies = [
  "bincode",
  "constcat",
@@ -1870,7 +1870,7 @@ dependencies = [
 [[package]]
 name = "fspy_seccomp_unotify"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=1ef4e2f6bd783472ffdaa1cae874d142e2f56322#1ef4e2f6bd783472ffdaa1cae874d142e2f56322"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
 dependencies = [
  "bincode",
  "futures-util",
@@ -1887,7 +1887,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=1ef4e2f6bd783472ffdaa1cae874d142e2f56322#1ef4e2f6bd783472ffdaa1cae874d142e2f56322"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
 dependencies = [
  "allocator-api2",
  "bincode",
@@ -1905,7 +1905,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=1ef4e2f6bd783472ffdaa1cae874d142e2f56322#1ef4e2f6bd783472ffdaa1cae874d142e2f56322"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2378,7 +2378,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2652,7 +2652,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2822,7 +2822,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
 dependencies = [
  "scopeguard",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3357,7 +3357,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4681,7 +4681,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal_test_client"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=1ef4e2f6bd783472ffdaa1cae874d142e2f56322#1ef4e2f6bd783472ffdaa1cae874d142e2f56322"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
 
 [[package]]
 name = "quote"
@@ -5891,7 +5891,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5947,7 +5947,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6081,7 +6081,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6401,7 +6401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6573,7 +6573,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6603,7 +6603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7319,7 +7319,7 @@ dependencies = [
 [[package]]
 name = "vite_glob"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=1ef4e2f6bd783472ffdaa1cae874d142e2f56322#1ef4e2f6bd783472ffdaa1cae874d142e2f56322"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
 dependencies = [
  "thiserror 2.0.18",
  "vite_path",
@@ -7363,7 +7363,7 @@ dependencies = [
 [[package]]
 name = "vite_graph_ser"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=1ef4e2f6bd783472ffdaa1cae874d142e2f56322#1ef4e2f6bd783472ffdaa1cae874d142e2f56322"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
 dependencies = [
  "petgraph 0.8.3",
  "serde",
@@ -7446,7 +7446,7 @@ dependencies = [
 [[package]]
 name = "vite_path"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=1ef4e2f6bd783472ffdaa1cae874d142e2f56322#1ef4e2f6bd783472ffdaa1cae874d142e2f56322"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
 dependencies = [
  "bincode",
  "diff-struct",
@@ -7460,7 +7460,7 @@ dependencies = [
 [[package]]
 name = "vite_select"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=1ef4e2f6bd783472ffdaa1cae874d142e2f56322#1ef4e2f6bd783472ffdaa1cae874d142e2f56322"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -7489,7 +7489,7 @@ dependencies = [
 [[package]]
 name = "vite_shell"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=1ef4e2f6bd783472ffdaa1cae874d142e2f56322#1ef4e2f6bd783472ffdaa1cae874d142e2f56322"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
 dependencies = [
  "bincode",
  "brush-parser 0.3.0 (git+https://github.com/reubeno/brush?rev=dcb760933b10ee0433d7b740a5709b06f5c67c6b)",
@@ -7516,7 +7516,7 @@ dependencies = [
 [[package]]
 name = "vite_str"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=1ef4e2f6bd783472ffdaa1cae874d142e2f56322#1ef4e2f6bd783472ffdaa1cae874d142e2f56322"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
 dependencies = [
  "bincode",
  "compact_str",
@@ -7527,7 +7527,7 @@ dependencies = [
 [[package]]
 name = "vite_task"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=1ef4e2f6bd783472ffdaa1cae874d142e2f56322#1ef4e2f6bd783472ffdaa1cae874d142e2f56322"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7566,7 +7566,7 @@ dependencies = [
 [[package]]
 name = "vite_task_graph"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=1ef4e2f6bd783472ffdaa1cae874d142e2f56322#1ef4e2f6bd783472ffdaa1cae874d142e2f56322"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7588,7 +7588,7 @@ dependencies = [
 [[package]]
 name = "vite_task_plan"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=1ef4e2f6bd783472ffdaa1cae874d142e2f56322#1ef4e2f6bd783472ffdaa1cae874d142e2f56322"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7618,7 +7618,7 @@ version = "0.0.0"
 [[package]]
 name = "vite_workspace"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=1ef4e2f6bd783472ffdaa1cae874d142e2f56322#1ef4e2f6bd783472ffdaa1cae874d142e2f56322"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
 dependencies = [
  "clap",
  "petgraph 0.8.3",
@@ -7896,7 +7896,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ dunce = "1.0.5"
 fast-glob = "1.0.0"
 flate2 = { version = "=1.1.9", features = ["zlib-rs"] }
 form_urlencoded = "1.2.1"
-fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "1ef4e2f6bd783472ffdaa1cae874d142e2f56322" }
+fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "eb746ad3f35bd994ddb39be001eaf58986f48388" }
 futures = "0.3.31"
 futures-util = "0.3.31"
 glob = "0.3.2"
@@ -186,15 +186,15 @@ vfs = "0.13.0"
 vite_command = { path = "crates/vite_command" }
 vite_error = { path = "crates/vite_error" }
 vite_js_runtime = { path = "crates/vite_js_runtime" }
-vite_glob = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "1ef4e2f6bd783472ffdaa1cae874d142e2f56322" }
+vite_glob = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "eb746ad3f35bd994ddb39be001eaf58986f48388" }
 vite_install = { path = "crates/vite_install" }
 vite_migration = { path = "crates/vite_migration" }
 vite_shared = { path = "crates/vite_shared" }
 vite_static_config = { path = "crates/vite_static_config" }
-vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "1ef4e2f6bd783472ffdaa1cae874d142e2f56322" }
-vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "1ef4e2f6bd783472ffdaa1cae874d142e2f56322" }
-vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "1ef4e2f6bd783472ffdaa1cae874d142e2f56322" }
-vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "1ef4e2f6bd783472ffdaa1cae874d142e2f56322" }
+vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "eb746ad3f35bd994ddb39be001eaf58986f48388" }
+vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "eb746ad3f35bd994ddb39be001eaf58986f48388" }
+vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "eb746ad3f35bd994ddb39be001eaf58986f48388" }
+vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "eb746ad3f35bd994ddb39be001eaf58986f48388" }
 walkdir = "2.5.0"
 wax = "0.6.0"
 which = "8.0.0"

--- a/packages/cli/snap-tests-global/create-from-bun-monorepo-subdir/apps/website/package.json
+++ b/packages/cli/snap-tests-global/create-from-bun-monorepo-subdir/apps/website/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "website",
+  "version": "0.0.0"
+}

--- a/packages/cli/snap-tests-global/create-from-bun-monorepo-subdir/package.json
+++ b/packages/cli/snap-tests-global/create-from-bun-monorepo-subdir/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "test-bun-monorepo",
+  "version": "0.0.0",
+  "private": true,
+  "workspaces": {
+    "packages": [
+      "apps/*",
+      "packages/*",
+      "tools/*"
+    ],
+    "catalog": {
+      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
+      "vitest": "npm:@voidzero-dev/vite-plus-test@latest",
+      "vite-plus": "latest"
+    }
+  },
+  "packageManager": "bun@1.3.11"
+}

--- a/packages/cli/snap-tests-global/create-from-bun-monorepo-subdir/scripts/helper/package.json
+++ b/packages/cli/snap-tests-global/create-from-bun-monorepo-subdir/scripts/helper/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "helper",
+  "version": "0.0.0"
+}

--- a/packages/cli/snap-tests-global/create-from-bun-monorepo-subdir/snap.txt
+++ b/packages/cli/snap-tests-global/create-from-bun-monorepo-subdir/snap.txt
@@ -1,0 +1,34 @@
+> cd apps/website && vp create --no-interactive vite:generator # from workspace subdir with object-form workspaces
+> test -f tools/vite-plus-generator/package.json && echo 'Created at tools/vite-plus-generator' || echo 'NOT at tools/'
+Created at tools/vite-plus-generator
+
+> test ! -f apps/website/tools/vite-plus-generator/package.json && echo 'Not in apps/website/' || echo 'BUG: in apps/website/'
+Not in apps/website/
+
+> cd apps && vp create --no-interactive vite:application # from workspace parent dir
+> test -f apps/vite-plus-application/package.json && echo 'Created at apps/vite-plus-application' || echo 'NOT at apps/'
+Created at apps/vite-plus-application
+
+> cd scripts/helper && vp create --no-interactive vite:library # from non-workspace dir
+> test -f packages/vite-plus-library/package.json && echo 'Created at packages/vite-plus-library' || echo 'NOT at packages/'
+Created at packages/vite-plus-library
+
+> cat package.json # verify workspaces object form preserved after workspace update
+{
+  "name": "test-bun-monorepo",
+  "version": "0.0.0",
+  "private": true,
+  "workspaces": {
+    "packages": [
+      "apps/*",
+      "packages/*",
+      "tools/*"
+    ],
+    "catalog": {
+      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
+      "vitest": "npm:@voidzero-dev/vite-plus-test@latest",
+      "vite-plus": "latest"
+    }
+  },
+  "packageManager": "bun@<semver>"
+}

--- a/packages/cli/snap-tests-global/create-from-bun-monorepo-subdir/steps.json
+++ b/packages/cli/snap-tests-global/create-from-bun-monorepo-subdir/steps.json
@@ -1,0 +1,25 @@
+{
+  "ignoredPlatforms": ["win32"],
+  "commands": [
+    {
+      "command": "cd apps/website && vp create --no-interactive vite:generator # from workspace subdir with object-form workspaces",
+      "ignoreOutput": true
+    },
+    "test -f tools/vite-plus-generator/package.json && echo 'Created at tools/vite-plus-generator' || echo 'NOT at tools/'",
+    "test ! -f apps/website/tools/vite-plus-generator/package.json && echo 'Not in apps/website/' || echo 'BUG: in apps/website/'",
+
+    {
+      "command": "cd apps && vp create --no-interactive vite:application # from workspace parent dir",
+      "ignoreOutput": true
+    },
+    "test -f apps/vite-plus-application/package.json && echo 'Created at apps/vite-plus-application' || echo 'NOT at apps/'",
+
+    {
+      "command": "cd scripts/helper && vp create --no-interactive vite:library # from non-workspace dir",
+      "ignoreOutput": true
+    },
+    "test -f packages/vite-plus-library/package.json && echo 'Created at packages/vite-plus-library' || echo 'NOT at packages/'",
+
+    "cat package.json # verify workspaces object form preserved after workspace update"
+  ]
+}

--- a/packages/cli/snap-tests-global/migration-monorepo-bun/.oxlintrc.json
+++ b/packages/cli/snap-tests-global/migration-monorepo-bun/.oxlintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-unused-vars": "error"
+  }
+}

--- a/packages/cli/snap-tests-global/migration-monorepo-bun/package.json
+++ b/packages/cli/snap-tests-global/migration-monorepo-bun/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "migration-monorepo-bun",
+  "version": "1.0.0",
+  "workspaces": {
+    "packages": [
+      "packages/*"
+    ],
+    "catalog": {
+      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
+      "vitest": "npm:@voidzero-dev/vite-plus-test@latest",
+      "vite-plus": "latest"
+    }
+  },
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "test": "vitest",
+    "lint": "oxlint",
+    "fmt": "oxfmt"
+  },
+  "dependencies": {
+    "testnpm2": "1.0.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "catalog:",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  },
+  "packageManager": "bun@1.3.11"
+}

--- a/packages/cli/snap-tests-global/migration-monorepo-bun/packages/app/package.json
+++ b/packages/cli/snap-tests-global/migration-monorepo-bun/packages/app/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "app",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@migration-bun-test/utils": "workspace:*",
+    "test-vite-plus-install": "1.0.0",
+    "testnpm2": "catalog:"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "1.0.0",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/cli/snap-tests-global/migration-monorepo-bun/packages/utils/package.json
+++ b/packages/cli/snap-tests-global/migration-monorepo-bun/packages/utils/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@migration-bun-test/utils",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "testnpm2": "1.0.0"
+  },
+  "devDependencies": {
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/cli/snap-tests-global/migration-monorepo-bun/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-bun/snap.txt
@@ -1,0 +1,107 @@
+> vp migrate --no-interactive # migration should work with bun object-form workspaces
+VITE+ - The Unified Toolchain for the Web
+
+
+✔ Merged .oxlintrc.json into vite.config.ts
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  bun <semver>
+• 1 config update applied, 1 file had imports rewritten
+
+> cat vite.config.ts # check vite.config.ts
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite-plus';
+
+export default defineConfig({
+  staged: {
+    "*": "vp check --fix"
+  },
+  fmt: {},
+  lint: {
+    "rules": {
+      "no-unused-vars": "error"
+    },
+    "options": {
+      "typeAware": true,
+      "typeCheck": true
+    }
+  },
+  plugins: [react()],
+});
+
+> test ! -f .oxlintrc.json # check .oxlintrc.json is removed
+> cat package.json # check package.json preserves workspaces object form
+{
+  "name": "migration-monorepo-bun",
+  "version": "1.0.0",
+  "workspaces": {
+    "packages": [
+      "packages/*"
+    ],
+    "catalog": {
+      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
+      "vitest": "npm:@voidzero-dev/vite-plus-test@latest",
+      "vite-plus": "latest"
+    }
+  },
+  "scripts": {
+    "dev": "vp dev",
+    "build": "vp build",
+    "test": "vp test",
+    "lint": "vp lint",
+    "fmt": "vp fmt",
+    "prepare": "vp config"
+  },
+  "dependencies": {
+    "testnpm2": "1.0.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:",
+    "vite-plus": "catalog:"
+  },
+  "packageManager": "bun@<semver>",
+  "overrides": {
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  }
+}
+
+> cat packages/app/package.json # check app package.json
+{
+  "name": "app",
+  "scripts": {
+    "dev": "vp dev",
+    "build": "vp build",
+    "test": "vp test"
+  },
+  "dependencies": {
+    "@migration-bun-test/utils": "workspace:*",
+    "test-vite-plus-install": "1.0.0",
+    "testnpm2": "catalog:"
+  },
+  "devDependencies": {
+    "test-vite-plus-package": "1.0.0",
+    "vite": "catalog:",
+    "vitest": "catalog:",
+    "vite-plus": "catalog:"
+  }
+}
+
+> cat packages/utils/package.json # check utils package.json
+{
+  "name": "@migration-bun-test/utils",
+  "scripts": {
+    "dev": "vp dev",
+    "build": "vp build",
+    "test": "vp test"
+  },
+  "dependencies": {
+    "testnpm2": "1.0.0"
+  },
+  "devDependencies": {
+    "vite": "catalog:",
+    "vitest": "catalog:",
+    "vite-plus": "catalog:"
+  }
+}

--- a/packages/cli/snap-tests-global/migration-monorepo-bun/steps.json
+++ b/packages/cli/snap-tests-global/migration-monorepo-bun/steps.json
@@ -1,0 +1,10 @@
+{
+  "commands": [
+    "vp migrate --no-interactive # migration should work with bun object-form workspaces",
+    "cat vite.config.ts # check vite.config.ts",
+    "test ! -f .oxlintrc.json # check .oxlintrc.json is removed",
+    "cat package.json # check package.json preserves workspaces object form",
+    "cat packages/app/package.json # check app package.json",
+    "cat packages/utils/package.json # check utils package.json"
+  ]
+}

--- a/packages/cli/snap-tests-global/migration-monorepo-bun/vite.config.ts
+++ b/packages/cli/snap-tests-global/migration-monorepo-bun/vite.config.ts
@@ -1,0 +1,6 @@
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [react()],
+});

--- a/packages/cli/src/migration/__tests__/migrator.spec.ts
+++ b/packages/cli/src/migration/__tests__/migrator.spec.ts
@@ -17,6 +17,7 @@ vi.mock('../../utils/constants.js', async (importOriginal) => {
 const {
   rewritePackageJson,
   rewriteStandaloneProject,
+  rewriteMonorepo,
   parseNvmrcVersion,
   detectNodeVersionManagerFile,
   migrateNodeVersionManagerFile,
@@ -428,5 +429,90 @@ describe('rewriteStandaloneProject pnpm workspace yaml', () => {
     const yaml = readYaml(path.join(tmpDir, 'pnpm-workspace.yaml'));
     expect(yaml).toContain("vite: 'catalog:'");
     expect(yaml).toContain("vitest: 'catalog:'");
+  });
+});
+
+describe('rewriteMonorepo bun catalog', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vp-test-bun-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('writes catalog to top-level when workspaces is an array', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({
+        name: 'bun-monorepo',
+        workspaces: ['packages/*'],
+        devDependencies: { vite: '^7.0.0' },
+        packageManager: 'bun@1.3.11',
+      }),
+    );
+    rewriteMonorepo(makeWorkspaceInfo(tmpDir, PackageManager.bun), true);
+
+    const pkg = readJson(path.join(tmpDir, 'package.json'));
+    // catalog should be at top level
+    const catalog = pkg.catalog as Record<string, string>;
+    expect(catalog.vite).toBeDefined();
+    expect(catalog['vite-plus']).toBe('latest');
+    // overrides should reference catalog:
+    const overrides = pkg.overrides as Record<string, string>;
+    expect(overrides.vite).toBe('catalog:');
+  });
+
+  it('writes catalog to workspaces.catalog when workspaces is an object with existing catalog', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({
+        name: 'bun-monorepo',
+        workspaces: {
+          packages: ['packages/*'],
+          catalog: { react: '^19.0.0' },
+        },
+        devDependencies: { vite: '^7.0.0' },
+        packageManager: 'bun@1.3.11',
+      }),
+    );
+    rewriteMonorepo(makeWorkspaceInfo(tmpDir, PackageManager.bun), true);
+
+    const pkg = readJson(path.join(tmpDir, 'package.json'));
+    // No top-level catalog
+    expect(pkg.catalog).toBeUndefined();
+    // workspaces.catalog should have merged entries
+    const workspaces = pkg.workspaces as { packages: string[]; catalog: Record<string, string> };
+    expect(workspaces.catalog.react).toBe('^19.0.0');
+    expect(workspaces.catalog.vite).toBeDefined();
+    expect(workspaces.catalog['vite-plus']).toBe('latest');
+    // workspaces.packages should be preserved
+    expect(workspaces.packages).toEqual(['packages/*']);
+  });
+
+  it('writes catalog to top-level when workspaces is an object without catalog', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({
+        name: 'bun-monorepo',
+        workspaces: {
+          packages: ['packages/*'],
+        },
+        devDependencies: { vite: '^7.0.0' },
+        packageManager: 'bun@1.3.11',
+      }),
+    );
+    rewriteMonorepo(makeWorkspaceInfo(tmpDir, PackageManager.bun), true);
+
+    const pkg = readJson(path.join(tmpDir, 'package.json'));
+    // catalog should be at top level since workspaces.catalog didn't exist
+    const catalog = pkg.catalog as Record<string, string>;
+    expect(catalog.vite).toBeDefined();
+    expect(catalog['vite-plus']).toBe('latest');
+    // workspaces object should be preserved
+    const workspaces = pkg.workspaces as { packages: string[] };
+    expect(workspaces.packages).toEqual(['packages/*']);
   });
 });

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -33,6 +33,7 @@ import {
   hasBaseUrlInTsconfig,
   removeDeprecatedTsconfigFalseOption,
 } from '../utils/tsconfig.js';
+import type { NpmWorkspaces } from '../utils/workspace.js';
 import { editYamlFile, scalarString, type YamlDocument } from '../utils/yaml.js';
 import {
   PRETTIER_CONFIG_FILES,
@@ -1159,12 +1160,18 @@ function rewriteBunCatalog(projectPath: string): void {
   }
 
   editJsonFile<{
+    workspaces?: NpmWorkspaces;
     catalog?: Record<string, string>;
     overrides?: Record<string, string>;
   }>(packageJsonPath, (pkg) => {
-    const catalog: Record<string, string> = { ...pkg.catalog };
+    // Bun supports catalogs in both workspaces.catalog and top-level catalog;
+    // prefer the location the user already chose to avoid moving their config.
+    const workspacesObj =
+      pkg.workspaces && !Array.isArray(pkg.workspaces) ? pkg.workspaces : undefined;
+    const catalog: Record<string, string> = {
+      ...(workspacesObj?.catalog ?? pkg.catalog),
+    };
 
-    // Add vite-plus managed packages to catalog
     for (const [key, value] of Object.entries(VITE_PLUS_OVERRIDE_PACKAGES)) {
       if (!value.startsWith('file:')) {
         catalog[key] = value;
@@ -1174,12 +1181,15 @@ function rewriteBunCatalog(projectPath: string): void {
       catalog[VITE_PLUS_NAME] = VITE_PLUS_VERSION;
     }
 
-    // Remove replaced packages from catalog
     for (const name of REMOVE_PACKAGES) {
       delete catalog[name];
     }
 
-    pkg.catalog = catalog;
+    if (workspacesObj?.catalog != null) {
+      workspacesObj.catalog = catalog;
+    } else {
+      pkg.catalog = catalog;
+    }
 
     // bun overrides support catalog: references
     const overrides: Record<string, string> = { ...pkg.overrides };

--- a/packages/cli/src/utils/workspace.ts
+++ b/packages/cli/src/utils/workspace.ts
@@ -17,6 +17,9 @@ import { editJsonFile, readJsonFile } from './json.js';
 import { getScopeFromPackageName } from './package.js';
 import { editYamlFile, readYamlFile } from './yaml.js';
 
+// npm/yarn use an array; Bun catalogs and Yarn classic nohoist use an object with `packages`.
+export type NpmWorkspaces = string[] | { packages?: string[]; catalog?: Record<string, string> };
+
 export function findPackageJsonFilesFromPatterns(patterns: string[], cwd: string): string[] {
   if (patterns.length === 0) {
     return [];
@@ -64,10 +67,12 @@ export async function detectWorkspace(rootDir: string): Promise<WorkspaceInfoOpt
         result.workspacePatterns = workspaceConfig.packages;
       }
     } else if (fs.existsSync(packageJsonFile)) {
-      // Check for npm/yarn workspace
-      const pkg = readJsonFile<{ workspaces?: string[] }>(packageJsonFile);
+      // Check for npm/yarn/bun workspace (array or object form)
+      const pkg = readJsonFile<{ workspaces?: NpmWorkspaces }>(packageJsonFile);
       if (Array.isArray(pkg.workspaces)) {
         result.workspacePatterns = pkg.workspaces;
+      } else if (pkg.workspaces && Array.isArray(pkg.workspaces.packages)) {
+        result.workspacePatterns = pkg.workspaces.packages;
       }
     }
 
@@ -193,11 +198,16 @@ export function updateWorkspaceConfig(projectPath: string, workspaceInfo: Worksp
       doc.setIn(['packages'], packages);
     });
   } else {
-    // Update package.json workspaces
-    editJsonFile<{ workspaces?: string[] }>(
+    // Update package.json workspaces (array or object form)
+    editJsonFile<{ workspaces?: NpmWorkspaces }>(
       path.join(workspaceInfo.rootDir, 'package.json'),
       (pkg) => {
-        pkg.workspaces = [...(pkg.workspaces || []), pattern];
+        if (pkg.workspaces && !Array.isArray(pkg.workspaces)) {
+          // Preserve object form (e.g., Bun catalogs, Yarn classic nohoist)
+          pkg.workspaces.packages = [...(pkg.workspaces.packages || []), pattern];
+        } else {
+          pkg.workspaces = [...(pkg.workspaces || []), pattern];
+        }
         return pkg;
       },
     );


### PR DESCRIPTION
Bun and Yarn classic support `workspaces` as an object with a
`packages` field (e.g., for Bun catalogs), not just an array.
Handle both forms in workspace detection, create, and migrate flows.

Closes #1247