### PR TITLE
refactor(tools): use .ts import extensions

### DIFF
--- a/justfile
+++ b/justfile
@@ -18,7 +18,7 @@ _clean_dist:
 
 init: _clean_dist
   cargo binstall watchexec-cli cargo-insta typos-cli cargo-shear dprint taplo-cli -y
-  node packages/tools/src/bin.js sync-remote
+  node packages/tools/src/index.ts sync-remote
   pnpm install
   pnpm -C docs install
 

--- a/packages/cli/binding/index.cjs
+++ b/packages/cli/binding/index.cjs
@@ -725,13 +725,17 @@ if (!nativeBinding || process.env.NAPI_RS_FORCE_WASI) {
       wasiBindingError = err;
     }
   }
-  if (!nativeBinding) {
+  if (!nativeBinding || process.env.NAPI_RS_FORCE_WASI) {
     try {
       wasiBinding = require('@voidzero-dev/vite-plus-wasm32-wasi');
       nativeBinding = wasiBinding;
     } catch (err) {
       if (process.env.NAPI_RS_FORCE_WASI) {
-        wasiBindingError.cause = err;
+        if (!wasiBindingError) {
+          wasiBindingError = err;
+        } else {
+          wasiBindingError.cause = err;
+        }
         loadErrors.push(err);
       }
     }

--- a/packages/tools/src/__tests__/utils.spec.ts
+++ b/packages/tools/src/__tests__/utils.spec.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 
 import { describe, expect, test } from '@voidzero-dev/vite-plus-test';
 
-import { isPassThroughEnv, replaceUnstableOutput } from '../utils.js';
+import { isPassThroughEnv, replaceUnstableOutput } from '../utils.ts';
 
 describe('replaceUnstableOutput()', () => {
   test('strip ANSI escape sequences', () => {

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -2,31 +2,31 @@ const subcommand = process.argv[2];
 
 switch (subcommand) {
   case 'snap-test':
-    const { snapTest } = await import('./snap-test.js');
+    const { snapTest } = await import('./snap-test.ts');
     await snapTest();
     break;
   case 'replace-file-content':
-    const { replaceFileContent } = await import('./replace-file-content.js');
+    const { replaceFileContent } = await import('./replace-file-content.ts');
     replaceFileContent();
     break;
   case 'sync-remote':
-    const { syncRemote } = await import('./sync-remote-deps.js');
+    const { syncRemote } = await import('./sync-remote-deps.ts');
     await syncRemote();
     break;
   case 'json-sort':
-    const { jsonSort } = await import('./json-sort.js');
+    const { jsonSort } = await import('./json-sort.ts');
     jsonSort();
     break;
   case 'merge-peer-deps':
-    const { mergePeerDeps } = await import('./merge-peer-deps.js');
+    const { mergePeerDeps } = await import('./merge-peer-deps.ts');
     mergePeerDeps();
     break;
   case 'install-global-cli':
-    const { installGlobalCli } = await import('./install-global-cli.js');
+    const { installGlobalCli } = await import('./install-global-cli.ts');
     installGlobalCli();
     break;
   case 'brand-vite':
-    const { brandVite } = await import('./brand-vite.js');
+    const { brandVite } = await import('./brand-vite.ts');
     brandVite();
     break;
   default:

--- a/packages/tools/src/sync-remote-deps.ts
+++ b/packages/tools/src/sync-remote-deps.ts
@@ -773,7 +773,7 @@ export async function syncRemote() {
   log('✓ package.json exports updated successfully!');
 
   // Apply Vite+ branding patches to vite source
-  const { brandVite } = await import('./brand-vite.js');
+  const { brandVite } = await import('./brand-vite.ts');
   brandVite(rootDir);
 
   log('✓ Done!');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "declaration": true,
     "esModuleInterop": true,
     "module": "nodenext",


### PR DESCRIPTION
Switch tools package imports from .js to .ts extensions, update entry
point from bin.js to index.ts, and enable allowImportingTsExtensions in
tsconfig. Also fix potential null reference on wasiBindingError in the
NAPI binding loader.

https://github.com/voidzero-dev/vite-plus/pull/1252#discussion_r3027858446