### PR TITLE
test(snap): reproduce build failure on NTFS junction paths

### DIFF
--- a/packages/cli/snap-tests/build-ntfs-junction/real/app/index.html
+++ b/packages/cli/snap-tests/build-ntfs-junction/real/app/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <body>
+    <script type="module">
+      console.log('hello from junction');
+    </script>
+  </body>
+</html>

--- a/packages/cli/snap-tests/build-ntfs-junction/real/app/package.json
+++ b/packages/cli/snap-tests/build-ntfs-junction/real/app/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "ntfs-junction-app",
+  "private": true
+}

--- a/packages/cli/snap-tests/build-ntfs-junction/setup.js
+++ b/packages/cli/snap-tests/build-ntfs-junction/setup.js
@@ -1,0 +1,9 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+// Reproduce issue #1374: build fails when project root is reached through an NTFS junction.
+// Layout after setup:
+//   ./real/app           <- the actual project (real path)
+//   ./via                <- NTFS junction pointing to ./real
+//   ./via/app            <- the project reached through the junction
+fs.symlinkSync(path.resolve('real'), path.resolve('via'), 'junction');

--- a/packages/cli/snap-tests/build-ntfs-junction/snap.txt
+++ b/packages/cli/snap-tests/build-ntfs-junction/snap.txt
@@ -1,2 +1,2 @@
-> cd via/app && vp build 2>&1 | grep -E 'built in|vite:build-html'
-✓ built in <variable>ms
+> node setup.js
+> cd via/app && vp build 2>&1

--- a/packages/cli/snap-tests/build-ntfs-junction/snap.txt
+++ b/packages/cli/snap-tests/build-ntfs-junction/snap.txt
@@ -1,0 +1,2 @@
+> cd via/app && vp build 2>&1 | grep -E 'built in|vite:build-html'
+✓ built in <variable>ms

--- a/packages/cli/snap-tests/build-ntfs-junction/steps.json
+++ b/packages/cli/snap-tests/build-ntfs-junction/steps.json
@@ -1,0 +1,7 @@
+{
+  "ignoredPlatforms": ["darwin", "linux"],
+  "commands": [
+    { "command": "node setup.js", "ignoreOutput": true },
+    "cd via/app && vp build 2>&1 | grep -E 'built in|vite:build-html'"
+  ]
+}

--- a/packages/cli/snap-tests/build-ntfs-junction/steps.json
+++ b/packages/cli/snap-tests/build-ntfs-junction/steps.json
@@ -2,6 +2,6 @@
   "ignoredPlatforms": ["darwin", "linux"],
   "commands": [
     { "command": "node setup.js", "ignoreOutput": true },
-    "cd via/app && vp build 2>&1 | grep -E 'built in|vite:build-html'"
+    "cd via/app && vp build 2>&1"
   ]
 }


### PR DESCRIPTION
Windows-only snap test that builds a project reached through an NTFS
junction prefix. Pre-populated snap.txt expects the post-fix success
output, so CI surfaces the bug as a snap diff until it's fixed.

Refs #1374