### PR TITLE
feat(cli): add --no-type-check to vp check

### DIFF
--- a/crates/vite_global_cli/src/help.rs
+++ b/crates/vite_global_cli/src/help.rs
@@ -761,6 +761,7 @@ fn delegated_help_doc(command: &str) -> Option<HelpDoc> {
                         row("--fix", "Auto-fix format and lint issues"),
                         row("--no-fmt", "Skip format check"),
                         row("--no-lint", "Skip lint check"),
+                        row("--no-type-check", "Skip type check"),
                         row(
                             "--no-error-on-unmatched-pattern",
                             "Do not exit with error when pattern is unmatched",

--- a/docs/guide/check.md
+++ b/docs/guide/check.md
@@ -17,6 +17,16 @@ vp check
 vp check --fix # Format and run autofixers.
 ```
 
+## Phase skip flags
+
+`vp check` runs three phases — format, lint rules, and type check — all enabled by default. Each phase can be skipped independently:
+
+| Flag | Skips |
+| ---- | ----- |
+| `--no-fmt` | Format check |
+| `--no-lint` | Lint rules (type check still runs if enabled in config) |
+| `--no-type-check` | Type check |
+
 ## Configuration
 
 `vp check` uses the same configuration you already define for linting and formatting:

--- a/packages/cli/binding/src/check/analysis.rs
+++ b/packages/cli/binding/src/check/analysis.rs
@@ -40,22 +40,12 @@ pub(super) enum LintMessageKind {
     LintOnly,
     LintAndTypeCheck,
     // Used when lint rules are skipped but type-check still runs.
-    #[allow(dead_code)]
     TypeCheckOnly,
 }
 
 impl LintMessageKind {
-    pub(super) fn from_lint_config(lint_config: Option<&serde_json::Value>) -> Self {
-        if lint_config_type_check_enabled(lint_config) {
-            Self::LintAndTypeCheck
-        } else {
-            Self::LintOnly
-        }
-    }
-
     // Selects a variant from the `(lint, type-check)` enabled tuple callers have
     // already resolved, avoiding a second config lookup inside the helper.
-    #[allow(dead_code)]
     pub(super) fn from_flags(lint_enabled: bool, type_check_enabled: bool) -> Self {
         match (lint_enabled, type_check_enabled) {
             (true, true) => Self::LintAndTypeCheck,
@@ -249,35 +239,4 @@ pub(super) fn analyze_lint_output(output: &str) -> Option<Result<LintSuccess, Li
     }
 
     Some(Err(LintFailure { summary, warnings, errors, diagnostics }))
-}
-
-#[cfg(test)]
-mod tests {
-    use serde_json::json;
-
-    use super::LintMessageKind;
-
-    #[test]
-    fn lint_message_kind_defaults_to_lint_only_without_typecheck() {
-        assert_eq!(LintMessageKind::from_lint_config(None), LintMessageKind::LintOnly);
-        assert_eq!(
-            LintMessageKind::from_lint_config(Some(&json!({ "options": {} }))),
-            LintMessageKind::LintOnly
-        );
-    }
-
-    #[test]
-    fn lint_message_kind_detects_typecheck_from_vite_config() {
-        let kind = LintMessageKind::from_lint_config(Some(&json!({
-            "options": {
-                "typeAware": true,
-                "typeCheck": true
-            }
-        })));
-
-        assert_eq!(kind, LintMessageKind::LintAndTypeCheck);
-        assert_eq!(kind.success_label(), "Found no warnings, lint errors, or type errors");
-        assert_eq!(kind.warning_heading(), "Lint or type warnings found");
-        assert_eq!(kind.issue_heading(), "Lint or type issues found");
-    }
 }

--- a/packages/cli/binding/src/check/analysis.rs
+++ b/packages/cli/binding/src/check/analysis.rs
@@ -39,23 +39,41 @@ pub(super) struct LintFailure {
 pub(super) enum LintMessageKind {
     LintOnly,
     LintAndTypeCheck,
+    // Used when lint rules are skipped but type-check still runs.
+    #[allow(dead_code)]
+    TypeCheckOnly,
 }
 
 impl LintMessageKind {
     pub(super) fn from_lint_config(lint_config: Option<&serde_json::Value>) -> Self {
-        let type_check_enabled = lint_config
-            .and_then(|config| config.get("options"))
-            .and_then(|options| options.get("typeCheck"))
-            .and_then(serde_json::Value::as_bool)
-            .unwrap_or(false);
+        if lint_config_type_check_enabled(lint_config) {
+            Self::LintAndTypeCheck
+        } else {
+            Self::LintOnly
+        }
+    }
 
-        if type_check_enabled { Self::LintAndTypeCheck } else { Self::LintOnly }
+    // Selects a variant from the `(lint, type-check)` enabled tuple callers have
+    // already resolved, avoiding a second config lookup inside the helper.
+    #[allow(dead_code)]
+    pub(super) fn from_flags(lint_enabled: bool, type_check_enabled: bool) -> Self {
+        match (lint_enabled, type_check_enabled) {
+            (true, true) => Self::LintAndTypeCheck,
+            (true, false) => Self::LintOnly,
+            (false, true) => Self::TypeCheckOnly,
+            (false, false) => {
+                unreachable!(
+                    "from_flags called with (false, false) — caller must ensure lint or type-check runs before selecting a message kind"
+                )
+            }
+        }
     }
 
     pub(super) fn success_label(self) -> &'static str {
         match self {
             Self::LintOnly => "Found no warnings or lint errors",
             Self::LintAndTypeCheck => "Found no warnings, lint errors, or type errors",
+            Self::TypeCheckOnly => "Found no type errors",
         }
     }
 
@@ -63,6 +81,7 @@ impl LintMessageKind {
         match self {
             Self::LintOnly => "Lint warnings found",
             Self::LintAndTypeCheck => "Lint or type warnings found",
+            Self::TypeCheckOnly => "Type warnings found",
         }
     }
 
@@ -70,8 +89,17 @@ impl LintMessageKind {
         match self {
             Self::LintOnly => "Lint issues found",
             Self::LintAndTypeCheck => "Lint or type issues found",
+            Self::TypeCheckOnly => "Type errors found",
         }
     }
+}
+
+pub(super) fn lint_config_type_check_enabled(lint_config: Option<&serde_json::Value>) -> bool {
+    lint_config
+        .and_then(|config| config.get("options"))
+        .and_then(|options| options.get("typeCheck"))
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
 }
 
 fn parse_check_summary(line: &str) -> Option<CheckSummary> {

--- a/packages/cli/binding/src/check/mod.rs
+++ b/packages/cli/binding/src/check/mod.rs
@@ -10,7 +10,8 @@ use vite_task::ExitStatus;
 
 use self::analysis::{
     LintMessageKind, analyze_fmt_check_output, analyze_lint_output, format_count, format_elapsed,
-    print_error_block, print_pass_line, print_stdout_block, print_summary_line,
+    lint_config_type_check_enabled, print_error_block, print_pass_line, print_stdout_block,
+    print_summary_line,
 };
 use crate::cli::{
     CapturedCommandOutput, SubcommandResolver, SynthesizableSubcommand, resolve_and_capture_output,
@@ -22,7 +23,7 @@ pub(crate) async fn execute_check(
     fix: bool,
     no_fmt: bool,
     no_lint: bool,
-    _no_type_check: bool,
+    no_type_check: bool,
     no_error_on_unmatched_pattern: bool,
     paths: Vec<String>,
     envs: &Arc<FxHashMap<Arc<OsStr>, Arc<OsStr>>>,
@@ -46,6 +47,31 @@ pub(crate) async fn execute_check(
     let mut fmt_fix_started: Option<Instant> = None;
     let mut deferred_lint_pass: Option<(String, String)> = None;
     let resolved_vite_config = resolver.resolve_universal_vite_config().await?;
+
+    // Per-phase enabled booleans derived from the raw flags plus the resolved
+    // config's `typeCheck` setting. Currently only the guard immediately below
+    // reads these; the fmt/lint phase conditions further down still consult the
+    // raw `no_fmt`/`no_lint` flags.
+    let config_type_check_enabled =
+        lint_config_type_check_enabled(resolved_vite_config.lint.as_ref());
+    let type_check_enabled = !no_type_check && config_type_check_enabled;
+    let lint_enabled = !no_lint;
+
+    // Reject `--fix --no-lint` when the project enables type-check. With lint
+    // rules skipped, oxlint would take the type-check-only path which it
+    // itself refuses to combine with `--fix`. Running fmt first and then
+    // hitting that rejection would leave the working tree partially formatted
+    // (a real hazard inside lint-staged). Failing up-front keeps the
+    // invocation transactional.
+    if fix && !lint_enabled && type_check_enabled {
+        output::error(
+            "`vp check --fix --no-lint` cannot be combined with type-check enabled in config",
+        );
+        print_summary_line(
+            "type-check diagnostics are read-only and cannot be auto-fixed. Add `--no-type-check` to format-only fix, or drop `--no-lint` to run lint fixes.",
+        );
+        return Ok(ExitStatus(1));
+    }
 
     if !no_fmt {
         let mut args = if fix { vec![] } else { vec!["--check".to_string()] };

--- a/packages/cli/binding/src/check/mod.rs
+++ b/packages/cli/binding/src/check/mod.rs
@@ -9,10 +9,13 @@ use vite_path::{AbsolutePath, AbsolutePathBuf};
 use vite_shared::output;
 use vite_task::ExitStatus;
 
-use self::analysis::{
-    LintMessageKind, analyze_fmt_check_output, analyze_lint_output, format_count, format_elapsed,
-    lint_config_type_check_enabled, print_error_block, print_pass_line, print_stdout_block,
-    print_summary_line,
+use self::{
+    analysis::{
+        LintMessageKind, analyze_fmt_check_output, analyze_lint_output, format_count,
+        format_elapsed, lint_config_type_check_enabled, print_error_block, print_pass_line,
+        print_stdout_block, print_summary_line,
+    },
+    sidecar::write_no_type_check_sidecar,
 };
 use crate::cli::{
     CapturedCommandOutput, SubcommandResolver, SynthesizableSubcommand, resolve_and_capture_output,
@@ -31,14 +34,6 @@ pub(crate) async fn execute_check(
     cwd: &AbsolutePathBuf,
     cwd_arc: &Arc<AbsolutePath>,
 ) -> Result<ExitStatus, Error> {
-    if no_fmt && no_lint {
-        output::error("No checks enabled");
-        print_summary_line(
-            "`vp check` did not run because both `--no-fmt` and `--no-lint` were set",
-        );
-        return Ok(ExitStatus(1));
-    }
-
     let mut status = ExitStatus::SUCCESS;
     let has_paths = !paths.is_empty();
     // In --fix mode with file paths (the lint-staged use case), implicitly suppress
@@ -50,13 +45,22 @@ pub(crate) async fn execute_check(
     let resolved_vite_config = resolver.resolve_universal_vite_config().await?;
 
     // Per-phase enabled booleans derived from the raw flags plus the resolved
-    // config's `typeCheck` setting. Currently only the guard immediately below
-    // reads these; the fmt/lint phase conditions further down still consult the
-    // raw `no_fmt`/`no_lint` flags.
+    // config's `typeCheck` setting. `run_lint_phase` drives whether the lint
+    // subprocess starts at all — true when lint rules should run, or when
+    // type-check should run via oxlint's type-check-only path.
     let config_type_check_enabled =
         lint_config_type_check_enabled(resolved_vite_config.lint.as_ref());
     let type_check_enabled = !no_type_check && config_type_check_enabled;
     let lint_enabled = !no_lint;
+    let run_lint_phase = lint_enabled || type_check_enabled;
+
+    if no_fmt && !run_lint_phase {
+        output::error("No checks enabled");
+        print_summary_line(
+            "`vp check` did not run because all checks were disabled by the provided flags",
+        );
+        return Ok(ExitStatus(1));
+    }
 
     // Reject `--fix --no-lint` when the project enables type-check. With lint
     // rules skipped, oxlint would take the type-check-only path which it
@@ -73,6 +77,18 @@ pub(crate) async fn execute_check(
         );
         return Ok(ExitStatus(1));
     }
+
+    // Build the `--no-type-check` sidecar up front, before any fmt side effects.
+    // If temp-dir write fails (full tmpfs, read-only mount, permission denied),
+    // we surface the error before fmt modifies files, mirroring the
+    // transactional guarantee of the hard-error guard above. The returned
+    // guard lives through both fmt and lint phases and is dropped at function
+    // exit, cleaning up the temp file.
+    let sidecar = if lint_enabled && no_type_check && config_type_check_enabled {
+        write_no_type_check_sidecar(&resolved_vite_config)?
+    } else {
+        None
+    };
 
     if !no_fmt {
         let mut args = if fix { vec![] } else { vec!["--check".to_string()] };
@@ -137,7 +153,7 @@ pub(crate) async fn execute_check(
             }
         }
 
-        if fix && no_lint && status == ExitStatus::SUCCESS {
+        if fix && !run_lint_phase && status == ExitStatus::SUCCESS {
             print_pass_line(
                 "Formatting completed for checked files",
                 Some(&format!("({})", format_elapsed(fmt_start.elapsed()))),
@@ -155,12 +171,22 @@ pub(crate) async fn execute_check(
         }
     }
 
-    if !no_lint {
-        let lint_message_kind =
-            LintMessageKind::from_lint_config(resolved_vite_config.lint.as_ref());
+    if run_lint_phase {
+        let lint_message_kind = LintMessageKind::from_flags(lint_enabled, type_check_enabled);
         let mut args = Vec::new();
-        if fix {
+        // Hard-error guard above rejects (fix && !lint_enabled && type_check_enabled),
+        // so when this branch runs with `fix`, lint_enabled is always true. The
+        // `lint_enabled` check is defense-in-depth against future guard changes.
+        if fix && lint_enabled {
             args.push("--fix".to_string());
+        }
+        // `--type-check-only` suppresses lint rules and runs only type-check
+        // diagnostics. oxlint accepts this as a hidden flag (oxc#21184). When
+        // config `typeCheck` is false this flag forces type-check ON, so we
+        // only emit it on the `--no-lint` + `typeCheck: true` path and skip
+        // the lint phase entirely when type_check_enabled is false.
+        if !lint_enabled && type_check_enabled {
+            args.push("--type-check-only".to_string());
         }
         // `vp check` parses oxlint's human-readable summary output to print
         // unified pass/fail lines. When `GITHUB_ACTIONS=true`, oxlint auto-switches
@@ -174,10 +200,17 @@ pub(crate) async fn execute_check(
         if has_paths {
             args.extend(paths.iter().cloned());
         }
+
+        // `sidecar` was built up front to surface temp-dir write failures
+        // before fmt made any changes. Borrow its config here to route oxlint
+        // through the override when present; otherwise use the resolved
+        // config unchanged.
+        let lint_vite_config = sidecar.as_ref().map(|s| &s.config).unwrap_or(&resolved_vite_config);
+
         let captured = resolve_and_capture_output(
             resolver,
             SynthesizableSubcommand::Lint { args },
-            Some(&resolved_vite_config),
+            Some(lint_vite_config),
             envs,
             cwd,
             cwd_arc,

--- a/packages/cli/binding/src/check/mod.rs
+++ b/packages/cli/binding/src/check/mod.rs
@@ -22,6 +22,7 @@ pub(crate) async fn execute_check(
     fix: bool,
     no_fmt: bool,
     no_lint: bool,
+    _no_type_check: bool,
     no_error_on_unmatched_pattern: bool,
     paths: Vec<String>,
     envs: &Arc<FxHashMap<Arc<OsStr>, Arc<OsStr>>>,

--- a/packages/cli/binding/src/check/mod.rs
+++ b/packages/cli/binding/src/check/mod.rs
@@ -1,4 +1,5 @@
 mod analysis;
+mod sidecar;
 
 use std::{ffi::OsStr, sync::Arc, time::Instant};
 

--- a/packages/cli/binding/src/check/sidecar.rs
+++ b/packages/cli/binding/src/check/sidecar.rs
@@ -1,0 +1,120 @@
+//! Transient `.mjs` config that overrides `lint.options.typeCheck` to `false`.
+//!
+//! oxlint loads the `-c <path>` target with dynamic `import()` and reads
+//! `.default.lint` when `VP_VERSION` is set (the vite-plus invocation path).
+//! Writing a sidecar module with that shape lets a single invocation opt out
+//! of type-check without mutating the project's `vite.config.ts`.
+
+use std::{
+    fs,
+    sync::atomic::{AtomicU64, Ordering},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use serde_json::Value;
+use vite_error::Error;
+use vite_path::AbsolutePathBuf;
+
+use crate::cli::ResolvedUniversalViteConfig;
+
+/// Override returned by [`write_no_type_check_sidecar`]. The `_guard` field
+/// deletes the sidecar file on drop; callers must keep the override alive
+/// until oxlint has finished reading the config.
+pub(super) struct SidecarOverride {
+    pub(super) config: ResolvedUniversalViteConfig,
+    _guard: SidecarCleanup,
+}
+
+struct SidecarCleanup {
+    path: AbsolutePathBuf,
+}
+
+impl Drop for SidecarCleanup {
+    fn drop(&mut self) {
+        // Best-effort: ignore errors (file already gone, permission denied, etc.).
+        let _ = fs::remove_file(self.path.as_path());
+    }
+}
+
+static SIDECAR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Write a sidecar `.mjs` that mirrors the project's lint config with
+/// `options.typeCheck = false`, and return a clone of
+/// `ResolvedUniversalViteConfig` pointing at the sidecar path.
+///
+/// Returns `Ok(None)` when the resolved config lacks either a `configFile` or
+/// a `lint` entry — there is nothing for the override to replace and the
+/// caller should run lint unchanged.
+///
+/// `typeAware` is intentionally untouched: the flag only disables type-check
+/// (tsgolint), not type-aware lint rules.
+pub(super) fn write_no_type_check_sidecar(
+    resolved_vite_config: &ResolvedUniversalViteConfig,
+) -> Result<Option<SidecarOverride>, Error> {
+    if resolved_vite_config.config_file.is_none() {
+        return Ok(None);
+    }
+    let Some(lint) = resolved_vite_config.lint.as_ref() else {
+        return Ok(None);
+    };
+
+    let mut lint_clone: Value = lint.clone();
+    let Some(options) = lint_clone.as_object_mut().and_then(|map| {
+        map.entry("options")
+            .or_insert_with(|| Value::Object(serde_json::Map::new()))
+            .as_object_mut()
+    }) else {
+        // Lint value isn't a JSON object — unexpected shape. Skip the
+        // override rather than guess at a structure.
+        return Ok(None);
+    };
+    options.insert("typeCheck".to_string(), Value::Bool(false));
+
+    // Contract check: `resolveUniversalViteConfig` returns the lint subtree at
+    // the top level, so the clone must not be re-wrapped under another `lint`
+    // key. Enforced in release too — a regression here would silently empty
+    // the sidecar when oxlint reads `.default.lint`.
+    if lint_clone.get("lint").is_some() {
+        return Err(Error::Anyhow(anyhow::anyhow!(
+            "resolved lint config unexpectedly wrapped under another `lint` key"
+        )));
+    }
+
+    let pid = std::process::id();
+    let nanos = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_nanos()).unwrap_or(0);
+    let counter = SIDECAR_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let filename = vite_str::format!("vite-plus-no-type-check-{pid}-{nanos}-{counter}.mjs");
+    let filename_str: &str = filename.as_ref();
+    let raw_temp_path = std::env::temp_dir().join(filename_str);
+    let sidecar_path = AbsolutePathBuf::new(raw_temp_path).ok_or_else(|| {
+        Error::Anyhow(anyhow::anyhow!("system temp dir resolved to a non-absolute path"))
+    })?;
+
+    // `serde_json::to_string` quotes keys and escapes string values, producing
+    // output that is also a valid JS object literal on Node ≥ 10 (the minimum
+    // already required by vite-plus).
+    let lint_json = serde_json::to_string(&lint_clone).map_err(|e| {
+        Error::Anyhow(anyhow::anyhow!("failed to serialize lint config for sidecar: {e}"))
+    })?;
+    let content = vite_str::format!("export default {{ lint: {lint_json} }};\n");
+    let content_str: &str = content.as_ref();
+
+    fs::write(sidecar_path.as_path(), content_str.as_bytes()).map_err(|e| {
+        Error::Anyhow(anyhow::anyhow!(
+            "failed to write sidecar at {}: {e}",
+            sidecar_path.as_path().display()
+        ))
+    })?;
+
+    // Keep the override internally consistent: any future reader of
+    // `config.lint` (e.g., cache-key hashing, logging) will see the same
+    // `typeCheck: false` value that oxlint reads from the sidecar file.
+    let mut config_override = resolved_vite_config.clone();
+    config_override.config_file = Some(sidecar_path.as_path().to_string_lossy().into_owned());
+    config_override.lint = Some(lint_clone);
+
+    Ok(Some(SidecarOverride {
+        config: config_override,
+        _guard: SidecarCleanup { path: sidecar_path },
+    }))
+}

--- a/packages/cli/binding/src/cli/mod.rs
+++ b/packages/cli/binding/src/cli/mod.rs
@@ -17,11 +17,11 @@ pub(crate) use execution::resolve_and_capture_output;
 // Re-exports for lib.rs and check/mod.rs
 pub use resolver::SubcommandResolver;
 use rustc_hash::FxHashMap;
-pub(crate) use types::CapturedCommandOutput;
 pub use types::{
     BoxedResolverFn, CliOptions, ResolveCommandResult, SynthesizableSubcommand,
     ViteConfigResolverFn,
 };
+pub(crate) use types::{CapturedCommandOutput, ResolvedUniversalViteConfig};
 use vite_error::Error;
 use vite_path::{AbsolutePath, AbsolutePathBuf};
 pub use vite_shared::init_tracing;

--- a/packages/cli/binding/src/cli/mod.rs
+++ b/packages/cli/binding/src/cli/mod.rs
@@ -67,6 +67,7 @@ async fn execute_direct_subcommand(
             fix,
             no_fmt,
             no_lint,
+            no_type_check,
             no_error_on_unmatched_pattern,
             paths,
         } => {
@@ -75,6 +76,7 @@ async fn execute_direct_subcommand(
                 fix,
                 no_fmt,
                 no_lint,
+                no_type_check,
                 no_error_on_unmatched_pattern,
                 paths,
                 &envs,

--- a/packages/cli/binding/src/cli/types.rs
+++ b/packages/cli/binding/src/cli/types.rs
@@ -93,6 +93,9 @@ pub enum SynthesizableSubcommand {
         /// Skip lint check
         #[arg(long = "no-lint")]
         no_lint: bool,
+        /// Skip type check
+        #[arg(long = "no-type-check")]
+        no_type_check: bool,
         /// Do not exit with error when pattern is unmatched
         #[arg(long = "no-error-on-unmatched-pattern")]
         no_error_on_unmatched_pattern: bool,

--- a/packages/cli/snap-tests-global/command-check-help/snap.txt
+++ b/packages/cli/snap-tests-global/command-check-help/snap.txt
@@ -9,6 +9,7 @@ Options:
   --fix                            Auto-fix format and lint issues
   --no-fmt                         Skip format check
   --no-lint                        Skip lint check
+  --no-type-check                  Skip type check
   --no-error-on-unmatched-pattern  Do not exit with error when pattern is unmatched
   -h, --help                       Print help
 
@@ -31,6 +32,7 @@ Options:
   --fix                            Auto-fix format and lint issues
   --no-fmt                         Skip format check
   --no-lint                        Skip lint check
+  --no-type-check                  Skip type check
   --no-error-on-unmatched-pattern  Do not exit with error when pattern is unmatched
   -h, --help                       Print help
 
@@ -53,6 +55,7 @@ Options:
   --fix                            Auto-fix format and lint issues
   --no-fmt                         Skip format check
   --no-lint                        Skip lint check
+  --no-type-check                  Skip type check
   --no-error-on-unmatched-pattern  Do not exit with error when pattern is unmatched
   -h, --help                       Print help
 

--- a/packages/cli/snap-tests/check-all-skipped/snap.txt
+++ b/packages/cli/snap-tests/check-all-skipped/snap.txt
@@ -1,4 +1,4 @@
 [1]> vp check --no-fmt --no-lint
 error: No checks enabled
 
-`vp check` did not run because both `--no-fmt` and `--no-lint` were set
+`vp check` did not run because all checks were disabled by the provided flags

--- a/packages/cli/snap-tests/check-all-three-skipped/package.json
+++ b/packages/cli/snap-tests/check-all-three-skipped/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "check-all-three-skipped",
+  "version": "0.0.0",
+  "private": true
+}

--- a/packages/cli/snap-tests/check-all-three-skipped/snap.txt
+++ b/packages/cli/snap-tests/check-all-three-skipped/snap.txt
@@ -1,0 +1,4 @@
+[1]> vp check --no-fmt --no-lint --no-type-check
+error: No checks enabled
+
+`vp check` did not run because all checks were disabled by the provided flags

--- a/packages/cli/snap-tests/check-all-three-skipped/src/index.ts
+++ b/packages/cli/snap-tests/check-all-three-skipped/src/index.ts
@@ -1,0 +1,1 @@
+export const value = 42;

--- a/packages/cli/snap-tests/check-all-three-skipped/steps.json
+++ b/packages/cli/snap-tests/check-all-three-skipped/steps.json
@@ -1,0 +1,6 @@
+{
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": ["vp check --no-fmt --no-lint --no-type-check"]
+}

--- a/packages/cli/snap-tests/check-all-three-skipped/vite.config.ts
+++ b/packages/cli/snap-tests/check-all-three-skipped/vite.config.ts
@@ -1,0 +1,8 @@
+export default {
+  lint: {
+    options: {
+      typeAware: true,
+      typeCheck: true,
+    },
+  },
+};

--- a/packages/cli/snap-tests/check-fix-no-lint-no-typecheck/package.json
+++ b/packages/cli/snap-tests/check-fix-no-lint-no-typecheck/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "check-fix-no-lint-no-typecheck",
+  "version": "0.0.0",
+  "private": true
+}

--- a/packages/cli/snap-tests/check-fix-no-lint-no-typecheck/snap.txt
+++ b/packages/cli/snap-tests/check-fix-no-lint-no-typecheck/snap.txt
@@ -1,0 +1,2 @@
+> vp check --fix --no-lint --no-type-check
+pass: Formatting completed for checked files (<variable>ms)

--- a/packages/cli/snap-tests/check-fix-no-lint-no-typecheck/src/index.ts
+++ b/packages/cli/snap-tests/check-fix-no-lint-no-typecheck/src/index.ts
@@ -1,0 +1,1 @@
+export const value = 42;

--- a/packages/cli/snap-tests/check-fix-no-lint-no-typecheck/steps.json
+++ b/packages/cli/snap-tests/check-fix-no-lint-no-typecheck/steps.json
@@ -1,0 +1,6 @@
+{
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": ["vp check --fix --no-lint --no-type-check"]
+}

--- a/packages/cli/snap-tests/check-fix-no-lint-no-typecheck/vite.config.ts
+++ b/packages/cli/snap-tests/check-fix-no-lint-no-typecheck/vite.config.ts
@@ -1,0 +1,8 @@
+export default {
+  lint: {
+    options: {
+      typeAware: true,
+      typeCheck: true,
+    },
+  },
+};

--- a/packages/cli/snap-tests/check-fix-no-lint-typecheck-error/package.json
+++ b/packages/cli/snap-tests/check-fix-no-lint-typecheck-error/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "check-fix-no-lint-typecheck-error",
+  "version": "0.0.0",
+  "private": true
+}

--- a/packages/cli/snap-tests/check-fix-no-lint-typecheck-error/snap.txt
+++ b/packages/cli/snap-tests/check-fix-no-lint-typecheck-error/snap.txt
@@ -1,0 +1,4 @@
+[1]> vp check --fix --no-lint
+error: `vp check --fix --no-lint` cannot be combined with type-check enabled in config
+
+type-check diagnostics are read-only and cannot be auto-fixed. Add `--no-type-check` to format-only fix, or drop `--no-lint` to run lint fixes.

--- a/packages/cli/snap-tests/check-fix-no-lint-typecheck-error/src/index.ts
+++ b/packages/cli/snap-tests/check-fix-no-lint-typecheck-error/src/index.ts
@@ -1,0 +1,1 @@
+export const value = 42;

--- a/packages/cli/snap-tests/check-fix-no-lint-typecheck-error/steps.json
+++ b/packages/cli/snap-tests/check-fix-no-lint-typecheck-error/steps.json
@@ -1,0 +1,6 @@
+{
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": ["vp check --fix --no-lint"]
+}

--- a/packages/cli/snap-tests/check-fix-no-lint-typecheck-error/vite.config.ts
+++ b/packages/cli/snap-tests/check-fix-no-lint-typecheck-error/vite.config.ts
@@ -1,0 +1,8 @@
+export default {
+  lint: {
+    options: {
+      typeAware: true,
+      typeCheck: true,
+    },
+  },
+};

--- a/packages/cli/snap-tests/check-fix-no-type-check/package.json
+++ b/packages/cli/snap-tests/check-fix-no-type-check/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "check-fix-no-type-check",
+  "version": "0.0.0",
+  "private": true
+}

--- a/packages/cli/snap-tests/check-fix-no-type-check/snap.txt
+++ b/packages/cli/snap-tests/check-fix-no-type-check/snap.txt
@@ -1,0 +1,3 @@
+> vp check --fix --no-type-check
+pass: Formatting completed for checked files (<variable>ms)
+pass: Found no warnings or lint errors in 2 files (<variable>ms, <variable> threads)

--- a/packages/cli/snap-tests/check-fix-no-type-check/src/index.ts
+++ b/packages/cli/snap-tests/check-fix-no-type-check/src/index.ts
@@ -1,0 +1,2 @@
+const value: number = "not a number";
+export { value };

--- a/packages/cli/snap-tests/check-fix-no-type-check/steps.json
+++ b/packages/cli/snap-tests/check-fix-no-type-check/steps.json
@@ -1,0 +1,6 @@
+{
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": ["vp check --fix --no-type-check"]
+}

--- a/packages/cli/snap-tests/check-fix-no-type-check/vite.config.ts
+++ b/packages/cli/snap-tests/check-fix-no-type-check/vite.config.ts
@@ -1,0 +1,8 @@
+export default {
+  lint: {
+    options: {
+      typeAware: true,
+      typeCheck: true,
+    },
+  },
+};

--- a/packages/cli/snap-tests/check-no-lint-no-typecheck-fmt-only/package.json
+++ b/packages/cli/snap-tests/check-no-lint-no-typecheck-fmt-only/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "check-no-lint-no-typecheck-fmt-only",
+  "version": "0.0.0",
+  "private": true
+}

--- a/packages/cli/snap-tests/check-no-lint-no-typecheck-fmt-only/snap.txt
+++ b/packages/cli/snap-tests/check-no-lint-no-typecheck-fmt-only/snap.txt
@@ -1,0 +1,2 @@
+> vp check --no-lint --no-type-check
+pass: All 4 files are correctly formatted (<variable>ms, <variable> threads)

--- a/packages/cli/snap-tests/check-no-lint-no-typecheck-fmt-only/src/index.ts
+++ b/packages/cli/snap-tests/check-no-lint-no-typecheck-fmt-only/src/index.ts
@@ -1,0 +1,2 @@
+const value: number = "not a number";
+export { value };

--- a/packages/cli/snap-tests/check-no-lint-no-typecheck-fmt-only/steps.json
+++ b/packages/cli/snap-tests/check-no-lint-no-typecheck-fmt-only/steps.json
@@ -1,0 +1,6 @@
+{
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": ["vp check --no-lint --no-type-check"]
+}

--- a/packages/cli/snap-tests/check-no-lint-no-typecheck-fmt-only/vite.config.ts
+++ b/packages/cli/snap-tests/check-no-lint-no-typecheck-fmt-only/vite.config.ts
@@ -1,0 +1,8 @@
+export default {
+  lint: {
+    options: {
+      typeAware: true,
+      typeCheck: true,
+    },
+  },
+};

--- a/packages/cli/snap-tests/check-no-type-check-pass/package.json
+++ b/packages/cli/snap-tests/check-no-type-check-pass/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "check-no-type-check-pass",
+  "version": "0.0.0",
+  "private": true
+}

--- a/packages/cli/snap-tests/check-no-type-check-pass/snap.txt
+++ b/packages/cli/snap-tests/check-no-type-check-pass/snap.txt
@@ -1,0 +1,3 @@
+> vp check --no-type-check
+pass: All 4 files are correctly formatted (<variable>ms, <variable> threads)
+pass: Found no warnings or lint errors in 2 files (<variable>ms, <variable> threads)

--- a/packages/cli/snap-tests/check-no-type-check-pass/src/index.ts
+++ b/packages/cli/snap-tests/check-no-type-check-pass/src/index.ts
@@ -1,0 +1,2 @@
+const value: number = "not a number";
+export { value };

--- a/packages/cli/snap-tests/check-no-type-check-pass/steps.json
+++ b/packages/cli/snap-tests/check-no-type-check-pass/steps.json
@@ -1,0 +1,6 @@
+{
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": ["vp check --no-type-check"]
+}

--- a/packages/cli/snap-tests/check-no-type-check-pass/vite.config.ts
+++ b/packages/cli/snap-tests/check-no-type-check-pass/vite.config.ts
@@ -1,0 +1,8 @@
+export default {
+  lint: {
+    options: {
+      typeAware: true,
+      typeCheck: true,
+    },
+  },
+};

--- a/packages/cli/snap-tests/check-type-check-only-fail/package.json
+++ b/packages/cli/snap-tests/check-type-check-only-fail/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "check-type-check-only-fail",
+  "version": "0.0.0",
+  "private": true
+}

--- a/packages/cli/snap-tests/check-type-check-only-fail/snap.txt
+++ b/packages/cli/snap-tests/check-type-check-only-fail/snap.txt
@@ -1,0 +1,11 @@
+[1]> vp check --no-lint
+pass: All 4 files are correctly formatted (<variable>ms, <variable> threads)
+error: Type errors found
+× typescript(TS2322): Type 'string' is not assignable to type 'number'.
+   ╭─[src/index.ts:1:7]
+ 1 │ const value: number = "not a number";
+   ·       ─────
+ 2 │ export { value };
+   ╰────
+
+Found 1 error and 0 warnings in 2 files (<variable>ms, <variable> threads)

--- a/packages/cli/snap-tests/check-type-check-only-fail/src/index.ts
+++ b/packages/cli/snap-tests/check-type-check-only-fail/src/index.ts
@@ -1,0 +1,2 @@
+const value: number = "not a number";
+export { value };

--- a/packages/cli/snap-tests/check-type-check-only-fail/steps.json
+++ b/packages/cli/snap-tests/check-type-check-only-fail/steps.json
@@ -1,0 +1,6 @@
+{
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": ["vp check --no-lint"]
+}

--- a/packages/cli/snap-tests/check-type-check-only-fail/vite.config.ts
+++ b/packages/cli/snap-tests/check-type-check-only-fail/vite.config.ts
@@ -1,0 +1,11 @@
+export default {
+  lint: {
+    options: {
+      typeAware: true,
+      typeCheck: true,
+    },
+    rules: {
+      "no-eval": "error",
+    },
+  },
+};

--- a/packages/cli/snap-tests/check-type-check-only-pass/package.json
+++ b/packages/cli/snap-tests/check-type-check-only-pass/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "check-type-check-only-pass",
+  "version": "0.0.0",
+  "private": true
+}

--- a/packages/cli/snap-tests/check-type-check-only-pass/snap.txt
+++ b/packages/cli/snap-tests/check-type-check-only-pass/snap.txt
@@ -1,0 +1,3 @@
+> vp check --no-lint
+pass: All 4 files are correctly formatted (<variable>ms, <variable> threads)
+pass: Found no type errors in 2 files (<variable>ms, <variable> threads)

--- a/packages/cli/snap-tests/check-type-check-only-pass/src/index.ts
+++ b/packages/cli/snap-tests/check-type-check-only-pass/src/index.ts
@@ -1,0 +1,2 @@
+const value: number = 42;
+export { value };

--- a/packages/cli/snap-tests/check-type-check-only-pass/steps.json
+++ b/packages/cli/snap-tests/check-type-check-only-pass/steps.json
@@ -1,0 +1,6 @@
+{
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": ["vp check --no-lint"]
+}

--- a/packages/cli/snap-tests/check-type-check-only-pass/vite.config.ts
+++ b/packages/cli/snap-tests/check-type-check-only-pass/vite.config.ts
@@ -1,0 +1,11 @@
+export default {
+  lint: {
+    options: {
+      typeAware: true,
+      typeCheck: true,
+    },
+    rules: {
+      "no-eval": "error",
+    },
+  },
+};


### PR DESCRIPTION
## Summary

Implements the 3-phase skip-flag matrix for `vp check` agreed on in #1275.
Each of format / lint rules / type check can now be skipped independently:

| Flag | Skips |
| ---- | ----- |
| `--no-fmt` | Format check |
| `--no-lint` | Lint rules (type check still runs when enabled in config) |
| `--no-type-check` | Type check |

`vp check --fix --no-lint` on a `typeCheck: true` project is rejected up front to avoid leaving the working tree partially formatted inside pre-commit hooks.

## Request for feedback: `sidecar.rs`

`--no-type-check` is implemented via a per-invocation `.mjs` sidecar that overrides `lint.options.typeCheck`. It leans on oxlint's `loadVitePlusConfigs` route loading `-c <path>` via dynamic `import()`, so we can toggle the flag without mutating `vite.config.ts`.

**This is the part of the PR I'd especially appreciate reviewer input on.** 
One approach I also considered was a wrapper `.mjs` that imports the original `vite.config.ts` and patches `typeCheck` in place — this would preserve non-serializable lint values but complicates relative-path resolution from the temp dir. Happy to switch to that, or to another pattern if the project has a preferred direction for per-invocation config overrides in the Rust binding.

## Related

- Fixes #1275
- Replaces #1387