### PR TITLE
fix(migration): add vitest to devDependencies for peer dep resolution

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -304,6 +304,10 @@ jobs:
             command: |
               npx playwright install chromium
               vp test
+          - name: vite-plus-vitest-type-aug
+            node-version: 24
+            command: |
+              vp check --fix
         exclude:
           # frm-stack uses Docker (testcontainers) which doesn't work the same way on Windows
           - os: windows-latest

--- a/ecosystem-ci/repo.json
+++ b/ecosystem-ci/repo.json
@@ -113,5 +113,11 @@
     "repository": "https://github.com/why-reproductions-are-required/vitest-playwright-repro.git",
     "branch": "main",
     "hash": "f7252170025c01ec482fa9ad43e09b965f46928f"
+  },
+  "vite-plus-vitest-type-aug": {
+    "repository": "https://github.com/why-reproductions-are-required/vite-plus-vitest-type-aug.git",
+    "branch": "main",
+    "hash": "6192f60653c124ae068efaf5d7d0a4134c95edbd",
+    "forceFreshMigration": true
   }
 }

--- a/packages/cli/snap-tests-global/migration-vitest-peer-dep/package.json
+++ b/packages/cli/snap-tests-global/migration-vitest-peer-dep/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "migration-vitest-peer-dep",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "vite": "^7.0.0",
+    "vitest-browser-svelte": "^2.1.0"
+  }
+}

--- a/packages/cli/snap-tests-global/migration-vitest-peer-dep/snap.txt
+++ b/packages/cli/snap-tests-global/migration-vitest-peer-dep/snap.txt
@@ -1,0 +1,40 @@
+> vp migrate --no-interactive # vitest should be added to devDeps when vitest-browser-svelte is present
+VITE+ - The Unified Toolchain for the Web
+
+◇ Migrated . to Vite+<repeat>
+• Node <semver>  pnpm <semver>
+• 2 config updates applied
+
+> cat package.json # vitest should be in devDependencies
+{
+  "name": "migration-vitest-peer-dep",
+  "scripts": {
+    "dev": "vp dev",
+    "build": "vp build",
+    "test": "vp test",
+    "prepare": "vp config"
+  },
+  "devDependencies": {
+    "vite": "catalog:",
+    "vitest-browser-svelte": "^2.1.0",
+    "vite-plus": "catalog:",
+    "vitest": "catalog:"
+  },
+  "packageManager": "pnpm@<semver>"
+}
+
+> cat pnpm-workspace.yaml
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'

--- a/packages/cli/snap-tests-global/migration-vitest-peer-dep/steps.json
+++ b/packages/cli/snap-tests-global/migration-vitest-peer-dep/steps.json
@@ -1,0 +1,7 @@
+{
+  "commands": [
+    "vp migrate --no-interactive # vitest should be added to devDeps when vitest-browser-svelte is present",
+    "cat package.json # vitest should be in devDependencies",
+    "cat pnpm-workspace.yaml"
+  ]
+}

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -1399,6 +1399,15 @@ export function rewritePackageJson(
       ...pkg.devDependencies,
       [VITE_PLUS_NAME]: version,
     };
+    // Add vitest to devDependencies when a remaining dependency likely peer-depends
+    // on vitest (e.g., vitest-browser-svelte). Without this, pnpm resolves the real
+    // vitest for peer deps instead of @voidzero-dev/vite-plus-test, causing
+    // third-party type augmentations to target the wrong module.
+    const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
+    if (!allDeps.vitest && Object.keys(allDeps).some((name) => name.includes('vitest'))) {
+      const ver = VITE_PLUS_OVERRIDE_PACKAGES.vitest;
+      pkg.devDependencies.vitest = supportCatalog && !ver.startsWith('file:') ? 'catalog:' : ver;
+    }
   }
   return extractedStagedConfig;
 }

--- a/packages/test/BUNDLING.md
+++ b/packages/test/BUNDLING.md
@@ -309,6 +309,8 @@ When upgrading the vitest version:
     - createNodeEntry()          index-node.js with browser-provider
     - copyBrowserClientFiles()
     - createBrowserEntryFiles()  browser/ entry files at package root
+    - patchModuleAugmentations() Rewrite @vitest/expect, @vitest/runner augmentations
+    - patchChaiTypeReference()   Add @types/chai triple-slash reference
     - createPluginExports()      dist/plugins/* for pnpm overrides
     - mergePackageJson()
     - validateExternalDeps()


### PR DESCRIPTION
## Summary

- When migrating projects that have packages with `vitest` in their name (e.g., `vitest-browser-svelte`), the migration now adds `vitest` to `devDependencies`. Without this, pnpm resolves the real `vitest@4.x` for peer deps instead of the aliased `@voidzero-dev/vite-plus-test`, causing third-party type augmentations (like `page.render()` from `vitest-browser-svelte`) to target the wrong module and fail type checking.
- Add `vite-plus-vitest-type-aug` reproduction project to ecosystem-ci for ongoing regression testing.
- Add snap test `migration-vitest-peer-dep` to verify the migration behavior.

## Test plan

- [x] Snap test `migration-vitest-peer-dep` verifies `vitest` is added to devDependencies when `vitest-browser-svelte` is present
- [x] Ecosystem-ci `vite-plus-vitest-type-aug` passes `vp check --fix` locally with 0 type errors

Closes #1256

🤖 Generated with [Claude Code](https://claude.com/claude-code)