### PR TITLE
test(e2e): add f3-app to ecosystem-ci

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -314,6 +314,11 @@ jobs:
             node-version: 24
             command: |
               vp check --fix
+          - name: f3-app
+            node-version: 24
+            command: |
+              vp run check
+              vp run build
         exclude:
           # frm-stack uses Docker (testcontainers) which doesn't work the same way on Windows
           - os: windows-latest
@@ -335,6 +340,10 @@ jobs:
           - os: windows-latest
             project:
               name: npmx.dev
+          # f3-app uses turbo + tanstack-start, ubuntu-only for now
+          - os: windows-latest
+            project:
+              name: f3-app
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/ecosystem-ci/repo.json
+++ b/ecosystem-ci/repo.json
@@ -119,5 +119,11 @@
     "branch": "main",
     "hash": "6192f60653c124ae068efaf5d7d0a4134c95edbd",
     "forceFreshMigration": true
+  },
+  "f3-app": {
+    "repository": "https://github.com/fisand/f3-app.git",
+    "branch": "main",
+    "hash": "3a481a19aeaaf61316bd9f42880b71b8282ed7e5",
+    "forceFreshMigration": true
   }
 }


### PR DESCRIPTION
Add fisand/f3-app as a new ecosystem-ci test case. It's a turbo +
tanstack-start monorepo that already uses vite-plus, so
forceFreshMigration is enabled. Runs vp run check and vp run build
on ubuntu-latest only.