### PR TITLE
fix(workflow): upgrade oxc catalog entries proactively

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,6 +17,8 @@
         "rolldown",
         "/^oxc-.*/",
         "@oxc-node/*",
+        "@oxc-project/*",
+        "@vitejs/devtools",
         "oxfmt",
         "oxlint",
         "oxlint-tsgolint",

--- a/.github/scripts/upgrade-deps.mjs
+++ b/.github/scripts/upgrade-deps.mjs
@@ -128,6 +128,36 @@ async function updatePnpmWorkspace(versions) {
       replacement: `oxlint-tsgolint: =${versions.oxlintTsgolint}`,
       newVersion: versions.oxlintTsgolint,
     },
+    {
+      name: '@oxc-project/runtime',
+      pattern: /'@oxc-project\/runtime': =([\d.]+(?:-[\w.]+)?)/,
+      replacement: `'@oxc-project/runtime': =${versions.oxcProjectRuntime}`,
+      newVersion: versions.oxcProjectRuntime,
+    },
+    {
+      name: '@oxc-project/types',
+      pattern: /'@oxc-project\/types': =([\d.]+(?:-[\w.]+)?)/,
+      replacement: `'@oxc-project/types': =${versions.oxcProjectTypes}`,
+      newVersion: versions.oxcProjectTypes,
+    },
+    {
+      name: 'oxc-minify',
+      pattern: /oxc-minify: =([\d.]+(?:-[\w.]+)?)/,
+      replacement: `oxc-minify: =${versions.oxcMinify}`,
+      newVersion: versions.oxcMinify,
+    },
+    {
+      name: 'oxc-parser',
+      pattern: /oxc-parser: =([\d.]+(?:-[\w.]+)?)/,
+      replacement: `oxc-parser: =${versions.oxcParser}`,
+      newVersion: versions.oxcParser,
+    },
+    {
+      name: 'oxc-transform',
+      pattern: /oxc-transform: =([\d.]+(?:-[\w.]+)?)/,
+      replacement: `oxc-transform: =${versions.oxcTransform}`,
+      newVersion: versions.oxcTransform,
+    },
   ];
 
   for (const { name, pattern, replacement, newVersion } of entries) {
@@ -278,6 +308,11 @@ const [
   oxfmtVersion,
   oxlintVersion,
   oxlintTsgolintVersion,
+  oxcProjectRuntimeVersion,
+  oxcProjectTypesVersion,
+  oxcMinifyVersion,
+  oxcParserVersion,
+  oxcTransformVersion,
 ] = await Promise.all([
   getLatestNpmVersion('vitest'),
   getLatestNpmVersion('tsdown'),
@@ -287,6 +322,11 @@ const [
   getLatestNpmVersion('oxfmt'),
   getLatestNpmVersion('oxlint'),
   getLatestNpmVersion('oxlint-tsgolint'),
+  getLatestNpmVersion('@oxc-project/runtime'),
+  getLatestNpmVersion('@oxc-project/types'),
+  getLatestNpmVersion('oxc-minify'),
+  getLatestNpmVersion('oxc-parser'),
+  getLatestNpmVersion('oxc-transform'),
 ]);
 
 console.log(`vitest: ${vitestVersion}`);
@@ -297,6 +337,11 @@ console.log(`@oxc-node/core: ${oxcNodeCoreVersion}`);
 console.log(`oxfmt: ${oxfmtVersion}`);
 console.log(`oxlint: ${oxlintVersion}`);
 console.log(`oxlint-tsgolint: ${oxlintTsgolintVersion}`);
+console.log(`@oxc-project/runtime: ${oxcProjectRuntimeVersion}`);
+console.log(`@oxc-project/types: ${oxcProjectTypesVersion}`);
+console.log(`oxc-minify: ${oxcMinifyVersion}`);
+console.log(`oxc-parser: ${oxcParserVersion}`);
+console.log(`oxc-transform: ${oxcTransformVersion}`);
 
 await updateUpstreamVersions();
 await updatePnpmWorkspace({
@@ -307,6 +352,11 @@ await updatePnpmWorkspace({
   oxfmt: oxfmtVersion,
   oxlint: oxlintVersion,
   oxlintTsgolint: oxlintTsgolintVersion,
+  oxcProjectRuntime: oxcProjectRuntimeVersion,
+  oxcProjectTypes: oxcProjectTypesVersion,
+  oxcMinify: oxcMinifyVersion,
+  oxcParser: oxcParserVersion,
+  oxcTransform: oxcTransformVersion,
 });
 await updateTestPackage(vitestVersion);
 await updateCorePackage(devtoolsVersion);


### PR DESCRIPTION
Include @oxc-project/runtime, @oxc-project/types, oxc-minify, oxc-parser,
and oxc-transform in upgrade-deps.mjs so the daily workflow bumps them to
the latest npm version. Previously they only advanced when sync-remote-deps.ts
resolved merge conflicts against rolldown/vite upstream catalogs.