### PR TITLE
chore(ecosystem-ci): bump vinext to latest main

### DIFF
--- a/ecosystem-ci/repo.json
+++ b/ecosystem-ci/repo.json
@@ -71,7 +71,7 @@
   "vinext": {
     "repository": "https://github.com/cloudflare/vinext.git",
     "branch": "main",
-    "hash": "f78dd2b39f5b02242417e0a684b1f2f55d3dbdff",
+    "hash": "88e57e1bcfef02b7463ebf08bcc355d207f7142c",
     "forceFreshMigration": true
   },
   "reactive-resume": {


### PR DESCRIPTION
## Summary
- Bump `vinext` hash in `ecosystem-ci/repo.json` from `f78dd2b3` to `88e57e1b` (latest `main`) to fix check failures.

## Test plan
- [ ] Ecosystem-CI `vinext` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)