### PR TITLE
fix(cli): update .yarnrc template to use node_modules

### DIFF
--- a/packages/cli/templates/monorepo/_yarnrc.yml
+++ b/packages/cli/templates/monorepo/_yarnrc.yml
@@ -1,4 +1,4 @@
-# used for install vite-plus
+nodeLinker: node-modules
 catalog:
   '@types/node': ^24
   typescript: ^5


### PR DESCRIPTION
Closes #1295

Vite / Vite+ don't work correctly with Yarn's PNP, which is enabled by default.

Since PNP is experimental anyway, I think the better solution is to just disable it rather than make Vite+ compatible with PNP, which should be done once the feature is stabilized.