### PR TITLE
chore: bump vite-task to 076cef48

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,7 +1838,7 @@ dependencies = [
 [[package]]
 name = "fspy"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=076cef486127e6cd1fefc58945f00dac316888ca#076cef486127e6cd1fefc58945f00dac316888ca"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1874,7 +1874,7 @@ dependencies = [
 [[package]]
 name = "fspy_detours_sys"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=076cef486127e6cd1fefc58945f00dac316888ca#076cef486127e6cd1fefc58945f00dac316888ca"
 dependencies = [
  "cc",
  "winapi",
@@ -1883,7 +1883,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=076cef486127e6cd1fefc58945f00dac316888ca#076cef486127e6cd1fefc58945f00dac316888ca"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1898,7 +1898,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_windows"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=076cef486127e6cd1fefc58945f00dac316888ca#076cef486127e6cd1fefc58945f00dac316888ca"
 dependencies = [
  "bincode",
  "constcat",
@@ -1914,7 +1914,7 @@ dependencies = [
 [[package]]
 name = "fspy_seccomp_unotify"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=076cef486127e6cd1fefc58945f00dac316888ca#076cef486127e6cd1fefc58945f00dac316888ca"
 dependencies = [
  "bincode",
  "futures-util",
@@ -1931,7 +1931,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=076cef486127e6cd1fefc58945f00dac316888ca#076cef486127e6cd1fefc58945f00dac316888ca"
 dependencies = [
  "allocator-api2",
  "bincode",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=076cef486127e6cd1fefc58945f00dac316888ca#076cef486127e6cd1fefc58945f00dac316888ca"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4734,7 +4734,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal_test_client"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=076cef486127e6cd1fefc58945f00dac316888ca#076cef486127e6cd1fefc58945f00dac316888ca"
 
 [[package]]
 name = "quote"
@@ -7383,7 +7383,7 @@ dependencies = [
 [[package]]
 name = "vite_glob"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=076cef486127e6cd1fefc58945f00dac316888ca#076cef486127e6cd1fefc58945f00dac316888ca"
 dependencies = [
  "thiserror 2.0.18",
  "vite_path",
@@ -7427,7 +7427,7 @@ dependencies = [
 [[package]]
 name = "vite_graph_ser"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=076cef486127e6cd1fefc58945f00dac316888ca#076cef486127e6cd1fefc58945f00dac316888ca"
 dependencies = [
  "petgraph 0.8.3",
  "serde",
@@ -7510,7 +7510,7 @@ dependencies = [
 [[package]]
 name = "vite_path"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=076cef486127e6cd1fefc58945f00dac316888ca#076cef486127e6cd1fefc58945f00dac316888ca"
 dependencies = [
  "bincode",
  "diff-struct",
@@ -7524,7 +7524,7 @@ dependencies = [
 [[package]]
 name = "vite_select"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=076cef486127e6cd1fefc58945f00dac316888ca#076cef486127e6cd1fefc58945f00dac316888ca"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -7553,7 +7553,7 @@ dependencies = [
 [[package]]
 name = "vite_shell"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=076cef486127e6cd1fefc58945f00dac316888ca#076cef486127e6cd1fefc58945f00dac316888ca"
 dependencies = [
  "bincode",
  "brush-parser 0.3.0 (git+https://github.com/reubeno/brush?rev=dcb760933b10ee0433d7b740a5709b06f5c67c6b)",
@@ -7580,7 +7580,7 @@ dependencies = [
 [[package]]
 name = "vite_str"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=076cef486127e6cd1fefc58945f00dac316888ca#076cef486127e6cd1fefc58945f00dac316888ca"
 dependencies = [
  "bincode",
  "compact_str",
@@ -7591,7 +7591,7 @@ dependencies = [
 [[package]]
 name = "vite_task"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=076cef486127e6cd1fefc58945f00dac316888ca#076cef486127e6cd1fefc58945f00dac316888ca"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7630,7 +7630,7 @@ dependencies = [
 [[package]]
 name = "vite_task_graph"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=076cef486127e6cd1fefc58945f00dac316888ca#076cef486127e6cd1fefc58945f00dac316888ca"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7652,7 +7652,7 @@ dependencies = [
 [[package]]
 name = "vite_task_plan"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=076cef486127e6cd1fefc58945f00dac316888ca#076cef486127e6cd1fefc58945f00dac316888ca"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7682,7 +7682,7 @@ version = "0.0.0"
 [[package]]
 name = "vite_workspace"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=eb746ad3f35bd994ddb39be001eaf58986f48388#eb746ad3f35bd994ddb39be001eaf58986f48388"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=076cef486127e6cd1fefc58945f00dac316888ca#076cef486127e6cd1fefc58945f00dac316888ca"
 dependencies = [
  "clap",
  "petgraph 0.8.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ dunce = "1.0.5"
 fast-glob = "1.0.0"
 flate2 = { version = "=1.1.9", features = ["zlib-rs"] }
 form_urlencoded = "1.2.1"
-fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "eb746ad3f35bd994ddb39be001eaf58986f48388" }
+fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "076cef486127e6cd1fefc58945f00dac316888ca" }
 futures = "0.3.31"
 futures-util = "0.3.31"
 glob = "0.3.2"
@@ -194,15 +194,15 @@ vfs = "0.13.0"
 vite_command = { path = "crates/vite_command" }
 vite_error = { path = "crates/vite_error" }
 vite_js_runtime = { path = "crates/vite_js_runtime" }
-vite_glob = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "eb746ad3f35bd994ddb39be001eaf58986f48388" }
+vite_glob = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "076cef486127e6cd1fefc58945f00dac316888ca" }
 vite_install = { path = "crates/vite_install" }
 vite_migration = { path = "crates/vite_migration" }
 vite_shared = { path = "crates/vite_shared" }
 vite_static_config = { path = "crates/vite_static_config" }
-vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "eb746ad3f35bd994ddb39be001eaf58986f48388" }
-vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "eb746ad3f35bd994ddb39be001eaf58986f48388" }
-vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "eb746ad3f35bd994ddb39be001eaf58986f48388" }
-vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "eb746ad3f35bd994ddb39be001eaf58986f48388" }
+vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "076cef486127e6cd1fefc58945f00dac316888ca" }
+vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "076cef486127e6cd1fefc58945f00dac316888ca" }
+vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "076cef486127e6cd1fefc58945f00dac316888ca" }
+vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "076cef486127e6cd1fefc58945f00dac316888ca" }
 walkdir = "2.5.0"
 wax = "0.6.0"
 which = "8.0.0"


### PR DESCRIPTION
## Summary
- Bump vite-task git dependency from `eb746ad3` to `076cef48`

## Changelog
https://github.com/voidzero-dev/vite-task/compare/eb746ad3f35bd994ddb39be001eaf58986f48388...076cef486127e6cd1fefc58945f00dac316888ca#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed

Notable changes:
- **Fixed** `vp run --cache` now supports running without a task specifier and opens the interactive task selector

## Test plan
- [x] `cargo check` passes
- [x] All unit tests pass (1,206 tests)
- [ ] CI passes (lint, test, snap tests, run task)