### PR TITLE
fix(check): respect oxlint exit code so denyWarnings fails `vp check`

### DIFF
--- a/packages/cli/binding/src/check/mod.rs
+++ b/packages/cli/binding/src/check/mod.rs
@@ -176,9 +176,12 @@ pub(crate) async fn execute_check(
                 }
             }
             Some(Err(failure)) => {
+                // Trust the oxlint exit code: oxlint exits 0 for warning-only
+                // output by default and exits non-zero when `denyWarnings` (or
+                // `--deny-warnings`) promotes warnings to failures. The heading
+                // still reflects the findings (warnings vs errors).
                 if failure.errors == 0 && failure.warnings > 0 {
                     output::warn(lint_message_kind.warning_heading());
-                    status = ExitStatus::SUCCESS;
                 } else {
                     output::error(lint_message_kind.issue_heading());
                 }

--- a/packages/cli/binding/src/check/mod.rs
+++ b/packages/cli/binding/src/check/mod.rs
@@ -176,10 +176,6 @@ pub(crate) async fn execute_check(
                 }
             }
             Some(Err(failure)) => {
-                // Trust the oxlint exit code: oxlint exits 0 for warning-only
-                // output by default and exits non-zero when `denyWarnings` (or
-                // `--deny-warnings`) promotes warnings to failures. The heading
-                // still reflects the findings (warnings vs errors).
                 if failure.errors == 0 && failure.warnings > 0 {
                     output::warn(lint_message_kind.warning_heading());
                 } else {

--- a/packages/cli/snap-tests/check-lint-warn-deny-warnings/package.json
+++ b/packages/cli/snap-tests/check-lint-warn-deny-warnings/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "check-lint-warn-deny-warnings",
+  "version": "0.0.0",
+  "private": true
+}

--- a/packages/cli/snap-tests/check-lint-warn-deny-warnings/snap.txt
+++ b/packages/cli/snap-tests/check-lint-warn-deny-warnings/snap.txt
@@ -1,0 +1,13 @@
+[1]> vp check
+pass: All 4 files are correctly formatted (<variable>ms, <variable> threads)
+warn: Lint warnings found
+⚠ eslint(no-console): Unexpected console statement.
+   ╭─[src/index.js:2:3]
+ 1 │ function hello() {
+ 2 │   console.log("hello");
+   ·   ───────────
+ 3 │ }
+   ╰────
+  help: Delete this console statement.
+
+Found 0 errors and 1 warning in 2 files (<variable>ms, <variable> threads)

--- a/packages/cli/snap-tests/check-lint-warn-deny-warnings/src/index.js
+++ b/packages/cli/snap-tests/check-lint-warn-deny-warnings/src/index.js
@@ -1,0 +1,5 @@
+function hello() {
+  console.log("hello");
+}
+
+export { hello };

--- a/packages/cli/snap-tests/check-lint-warn-deny-warnings/steps.json
+++ b/packages/cli/snap-tests/check-lint-warn-deny-warnings/steps.json
@@ -1,0 +1,6 @@
+{
+  "env": {
+    "VITE_DISABLE_AUTO_INSTALL": "1"
+  },
+  "commands": ["vp check"]
+}

--- a/packages/cli/snap-tests/check-lint-warn-deny-warnings/vite.config.ts
+++ b/packages/cli/snap-tests/check-lint-warn-deny-warnings/vite.config.ts
@@ -1,0 +1,10 @@
+export default {
+  lint: {
+    options: {
+      denyWarnings: true,
+    },
+    rules: {
+      "no-console": "warn",
+    },
+  },
+};


### PR DESCRIPTION
`vp check` was unconditionally resetting the status to success whenever
lint reported only warnings, masking the non-zero exit code produced by
oxlint when `options.denyWarnings` (or `--deny-warnings`) is enabled.
Drop the override and trust oxlint's exit code so warning-only runs fail
the check when warnings have been opted in as failures.

Closes #1424

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `vp check` exit-code behavior for warning-only lint results, which can cause previously-passing pipelines to fail when `denyWarnings` is enabled. Scope is small and localized to the check command plus a new regression snap-test.
> 
> **Overview**
> `vp check` no longer forces a success exit status when oxlint reports only warnings; it now propagates oxlint’s actual exit code so `lint.options.denyWarnings` (or `--deny-warnings`) correctly fails the check.
> 
> Adds a new snap-test fixture `check-lint-warn-deny-warnings` that configures `denyWarnings: true` with a warning-level `no-console` rule and asserts the expected warning output and summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6466c29da42121aef3a5d470b92ea2f4eef487e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->