### PR TITLE
fix(cli): scope CI env var to child process in Windows install script

### DIFF
--- a/packages/cli/install.ps1
+++ b/packages/cli/install.ps1
@@ -374,8 +374,9 @@ function Main {
         $installLog = Join-Path $VersionDir "install.log"
         Push-Location $VersionDir
         try {
-            $env:CI = "true"
-            & "$BinDir\vp.exe" install --silent *> $installLog
+            # Use cmd /c so CI=true is scoped to the child process only,
+            # avoiding leaking it into the user's shell session.
+            cmd /c "set CI=true && `"$BinDir\vp.exe`" install --silent" *> $installLog
             if ($LASTEXITCODE -ne 0) {
                 Write-Host "error: Failed to install dependencies. See log for details: $installLog" -ForegroundColor Red
                 exit 1

--- a/packages/cli/snap-tests-global/new-vite-monorepo-bun/snap.txt
+++ b/packages/cli/snap-tests-global/new-vite-monorepo-bun/snap.txt
@@ -66,7 +66,7 @@ website
     "preview": "vp preview"
   },
   "devDependencies": {
-    "typescript": "~5.9.3",
+    "typescript": "~6.0.2",
     "vite": "catalog:",
     "vite-plus": "catalog:"
   }


### PR DESCRIPTION
Use `cmd /c "set CI=true && ..."` instead of setting `$env:CI` directly,
so the variable is scoped to the child process and does not persist in the
user's PowerShell session. This prevented `vp create` from entering
interactive mode when run in the same terminal after installation.

Closes #1288