### PR TITLE
fix(lint): resolve tsgolint on Windows with bun package manager

### DIFF
--- a/packages/cli/src/__tests__/resolve-lint.spec.ts
+++ b/packages/cli/src/__tests__/resolve-lint.spec.ts
@@ -1,0 +1,24 @@
+import { existsSync } from 'node:fs';
+
+import { describe, expect, it } from '@voidzero-dev/vite-plus-test';
+
+import { lint } from '../resolve-lint.js';
+
+describe('resolve-lint', () => {
+  it('should resolve binPath and OXLINT_TSGOLINT_PATH to existing files', async () => {
+    const result = await lint();
+
+    expect(result.binPath).toBeTruthy();
+    expect(
+      existsSync(result.binPath),
+      `oxlint binPath should point to an existing file, got: ${result.binPath}`,
+    ).toBe(true);
+
+    const tsgolintPath = result.envs.OXLINT_TSGOLINT_PATH;
+    expect(tsgolintPath).toBeTruthy();
+    expect(
+      existsSync(tsgolintPath),
+      `OXLINT_TSGOLINT_PATH should point to an existing file, got: ${tsgolintPath}`,
+    ).toBe(true);
+  });
+});

--- a/packages/cli/src/resolve-lint.ts
+++ b/packages/cli/src/resolve-lint.ts
@@ -11,7 +11,7 @@
  * provides ESLint-compatible linting with significantly better performance.
  */
 
-import { existsSync } from 'node:fs';
+import { existsSync, realpathSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { relative } from 'node:path/win32';
 import { fileURLToPath } from 'node:url';
@@ -43,7 +43,8 @@ export async function lint(): Promise<{
   let oxlintTsgolintPath = resolve('oxlint-tsgolint/bin/tsgolint');
   if (process.platform === 'win32') {
     // On Windows, try .exe first (bun creates .exe), then .cmd (npm/pnpm/yarn create .cmd)
-    const localBinDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'node_modules', '.bin');
+    const scriptDir = dirname(fileURLToPath(import.meta.url));
+    const localBinDir = join(scriptDir, '..', 'node_modules', '.bin');
     const cwdBinDir = join(process.cwd(), 'node_modules', '.bin');
     oxlintTsgolintPath =
       [
@@ -51,7 +52,23 @@ export async function lint(): Promise<{
         join(localBinDir, 'tsgolint.cmd'),
         join(cwdBinDir, 'tsgolint.exe'),
         join(cwdBinDir, 'tsgolint.cmd'),
-      ].find((p) => existsSync(p)) ?? join(cwdBinDir, 'tsgolint.cmd');
+      ].find((p) => existsSync(p)) ?? '';
+    // Bun stores packages in .bun/ cache dirs where the symlinked paths above won't match.
+    if (!oxlintTsgolintPath) {
+      try {
+        const realPkgDir = realpathSync(join(scriptDir, '..'));
+        const realBinDir = join(dirname(realPkgDir), '.bin');
+        oxlintTsgolintPath =
+          [join(realBinDir, 'tsgolint.exe'), join(realBinDir, 'tsgolint.cmd')].find((p) =>
+            existsSync(p),
+          ) ?? '';
+      } catch {
+        // realpath failed, fall through to default
+      }
+    }
+    if (!oxlintTsgolintPath) {
+      oxlintTsgolintPath = join(cwdBinDir, 'tsgolint.cmd');
+    }
     const relativePath = relative(process.cwd(), oxlintTsgolintPath);
     // Only prepend .\ if it's actually a relative path (not an absolute path returned by relative())
     oxlintTsgolintPath = /^[a-zA-Z]:/.test(relativePath) ? relativePath : `.\\${relativePath}`;


### PR DESCRIPTION
Bun stores packages in .bun/ cache dirs with symlinks, so the
hardcoded node_modules/.bin paths don't contain tsgolint.exe.
Add a fallback that resolves the real path of vite-plus and looks
for tsgolint in the sibling .bin directory.