### PR TITLE
fix: route Windows `.cmd` shims through PowerShell to fix Ctrl+C terminal corruption

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,13 @@ jobs:
       # Pin Rust tooling paths to avoid $HOME mismatch issues.
       CARGO_HOME: /root/.cargo
       RUSTUP_HOME: /root/.rustup
+      # `-crt-static`: vite-task's `fspy_preload_unix` cdylib (unconditional
+      # build-dep since voidzero-dev/vite-task#344) can't link against a
+      # static musl libc. vite+ ships as a NAPI module that links musl libc
+      # dynamically anyway, so matching here is correct.
+      # Must mirror `.cargo/config.toml` rustflags — RUSTFLAGS env overrides
+      # both [build] and [target.*] levels.
+      RUSTFLAGS: --cfg tokio_unstable -C link-args=-Wl,--warn-unresolved-symbols -C target-feature=-crt-static
     steps:
       - name: Install Alpine dependencies
         shell: sh {0}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 [[package]]
 name = "fspy"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1908,7 +1908,7 @@ dependencies = [
 [[package]]
 name = "fspy_detours_sys"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
 dependencies = [
  "cc",
  "winapi",
@@ -1917,7 +1917,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
 dependencies = [
  "anyhow",
  "bstr",
@@ -1932,7 +1932,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_windows"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
 dependencies = [
  "constcat",
  "fspy_detours_sys",
@@ -1948,7 +1948,7 @@ dependencies = [
 [[package]]
 name = "fspy_seccomp_unotify"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
 dependencies = [
  "futures-util",
  "libc",
@@ -1965,7 +1965,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
 dependencies = [
  "allocator-api2",
  "bitflags 2.11.0",
@@ -1984,7 +1984,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3124,7 +3124,7 @@ dependencies = [
 [[package]]
 name = "materialized_artifact"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
 dependencies = [
  "tempfile",
 ]
@@ -3132,7 +3132,7 @@ dependencies = [
 [[package]]
 name = "materialized_artifact_build"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
 dependencies = [
  "xxhash-rust",
 ]
@@ -3346,7 +3346,7 @@ dependencies = [
 [[package]]
 name = "native_str"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
 dependencies = [
  "allocator-api2",
  "bytemuck",
@@ -4821,7 +4821,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal_test_client"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
 
 [[package]]
 name = "quote"
@@ -7477,7 +7477,7 @@ dependencies = [
 [[package]]
 name = "vite_glob"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
 dependencies = [
  "thiserror 2.0.18",
  "vite_path",
@@ -7517,7 +7517,7 @@ dependencies = [
 [[package]]
 name = "vite_graph_ser"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
 dependencies = [
  "petgraph 0.8.3",
  "serde",
@@ -7616,7 +7616,7 @@ dependencies = [
 [[package]]
 name = "vite_path"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
 dependencies = [
  "diff-struct",
  "path-clean",
@@ -7630,7 +7630,7 @@ dependencies = [
 [[package]]
 name = "vite_select"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -7680,7 +7680,7 @@ dependencies = [
 [[package]]
 name = "vite_shell"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
 dependencies = [
  "brush-parser 0.3.0 (git+https://github.com/reubeno/brush?rev=dcb760933b10ee0433d7b740a5709b06f5c67c6b)",
  "diff-struct",
@@ -7707,7 +7707,7 @@ dependencies = [
 [[package]]
 name = "vite_str"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
 dependencies = [
  "compact_str",
  "diff-struct",
@@ -7718,7 +7718,7 @@ dependencies = [
 [[package]]
 name = "vite_task"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7757,7 +7757,7 @@ dependencies = [
 [[package]]
 name = "vite_task_graph"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7779,7 +7779,7 @@ dependencies = [
 [[package]]
 name = "vite_task_plan"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7809,7 +7809,7 @@ version = "0.0.0"
 [[package]]
 name = "vite_workspace"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
 dependencies = [
  "clap",
  "petgraph 0.8.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1873,7 +1873,7 @@ dependencies = [
 [[package]]
 name = "fspy"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1909,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "fspy_detours_sys"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
 dependencies = [
  "cc",
  "winapi",
@@ -1918,7 +1918,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
 dependencies = [
  "anyhow",
  "bstr",
@@ -1933,7 +1933,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_windows"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
 dependencies = [
  "constcat",
  "fspy_detours_sys",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "fspy_seccomp_unotify"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
 dependencies = [
  "futures-util",
  "libc",
@@ -1966,7 +1966,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
 dependencies = [
  "allocator-api2",
  "bitflags 2.11.0",
@@ -1985,7 +1985,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3346,7 +3346,7 @@ dependencies = [
 [[package]]
 name = "native_str"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
 dependencies = [
  "allocator-api2",
  "bytemuck",
@@ -4821,7 +4821,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal_test_client"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
 
 [[package]]
 name = "quote"
@@ -7477,7 +7477,7 @@ dependencies = [
 [[package]]
 name = "vite_glob"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
 dependencies = [
  "thiserror 2.0.18",
  "vite_path",
@@ -7517,7 +7517,7 @@ dependencies = [
 [[package]]
 name = "vite_graph_ser"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
 dependencies = [
  "petgraph 0.8.3",
  "serde",
@@ -7616,7 +7616,7 @@ dependencies = [
 [[package]]
 name = "vite_path"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
 dependencies = [
  "diff-struct",
  "path-clean",
@@ -7630,7 +7630,7 @@ dependencies = [
 [[package]]
 name = "vite_select"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -7680,7 +7680,7 @@ dependencies = [
 [[package]]
 name = "vite_shell"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
 dependencies = [
  "brush-parser 0.3.0 (git+https://github.com/reubeno/brush?rev=dcb760933b10ee0433d7b740a5709b06f5c67c6b)",
  "diff-struct",
@@ -7707,7 +7707,7 @@ dependencies = [
 [[package]]
 name = "vite_str"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
 dependencies = [
  "compact_str",
  "diff-struct",
@@ -7718,7 +7718,7 @@ dependencies = [
 [[package]]
 name = "vite_task"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7749,6 +7749,7 @@ dependencies = [
  "vite_task_plan",
  "vite_workspace",
  "wax 0.7.0",
+ "which",
  "winapi",
  "wincode",
 ]
@@ -7756,7 +7757,7 @@ dependencies = [
 [[package]]
 name = "vite_task_graph"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7778,7 +7779,7 @@ dependencies = [
 [[package]]
 name = "vite_task_plan"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7808,7 +7809,7 @@ version = "0.0.0"
 [[package]]
 name = "vite_workspace"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
 dependencies = [
  "clap",
  "petgraph 0.8.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1873,7 +1873,7 @@ dependencies = [
 [[package]]
 name = "fspy"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1909,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "fspy_detours_sys"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
 dependencies = [
  "cc",
  "winapi",
@@ -1918,7 +1918,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
 dependencies = [
  "anyhow",
  "bstr",
@@ -1933,7 +1933,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_windows"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
 dependencies = [
  "constcat",
  "fspy_detours_sys",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "fspy_seccomp_unotify"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
 dependencies = [
  "futures-util",
  "libc",
@@ -1966,7 +1966,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
 dependencies = [
  "allocator-api2",
  "bitflags 2.11.0",
@@ -1985,7 +1985,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3346,7 +3346,7 @@ dependencies = [
 [[package]]
 name = "native_str"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
 dependencies = [
  "allocator-api2",
  "bytemuck",
@@ -4821,7 +4821,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal_test_client"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
 
 [[package]]
 name = "quote"
@@ -7477,7 +7477,7 @@ dependencies = [
 [[package]]
 name = "vite_glob"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
 dependencies = [
  "thiserror 2.0.18",
  "vite_path",
@@ -7517,7 +7517,7 @@ dependencies = [
 [[package]]
 name = "vite_graph_ser"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
 dependencies = [
  "petgraph 0.8.3",
  "serde",
@@ -7616,7 +7616,7 @@ dependencies = [
 [[package]]
 name = "vite_path"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
 dependencies = [
  "diff-struct",
  "path-clean",
@@ -7630,7 +7630,7 @@ dependencies = [
 [[package]]
 name = "vite_select"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -7680,7 +7680,7 @@ dependencies = [
 [[package]]
 name = "vite_shell"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
 dependencies = [
  "brush-parser 0.3.0 (git+https://github.com/reubeno/brush?rev=dcb760933b10ee0433d7b740a5709b06f5c67c6b)",
  "diff-struct",
@@ -7707,7 +7707,7 @@ dependencies = [
 [[package]]
 name = "vite_str"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
 dependencies = [
  "compact_str",
  "diff-struct",
@@ -7718,7 +7718,7 @@ dependencies = [
 [[package]]
 name = "vite_task"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7757,7 +7757,7 @@ dependencies = [
 [[package]]
 name = "vite_task_graph"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7779,7 +7779,7 @@ dependencies = [
 [[package]]
 name = "vite_task_plan"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7809,7 +7809,7 @@ version = "0.0.0"
 [[package]]
 name = "vite_workspace"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
 dependencies = [
  "clap",
  "petgraph 0.8.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1873,7 +1873,7 @@ dependencies = [
 [[package]]
 name = "fspy"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1909,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "fspy_detours_sys"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
 dependencies = [
  "cc",
  "winapi",
@@ -1918,7 +1918,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
 dependencies = [
  "anyhow",
  "bstr",
@@ -1933,7 +1933,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_windows"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
 dependencies = [
  "constcat",
  "fspy_detours_sys",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "fspy_seccomp_unotify"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
 dependencies = [
  "futures-util",
  "libc",
@@ -1966,7 +1966,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
 dependencies = [
  "allocator-api2",
  "bitflags 2.11.0",
@@ -1985,7 +1985,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3346,7 +3346,7 @@ dependencies = [
 [[package]]
 name = "native_str"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
 dependencies = [
  "allocator-api2",
  "bytemuck",
@@ -4821,7 +4821,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal_test_client"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
 
 [[package]]
 name = "quote"
@@ -7477,7 +7477,7 @@ dependencies = [
 [[package]]
 name = "vite_glob"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
 dependencies = [
  "thiserror 2.0.18",
  "vite_path",
@@ -7517,7 +7517,7 @@ dependencies = [
 [[package]]
 name = "vite_graph_ser"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
 dependencies = [
  "petgraph 0.8.3",
  "serde",
@@ -7616,7 +7616,7 @@ dependencies = [
 [[package]]
 name = "vite_path"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
 dependencies = [
  "diff-struct",
  "path-clean",
@@ -7630,7 +7630,7 @@ dependencies = [
 [[package]]
 name = "vite_select"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -7680,7 +7680,7 @@ dependencies = [
 [[package]]
 name = "vite_shell"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
 dependencies = [
  "brush-parser 0.3.0 (git+https://github.com/reubeno/brush?rev=dcb760933b10ee0433d7b740a5709b06f5c67c6b)",
  "diff-struct",
@@ -7707,7 +7707,7 @@ dependencies = [
 [[package]]
 name = "vite_str"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
 dependencies = [
  "compact_str",
  "diff-struct",
@@ -7718,7 +7718,7 @@ dependencies = [
 [[package]]
 name = "vite_task"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7756,7 +7756,7 @@ dependencies = [
 [[package]]
 name = "vite_task_graph"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7778,7 +7778,7 @@ dependencies = [
 [[package]]
 name = "vite_task_plan"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7808,7 +7808,7 @@ version = "0.0.0"
 [[package]]
 name = "vite_workspace"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c75236843f47bd6b007b11b130a496d18a183276#c75236843f47bd6b007b11b130a496d18a183276"
 dependencies = [
  "clap",
  "petgraph 0.8.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 [[package]]
 name = "fspy"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c45e5e72d3a17b850310128480e92d3e332c2d5a#c45e5e72d3a17b850310128480e92d3e332c2d5a"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1908,7 +1908,7 @@ dependencies = [
 [[package]]
 name = "fspy_detours_sys"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c45e5e72d3a17b850310128480e92d3e332c2d5a#c45e5e72d3a17b850310128480e92d3e332c2d5a"
 dependencies = [
  "cc",
  "winapi",
@@ -1917,7 +1917,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c45e5e72d3a17b850310128480e92d3e332c2d5a#c45e5e72d3a17b850310128480e92d3e332c2d5a"
 dependencies = [
  "anyhow",
  "bstr",
@@ -1932,7 +1932,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_windows"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c45e5e72d3a17b850310128480e92d3e332c2d5a#c45e5e72d3a17b850310128480e92d3e332c2d5a"
 dependencies = [
  "constcat",
  "fspy_detours_sys",
@@ -1948,7 +1948,7 @@ dependencies = [
 [[package]]
 name = "fspy_seccomp_unotify"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c45e5e72d3a17b850310128480e92d3e332c2d5a#c45e5e72d3a17b850310128480e92d3e332c2d5a"
 dependencies = [
  "futures-util",
  "libc",
@@ -1965,7 +1965,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c45e5e72d3a17b850310128480e92d3e332c2d5a#c45e5e72d3a17b850310128480e92d3e332c2d5a"
 dependencies = [
  "allocator-api2",
  "bitflags 2.11.0",
@@ -1984,7 +1984,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c45e5e72d3a17b850310128480e92d3e332c2d5a#c45e5e72d3a17b850310128480e92d3e332c2d5a"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3124,7 +3124,7 @@ dependencies = [
 [[package]]
 name = "materialized_artifact"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c45e5e72d3a17b850310128480e92d3e332c2d5a#c45e5e72d3a17b850310128480e92d3e332c2d5a"
 dependencies = [
  "tempfile",
 ]
@@ -3132,7 +3132,7 @@ dependencies = [
 [[package]]
 name = "materialized_artifact_build"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c45e5e72d3a17b850310128480e92d3e332c2d5a#c45e5e72d3a17b850310128480e92d3e332c2d5a"
 dependencies = [
  "xxhash-rust",
 ]
@@ -3346,7 +3346,7 @@ dependencies = [
 [[package]]
 name = "native_str"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c45e5e72d3a17b850310128480e92d3e332c2d5a#c45e5e72d3a17b850310128480e92d3e332c2d5a"
 dependencies = [
  "allocator-api2",
  "bytemuck",
@@ -4821,7 +4821,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal_test_client"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c45e5e72d3a17b850310128480e92d3e332c2d5a#c45e5e72d3a17b850310128480e92d3e332c2d5a"
 
 [[package]]
 name = "quote"
@@ -7477,7 +7477,7 @@ dependencies = [
 [[package]]
 name = "vite_glob"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c45e5e72d3a17b850310128480e92d3e332c2d5a#c45e5e72d3a17b850310128480e92d3e332c2d5a"
 dependencies = [
  "thiserror 2.0.18",
  "vite_path",
@@ -7517,7 +7517,7 @@ dependencies = [
 [[package]]
 name = "vite_graph_ser"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c45e5e72d3a17b850310128480e92d3e332c2d5a#c45e5e72d3a17b850310128480e92d3e332c2d5a"
 dependencies = [
  "petgraph 0.8.3",
  "serde",
@@ -7616,7 +7616,7 @@ dependencies = [
 [[package]]
 name = "vite_path"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c45e5e72d3a17b850310128480e92d3e332c2d5a#c45e5e72d3a17b850310128480e92d3e332c2d5a"
 dependencies = [
  "diff-struct",
  "path-clean",
@@ -7630,7 +7630,7 @@ dependencies = [
 [[package]]
 name = "vite_select"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c45e5e72d3a17b850310128480e92d3e332c2d5a#c45e5e72d3a17b850310128480e92d3e332c2d5a"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -7680,7 +7680,7 @@ dependencies = [
 [[package]]
 name = "vite_shell"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c45e5e72d3a17b850310128480e92d3e332c2d5a#c45e5e72d3a17b850310128480e92d3e332c2d5a"
 dependencies = [
  "brush-parser 0.3.0 (git+https://github.com/reubeno/brush?rev=dcb760933b10ee0433d7b740a5709b06f5c67c6b)",
  "diff-struct",
@@ -7707,7 +7707,7 @@ dependencies = [
 [[package]]
 name = "vite_str"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c45e5e72d3a17b850310128480e92d3e332c2d5a#c45e5e72d3a17b850310128480e92d3e332c2d5a"
 dependencies = [
  "compact_str",
  "diff-struct",
@@ -7718,7 +7718,7 @@ dependencies = [
 [[package]]
 name = "vite_task"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c45e5e72d3a17b850310128480e92d3e332c2d5a#c45e5e72d3a17b850310128480e92d3e332c2d5a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7756,7 +7756,7 @@ dependencies = [
 [[package]]
 name = "vite_task_graph"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c45e5e72d3a17b850310128480e92d3e332c2d5a#c45e5e72d3a17b850310128480e92d3e332c2d5a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7778,12 +7778,13 @@ dependencies = [
 [[package]]
 name = "vite_task_plan"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c45e5e72d3a17b850310128480e92d3e332c2d5a#c45e5e72d3a17b850310128480e92d3e332c2d5a"
 dependencies = [
  "anyhow",
  "async-trait",
  "cow-utils",
  "futures-util",
+ "pathdiff",
  "petgraph 0.8.3",
  "rustc-hash",
  "serde",
@@ -7809,7 +7810,7 @@ version = "0.0.0"
 [[package]]
 name = "vite_workspace"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c45e5e72d3a17b850310128480e92d3e332c2d5a#c45e5e72d3a17b850310128480e92d3e332c2d5a"
 dependencies = [
  "clap",
  "petgraph 0.8.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1873,7 +1873,7 @@ dependencies = [
 [[package]]
 name = "fspy"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1909,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "fspy_detours_sys"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
 dependencies = [
  "cc",
  "winapi",
@@ -1918,7 +1918,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
 dependencies = [
  "anyhow",
  "bstr",
@@ -1933,7 +1933,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_windows"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
 dependencies = [
  "constcat",
  "fspy_detours_sys",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "fspy_seccomp_unotify"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
 dependencies = [
  "futures-util",
  "libc",
@@ -1966,7 +1966,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
 dependencies = [
  "allocator-api2",
  "bitflags 2.11.0",
@@ -1985,7 +1985,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3346,7 +3346,7 @@ dependencies = [
 [[package]]
 name = "native_str"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
 dependencies = [
  "allocator-api2",
  "bytemuck",
@@ -4821,7 +4821,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal_test_client"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
 
 [[package]]
 name = "quote"
@@ -7477,7 +7477,7 @@ dependencies = [
 [[package]]
 name = "vite_glob"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
 dependencies = [
  "thiserror 2.0.18",
  "vite_path",
@@ -7517,7 +7517,7 @@ dependencies = [
 [[package]]
 name = "vite_graph_ser"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
 dependencies = [
  "petgraph 0.8.3",
  "serde",
@@ -7616,7 +7616,7 @@ dependencies = [
 [[package]]
 name = "vite_path"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
 dependencies = [
  "diff-struct",
  "path-clean",
@@ -7630,7 +7630,7 @@ dependencies = [
 [[package]]
 name = "vite_select"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -7680,7 +7680,7 @@ dependencies = [
 [[package]]
 name = "vite_shell"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
 dependencies = [
  "brush-parser 0.3.0 (git+https://github.com/reubeno/brush?rev=dcb760933b10ee0433d7b740a5709b06f5c67c6b)",
  "diff-struct",
@@ -7707,7 +7707,7 @@ dependencies = [
 [[package]]
 name = "vite_str"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
 dependencies = [
  "compact_str",
  "diff-struct",
@@ -7718,7 +7718,7 @@ dependencies = [
 [[package]]
 name = "vite_task"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7757,7 +7757,7 @@ dependencies = [
 [[package]]
 name = "vite_task_graph"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7779,7 +7779,7 @@ dependencies = [
 [[package]]
 name = "vite_task_plan"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7809,7 +7809,7 @@ version = "0.0.0"
 [[package]]
 name = "vite_workspace"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=9b5cad2277feccb76a8963c8819edc0c7635e022#9b5cad2277feccb76a8963c8819edc0c7635e022"
 dependencies = [
  "clap",
  "petgraph 0.8.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1873,7 +1873,7 @@ dependencies = [
 [[package]]
 name = "fspy"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1909,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "fspy_detours_sys"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
 dependencies = [
  "cc",
  "winapi",
@@ -1918,7 +1918,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
 dependencies = [
  "anyhow",
  "bstr",
@@ -1933,7 +1933,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_windows"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
 dependencies = [
  "constcat",
  "fspy_detours_sys",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "fspy_seccomp_unotify"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
 dependencies = [
  "futures-util",
  "libc",
@@ -1966,7 +1966,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
 dependencies = [
  "allocator-api2",
  "bitflags 2.11.0",
@@ -1985,7 +1985,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3346,7 +3346,7 @@ dependencies = [
 [[package]]
 name = "native_str"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
 dependencies = [
  "allocator-api2",
  "bytemuck",
@@ -4821,7 +4821,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal_test_client"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
 
 [[package]]
 name = "quote"
@@ -7477,7 +7477,7 @@ dependencies = [
 [[package]]
 name = "vite_glob"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
 dependencies = [
  "thiserror 2.0.18",
  "vite_path",
@@ -7517,7 +7517,7 @@ dependencies = [
 [[package]]
 name = "vite_graph_ser"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
 dependencies = [
  "petgraph 0.8.3",
  "serde",
@@ -7616,7 +7616,7 @@ dependencies = [
 [[package]]
 name = "vite_path"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
 dependencies = [
  "diff-struct",
  "path-clean",
@@ -7630,7 +7630,7 @@ dependencies = [
 [[package]]
 name = "vite_select"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -7680,7 +7680,7 @@ dependencies = [
 [[package]]
 name = "vite_shell"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
 dependencies = [
  "brush-parser 0.3.0 (git+https://github.com/reubeno/brush?rev=dcb760933b10ee0433d7b740a5709b06f5c67c6b)",
  "diff-struct",
@@ -7707,7 +7707,7 @@ dependencies = [
 [[package]]
 name = "vite_str"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
 dependencies = [
  "compact_str",
  "diff-struct",
@@ -7718,7 +7718,7 @@ dependencies = [
 [[package]]
 name = "vite_task"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7757,7 +7757,7 @@ dependencies = [
 [[package]]
 name = "vite_task_graph"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7779,7 +7779,7 @@ dependencies = [
 [[package]]
 name = "vite_task_plan"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7809,7 +7809,7 @@ version = "0.0.0"
 [[package]]
 name = "vite_workspace"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=7b74d616351a9caa3f25ac188ca062d4aab31e60#7b74d616351a9caa3f25ac188ca062d4aab31e60"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=4f14ebe03600a8996f135d7ee11574346c055901#4f14ebe03600a8996f135d7ee11574346c055901"
 dependencies = [
  "clap",
  "petgraph 0.8.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1873,7 +1873,7 @@ dependencies = [
 [[package]]
 name = "fspy"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=954cd3bead71be4ddc1e3183110d713bbe26286b#954cd3bead71be4ddc1e3183110d713bbe26286b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1909,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "fspy_detours_sys"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=954cd3bead71be4ddc1e3183110d713bbe26286b#954cd3bead71be4ddc1e3183110d713bbe26286b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
 dependencies = [
  "cc",
  "winapi",
@@ -1918,7 +1918,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=954cd3bead71be4ddc1e3183110d713bbe26286b#954cd3bead71be4ddc1e3183110d713bbe26286b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
 dependencies = [
  "anyhow",
  "bstr",
@@ -1933,7 +1933,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_windows"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=954cd3bead71be4ddc1e3183110d713bbe26286b#954cd3bead71be4ddc1e3183110d713bbe26286b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
 dependencies = [
  "constcat",
  "fspy_detours_sys",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "fspy_seccomp_unotify"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=954cd3bead71be4ddc1e3183110d713bbe26286b#954cd3bead71be4ddc1e3183110d713bbe26286b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
 dependencies = [
  "futures-util",
  "libc",
@@ -1966,7 +1966,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=954cd3bead71be4ddc1e3183110d713bbe26286b#954cd3bead71be4ddc1e3183110d713bbe26286b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
 dependencies = [
  "allocator-api2",
  "bitflags 2.11.0",
@@ -1985,7 +1985,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=954cd3bead71be4ddc1e3183110d713bbe26286b#954cd3bead71be4ddc1e3183110d713bbe26286b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3346,7 +3346,7 @@ dependencies = [
 [[package]]
 name = "native_str"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=954cd3bead71be4ddc1e3183110d713bbe26286b#954cd3bead71be4ddc1e3183110d713bbe26286b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
 dependencies = [
  "allocator-api2",
  "bytemuck",
@@ -4821,7 +4821,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal_test_client"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=954cd3bead71be4ddc1e3183110d713bbe26286b#954cd3bead71be4ddc1e3183110d713bbe26286b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
 
 [[package]]
 name = "quote"
@@ -7477,7 +7477,7 @@ dependencies = [
 [[package]]
 name = "vite_glob"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=954cd3bead71be4ddc1e3183110d713bbe26286b#954cd3bead71be4ddc1e3183110d713bbe26286b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
 dependencies = [
  "thiserror 2.0.18",
  "vite_path",
@@ -7517,7 +7517,7 @@ dependencies = [
 [[package]]
 name = "vite_graph_ser"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=954cd3bead71be4ddc1e3183110d713bbe26286b#954cd3bead71be4ddc1e3183110d713bbe26286b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
 dependencies = [
  "petgraph 0.8.3",
  "serde",
@@ -7616,7 +7616,7 @@ dependencies = [
 [[package]]
 name = "vite_path"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=954cd3bead71be4ddc1e3183110d713bbe26286b#954cd3bead71be4ddc1e3183110d713bbe26286b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
 dependencies = [
  "diff-struct",
  "path-clean",
@@ -7630,7 +7630,7 @@ dependencies = [
 [[package]]
 name = "vite_select"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=954cd3bead71be4ddc1e3183110d713bbe26286b#954cd3bead71be4ddc1e3183110d713bbe26286b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -7680,7 +7680,7 @@ dependencies = [
 [[package]]
 name = "vite_shell"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=954cd3bead71be4ddc1e3183110d713bbe26286b#954cd3bead71be4ddc1e3183110d713bbe26286b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
 dependencies = [
  "brush-parser 0.3.0 (git+https://github.com/reubeno/brush?rev=dcb760933b10ee0433d7b740a5709b06f5c67c6b)",
  "diff-struct",
@@ -7707,7 +7707,7 @@ dependencies = [
 [[package]]
 name = "vite_str"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=954cd3bead71be4ddc1e3183110d713bbe26286b#954cd3bead71be4ddc1e3183110d713bbe26286b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
 dependencies = [
  "compact_str",
  "diff-struct",
@@ -7718,7 +7718,7 @@ dependencies = [
 [[package]]
 name = "vite_task"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=954cd3bead71be4ddc1e3183110d713bbe26286b#954cd3bead71be4ddc1e3183110d713bbe26286b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7756,7 +7756,7 @@ dependencies = [
 [[package]]
 name = "vite_task_graph"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=954cd3bead71be4ddc1e3183110d713bbe26286b#954cd3bead71be4ddc1e3183110d713bbe26286b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7778,7 +7778,7 @@ dependencies = [
 [[package]]
 name = "vite_task_plan"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=954cd3bead71be4ddc1e3183110d713bbe26286b#954cd3bead71be4ddc1e3183110d713bbe26286b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7808,7 +7808,7 @@ version = "0.0.0"
 [[package]]
 name = "vite_workspace"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=954cd3bead71be4ddc1e3183110d713bbe26286b#954cd3bead71be4ddc1e3183110d713bbe26286b"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e0229ffbb8e128bf8496a030588202b9e1be6376#e0229ffbb8e128bf8496a030588202b9e1be6376"
 dependencies = [
  "clap",
  "petgraph 0.8.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,7 +1872,7 @@ dependencies = [
 [[package]]
 name = "fspy"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1908,7 +1908,7 @@ dependencies = [
 [[package]]
 name = "fspy_detours_sys"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
 dependencies = [
  "cc",
  "winapi",
@@ -1917,7 +1917,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
 dependencies = [
  "anyhow",
  "bstr",
@@ -1932,7 +1932,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_windows"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
 dependencies = [
  "constcat",
  "fspy_detours_sys",
@@ -1948,7 +1948,7 @@ dependencies = [
 [[package]]
 name = "fspy_seccomp_unotify"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
 dependencies = [
  "futures-util",
  "libc",
@@ -1965,7 +1965,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
 dependencies = [
  "allocator-api2",
  "bitflags 2.11.0",
@@ -1984,7 +1984,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3124,7 +3124,7 @@ dependencies = [
 [[package]]
 name = "materialized_artifact"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
 dependencies = [
  "tempfile",
 ]
@@ -3132,7 +3132,7 @@ dependencies = [
 [[package]]
 name = "materialized_artifact_build"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
 dependencies = [
  "xxhash-rust",
 ]
@@ -3346,7 +3346,7 @@ dependencies = [
 [[package]]
 name = "native_str"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
 dependencies = [
  "allocator-api2",
  "bytemuck",
@@ -4821,7 +4821,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal_test_client"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
 
 [[package]]
 name = "quote"
@@ -7477,7 +7477,7 @@ dependencies = [
 [[package]]
 name = "vite_glob"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
 dependencies = [
  "thiserror 2.0.18",
  "vite_path",
@@ -7517,7 +7517,7 @@ dependencies = [
 [[package]]
 name = "vite_graph_ser"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
 dependencies = [
  "petgraph 0.8.3",
  "serde",
@@ -7616,7 +7616,7 @@ dependencies = [
 [[package]]
 name = "vite_path"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
 dependencies = [
  "diff-struct",
  "path-clean",
@@ -7630,7 +7630,7 @@ dependencies = [
 [[package]]
 name = "vite_select"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -7680,7 +7680,7 @@ dependencies = [
 [[package]]
 name = "vite_shell"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
 dependencies = [
  "brush-parser 0.3.0 (git+https://github.com/reubeno/brush?rev=dcb760933b10ee0433d7b740a5709b06f5c67c6b)",
  "diff-struct",
@@ -7707,7 +7707,7 @@ dependencies = [
 [[package]]
 name = "vite_str"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
 dependencies = [
  "compact_str",
  "diff-struct",
@@ -7718,7 +7718,7 @@ dependencies = [
 [[package]]
 name = "vite_task"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7749,7 +7749,6 @@ dependencies = [
  "vite_task_plan",
  "vite_workspace",
  "wax 0.7.0",
- "which",
  "winapi",
  "wincode",
 ]
@@ -7757,7 +7756,7 @@ dependencies = [
 [[package]]
 name = "vite_task_graph"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7779,10 +7778,11 @@ dependencies = [
 [[package]]
 name = "vite_task_plan"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
 dependencies = [
  "anyhow",
  "async-trait",
+ "cow-utils",
  "futures-util",
  "petgraph 0.8.3",
  "rustc-hash",
@@ -7809,7 +7809,7 @@ version = "0.0.0"
 [[package]]
 name = "vite_workspace"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=26021ca154c9de676b3a37ff415f7a9a821e03a9#26021ca154c9de676b3a37ff415f7a9a821e03a9"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=892af621431cbc4219495784c14a95f9d260523b#892af621431cbc4219495784c14a95f9d260523b"
 dependencies = [
  "clap",
  "petgraph 0.8.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,7 +1014,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
 dependencies = [
  "const_format_proc_macros",
- "konst",
 ]
 
 [[package]]
@@ -1873,13 +1872,12 @@ dependencies = [
 [[package]]
 name = "fspy"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
 dependencies = [
  "allocator-api2",
  "anyhow",
  "bstr",
  "bumpalo",
- "const_format",
  "derive_more",
  "flate2",
  "fspy_detours_sys",
@@ -1890,10 +1888,12 @@ dependencies = [
  "fspy_shared_unix",
  "futures-util",
  "libc",
+ "materialized_artifact",
+ "materialized_artifact_build",
  "nix 0.30.1",
  "ouroboros",
- "rand 0.9.2",
  "rustc-hash",
+ "sha2",
  "tar",
  "tempfile",
  "thiserror 2.0.18",
@@ -1903,13 +1903,12 @@ dependencies = [
  "winapi",
  "wincode",
  "winsafe",
- "xxhash-rust",
 ]
 
 [[package]]
 name = "fspy_detours_sys"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
 dependencies = [
  "cc",
  "winapi",
@@ -1918,7 +1917,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
 dependencies = [
  "anyhow",
  "bstr",
@@ -1933,7 +1932,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_windows"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
 dependencies = [
  "constcat",
  "fspy_detours_sys",
@@ -1949,7 +1948,7 @@ dependencies = [
 [[package]]
 name = "fspy_seccomp_unotify"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
 dependencies = [
  "futures-util",
  "libc",
@@ -1966,7 +1965,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
 dependencies = [
  "allocator-api2",
  "bitflags 2.11.0",
@@ -1985,7 +1984,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2924,21 +2923,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "konst"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330f0e13e6483b8c34885f7e6c9f19b1a7bd449c673fbb948a51c99d66ef74f4"
-dependencies = [
- "konst_macro_rules",
-]
-
-[[package]]
-name = "konst_macro_rules"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
-
-[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3135,6 +3119,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
+]
+
+[[package]]
+name = "materialized_artifact"
+version = "0.0.0"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
+dependencies = [
+ "tempfile",
+]
+
+[[package]]
+name = "materialized_artifact_build"
+version = "0.0.0"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
+dependencies = [
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -3346,7 +3346,7 @@ dependencies = [
 [[package]]
 name = "native_str"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
 dependencies = [
  "allocator-api2",
  "bytemuck",
@@ -4821,7 +4821,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal_test_client"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
 
 [[package]]
 name = "quote"
@@ -7477,7 +7477,7 @@ dependencies = [
 [[package]]
 name = "vite_glob"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
 dependencies = [
  "thiserror 2.0.18",
  "vite_path",
@@ -7517,7 +7517,7 @@ dependencies = [
 [[package]]
 name = "vite_graph_ser"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
 dependencies = [
  "petgraph 0.8.3",
  "serde",
@@ -7616,7 +7616,7 @@ dependencies = [
 [[package]]
 name = "vite_path"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
 dependencies = [
  "diff-struct",
  "path-clean",
@@ -7630,7 +7630,7 @@ dependencies = [
 [[package]]
 name = "vite_select"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -7680,7 +7680,7 @@ dependencies = [
 [[package]]
 name = "vite_shell"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
 dependencies = [
  "brush-parser 0.3.0 (git+https://github.com/reubeno/brush?rev=dcb760933b10ee0433d7b740a5709b06f5c67c6b)",
  "diff-struct",
@@ -7707,7 +7707,7 @@ dependencies = [
 [[package]]
 name = "vite_str"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
 dependencies = [
  "compact_str",
  "diff-struct",
@@ -7718,7 +7718,7 @@ dependencies = [
 [[package]]
 name = "vite_task"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7757,7 +7757,7 @@ dependencies = [
 [[package]]
 name = "vite_task_graph"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7779,7 +7779,7 @@ dependencies = [
 [[package]]
 name = "vite_task_plan"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7809,7 +7809,7 @@ version = "0.0.0"
 [[package]]
 name = "vite_workspace"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d#5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=3e1fc38a54eb87447a4456186cb4bdbfb6b416f3#3e1fc38a54eb87447a4456186cb4bdbfb6b416f3"
 dependencies = [
  "clap",
  "petgraph 0.8.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ dunce = "1.0.5"
 fast-glob = "1.0.0"
 flate2 = { version = "=1.1.9", features = ["zlib-rs"] }
 form_urlencoded = "1.2.1"
-fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "954cd3bead71be4ddc1e3183110d713bbe26286b" }
+fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "e0229ffbb8e128bf8496a030588202b9e1be6376" }
 futures = "0.3.31"
 futures-util = "0.3.31"
 glob = "0.3.2"
@@ -194,16 +194,16 @@ vfs = "0.13.0"
 vite_command = { path = "crates/vite_command" }
 vite_error = { path = "crates/vite_error" }
 vite_js_runtime = { path = "crates/vite_js_runtime" }
-vite_glob = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "954cd3bead71be4ddc1e3183110d713bbe26286b" }
+vite_glob = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "e0229ffbb8e128bf8496a030588202b9e1be6376" }
 vite_install = { path = "crates/vite_install" }
 vite_migration = { path = "crates/vite_migration" }
 vite_setup = { path = "crates/vite_setup" }
 vite_shared = { path = "crates/vite_shared" }
 vite_static_config = { path = "crates/vite_static_config" }
-vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "954cd3bead71be4ddc1e3183110d713bbe26286b" }
-vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "954cd3bead71be4ddc1e3183110d713bbe26286b" }
-vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "954cd3bead71be4ddc1e3183110d713bbe26286b" }
-vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "954cd3bead71be4ddc1e3183110d713bbe26286b" }
+vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "e0229ffbb8e128bf8496a030588202b9e1be6376" }
+vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "e0229ffbb8e128bf8496a030588202b9e1be6376" }
+vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "e0229ffbb8e128bf8496a030588202b9e1be6376" }
+vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "e0229ffbb8e128bf8496a030588202b9e1be6376" }
 walkdir = "2.5.0"
 wax = "0.6.0"
 which = "8.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ dunce = "1.0.5"
 fast-glob = "1.0.0"
 flate2 = { version = "=1.1.9", features = ["zlib-rs"] }
 form_urlencoded = "1.2.1"
-fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c75236843f47bd6b007b11b130a496d18a183276" }
+fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "7b74d616351a9caa3f25ac188ca062d4aab31e60" }
 futures = "0.3.31"
 futures-util = "0.3.31"
 glob = "0.3.2"
@@ -194,16 +194,16 @@ vfs = "0.13.0"
 vite_command = { path = "crates/vite_command" }
 vite_error = { path = "crates/vite_error" }
 vite_js_runtime = { path = "crates/vite_js_runtime" }
-vite_glob = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c75236843f47bd6b007b11b130a496d18a183276" }
+vite_glob = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "7b74d616351a9caa3f25ac188ca062d4aab31e60" }
 vite_install = { path = "crates/vite_install" }
 vite_migration = { path = "crates/vite_migration" }
 vite_setup = { path = "crates/vite_setup" }
 vite_shared = { path = "crates/vite_shared" }
 vite_static_config = { path = "crates/vite_static_config" }
-vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c75236843f47bd6b007b11b130a496d18a183276" }
-vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c75236843f47bd6b007b11b130a496d18a183276" }
-vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c75236843f47bd6b007b11b130a496d18a183276" }
-vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c75236843f47bd6b007b11b130a496d18a183276" }
+vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "7b74d616351a9caa3f25ac188ca062d4aab31e60" }
+vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "7b74d616351a9caa3f25ac188ca062d4aab31e60" }
+vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "7b74d616351a9caa3f25ac188ca062d4aab31e60" }
+vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "7b74d616351a9caa3f25ac188ca062d4aab31e60" }
 walkdir = "2.5.0"
 wax = "0.6.0"
 which = "8.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ dunce = "1.0.5"
 fast-glob = "1.0.0"
 flate2 = { version = "=1.1.9", features = ["zlib-rs"] }
 form_urlencoded = "1.2.1"
-fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "4f14ebe03600a8996f135d7ee11574346c055901" }
+fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "9b5cad2277feccb76a8963c8819edc0c7635e022" }
 futures = "0.3.31"
 futures-util = "0.3.31"
 glob = "0.3.2"
@@ -194,16 +194,16 @@ vfs = "0.13.0"
 vite_command = { path = "crates/vite_command" }
 vite_error = { path = "crates/vite_error" }
 vite_js_runtime = { path = "crates/vite_js_runtime" }
-vite_glob = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "4f14ebe03600a8996f135d7ee11574346c055901" }
+vite_glob = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "9b5cad2277feccb76a8963c8819edc0c7635e022" }
 vite_install = { path = "crates/vite_install" }
 vite_migration = { path = "crates/vite_migration" }
 vite_setup = { path = "crates/vite_setup" }
 vite_shared = { path = "crates/vite_shared" }
 vite_static_config = { path = "crates/vite_static_config" }
-vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "4f14ebe03600a8996f135d7ee11574346c055901" }
-vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "4f14ebe03600a8996f135d7ee11574346c055901" }
-vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "4f14ebe03600a8996f135d7ee11574346c055901" }
-vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "4f14ebe03600a8996f135d7ee11574346c055901" }
+vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "9b5cad2277feccb76a8963c8819edc0c7635e022" }
+vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "9b5cad2277feccb76a8963c8819edc0c7635e022" }
+vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "9b5cad2277feccb76a8963c8819edc0c7635e022" }
+vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "9b5cad2277feccb76a8963c8819edc0c7635e022" }
 walkdir = "2.5.0"
 wax = "0.6.0"
 which = "8.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ dunce = "1.0.5"
 fast-glob = "1.0.0"
 flate2 = { version = "=1.1.9", features = ["zlib-rs"] }
 form_urlencoded = "1.2.1"
-fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "7b74d616351a9caa3f25ac188ca062d4aab31e60" }
+fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "4f14ebe03600a8996f135d7ee11574346c055901" }
 futures = "0.3.31"
 futures-util = "0.3.31"
 glob = "0.3.2"
@@ -194,16 +194,16 @@ vfs = "0.13.0"
 vite_command = { path = "crates/vite_command" }
 vite_error = { path = "crates/vite_error" }
 vite_js_runtime = { path = "crates/vite_js_runtime" }
-vite_glob = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "7b74d616351a9caa3f25ac188ca062d4aab31e60" }
+vite_glob = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "4f14ebe03600a8996f135d7ee11574346c055901" }
 vite_install = { path = "crates/vite_install" }
 vite_migration = { path = "crates/vite_migration" }
 vite_setup = { path = "crates/vite_setup" }
 vite_shared = { path = "crates/vite_shared" }
 vite_static_config = { path = "crates/vite_static_config" }
-vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "7b74d616351a9caa3f25ac188ca062d4aab31e60" }
-vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "7b74d616351a9caa3f25ac188ca062d4aab31e60" }
-vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "7b74d616351a9caa3f25ac188ca062d4aab31e60" }
-vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "7b74d616351a9caa3f25ac188ca062d4aab31e60" }
+vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "4f14ebe03600a8996f135d7ee11574346c055901" }
+vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "4f14ebe03600a8996f135d7ee11574346c055901" }
+vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "4f14ebe03600a8996f135d7ee11574346c055901" }
+vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "4f14ebe03600a8996f135d7ee11574346c055901" }
 walkdir = "2.5.0"
 wax = "0.6.0"
 which = "8.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ dunce = "1.0.5"
 fast-glob = "1.0.0"
 flate2 = { version = "=1.1.9", features = ["zlib-rs"] }
 form_urlencoded = "1.2.1"
-fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d" }
+fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "3e1fc38a54eb87447a4456186cb4bdbfb6b416f3" }
 futures = "0.3.31"
 futures-util = "0.3.31"
 glob = "0.3.2"
@@ -194,16 +194,16 @@ vfs = "0.13.0"
 vite_command = { path = "crates/vite_command" }
 vite_error = { path = "crates/vite_error" }
 vite_js_runtime = { path = "crates/vite_js_runtime" }
-vite_glob = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d" }
+vite_glob = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "3e1fc38a54eb87447a4456186cb4bdbfb6b416f3" }
 vite_install = { path = "crates/vite_install" }
 vite_migration = { path = "crates/vite_migration" }
 vite_setup = { path = "crates/vite_setup" }
 vite_shared = { path = "crates/vite_shared" }
 vite_static_config = { path = "crates/vite_static_config" }
-vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d" }
-vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d" }
-vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d" }
-vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d" }
+vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "3e1fc38a54eb87447a4456186cb4bdbfb6b416f3" }
+vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "3e1fc38a54eb87447a4456186cb4bdbfb6b416f3" }
+vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "3e1fc38a54eb87447a4456186cb4bdbfb6b416f3" }
+vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "3e1fc38a54eb87447a4456186cb4bdbfb6b416f3" }
 walkdir = "2.5.0"
 wax = "0.6.0"
 which = "8.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ dunce = "1.0.5"
 fast-glob = "1.0.0"
 flate2 = { version = "=1.1.9", features = ["zlib-rs"] }
 form_urlencoded = "1.2.1"
-fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "9b5cad2277feccb76a8963c8819edc0c7635e022" }
+fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d" }
 futures = "0.3.31"
 futures-util = "0.3.31"
 glob = "0.3.2"
@@ -194,16 +194,16 @@ vfs = "0.13.0"
 vite_command = { path = "crates/vite_command" }
 vite_error = { path = "crates/vite_error" }
 vite_js_runtime = { path = "crates/vite_js_runtime" }
-vite_glob = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "9b5cad2277feccb76a8963c8819edc0c7635e022" }
+vite_glob = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d" }
 vite_install = { path = "crates/vite_install" }
 vite_migration = { path = "crates/vite_migration" }
 vite_setup = { path = "crates/vite_setup" }
 vite_shared = { path = "crates/vite_shared" }
 vite_static_config = { path = "crates/vite_static_config" }
-vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "9b5cad2277feccb76a8963c8819edc0c7635e022" }
-vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "9b5cad2277feccb76a8963c8819edc0c7635e022" }
-vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "9b5cad2277feccb76a8963c8819edc0c7635e022" }
-vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "9b5cad2277feccb76a8963c8819edc0c7635e022" }
+vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d" }
+vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d" }
+vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d" }
+vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "5ce6c621ea6ee92a7746ade80bb9cbfb269dc96d" }
 walkdir = "2.5.0"
 wax = "0.6.0"
 which = "8.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ dunce = "1.0.5"
 fast-glob = "1.0.0"
 flate2 = { version = "=1.1.9", features = ["zlib-rs"] }
 form_urlencoded = "1.2.1"
-fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "3e1fc38a54eb87447a4456186cb4bdbfb6b416f3" }
+fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "26021ca154c9de676b3a37ff415f7a9a821e03a9" }
 futures = "0.3.31"
 futures-util = "0.3.31"
 glob = "0.3.2"
@@ -194,16 +194,16 @@ vfs = "0.13.0"
 vite_command = { path = "crates/vite_command" }
 vite_error = { path = "crates/vite_error" }
 vite_js_runtime = { path = "crates/vite_js_runtime" }
-vite_glob = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "3e1fc38a54eb87447a4456186cb4bdbfb6b416f3" }
+vite_glob = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "26021ca154c9de676b3a37ff415f7a9a821e03a9" }
 vite_install = { path = "crates/vite_install" }
 vite_migration = { path = "crates/vite_migration" }
 vite_setup = { path = "crates/vite_setup" }
 vite_shared = { path = "crates/vite_shared" }
 vite_static_config = { path = "crates/vite_static_config" }
-vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "3e1fc38a54eb87447a4456186cb4bdbfb6b416f3" }
-vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "3e1fc38a54eb87447a4456186cb4bdbfb6b416f3" }
-vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "3e1fc38a54eb87447a4456186cb4bdbfb6b416f3" }
-vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "3e1fc38a54eb87447a4456186cb4bdbfb6b416f3" }
+vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "26021ca154c9de676b3a37ff415f7a9a821e03a9" }
+vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "26021ca154c9de676b3a37ff415f7a9a821e03a9" }
+vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "26021ca154c9de676b3a37ff415f7a9a821e03a9" }
+vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "26021ca154c9de676b3a37ff415f7a9a821e03a9" }
 walkdir = "2.5.0"
 wax = "0.6.0"
 which = "8.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ dunce = "1.0.5"
 fast-glob = "1.0.0"
 flate2 = { version = "=1.1.9", features = ["zlib-rs"] }
 form_urlencoded = "1.2.1"
-fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "892af621431cbc4219495784c14a95f9d260523b" }
+fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c45e5e72d3a17b850310128480e92d3e332c2d5a" }
 futures = "0.3.31"
 futures-util = "0.3.31"
 glob = "0.3.2"
@@ -194,16 +194,16 @@ vfs = "0.13.0"
 vite_command = { path = "crates/vite_command" }
 vite_error = { path = "crates/vite_error" }
 vite_js_runtime = { path = "crates/vite_js_runtime" }
-vite_glob = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "892af621431cbc4219495784c14a95f9d260523b" }
+vite_glob = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c45e5e72d3a17b850310128480e92d3e332c2d5a" }
 vite_install = { path = "crates/vite_install" }
 vite_migration = { path = "crates/vite_migration" }
 vite_setup = { path = "crates/vite_setup" }
 vite_shared = { path = "crates/vite_shared" }
 vite_static_config = { path = "crates/vite_static_config" }
-vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "892af621431cbc4219495784c14a95f9d260523b" }
-vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "892af621431cbc4219495784c14a95f9d260523b" }
-vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "892af621431cbc4219495784c14a95f9d260523b" }
-vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "892af621431cbc4219495784c14a95f9d260523b" }
+vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c45e5e72d3a17b850310128480e92d3e332c2d5a" }
+vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c45e5e72d3a17b850310128480e92d3e332c2d5a" }
+vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c45e5e72d3a17b850310128480e92d3e332c2d5a" }
+vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c45e5e72d3a17b850310128480e92d3e332c2d5a" }
 walkdir = "2.5.0"
 wax = "0.6.0"
 which = "8.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ dunce = "1.0.5"
 fast-glob = "1.0.0"
 flate2 = { version = "=1.1.9", features = ["zlib-rs"] }
 form_urlencoded = "1.2.1"
-fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "26021ca154c9de676b3a37ff415f7a9a821e03a9" }
+fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "892af621431cbc4219495784c14a95f9d260523b" }
 futures = "0.3.31"
 futures-util = "0.3.31"
 glob = "0.3.2"
@@ -194,16 +194,16 @@ vfs = "0.13.0"
 vite_command = { path = "crates/vite_command" }
 vite_error = { path = "crates/vite_error" }
 vite_js_runtime = { path = "crates/vite_js_runtime" }
-vite_glob = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "26021ca154c9de676b3a37ff415f7a9a821e03a9" }
+vite_glob = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "892af621431cbc4219495784c14a95f9d260523b" }
 vite_install = { path = "crates/vite_install" }
 vite_migration = { path = "crates/vite_migration" }
 vite_setup = { path = "crates/vite_setup" }
 vite_shared = { path = "crates/vite_shared" }
 vite_static_config = { path = "crates/vite_static_config" }
-vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "26021ca154c9de676b3a37ff415f7a9a821e03a9" }
-vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "26021ca154c9de676b3a37ff415f7a9a821e03a9" }
-vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "26021ca154c9de676b3a37ff415f7a9a821e03a9" }
-vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "26021ca154c9de676b3a37ff415f7a9a821e03a9" }
+vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "892af621431cbc4219495784c14a95f9d260523b" }
+vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "892af621431cbc4219495784c14a95f9d260523b" }
+vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "892af621431cbc4219495784c14a95f9d260523b" }
+vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "892af621431cbc4219495784c14a95f9d260523b" }
 walkdir = "2.5.0"
 wax = "0.6.0"
 which = "8.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ dunce = "1.0.5"
 fast-glob = "1.0.0"
 flate2 = { version = "=1.1.9", features = ["zlib-rs"] }
 form_urlencoded = "1.2.1"
-fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "e0229ffbb8e128bf8496a030588202b9e1be6376" }
+fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c75236843f47bd6b007b11b130a496d18a183276" }
 futures = "0.3.31"
 futures-util = "0.3.31"
 glob = "0.3.2"
@@ -194,16 +194,16 @@ vfs = "0.13.0"
 vite_command = { path = "crates/vite_command" }
 vite_error = { path = "crates/vite_error" }
 vite_js_runtime = { path = "crates/vite_js_runtime" }
-vite_glob = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "e0229ffbb8e128bf8496a030588202b9e1be6376" }
+vite_glob = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c75236843f47bd6b007b11b130a496d18a183276" }
 vite_install = { path = "crates/vite_install" }
 vite_migration = { path = "crates/vite_migration" }
 vite_setup = { path = "crates/vite_setup" }
 vite_shared = { path = "crates/vite_shared" }
 vite_static_config = { path = "crates/vite_static_config" }
-vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "e0229ffbb8e128bf8496a030588202b9e1be6376" }
-vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "e0229ffbb8e128bf8496a030588202b9e1be6376" }
-vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "e0229ffbb8e128bf8496a030588202b9e1be6376" }
-vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "e0229ffbb8e128bf8496a030588202b9e1be6376" }
+vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c75236843f47bd6b007b11b130a496d18a183276" }
+vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c75236843f47bd6b007b11b130a496d18a183276" }
+vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c75236843f47bd6b007b11b130a496d18a183276" }
+vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c75236843f47bd6b007b11b130a496d18a183276" }
 walkdir = "2.5.0"
 wax = "0.6.0"
 which = "8.0.0"

--- a/packages/cli/snap-tests/npm-install-with-options/snap.txt
+++ b/packages/cli/snap-tests/npm-install-with-options/snap.txt
@@ -23,15 +23,28 @@ Run "npm help install" for more info
 > vp run install # https://docs.npmjs.com/cli/v10/commands/npm-install
 $ vp install --production --silent
 
----
-vp run: npm-install-with-options#install not cached because it modified its input. (Run `vp run --last-details` for full details)
 
 > ls node_modules
 @oxlint
 tslib
 
 > vp run install # install again hit cache
-$ vp install --production --silent
+$ vp install --production --silent ◉ cache hit, replaying
 
 ---
-vp run: npm-install-with-options#install not cached because it modified its input. (Run `vp run --last-details` for full details)
+vp run: cache hit, <variable>ms saved.
+
+> vp run --last-details
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    Vite+ Task Runner • Execution Summary
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Statistics:   1 tasks • 1 cache hits • 0 cache misses
+Performance:  100% cache hit rate, <variable>ms saved in total
+
+Task Details:
+────────────────────────────────────────────────
+  [1] npm-install-with-options#install: $ vp install --production --silent ✓
+      → Cache hit - output replayed - <variable>ms saved
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/packages/cli/snap-tests/npm-install-with-options/steps.json
+++ b/packages/cli/snap-tests/npm-install-with-options/steps.json
@@ -3,6 +3,7 @@
     "vp install --help # print help message",
     "vp run install # https://docs.npmjs.com/cli/v10/commands/npm-install",
     "ls node_modules",
-    "vp run install # install again hit cache"
+    "vp run install # install again hit cache",
+    "vp run --last-details"
   ]
 }

--- a/packages/cli/snap-tests/npm-install-with-options/vite.config.ts
+++ b/packages/cli/snap-tests/npm-install-with-options/vite.config.ts
@@ -4,6 +4,7 @@ export default {
     tasks: {
       install: {
         command: 'vp install --production --silent',
+        input: [{ auto: true }, '!node_modules/**', '!package-lock.json'],
       },
     },
   },


### PR DESCRIPTION
## Summary

Running a `node_modules/.bin/*.cmd` shim on Windows — what `vp run <script>` does when resolving `vite`, `tsc`, etc. — triggers `cmd.exe`'s *"Terminate batch job (Y/N)?"* prompt on Ctrl+C. That prompt leaves the terminal in a corrupt state: backspace prints `^H`, Ctrl+C prints `^C`, input becomes sluggish.

Pulls in voidzero-dev/vite-task#345 (merged as `c45e5e72`), which teaches the plan layer to rewrite the invocation at plan time:

```
program_path: <abs path to pwsh.exe or powershell.exe>
args:         [-NoProfile, -NoLogo, -ExecutionPolicy, Bypass, -File,
               <.ps1 path relative to task cwd>, ...original_args]
```

PowerShell resolves `-File <relative>` against its own working directory (= the task's cwd) and lands on the correct `.ps1`, so Ctrl+C propagates cleanly without the `cmd.exe` hop. The `.ps1` path is **cwd-relative** so `SpawnFingerprint.args` stays portable — no absolute paths leak into cache keys.

The rewrite only fires when **all** of these hold: extension is `.cmd`, path lives inside the workspace root, the two last path components are `.bin` / `node_modules` (case-insensitive), a sibling `.ps1` exists, and `pwsh.exe` / `powershell.exe` is on PATH. Any miss keeps the original `.cmd` path — behavior matches pre-merge.

Also includes a previously-pushed CI fix: the musl test job disables `crt-static` so `fspy_preload_unix`'s cdylib build doesn't fail after voidzero-dev/vite-task#344 made that crate an unconditional build-dep.

Closes #1176

## Test plan

- [x] `cargo check --workspace` clean on macOS
- [x] vite-task CI green on the merged PR (includes new Windows-only plan snapshot verifying the rewrite end-to-end across `cwd` and `--filter` invocations)
- [ ] vite-plus CI green
- [ ] Manual on Windows: reproduce with https://github.com/Curtion/report-vite-plus-1; Ctrl+C during `vp run dev` should leave the terminal clean
- [ ] Manual: confirm `.cmd` fallback on a Windows box with PATH stripped of PowerShell
- [ ] Manual: confirm a globally installed `.cmd` outside the workspace is *not* rewritten