### PR TITLE
fix(create): stop forwarding `--` to npx-invoked remote templates

### DIFF
--- a/packages/cli/src/create/command.ts
+++ b/packages/cli/src/create/command.ts
@@ -168,10 +168,9 @@ export function formatDlxCommand(
   workspaceInfo: WorkspaceInfo,
 ) {
   const runner = getPackageRunner(workspaceInfo);
-  const dlxArgs = runner.command === 'npx' ? ['--', ...args] : args;
   return {
     command: runner.command,
-    args: [...runner.args, packageName, ...dlxArgs],
+    args: [...runner.args, packageName, ...args],
   };
 }
 


### PR DESCRIPTION
Closes #1420.

## Summary

`vp create @tanstack/start` fails with `error: too many arguments for 'create'. Expected 1 argument but got 2.` on npm (reproducible on macOS and Windows, not platform-specific as originally reported).

## Root cause

`formatDlxCommand` injected `--` between the package name and its args on the npx path (`npx <pkg> -- <args>`). Per the [npm v8 `npx` docs](https://docs.npmjs.com/cli/v8/commands/npx), `--` belongs before the package name; when placed after, npx forwards it to the target binary. Commander then treats it as end-of-options and promotes subsequent flags into positional args — exceeding `@tanstack/cli create [project-name]`'s arity of 1.

Single-entry CLIs (`create-vite`, `create-nuxt`, `sv`) absorbed the stray `--` harmlessly, which is why this surfaced only after #1238 switched to the Commander-based `@tanstack/cli create`. Fix drops the `--` from the npx branch; non-npx runners unchanged.

## Verification

Manual smoke in scratch directories with npm and pnpm:

- `vp create @tanstack/start` — TanStack `create` interactive prompt reached (fix verified for #1420).
- `vp create vite` — `create-vite` prompt reached (blast-radius check).
- `vp create nuxt` — `create-nuxt` prompt reached (blast-radius check).
