### PR TITLE
fix(init): auto-fix git symlinks when `core.symlinks` is false

### DIFF
--- a/justfile
+++ b/justfile
@@ -16,11 +16,29 @@ _clean_dist:
 _clean_dist:
   Remove-Item -Path 'packages/*/dist' -Recurse -Force -ErrorAction SilentlyContinue
 
-init: _clean_dist
+init: _clean_dist _fix_symlinks
   cargo binstall watchexec-cli cargo-insta typos-cli cargo-shear dprint taplo-cli -y
   node packages/tools/src/index.ts sync-remote
   pnpm install
   pnpm -C docs install
+
+[unix]
+_fix_symlinks:
+  #!/usr/bin/env bash
+  if [ "$(git config --get core.symlinks)" != "true" ]; then \
+    echo "Enabling core.symlinks and re-checking out symlinks..."; \
+    git config core.symlinks true; \
+    git ls-files -s | grep '^120000' | cut -f2 | while read -r f; do git checkout -- "$f"; done; \
+  fi
+
+[windows]
+_fix_symlinks:
+  $symlinks = git config --get core.symlinks; \
+  if ($symlinks -ne 'true') { \
+    Write-Host 'Enabling core.symlinks and re-checking out symlinks...'; \
+    git config core.symlinks true; \
+    git ls-files -s | Where-Object { $_ -match '^120000' } | ForEach-Object { ($_ -split "`t", 2)[1] } | ForEach-Object { git checkout -- $_ }; \
+  }
 
 build:
   pnpm install


### PR DESCRIPTION
## Problem

This repository contains git symlinks in `packages/core/` that reference files in the upstream `vite/`
directory:

- `packages/core/vite-rolldown.config.ts` → `../../vite/packages/vite/rolldown.config.ts`
- `packages/core/rollupLicensePlugin.ts` → `../../vite/packages/vite/rollupLicensePlugin.ts`

In a fresh Windows clone of this repository, `core.symlinks` can be `false`. In that case, git checks
out these entries as plain text files containing the target path instead of actual symlinks. This
causes the build to fail with `Unexpected token`, because the files are imported as TypeScript modules
but only contain a path string.

## Solution

Add a `_fix_symlinks` recipe to `justfile` and run it as part of `just init`. The recipe checks
`core.symlinks`, and when it is not `true`, it enables it and re-checks out all tracked symlink
entries.

Both unix and Windows implementations are included.

The recipe is idempotent: when `core.symlinks=true`, it does nothing.

## Test plan

- Verified on Windows with a fresh `git clone` of this repository that `core.symlinks=false` and the
symlinks are checked out incorrectly
- Ran `just _fix_symlinks` on Windows via PowerShell and confirmed the symlinks were restored
- Ran the unix `_fix_symlinks` commands manually in Git Bash and confirmed the symlinks were restored
- Confirmed idempotency: running the recipe again with `core.symlinks=true` is a no-op
