### PR TITLE
docs: point windows installer at setup.viteplus.dev

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -18,7 +18,7 @@ curl -fsSL https://vite.plus | bash
 irm https://vite.plus/ps1 | iex
 ```
 
-Alternatively, download and run [`vp-setup.exe`](https://viteplus.dev/vp-setup).
+Alternatively, download and run [`vp-setup.exe`](https://setup.viteplus.dev).
 
 ::: tip SmartScreen warning
 The `vp-setup.exe` is not yet code-signed. Your browser may show a warning when downloading. Click **"..."** → **"Keep"** → **"Keep anyway"** to proceed. If Windows Defender SmartScreen blocks the file when you run it, click **"More info"** → **"Run anyway"**.

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,5 +6,5 @@ publish = ".vitepress/dist"
 # Windows installer redirect
 [[redirects]]
 from = "/vp-setup"
-to = "https://vp-setup.void.app"
+to = "https://setup.viteplus.dev"
 status = 302

--- a/rfcs/windows-installer.md
+++ b/rfcs/windows-installer.md
@@ -413,7 +413,7 @@ The release workflow already creates GitHub Releases. Add build + upload steps f
 
 ### Phase 2: Direct Download URL (done)
 
-`https://viteplus.dev/vp-setup` redirects (302) to `https://vp-setup.void.app` via Netlify redirect in `netlify.toml`. Installation docs link to the user-facing `viteplus.dev` URL.
+`https://viteplus.dev/vp-setup` redirects (302) to `https://setup.viteplus.dev` via Netlify redirect in `netlify.toml`. Installation docs link to the user-facing `viteplus.dev` URL.
 
 ### Phase 3: Package Managers
 


### PR DESCRIPTION
Move the Windows installer download URL from vp-setup.void.app to
setup.viteplus.dev, updating the Netlify redirect target, the RFC,
and the user-facing docs link.