### PR TITLE
feat(check): support `--disable-nested-config` flag

### DIFF
--- a/crates/vite_global_cli/src/help.rs
+++ b/crates/vite_global_cli/src/help.rs
@@ -765,6 +765,10 @@ fn delegated_help_doc(command: &str) -> Option<HelpDoc> {
                             "--no-error-on-unmatched-pattern",
                             "Do not exit with error when pattern is unmatched",
                         ),
+                        row(
+                            "--disable-nested-config",
+                            "Disable the automatic loading of nested configuration files (lint only)",
+                        ),
                         row("-h, --help", "Print help"),
                     ],
                 ),

--- a/packages/cli/binding/src/check/mod.rs
+++ b/packages/cli/binding/src/check/mod.rs
@@ -23,6 +23,7 @@ pub(crate) async fn execute_check(
     no_fmt: bool,
     no_lint: bool,
     no_error_on_unmatched_pattern: bool,
+    disable_nested_config: bool,
     paths: Vec<String>,
     envs: &Arc<FxHashMap<Arc<OsStr>, Arc<OsStr>>>,
     cwd: &AbsolutePathBuf,
@@ -142,6 +143,9 @@ pub(crate) async fn execute_check(
         args.push("--format=default".to_string());
         if suppress_unmatched {
             args.push("--no-error-on-unmatched-pattern".to_string());
+        }
+        if disable_nested_config {
+            args.push("--disable-nested-config".to_string());
         }
         if has_paths {
             args.extend(paths.iter().cloned());

--- a/packages/cli/binding/src/cli/mod.rs
+++ b/packages/cli/binding/src/cli/mod.rs
@@ -68,6 +68,7 @@ async fn execute_direct_subcommand(
             no_fmt,
             no_lint,
             no_error_on_unmatched_pattern,
+            disable_nested_config,
             paths,
         } => {
             return crate::check::execute_check(
@@ -76,6 +77,7 @@ async fn execute_direct_subcommand(
                 no_fmt,
                 no_lint,
                 no_error_on_unmatched_pattern,
+                disable_nested_config,
                 paths,
                 &envs,
                 cwd,

--- a/packages/cli/binding/src/cli/types.rs
+++ b/packages/cli/binding/src/cli/types.rs
@@ -96,6 +96,9 @@ pub enum SynthesizableSubcommand {
         /// Do not exit with error when pattern is unmatched
         #[arg(long = "no-error-on-unmatched-pattern")]
         no_error_on_unmatched_pattern: bool,
+        /// Disable the automatic loading of nested configuration files (forwarded to lint; ignored by fmt)
+        #[arg(long)]
+        disable_nested_config: bool,
         /// File paths to check (passed through to fmt and lint)
         #[arg(trailing_var_arg = true)]
         paths: Vec<String>,

--- a/packages/cli/snap-tests-global/command-check-help/snap.txt
+++ b/packages/cli/snap-tests-global/command-check-help/snap.txt
@@ -10,6 +10,7 @@ Options:
   --no-fmt                         Skip format check
   --no-lint                        Skip lint check
   --no-error-on-unmatched-pattern  Do not exit with error when pattern is unmatched
+  --disable-nested-config          Disable the automatic loading of nested configuration files (lint only)
   -h, --help                       Print help
 
 Examples:
@@ -32,6 +33,7 @@ Options:
   --no-fmt                         Skip format check
   --no-lint                        Skip lint check
   --no-error-on-unmatched-pattern  Do not exit with error when pattern is unmatched
+  --disable-nested-config          Disable the automatic loading of nested configuration files (lint only)
   -h, --help                       Print help
 
 Examples:
@@ -54,6 +56,7 @@ Options:
   --no-fmt                         Skip format check
   --no-lint                        Skip lint check
   --no-error-on-unmatched-pattern  Do not exit with error when pattern is unmatched
+  --disable-nested-config          Disable the automatic loading of nested configuration files (lint only)
   -h, --help                       Print help
 
 Examples:


### PR DESCRIPTION
Forward the flag to oxlint only; silently ignored for fmt since oxfmt
does not support it.