### PR TITLE
feat(cli/bin): Allow --stdin-filepath for oxfmt bin

### DIFF
--- a/packages/cli/bin/oxfmt
+++ b/packages/cli/bin/oxfmt
@@ -4,8 +4,10 @@
 // This enables IDE extensions (e.g., oxc-vscode) to discover and start the LSP server.
 // Binary resolution follows the same approach as `src/resolve-fmt.ts`.
 
-if (!process.argv.includes('--lsp')) {
-  console.error('This oxfmt wrapper is for IDE extension use only (--lsp mode).');
+const isLSP = process.argv.includes('--lsp');
+const isStdin = process.argv.some((arg) => arg.startsWith('--stdin-filepath'));
+if (!isLSP && !isStdin) {
+  console.error('This oxfmt wrapper is for IDE extension use only (lsp or stdin mode).');
   console.error('To format your code, run: vp fmt');
   process.exit(1);
 }

--- a/packages/cli/snap-tests/bin-oxfmt-wrapper/snap.txt
+++ b/packages/cli/snap-tests/bin-oxfmt-wrapper/snap.txt
@@ -1,12 +1,52 @@
 [1]> node ../node_modules/vite-plus/bin/oxfmt # should reject non-LSP usage
-This oxfmt wrapper is for IDE extension use only (--lsp mode).
+This oxfmt wrapper is for IDE extension use only (lsp or stdin mode).
 To format your code, run: vp fmt
 
 [1]> node ../node_modules/vite-plus/bin/oxfmt --help # should reject non-LSP usage
-This oxfmt wrapper is for IDE extension use only (--lsp mode).
+This oxfmt wrapper is for IDE extension use only (lsp or stdin mode).
 To format your code, run: vp fmt
 
-> node ../node_modules/vite-plus/bin/oxfmt --lsp --help # should exercise import path
+> node ../node_modules/vite-plus/bin/oxfmt --lsp --help # should allow LSP mode
+Usage: [-c=PATH] [PATH]...
+
+Mode Options:
+        --init               Initialize `.oxfmtrc.json` with default values
+        --migrate=SOURCE     Migrate configuration to `.oxfmtrc.json` from specified source
+                             Available sources: prettier, biome
+        --lsp                Start language server protocol (LSP) server
+        --stdin-filepath=PATH  Specify the file name to use to infer which parser to use
+
+Output Options:
+        --write              Format and write files in place (default)
+        --check              Check if files are formatted, also show statistics
+        --list-different     List files that would be changed
+
+Config Options
+    -c, --config=PATH        Path to the configuration file (.json, .jsonc, .ts, .mts, .cts, .js,
+                             .mjs, .cjs)
+
+Ignore Options
+        --ignore-path=PATH   Path to ignore file(s). Can be specified multiple times. If not
+                             specified, .gitignore and .prettierignore in the current directory are
+                             used.
+        --with-node-modules  Format code in node_modules directory (skipped by default)
+
+Runtime Options
+        --no-error-on-unmatched-pattern  Do not exit with error when pattern is unmatched
+        --threads=INT        Number of threads to use. Set to 1 for using only 1 CPU core.
+
+Available positional items:
+    PATH                     Single file, path or list of paths. Glob patterns are also supported.
+                             (Be sure to quote them, otherwise your shell may expand them before
+                             passing.) Exclude patterns with `!` prefix like `'!**/fixtures/*.js'`
+                             are also supported. If not provided, current working directory is used.
+
+Available options:
+    -h, --help               Prints help information
+    -V, --version            Prints version information
+
+
+> node ../node_modules/vite-plus/bin/oxfmt --stdin-filepath=a.ts --help # should allow Stdin mode
 Usage: [-c=PATH] [PATH]...
 
 Mode Options:

--- a/packages/cli/snap-tests/bin-oxfmt-wrapper/steps.json
+++ b/packages/cli/snap-tests/bin-oxfmt-wrapper/steps.json
@@ -2,6 +2,7 @@
   "commands": [
     "node ../node_modules/vite-plus/bin/oxfmt # should reject non-LSP usage",
     "node ../node_modules/vite-plus/bin/oxfmt --help # should reject non-LSP usage",
-    "node ../node_modules/vite-plus/bin/oxfmt --lsp --help # should exercise import path"
+    "node ../node_modules/vite-plus/bin/oxfmt --lsp --help # should allow LSP mode",
+    "node ../node_modules/vite-plus/bin/oxfmt --stdin-filepath=a.ts --help # should allow Stdin mode"
   ]
 }


### PR DESCRIPTION
Partially helps #979

I think the path to deprecating the wrapper bin is still way too far, so I improve the current situation.

Regarding oxlint, we do not have received any specific usage reports yet, so do nothing for now.
