### PR TITLE
test(e2e): add varlet ecosystem-ci test case

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -314,6 +314,15 @@ jobs:
             node-version: 24
             command: |
               vp check --fix
+          - name: varlet
+            node-version: 22
+            command: |
+              # scripts/bootstrap.mjs spawns `pnpm build` via tinyexec and needs
+              # pnpm on PATH (not exposed by the vp install itself).
+              vp i -g pnpm
+              node scripts/bootstrap.mjs
+              vp run lint
+              vp run test:coverage
         exclude:
           # frm-stack uses Docker (testcontainers) which doesn't work the same way on Windows
           - os: windows-latest
@@ -335,6 +344,10 @@ jobs:
           - os: windows-latest
             project:
               name: npmx.dev
+          # varlet upstream CI is ubuntu-only
+          - os: windows-latest
+            project:
+              name: varlet
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/ecosystem-ci/repo.json
+++ b/ecosystem-ci/repo.json
@@ -119,5 +119,11 @@
     "branch": "main",
     "hash": "6192f60653c124ae068efaf5d7d0a4134c95edbd",
     "forceFreshMigration": true
+  },
+  "varlet": {
+    "repository": "https://github.com/varletjs/varlet.git",
+    "branch": "dev",
+    "hash": "83f6c6a418ab9319e07d719d86d4fa952f99e266",
+    "forceFreshMigration": true
   }
 }


### PR DESCRIPTION
## Summary

- Adds [varletjs/varlet](https://github.com/varletjs/varlet) (Vue 3 component library) to the ecosystem-ci matrix
- Runs upstream's [ci.yaml](https://github.com/varletjs/varlet/blob/dev/.github/workflows/ci.yaml) workflow: `node scripts/bootstrap.mjs`, `vp run lint`, `vp run test:coverage`
- Ubuntu-only, Node 22, pinned to commit `83f6c6a` of the `dev` branch
- `forceFreshMigration: true` because the project already lists `vite-plus: catalog:` in devDependencies

## Test plan

- [x] Local verification: `node ecosystem-ci/clone.ts varlet` + `patch-project.ts varlet`
  - migrate + `vp install`: 16s
  - `node scripts/bootstrap.mjs`: 12.9s (builds all internal packages via varlet-cli)
  - `vp run lint`: 0 warnings / 0 errors on 1128 files
  - `vp run test:coverage`: 81 test files, 921 tests passed (10.5s) using `vitest@0.0.0` (vite-plus-test)
- [ ] Verify e2e-test workflow passes in CI