### PR TITLE
fix(init): use bin.js entry point for TypeScript loader in justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -18,7 +18,7 @@ _clean_dist:
 
 init: _clean_dist
   cargo binstall watchexec-cli cargo-insta typos-cli cargo-shear dprint taplo-cli -y
-  node packages/tools/src/index.ts sync-remote
+  node packages/tools/src/bin.js sync-remote
   pnpm install
   pnpm -C docs install
 


### PR DESCRIPTION
## Summary
Closes #1251 

- `just init` fails with `ERR_MODULE_NOT_FOUND` because `node packages/tools/src/index.ts` runs without a TypeScript loader, so Node.js cannot resolve `.js` imports to `.ts` files
- Changed to `node packages/tools/src/bin.js` which registers `@oxc-node/core/register` before importing `index.ts`, enabling proper `.js` → `.ts` resolution

