### PR TITLE
chore(renovate): ignore oxc,oxfmt,oxlint,tsgolint updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,19 +11,26 @@
   ],
   "packageRules": [
     {
-      "matchPackageNames": ["vitest-dev"],
+      "description": "Ignore selected npm package updates",
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "rolldown",
+        "/^oxc-.*/",
+        "@oxc-node/*",
+        "oxfmt",
+        "oxlint",
+        "oxlint-tsgolint",
+        "tsdown",
+        "vite",
+        "vitest",
+        "vitest-dev"
+      ],
       "enabled": false
     },
     {
       "description": "Ignore oxc crate updates",
       "matchManagers": ["cargo"],
       "matchPackageNames": ["/^oxc([_-].*)?$/"],
-      "enabled": false
-    },
-    {
-      "description": "Ignore oxlint and oxfmt package updates",
-      "matchManagers": ["npm"],
-      "matchPackageNames": ["oxfmt", "oxlint", "oxlint-tsgolint"],
       "enabled": false
     },
     {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,6 +15,18 @@
       "enabled": false
     },
     {
+      "description": "Ignore oxc crate updates",
+      "matchManagers": ["cargo"],
+      "matchPackageNames": ["/^oxc([_-].*)?$/"],
+      "enabled": false
+    },
+    {
+      "description": "Ignore oxlint and oxfmt package updates",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["oxfmt", "oxlint", "oxlint-tsgolint"],
+      "enabled": false
+    },
+    {
       "matchDepNames": [
         "fspy",
         "vite_glob",


### PR DESCRIPTION
Broooklyn updates oxlint/oxfmt/oxlint-tsgolint/oxc/rolldown/vite/vitest/tsdown crates in e.g. https://github.com/voidzero-dev/vite-plus/pull/1334, https://github.com/voidzero-dev/vite-plus/pull/1267 so we don't need renovate to make these PRs and clog up our GH notifications