### PR TITLE
fix(check): do not treat lint warnings as errors in exit code

### DIFF
--- a/packages/cli/binding/src/cli.rs
+++ b/packages/cli/binding/src/cli.rs
@@ -1214,6 +1214,7 @@ async fn execute_direct_subcommand(
                     Some(Err(failure)) => {
                         if failure.errors == 0 && failure.warnings > 0 {
                             output::warn(lint_message_kind.warning_heading());
+                            status = ExitStatus::SUCCESS;
                         } else {
                             output::error(lint_message_kind.issue_heading());
                         }

--- a/packages/cli/snap-tests/check-fix-lint-warn/.oxlintrc.json
+++ b/packages/cli/snap-tests/check-fix-lint-warn/.oxlintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-console": "warn"
+  }
+}

--- a/packages/cli/snap-tests/check-fix-lint-warn/package.json
+++ b/packages/cli/snap-tests/check-fix-lint-warn/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "check-fix-lint-warn",
+  "version": "0.0.0",
+  "private": true
+}

--- a/packages/cli/snap-tests/check-fix-lint-warn/snap.txt
+++ b/packages/cli/snap-tests/check-fix-lint-warn/snap.txt
@@ -1,0 +1,13 @@
+> vp check --fix
+warn: Lint warnings found
+⚠ eslint(no-console): Unexpected console statement.
+   ╭─[src/index.js:2:3]
+ 1 │ function hello() {
+ 2 │   console.log("hello");
+   ·   ───────────
+ 3 │ }
+   ╰────
+  help: Delete this console statement.
+
+Found 0 errors and 1 warning in 1 file (<variable>ms, <variable> threads)
+pass: Formatting completed for checked files (<variable>ms)

--- a/packages/cli/snap-tests/check-fix-lint-warn/snap.txt
+++ b/packages/cli/snap-tests/check-fix-lint-warn/snap.txt
@@ -11,3 +11,17 @@ warn: Lint warnings found
 
 Found 0 errors and 1 warning in 1 file (<variable>ms, <variable> threads)
 pass: Formatting completed for checked files (<variable>ms)
+
+> vp check
+pass: All 4 files are correctly formatted (<variable>ms, <variable> threads)
+warn: Lint warnings found
+⚠ eslint(no-console): Unexpected console statement.
+   ╭─[src/index.js:2:3]
+ 1 │ function hello() {
+ 2 │   console.log("hello");
+   ·   ───────────
+ 3 │ }
+   ╰────
+  help: Delete this console statement.
+
+Found 0 errors and 1 warning in 1 file (<variable>ms, <variable> threads)

--- a/packages/cli/snap-tests/check-fix-lint-warn/src/index.js
+++ b/packages/cli/snap-tests/check-fix-lint-warn/src/index.js
@@ -1,0 +1,5 @@
+function hello() {
+  console.log("hello");
+}
+
+export { hello };

--- a/packages/cli/snap-tests/check-fix-lint-warn/steps.json
+++ b/packages/cli/snap-tests/check-fix-lint-warn/steps.json
@@ -1,0 +1,6 @@
+{
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": ["vp check --fix"]
+}

--- a/packages/cli/snap-tests/check-fix-lint-warn/steps.json
+++ b/packages/cli/snap-tests/check-fix-lint-warn/steps.json
@@ -2,5 +2,5 @@
   "env": {
     "VITE_DISABLE_AUTO_INSTALL": "1"
   },
-  "commands": ["vp check --fix"]
+  "commands": ["vp check --fix", "vp check"]
 }


### PR DESCRIPTION
When oxlint reports only warnings (0 errors), override the raw exit code
to SUCCESS instead of propagating oxlint's non-zero exit code. This
fixes ecosystem-ci failures where type-aware lint rules (e.g.
typescript-eslint/await-thenable) produce warnings that cause
`vp check --fix` to exit with code 1.