### PR TITLE
fix(cli): Resolve bin/oxfmt as like oxlint

### DIFF
--- a/packages/cli/bin/oxfmt
+++ b/packages/cli/bin/oxfmt
@@ -11,9 +11,11 @@ if (!process.argv.includes('--lsp')) {
 }
 
 import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 const require = createRequire(import.meta.url);
-const oxfmtBin = require.resolve('oxfmt/bin/oxfmt');
+const oxfmtMainPath = require.resolve('oxfmt');
+const oxfmtBin = join(dirname(dirname(oxfmtMainPath)), 'bin', 'oxfmt');
 
 await import(pathToFileURL(oxfmtBin).href);

--- a/packages/cli/src/resolve-fmt.ts
+++ b/packages/cli/src/resolve-fmt.ts
@@ -11,6 +11,8 @@
  * provides high-performance code formatting capabilities.
  */
 
+import { dirname, join } from 'node:path';
+
 import { DEFAULT_ENVS, resolve } from './utils/constants.ts';
 
 /**
@@ -27,8 +29,13 @@ export async function fmt(): Promise<{
   binPath: string;
   envs: Record<string, string>;
 }> {
-  // Resolve the oxfmt binary directly (it's a native executable)
-  const binPath = resolve('oxfmt/bin/oxfmt');
+  // Resolve the oxfmt package path first, then navigate to the bin file.
+  // The bin/oxfmt subpath is not exported in package.json exports, so we
+  // resolve the main entry point and derive the bin path from it.
+  // resolve('oxfmt') returns .../oxfmt/dist/index.js, so we need to go up
+  // two directories (past 'dist') to reach the package root.
+  const oxfmtMainPath = resolve('oxfmt');
+  const binPath = join(dirname(dirname(oxfmtMainPath)), 'bin', 'oxfmt');
 
   return {
     binPath,


### PR DESCRIPTION
- `oxfmt@0.44` added `package.json` exports
  - https://github.com/oxc-project/oxc/pull/20784, for #1162
- This prevents access to unspecified subpaths
- As a result, this type of error will occur
  - https://github.com/rolldown/rolldown/actions/runs/24068646976/job/70200159260?pr=9018
  - At the moment, `vite-plus` bundles `oxfmt@0.43`, so this should not be an issue
  - It was only causing a problem because rolldown repo happened to overwrite it by installing `oxfmt@0.44` separately
- However, this issue will happen for us when updating to bundle `oxfmt@0.44` in the future

We can avoid this issue by following the `oxlint` resolution approach. And now, it's ready to update `oxfmt@0.44` safely.