### PR TITLE
ci: switch mac runners from namespace to GitHub runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-          - os: namespace-profile-mac-default
+          - os: macos-latest
             target: aarch64-apple-darwin
     runs-on: ${{ matrix.os }}
     steps:
@@ -200,7 +200,7 @@ jobs:
         include:
           - os: namespace-profile-linux-x64-default
             target: x86_64-unknown-linux-gnu
-          - os: namespace-profile-mac-default
+          - os: macos-latest
             target: aarch64-apple-darwin
           - os: windows-latest
             target: x86_64-pc-windows-msvc
@@ -614,15 +614,15 @@ jobs:
             target: x86_64-unknown-linux-gnu
             shard: 3
             shardTotal: 3
-          - os: namespace-profile-mac-default
+          - os: macos-latest
             target: aarch64-apple-darwin
             shard: 1
             shardTotal: 3
-          - os: namespace-profile-mac-default
+          - os: macos-latest
             target: aarch64-apple-darwin
             shard: 2
             shardTotal: 3
-          - os: namespace-profile-mac-default
+          - os: macos-latest
             target: aarch64-apple-darwin
             shard: 3
             shardTotal: 3


### PR DESCRIPTION
## Summary

- The `namespace-profile-mac-default` runner resources are exhausted and frequently queued, causing CI delays.
- Switch all 5 occurrences in `.github/workflows/ci.yml` to `macos-latest` (Apple Silicon, matches the `aarch64-apple-darwin` target and `release.yml` convention).

## Test plan

- [ ] Verify `test`, `cli-e2e-test`, and sharded test jobs run on `macos-latest`
- [ ] Confirm Mac jobs are no longer queued waiting for namespace runners