### PR TITLE
fix(cli): suppress Vite+ header in non-TTY and git hook contexts

### DIFF
--- a/crates/vite_global_cli/src/cli.rs
+++ b/crates/vite_global_cli/src/cli.rs
@@ -2102,8 +2102,7 @@ fn print_runtime_header(show_header: bool) {
     if !show_header {
         return;
     }
-    println!("{}", vite_shared::header::vite_plus_header());
-    println!();
+    vite_shared::header::print_header();
 }
 
 /// Build a clap Command with custom help formatting matching the JS CLI output.
@@ -2120,7 +2119,7 @@ pub fn command_with_help_with_options(render_options: RenderOptions) -> clap::Co
 fn apply_custom_help(cmd: clap::Command, render_options: RenderOptions) -> clap::Command {
     let after_help = help::render_help_doc(&help::top_level_help_doc());
     let options_heading = help::render_heading("Options");
-    let header = if render_options.show_header {
+    let header = if render_options.show_header && vite_shared::header::should_print_header() {
         vite_shared::header::vite_plus_header()
     } else {
         String::new()

--- a/crates/vite_global_cli/src/commands/env/mod.rs
+++ b/crates/vite_global_cli/src/commands/env/mod.rs
@@ -32,8 +32,7 @@ use crate::{
 };
 
 fn print_env_header() {
-    println!("{}", vite_shared::header::vite_plus_header());
-    println!();
+    vite_shared::header::print_header();
 }
 
 fn should_print_env_header(subcommand: &EnvSubcommands) -> bool {
@@ -140,8 +139,7 @@ pub async fn execute(cwd: AbsolutePathBuf, args: EnvArgs) -> Result<ExitStatus, 
     if !crate::help::print_unified_clap_help_for_path(&["env"]) {
         // Fallback to clap's built-in help printer if unified rendering fails.
         use clap::CommandFactory;
-        println!("{}", vite_shared::header::vite_plus_header());
-        println!();
+        vite_shared::header::print_header();
         crate::cli::Args::command()
             .find_subcommand("env")
             .unwrap()

--- a/crates/vite_global_cli/src/commands/version.rs
+++ b/crates/vite_global_cli/src/commands/version.rs
@@ -161,8 +161,7 @@ fn detect_system_node_version() -> Option<String> {
 
 /// Execute the `--version` command.
 pub async fn execute(cwd: AbsolutePathBuf) -> Result<ExitStatus, Error> {
-    println!("{}", vite_shared::header::vite_plus_header());
-    println!();
+    vite_shared::header::print_header();
 
     println!("vp v{}", env!("CARGO_PKG_VERSION"));
     println!();

--- a/crates/vite_global_cli/src/help.rs
+++ b/crates/vite_global_cli/src/help.rs
@@ -993,8 +993,7 @@ pub fn maybe_print_unified_clap_subcommand_help(argv: &[String]) -> bool {
     }
 
     if command_path.len() == 1 && command_path[0] == "env" {
-        println!("{}", vite_shared::header::vite_plus_header());
-        println!();
+        vite_shared::header::print_header();
         println!("{}", render_help_doc(&env_help_doc()));
         return true;
     }
@@ -1024,8 +1023,7 @@ pub fn maybe_print_unified_delegate_help(
     };
 
     if show_header {
-        println!("{}", vite_shared::header::vite_plus_header());
-        println!();
+        vite_shared::header::print_header();
     }
     println!("{}", render_help_doc(&doc));
     true
@@ -1033,8 +1031,7 @@ pub fn maybe_print_unified_delegate_help(
 
 pub fn print_unified_clap_help_for_path(command_path: &[&str]) -> bool {
     if command_path == ["env"] {
-        println!("{}", vite_shared::header::vite_plus_header());
-        println!();
+        vite_shared::header::print_header();
         println!("{}", render_help_doc(&env_help_doc()));
         return true;
     }
@@ -1057,8 +1054,7 @@ pub fn print_unified_clap_help_for_path(command_path: &[&str]) -> bool {
         ..doc
     };
 
-    println!("{}", vite_shared::header::vite_plus_header());
-    println!();
+    vite_shared::header::print_header();
     println!("{}", render_owned_help_doc(&doc));
     true
 }

--- a/crates/vite_global_cli/src/main.rs
+++ b/crates/vite_global_cli/src/main.rs
@@ -116,8 +116,7 @@ fn extract_invalid_subcommand_details(error: &clap::Error) -> Option<InvalidSubc
 }
 
 fn print_invalid_subcommand_error(details: &InvalidSubcommandDetails) {
-    println!("{}", vite_shared::header::vite_plus_header());
-    println!();
+    vite_shared::header::print_header();
 
     let highlighted_subcommand = details.invalid_subcommand.bright_blue().to_string();
     output::error(&format!("Command '{highlighted_subcommand}' not found"));
@@ -237,8 +236,7 @@ fn print_unknown_argument_error(error: &clap::Error) -> bool {
         return false;
     };
 
-    println!("{}", vite_shared::header::vite_plus_header());
-    println!();
+    vite_shared::header::print_header();
 
     let highlighted_argument = invalid_argument.bright_blue().to_string();
     output::error(&format!("Unexpected argument '{highlighted_argument}'"));

--- a/crates/vite_shared/src/header.rs
+++ b/crates/vite_shared/src/header.rs
@@ -536,6 +536,36 @@ pub fn vite_plus_header() -> String {
     render_header_variant(header_colors.blue, &header_colors.suffix_gradient, true, true)
 }
 
+/// Whether the Vite+ banner should be emitted in the current environment.
+///
+/// The banner is cosmetic and assumes an interactive terminal; it's
+/// suppressed when:
+/// - stdout is piped or redirected (lefthook/husky, `execSync`, CI, pagers).
+/// - a git commit-flow hook is running. Direct shell hooks inherit the
+///   terminal for stdout, so the TTY check alone doesn't catch them; git
+///   sets `GIT_INDEX_FILE` for pre-commit / commit-msg / prepare-commit-msg,
+///   which is where `vp check --fix` typically runs.
+#[must_use]
+pub fn should_print_header() -> bool {
+    if !std::io::stdout().is_terminal() {
+        return false;
+    }
+    if std::env::var_os("GIT_INDEX_FILE").is_some() {
+        return false;
+    }
+    true
+}
+
+/// Emit the Vite+ banner (header line + trailing blank line) to stdout, but
+/// only when the environment is interactive. No-op otherwise.
+pub fn print_header() {
+    if !should_print_header() {
+        return;
+    }
+    println!("{}", vite_plus_header());
+    println!();
+}
+
 #[cfg(all(test, unix))]
 mod tests {
     use std::io::{BufReader, Cursor};

--- a/packages/cli/binding/index.cjs
+++ b/packages/cli/binding/index.cjs
@@ -775,4 +775,5 @@ module.exports.rewritePrettier = nativeBinding.rewritePrettier;
 module.exports.rewriteScripts = nativeBinding.rewriteScripts;
 module.exports.run = nativeBinding.run;
 module.exports.runCommand = nativeBinding.runCommand;
+module.exports.shouldPrintVitePlusHeader = nativeBinding.shouldPrintVitePlusHeader;
 module.exports.vitePlusHeader = nativeBinding.vitePlusHeader;

--- a/packages/cli/binding/index.d.cts
+++ b/packages/cli/binding/index.d.cts
@@ -369,5 +369,13 @@ export interface RunCommandResult {
   pathAccesses: Record<string, PathAccess>;
 }
 
+/**
+ * Whether the Vite+ banner should be emitted in the current environment.
+ *
+ * Mirrors `vite_shared::header::should_print_header` so both CLIs apply
+ * the same TTY + git-hook gating without duplicating the rules in JS.
+ */
+export declare function shouldPrintVitePlusHeader(): boolean;
+
 /** Render the Vite+ header using the Rust implementation. */
 export declare function vitePlusHeader(): string;

--- a/packages/cli/binding/src/cli/help.rs
+++ b/packages/cli/binding/src/cli/help.rs
@@ -169,14 +169,16 @@ fn print_unknown_argument_error(error: &clap::Error) -> bool {
 }
 
 pub(super) fn print_help() {
-    let header = vite_shared::header::vite_plus_header();
+    let header = if vite_shared::header::should_print_header() {
+        format!("{}\n\n", vite_shared::header::vite_plus_header())
+    } else {
+        String::new()
+    };
     let bold = "\x1b[1m";
     let bold_underline = "\x1b[1;4m";
     let reset = "\x1b[0m";
     println!(
-        "{header}
-
-{bold_underline}Usage:{reset} {bold}vp{reset} <COMMAND>
+        "{header}{bold_underline}Usage:{reset} {bold}vp{reset} <COMMAND>
 
 {bold_underline}Core Commands:{reset}
   {bold}dev{reset}            Run the development server

--- a/packages/cli/binding/src/lib.rs
+++ b/packages/cli/binding/src/lib.rs
@@ -215,3 +215,12 @@ pub async fn run(options: CliOptions) -> Result<i32> {
 pub fn vite_plus_header() -> String {
     vite_shared::header::vite_plus_header()
 }
+
+/// Whether the Vite+ banner should be emitted in the current environment.
+///
+/// Mirrors `vite_shared::header::should_print_header` so both CLIs apply
+/// the same TTY + git-hook gating without duplicating the rules in JS.
+#[napi]
+pub fn should_print_vite_plus_header() -> bool {
+    vite_shared::header::should_print_header()
+}

--- a/packages/cli/snap-tests-global/cli-helper-message/snap.txt
+++ b/packages/cli/snap-tests-global/cli-helper-message/snap.txt
@@ -1,5 +1,4 @@
 > vp -h # show help message
-VITE+ - The Unified Toolchain for the Web
 
 Usage: vp [COMMAND]
 
@@ -55,8 +54,6 @@ Options:
   -h, --help     Print help
 
 > vp -V # show version
-VITE+ - The Unified Toolchain for the Web
-
 vp v<semver>
 
 Local vite-plus:
@@ -76,8 +73,6 @@ Environment:
   Node.js          v<semver>
 
 > vp install -h # show install help message
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp install [OPTIONS] [PACKAGES]... [-- <PASS_THROUGH_ARGS>...]
 
 Install all dependencies, or add packages if package names are provided
@@ -116,8 +111,6 @@ Documentation: https://viteplus.dev/guide/install
 
 
 > vp add -h # show add help message
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp add [OPTIONS] <PACKAGES>... [-- <PASS_THROUGH_ARGS>...]
 
 Add packages to dependencies
@@ -146,8 +139,6 @@ Documentation: https://viteplus.dev/guide/install
 
 
 > vp remove -h # show remove help message
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp remove [OPTIONS] <PACKAGES>... [-- <PASS_THROUGH_ARGS>...]
 
 Remove packages from dependencies
@@ -171,8 +162,6 @@ Documentation: https://viteplus.dev/guide/install
 
 
 > vp update -h # show update help message
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp update [OPTIONS] [PACKAGES]... [-- <PASS_THROUGH_ARGS>...]
 
 Update packages to their latest versions
@@ -199,8 +188,6 @@ Documentation: https://viteplus.dev/guide/install
 
 
 > vp link -h # show link help message
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp link [PACKAGE|DIR] [ARGS]...
 
 Link packages for local development
@@ -216,8 +203,6 @@ Documentation: https://viteplus.dev/guide/install
 
 
 > vp unlink -h # show unlink help message
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp unlink [OPTIONS] [PACKAGE|DIR] [ARGS]...
 
 Unlink packages
@@ -234,8 +219,6 @@ Documentation: https://viteplus.dev/guide/install
 
 
 > vp dedupe -h # show dedupe help message
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp dedupe [OPTIONS] [-- <PASS_THROUGH_ARGS>...]
 
 Deduplicate dependencies
@@ -251,8 +234,6 @@ Documentation: https://viteplus.dev/guide/install
 
 
 > vp outdated -h # show outdated help message
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp outdated [OPTIONS] [PACKAGES]... [-- <PASS_THROUGH_ARGS>...]
 
 Check for outdated packages
@@ -279,8 +260,6 @@ Documentation: https://viteplus.dev/guide/install
 
 
 > vp why -h # show why help message
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp why [OPTIONS] <PACKAGES>... [-- <PASS_THROUGH_ARGS>...]
 
 Show why a package is installed
@@ -309,8 +288,6 @@ Documentation: https://viteplus.dev/guide/install
 
 
 > vp info -h # show info help message
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp info [OPTIONS] <PACKAGE> [FIELD] [-- <PASS_THROUGH_ARGS>...]
 
 View package information from the registry
@@ -328,8 +305,6 @@ Documentation: https://viteplus.dev/guide/install
 
 
 > vp pm -h # show pm help message
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp pm <COMMAND>
 
 Forward a command to the package manager
@@ -362,8 +337,6 @@ Documentation: https://viteplus.dev/guide/install
 
 
 > vp env # show env help message
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp env [COMMAND]
 
 Manage Node.js versions
@@ -423,8 +396,6 @@ Documentation: https://viteplus.dev/guide/env
 
 
 > vp upgrade -h # show upgrade help message
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp upgrade [OPTIONS] [VERSION]
 
 Update vp itself to the latest version

--- a/packages/cli/snap-tests-global/command-add-bun/snap.txt
+++ b/packages/cli/snap-tests-global/command-add-bun/snap.txt
@@ -1,6 +1,4 @@
 > vp add --help # should show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp add [OPTIONS] <PACKAGES>... [-- <PASS_THROUGH_ARGS>...]
 
 Add packages to dependencies
@@ -71,8 +69,6 @@ installed test-vite-plus-install@<semver>
 }
 
 > vp install test-vite-plus-package@1.0.0 --save-peer && cat package.json # should install package alias for add
-VITE+ - The Unified Toolchain for the Web
-
 bun add v<semver> (af24e281)
 
 installed test-vite-plus-package@<semver>

--- a/packages/cli/snap-tests-global/command-add-npm10-with-workspace/snap.txt
+++ b/packages/cli/snap-tests-global/command-add-npm10-with-workspace/snap.txt
@@ -180,8 +180,6 @@ up to date in <variable>ms
 }
 
 > vp install test-vite-plus-package@1.0.0 --filter "*" --workspace-root -- --no-audit && cat package.json packages/app/package.json packages/utils/package.json # should install packages alias for add command
-VITE+ - The Unified Toolchain for the Web
-
 
 added 1 package in <variable>ms
 {

--- a/packages/cli/snap-tests-global/command-add-npm10/snap.txt
+++ b/packages/cli/snap-tests-global/command-add-npm10/snap.txt
@@ -1,6 +1,4 @@
 > vp add --help # should show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp add [OPTIONS] <PACKAGES>... [-- <PASS_THROUGH_ARGS>...]
 
 Add packages to dependencies
@@ -56,8 +54,6 @@ added 1 package in <variable>ms
 }
 
 > vp install test-vite-plus-package@1.0.0 --save-peer -- --no-audit && cat package.json # should install package alias for add
-VITE+ - The Unified Toolchain for the Web
-
 
 added 1 package in <variable>ms
 {

--- a/packages/cli/snap-tests-global/command-add-npm11-with-workspace/snap.txt
+++ b/packages/cli/snap-tests-global/command-add-npm11-with-workspace/snap.txt
@@ -180,8 +180,6 @@ up to date in <variable>ms
 }
 
 > vp install test-vite-plus-package@1.0.0 --filter "*" --workspace-root -- --no-audit && cat package.json packages/app/package.json packages/utils/package.json # should install packages alias for add command
-VITE+ - The Unified Toolchain for the Web
-
 
 added 1 package in <variable>ms
 {

--- a/packages/cli/snap-tests-global/command-add-npm11/snap.txt
+++ b/packages/cli/snap-tests-global/command-add-npm11/snap.txt
@@ -1,6 +1,4 @@
 > vp add --help # should show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp add [OPTIONS] <PACKAGES>... [-- <PASS_THROUGH_ARGS>...]
 
 Add packages to dependencies
@@ -56,8 +54,6 @@ added 1 package in <variable>ms
 }
 
 > vp install test-vite-plus-package@1.0.0 --save-peer -- --no-audit && cat package.json # should install package alias for add
-VITE+ - The Unified Toolchain for the Web
-
 
 added 1 package in <variable>ms
 {

--- a/packages/cli/snap-tests-global/command-add-pnpm10-with-workspace/snap.txt
+++ b/packages/cli/snap-tests-global/command-add-pnpm10-with-workspace/snap.txt
@@ -125,8 +125,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp install test-vite-plus-package@1.0.0 --filter "*" --workspace-root --save-catalog && cat package.json packages/app/package.json packages/utils/package.json pnpm-workspace.yaml # should install packages alias for add command
-VITE+ - The Unified Toolchain for the Web
-
 .                                        |   +1 +<repeat>
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 Done in <variable>ms using pnpm v<semver>

--- a/packages/cli/snap-tests-global/command-add-pnpm10/snap.txt
+++ b/packages/cli/snap-tests-global/command-add-pnpm10/snap.txt
@@ -1,6 +1,4 @@
 > vp add --help # should show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp add [OPTIONS] <PACKAGES>... [-- <PASS_THROUGH_ARGS>...]
 
 Add packages to dependencies
@@ -76,8 +74,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp install test-vite-plus-package@1.0.0 --save-peer && cat package.json # should install package alias for add
-VITE+ - The Unified Toolchain for the Web
-
 Packages: +<variable>
 +<repeat>
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done

--- a/packages/cli/snap-tests-global/command-add-pnpm9-with-workspace/snap.txt
+++ b/packages/cli/snap-tests-global/command-add-pnpm9-with-workspace/snap.txt
@@ -101,8 +101,6 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp install test-vite-plus-package@1.0.0 --filter "*" --workspace-root && cat package.json packages/app/package.json packages/utils/package.json pnpm-workspace.yaml # should install packages alias for add command
-VITE+ - The Unified Toolchain for the Web
-
 .                                        |   +1 +<repeat>
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 Done in <variable>ms using pnpm v<semver>

--- a/packages/cli/snap-tests-global/command-add-pnpm9/snap.txt
+++ b/packages/cli/snap-tests-global/command-add-pnpm9/snap.txt
@@ -1,6 +1,4 @@
 > vp add --help # should show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp add [OPTIONS] <PACKAGES>... [-- <PASS_THROUGH_ARGS>...]
 
 Add packages to dependencies
@@ -72,8 +70,6 @@ Done in <variable>ms using pnpm v<semver>
 For help, run: pnpm help add
 
 > vp install test-vite-plus-package@1.0.0 --save-peer && cat package.json # should install package alias for add
-VITE+ - The Unified Toolchain for the Web
-
 Packages: +<variable>
 +<repeat>
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done

--- a/packages/cli/snap-tests-global/command-add-yarn4-with-workspace/snap.txt
+++ b/packages/cli/snap-tests-global/command-add-yarn4-with-workspace/snap.txt
@@ -211,8 +211,6 @@ Done in <variable>ms <variable>ms
 }
 
 > vp install -O test-vite-plus-package-optional --filter "*" && cat package.json packages/app/package.json packages/admin/package.json packages/utils/package.json # should install packages alias for add command
-VITE+ - The Unified Toolchain for the Web
-
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0085: │ + test-vite-plus-package-optional@npm:1.0.0

--- a/packages/cli/snap-tests-global/command-add-yarn4/snap.txt
+++ b/packages/cli/snap-tests-global/command-add-yarn4/snap.txt
@@ -1,6 +1,4 @@
 > vp add --help # should show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp add [OPTIONS] <PACKAGES>... [-- <PASS_THROUGH_ARGS>...]
 
 Add packages to dependencies
@@ -70,8 +68,6 @@ Documentation: https://viteplus.dev/guide/install
 }
 
 > vp install test-vite-plus-package@1.0.0 --save-peer && cat package.json # should install package alias for add
-VITE+ - The Unified Toolchain for the Web
-
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0000: └ Completed

--- a/packages/cli/snap-tests-global/command-cache-bun/snap.txt
+++ b/packages/cli/snap-tests-global/command-cache-bun/snap.txt
@@ -1,6 +1,4 @@
 > vp pm cache --help # should show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp pm cache <SUBCOMMAND> [-- <PASS_THROUGH_ARGS>...]
 
 Manage package cache

--- a/packages/cli/snap-tests-global/command-cache-pnpm10/snap.txt
+++ b/packages/cli/snap-tests-global/command-cache-pnpm10/snap.txt
@@ -1,6 +1,4 @@
 > vp pm cache --help # should show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp pm cache <SUBCOMMAND> [-- <PASS_THROUGH_ARGS>...]
 
 Manage package cache

--- a/packages/cli/snap-tests-global/command-check-help/snap.txt
+++ b/packages/cli/snap-tests-global/command-check-help/snap.txt
@@ -1,6 +1,4 @@
 > vp check -h
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp check [OPTIONS] [PATHS]...
 
 Run format, lint, and type checks.
@@ -21,8 +19,6 @@ Documentation: https://viteplus.dev/guide/check
 
 
 > vp check --help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp check [OPTIONS] [PATHS]...
 
 Run format, lint, and type checks.
@@ -43,8 +39,6 @@ Documentation: https://viteplus.dev/guide/check
 
 
 > vp help check
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp check [OPTIONS] [PATHS]...
 
 Run format, lint, and type checks.

--- a/packages/cli/snap-tests-global/command-config-help/snap.txt
+++ b/packages/cli/snap-tests-global/command-config-help/snap.txt
@@ -1,6 +1,4 @@
 > vp config -h
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp config [OPTIONS]
 
 Configure Vite+ for the current project (hooks + agent integration).
@@ -16,8 +14,6 @@ Documentation: https://viteplus.dev/guide/commit-hooks
 
 
 > vp config --help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp config [OPTIONS]
 
 Configure Vite+ for the current project (hooks + agent integration).
@@ -33,8 +29,6 @@ Documentation: https://viteplus.dev/guide/commit-hooks
 
 
 > vp help config
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp config [OPTIONS]
 
 Configure Vite+ for the current project (hooks + agent integration).

--- a/packages/cli/snap-tests-global/command-config-pnpm10/snap.txt
+++ b/packages/cli/snap-tests-global/command-config-pnpm10/snap.txt
@@ -1,6 +1,4 @@
 > vp pm config --help # should show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp pm config <COMMAND>
 
 Manage package manager configuration

--- a/packages/cli/snap-tests-global/command-create-help/snap.txt
+++ b/packages/cli/snap-tests-global/command-create-help/snap.txt
@@ -1,6 +1,4 @@
 > vp create -h
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp create [TEMPLATE] [OPTIONS] [-- TEMPLATE_OPTIONS]
 
 Use any builtin, local or remote template with Vite+.
@@ -55,8 +53,6 @@ Documentation: https://viteplus.dev/guide/create
 
 
 > vp create --help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp create [TEMPLATE] [OPTIONS] [-- TEMPLATE_OPTIONS]
 
 Use any builtin, local or remote template with Vite+.
@@ -111,8 +107,6 @@ Documentation: https://viteplus.dev/guide/create
 
 
 > vp help create
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp create [TEMPLATE] [OPTIONS] [-- TEMPLATE_OPTIONS]
 
 Use any builtin, local or remote template with Vite+.

--- a/packages/cli/snap-tests-global/command-dedupe-pnpm10/snap.txt
+++ b/packages/cli/snap-tests-global/command-dedupe-pnpm10/snap.txt
@@ -1,6 +1,4 @@
 > vp dedupe --help # should show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp dedupe [OPTIONS] [-- <PASS_THROUGH_ARGS>...]
 
 Deduplicate dependencies

--- a/packages/cli/snap-tests-global/command-dlx-bun/snap.txt
+++ b/packages/cli/snap-tests-global/command-dlx-bun/snap.txt
@@ -1,6 +1,4 @@
 > vp dlx --help # should show help message
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp dlx [OPTIONS] <ARGS>...
 
 Execute a package binary without installing it

--- a/packages/cli/snap-tests-global/command-dlx-npm10/snap.txt
+++ b/packages/cli/snap-tests-global/command-dlx-npm10/snap.txt
@@ -1,6 +1,4 @@
 > vp dlx --help # should show help message
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp dlx [OPTIONS] <ARGS>...
 
 Execute a package binary without installing it

--- a/packages/cli/snap-tests-global/command-dlx-pnpm10/snap.txt
+++ b/packages/cli/snap-tests-global/command-dlx-pnpm10/snap.txt
@@ -1,6 +1,4 @@
 > vp dlx --help # should show help message
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp dlx [OPTIONS] <ARGS>...
 
 Execute a package binary without installing it

--- a/packages/cli/snap-tests-global/command-dlx-yarn4/snap.txt
+++ b/packages/cli/snap-tests-global/command-dlx-yarn4/snap.txt
@@ -1,6 +1,4 @@
 > vp dlx --help # should show help message
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp dlx [OPTIONS] <ARGS>...
 
 Execute a package binary without installing it

--- a/packages/cli/snap-tests-global/command-env-install-conflict/snap.txt
+++ b/packages/cli/snap-tests-global/command-env-install-conflict/snap.txt
@@ -1,6 +1,4 @@
 > vp install -g ./conflict-pkg # Install package with conflicting binary name (uses cwd version)
-VITE+ - The Unified Toolchain for the Web
-
 Installing ./conflict-pkg globally...
 warn: Package './conflict-pkg' provides 'node' binary, but it conflicts with a core shim. Skipping.
 Installed ./conflict-pkg v<semver>
@@ -10,8 +8,6 @@ Binaries: conflict-cli, node
 Uninstalled conflict-pkg
 
 > vp install -g --node 20 ./conflict-pkg # Install with specific Node.js version
-VITE+ - The Unified Toolchain for the Web
-
 Installing ./conflict-pkg globally...
 warn: Package './conflict-pkg' provides 'node' binary, but it conflicts with a core shim. Skipping.
 Installed ./conflict-pkg v<semver>

--- a/packages/cli/snap-tests-global/command-env-install-fail/snap.txt
+++ b/packages/cli/snap-tests-global/command-env-install-fail/snap.txt
@@ -1,6 +1,4 @@
 [1]> vp install -g voidzero-nonexistent-pkg-xyz-12345 # Install non-existent package
-VITE+ - The Unified Toolchain for the Web
-
 Installing voidzero-nonexistent-pkg-xyz-12345 globally...
 npm error code E404
 npm error 404 Not Found - GET https://registry.<domain>/voidzero-nonexistent-pkg-xyz-12345 - Not found

--- a/packages/cli/snap-tests-global/command-env-install-no-arg-fail/snap.txt
+++ b/packages/cli/snap-tests-global/command-env-install-no-arg-fail/snap.txt
@@ -1,6 +1,4 @@
 [1]> vp env install # No version config - should error
-VITE+ - The Unified Toolchain for the Web
-
 No Node.js version found in current project.
 Specify a version: vp env install <VERSION>
 Or pin one:       vp env pin <VERSION>

--- a/packages/cli/snap-tests-global/command-env-install-no-arg/snap.txt
+++ b/packages/cli/snap-tests-global/command-env-install-no-arg/snap.txt
@@ -1,5 +1,3 @@
 > vp env install # Install version from .node-version (22.x)
-VITE+ - The Unified Toolchain for the Web
-
 Installing Node.js v<semver>...
 Installed Node.js v<semver>

--- a/packages/cli/snap-tests-global/command-env-install-node-version/snap.txt
+++ b/packages/cli/snap-tests-global/command-env-install-node-version/snap.txt
@@ -1,6 +1,4 @@
 > vp install -g --node 22 ./command-env-install-node-version-pkg # Install with Node.js 22
-VITE+ - The Unified Toolchain for the Web
-
 Installing ./command-env-install-node-version-pkg globally...
 Installed ./command-env-install-node-version-pkg v<semver>
 Binaries: command-env-install-node-version-pkg-cli
@@ -12,8 +10,6 @@ Node major: 22
 Uninstalled command-env-install-node-version-pkg
 
 > vp install -g --node 20 ./command-env-install-node-version-pkg # Install with Node.js 20
-VITE+ - The Unified Toolchain for the Web
-
 Installing ./command-env-install-node-version-pkg globally...
 Installed ./command-env-install-node-version-pkg v<semver>
 Binaries: command-env-install-node-version-pkg-cli

--- a/packages/cli/snap-tests-global/command-env-install-version-alias/snap.txt
+++ b/packages/cli/snap-tests-global/command-env-install-version-alias/snap.txt
@@ -1,6 +1,4 @@
 > vp install -g --node lts ./command-env-install-version-alias-pkg # Install with LTS alias
-VITE+ - The Unified Toolchain for the Web
-
 Installing ./command-env-install-version-alias-pkg globally...
 Installed ./command-env-install-version-alias-pkg v<semver>
 Binaries: command-env-install-version-alias-pkg-cli
@@ -12,8 +10,6 @@ LTS major >= 20: true
 Uninstalled command-env-install-version-alias-pkg
 
 > vp install -g --node latest ./command-env-install-version-alias-pkg # Install with latest alias
-VITE+ - The Unified Toolchain for the Web
-
 Installing ./command-env-install-version-alias-pkg globally...
 Installed ./command-env-install-version-alias-pkg v<semver>
 Binaries: command-env-install-version-alias-pkg-cli

--- a/packages/cli/snap-tests-global/command-env-off-on/snap.txt
+++ b/packages/cli/snap-tests-global/command-env-off-on/snap.txt
@@ -1,13 +1,9 @@
 > vp run assert-managed # Managed mode: should use project's engines.node 22.12.0
-VITE+ - The Unified Toolchain for the Web
-
 $ node src/assert-managed.mjs ⊘ cache disabled
 OK: v<semver>
 
 
 > vp env off # Switch to system-first mode
-VITE+ - The Unified Toolchain for the Web
-
 ✓ Node.js management set to system-first.
 
 All vp commands and shims will now prefer system Node.js, falling back to managed if not found.
@@ -15,15 +11,11 @@ All vp commands and shims will now prefer system Node.js, falling back to manage
 Run `vp env on` to always use Vite+ managed Node.js.
 
 > vp run assert-not-managed # System-first mode: must NOT use 22.12.0
-VITE+ - The Unified Toolchain for the Web
-
 $ node src/assert-not-managed.mjs ⊘ cache disabled
 OK: v<semver>
 
 
 > vp env on # Switch back to managed mode
-VITE+ - The Unified Toolchain for the Web
-
 ✓ Node.js management set to managed.
 
 All vp commands and shims will now always use Vite+ managed Node.js.
@@ -31,8 +23,6 @@ All vp commands and shims will now always use Vite+ managed Node.js.
 Run `vp env off` to prefer system Node.js instead.
 
 > vp run assert-managed # Managed mode restored: should use 22.12.0 again
-VITE+ - The Unified Toolchain for the Web
-
 $ node src/assert-managed.mjs ⊘ cache disabled
 OK: v<semver>
 

--- a/packages/cli/snap-tests-global/command-env-use/snap.txt
+++ b/packages/cli/snap-tests-global/command-env-use/snap.txt
@@ -1,6 +1,4 @@
 > vp env use --help # should show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp env use [OPTIONS] [VERSION]
 
 Use a specific Node.js version for this shell session

--- a/packages/cli/snap-tests-global/command-env-which/snap.txt
+++ b/packages/cli/snap-tests-global/command-env-which/snap.txt
@@ -2,36 +2,26 @@
 v20.18.0
 
 > vp env which node # Core tool - shows resolved Node.js binary path
-VITE+ - The Unified Toolchain for the Web
-
 <vite-plus-home>/js_runtime/node/<semver>/bin/node
   Version:    <semver>
   Source:     <cwd>/.node-version
 
 > vp env which npm # Core tool - shows resolved npm binary path
-VITE+ - The Unified Toolchain for the Web
-
 <vite-plus-home>/js_runtime/node/<semver>/bin/npm
   Version:    <semver>
   Source:     <cwd>/.node-version
 
 > vp env which npx # Core tool - shows resolved npx binary path
-VITE+ - The Unified Toolchain for the Web
-
 <vite-plus-home>/js_runtime/node/<semver>/bin/npx
   Version:    <semver>
   Source:     <cwd>/.node-version
 
 > vp install -g cowsay@1.6.0 # Install a global package via vp
-VITE+ - The Unified Toolchain for the Web
-
 Installing cowsay@<semver> globally...
 Installed cowsay v<semver>
 Binaries: cowsay, cowthink
 
 > vp env which cowsay # Global package - shows binary path with metadata
-VITE+ - The Unified Toolchain for the Web
-
 <vite-plus-home>/packages/cowsay/lib/node_modules/cowsay/./cli.js
   Package:    cowsay@<semver>
   Binaries:   cowsay, cowthink
@@ -42,8 +32,6 @@ VITE+ - The Unified Toolchain for the Web
 Uninstalled cowsay
 
 [1]> vp env which unknown-tool # Unknown tool - error message
-VITE+ - The Unified Toolchain for the Web
-
 error: tool 'unknown-tool' not found
 Not a core tool (node, npm, npx) or installed global package.
 Run 'vp list -g' to see installed packages.

--- a/packages/cli/snap-tests-global/command-exec/snap.txt
+++ b/packages/cli/snap-tests-global/command-exec/snap.txt
@@ -1,32 +1,20 @@
 > node setup-bin.js
 > vp exec hello-test # exec binary from node_modules/.bin
-VITE+ - The Unified Toolchain for the Web
-
 hello from test-bin
 
 > vp exec echo hello # basic exec
-VITE+ - The Unified Toolchain for the Web
-
 hello
 
 > vp exec -- echo with-separator # explicit -- separator
-VITE+ - The Unified Toolchain for the Web
-
 with-separator
 
 > vp exec node -e "console.log('hi')" # exec with args passthrough
-VITE+ - The Unified Toolchain for the Web
-
 hi
 
 > vp exec -c 'echo hello from shell' # shell mode
-VITE+ - The Unified Toolchain for the Web
-
 hello from shell
 
 > vp exec --help # should show help message
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp exec [OPTIONS] [COMMAND]...
 
 Execute a command from local node_modules/.bin.
@@ -66,8 +54,6 @@ Documentation: https://viteplus.dev/guide/vpx
 
 
 [1]> vp exec # missing command should error
-VITE+ - The Unified Toolchain for the Web
-
 error: 'vp exec' requires a command to run
 
 Usage: vp exec [--] <command> [args...]
@@ -77,8 +63,6 @@ Examples:
   vp exec tsc --noEmit
 
 [1]> vp exec nonexistent-cmd-12345 # command not found error
-VITE+ - The Unified Toolchain for the Web
-
 error: Command 'nonexistent-cmd-12345' not found in node_modules/.bin
 
 Run `vp install` to install dependencies, or use `vpx` for invoking remote commands.

--- a/packages/cli/snap-tests-global/command-fmt-help/snap.txt
+++ b/packages/cli/snap-tests-global/command-fmt-help/snap.txt
@@ -1,6 +1,4 @@
 > vp fmt -h
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp fmt [PATH]... [OPTIONS]
 
 Format code.
@@ -23,8 +21,6 @@ Documentation: https://viteplus.dev/guide/fmt
 
 
 > vp fmt --help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp fmt [PATH]... [OPTIONS]
 
 Format code.
@@ -47,8 +43,6 @@ Documentation: https://viteplus.dev/guide/fmt
 
 
 > vp help fmt
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp fmt [PATH]... [OPTIONS]
 
 Format code.

--- a/packages/cli/snap-tests-global/command-link-pnpm10/snap.txt
+++ b/packages/cli/snap-tests-global/command-link-pnpm10/snap.txt
@@ -1,6 +1,4 @@
 > vp link -h # should show help message
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp link [PACKAGE|DIR] [ARGS]...
 
 Link packages for local development
@@ -16,8 +14,6 @@ Documentation: https://viteplus.dev/guide/install
 
 
 > vp install # install initial dependencies
-VITE+ - The Unified Toolchain for the Web
-
 Packages: +<variable>
 +<repeat>
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done

--- a/packages/cli/snap-tests-global/command-lint-help/snap.txt
+++ b/packages/cli/snap-tests-global/command-lint-help/snap.txt
@@ -1,6 +1,4 @@
 > vp lint -h
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp lint [PATH]... [OPTIONS]
 
 Lint code.
@@ -23,8 +21,6 @@ Documentation: https://viteplus.dev/guide/lint
 
 
 > vp lint --help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp lint [PATH]... [OPTIONS]
 
 Lint code.
@@ -47,8 +43,6 @@ Documentation: https://viteplus.dev/guide/lint
 
 
 > vp help lint
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp lint [PATH]... [OPTIONS]
 
 Lint code.

--- a/packages/cli/snap-tests-global/command-list-bun/snap.txt
+++ b/packages/cli/snap-tests-global/command-list-bun/snap.txt
@@ -1,6 +1,4 @@
 > vp install # should install packages first
-VITE+ - The Unified Toolchain for the Web
-
 bun install v<semver> (af24e281)
 
 + test-vite-plus-package@<semver>
@@ -10,8 +8,6 @@ bun install v<semver> (af24e281)
 3 packages installed [<variable>ms]
 
 > vp pm list --help # should show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp pm list [OPTIONS] [PATTERN] [-- <PASS_THROUGH_ARGS>...]
 
 List installed packages

--- a/packages/cli/snap-tests-global/command-list-npm10-with-workspace/snap.txt
+++ b/packages/cli/snap-tests-global/command-list-npm10-with-workspace/snap.txt
@@ -1,6 +1,4 @@
 > vp install # should install packages first
-VITE+ - The Unified Toolchain for the Web
-
 
 added 4 packages in <variable>ms
 

--- a/packages/cli/snap-tests-global/command-list-npm10/snap.txt
+++ b/packages/cli/snap-tests-global/command-list-npm10/snap.txt
@@ -1,6 +1,4 @@
 > vp install # should install packages first
-VITE+ - The Unified Toolchain for the Web
-
 
 added 3 packages in <variable>ms
 

--- a/packages/cli/snap-tests-global/command-list-pnpm10-with-workspace/snap.txt
+++ b/packages/cli/snap-tests-global/command-list-pnpm10-with-workspace/snap.txt
@@ -1,6 +1,4 @@
 > vp install # should install packages first
-VITE+ - The Unified Toolchain for the Web
-
 Scope: all <variable> workspace projects
 Packages: +<variable>
 +<repeat>

--- a/packages/cli/snap-tests-global/command-list-pnpm10/snap.txt
+++ b/packages/cli/snap-tests-global/command-list-pnpm10/snap.txt
@@ -1,6 +1,4 @@
 > vp install # should install packages first
-VITE+ - The Unified Toolchain for the Web
-
 Packages: +<variable>
 +<repeat>
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
@@ -15,8 +13,6 @@ devDependencies:
 Done in <variable>ms using pnpm v<semver>
 
 > vp pm list --help # should show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp pm list [OPTIONS] [PATTERN] [-- <PASS_THROUGH_ARGS>...]
 
 List installed packages

--- a/packages/cli/snap-tests-global/command-list-yarn1/snap.txt
+++ b/packages/cli/snap-tests-global/command-list-yarn1/snap.txt
@@ -1,6 +1,4 @@
 > vp install # should install packages first
-VITE+ - The Unified Toolchain for the Web
-
 yarn install v<semver>
 info No lockfile found.
 [1/4] Resolving packages...

--- a/packages/cli/snap-tests-global/command-outdated-bun/snap.txt
+++ b/packages/cli/snap-tests-global/command-outdated-bun/snap.txt
@@ -1,6 +1,4 @@
 > vp outdated --help # should show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp outdated [OPTIONS] [PACKAGES]... [-- <PASS_THROUGH_ARGS>...]
 
 Check for outdated packages
@@ -27,8 +25,6 @@ Documentation: https://viteplus.dev/guide/install
 
 
 > vp install # should install packages first
-VITE+ - The Unified Toolchain for the Web
-
 bun install v<semver> (af24e281)
 
 + test-vite-plus-top-package@<semver>

--- a/packages/cli/snap-tests-global/command-outdated-npm10-with-workspace/snap.txt
+++ b/packages/cli/snap-tests-global/command-outdated-npm10-with-workspace/snap.txt
@@ -1,6 +1,4 @@
 > vp install
-VITE+ - The Unified Toolchain for the Web
-
 
 added 6 packages in <variable>ms
 

--- a/packages/cli/snap-tests-global/command-outdated-npm10/snap.txt
+++ b/packages/cli/snap-tests-global/command-outdated-npm10/snap.txt
@@ -1,6 +1,4 @@
 > vp install # should install packages first
-VITE+ - The Unified Toolchain for the Web
-
 
 added 4 packages in <variable>ms
 

--- a/packages/cli/snap-tests-global/command-outdated-pnpm10-with-workspace/snap.txt
+++ b/packages/cli/snap-tests-global/command-outdated-pnpm10-with-workspace/snap.txt
@@ -1,6 +1,4 @@
 > vp install
-VITE+ - The Unified Toolchain for the Web
-
 Scope: all <variable> workspace projects
 Packages: +<variable>
 +<repeat>

--- a/packages/cli/snap-tests-global/command-outdated-pnpm10/snap.txt
+++ b/packages/cli/snap-tests-global/command-outdated-pnpm10/snap.txt
@@ -1,6 +1,4 @@
 > vp outdated --help # should show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp outdated [OPTIONS] [PACKAGES]... [-- <PASS_THROUGH_ARGS>...]
 
 Check for outdated packages
@@ -27,8 +25,6 @@ Documentation: https://viteplus.dev/guide/install
 
 
 > vp install # should install packages first
-VITE+ - The Unified Toolchain for the Web
-
 Packages: +<variable>
 +<repeat>
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done

--- a/packages/cli/snap-tests-global/command-owner-pnpm10/snap.txt
+++ b/packages/cli/snap-tests-global/command-owner-pnpm10/snap.txt
@@ -1,6 +1,4 @@
 > vp pm owner --help # should show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp pm owner <COMMAND>
 
 Manage package owners

--- a/packages/cli/snap-tests-global/command-pack-exe-error/snap.txt
+++ b/packages/cli/snap-tests-global/command-pack-exe-error/snap.txt
@@ -1,6 +1,4 @@
 [1]> vp pack src/index.ts --exe
-VITE+ - The Unified Toolchain for the Web
-
 ℹ entry: src/index.ts
 ℹ target: node22.22.0
 error: Node.js version v<semver> does not support `exe` option. Please upgrade to Node.js <semver> or later.

--- a/packages/cli/snap-tests-global/command-pack-exe/snap.txt
+++ b/packages/cli/snap-tests-global/command-pack-exe/snap.txt
@@ -1,6 +1,4 @@
 > vp pack src/index.ts --exe 2>&1
-VITE+ - The Unified Toolchain for the Web
-
 ℹ entry: src/index.ts
 ℹ target: node25.7.0
 ℹ `exe` option is experimental and may change in future releases.

--- a/packages/cli/snap-tests-global/command-pack-pnpm10/snap.txt
+++ b/packages/cli/snap-tests-global/command-pack-pnpm10/snap.txt
@@ -1,6 +1,4 @@
 > vp pm pack --help # should show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp pm pack [OPTIONS] [-- <PASS_THROUGH_ARGS>...]
 
 Create a tarball of the package

--- a/packages/cli/snap-tests-global/command-pack-yarn4-with-workspace/snap.txt
+++ b/packages/cli/snap-tests-global/command-pack-yarn4-with-workspace/snap.txt
@@ -1,6 +1,4 @@
 > vp install -- --mode=update-lockfile # should install packages first
-VITE+ - The Unified Toolchain for the Web
-
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0000: └ Completed

--- a/packages/cli/snap-tests-global/command-prune-npm10/snap.txt
+++ b/packages/cli/snap-tests-global/command-prune-npm10/snap.txt
@@ -1,12 +1,8 @@
 > vp install # should install packages first
-VITE+ - The Unified Toolchain for the Web
-
 
 added 3 packages in <variable>ms
 
 > vp pm prune --help # should show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp pm prune [OPTIONS] [-- <PASS_THROUGH_ARGS>...]
 
 Remove unnecessary packages

--- a/packages/cli/snap-tests-global/command-prune-pnpm10/snap.txt
+++ b/packages/cli/snap-tests-global/command-prune-pnpm10/snap.txt
@@ -1,6 +1,4 @@
 > vp install # should install packages first
-VITE+ - The Unified Toolchain for the Web
-
 Packages: +<variable>
 +<repeat>
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
@@ -17,8 +15,6 @@ devDependencies:
 Done in <variable>ms using pnpm v<semver>
 
 > vp pm prune --help # should show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp pm prune [OPTIONS] [-- <PASS_THROUGH_ARGS>...]
 
 Remove unnecessary packages

--- a/packages/cli/snap-tests-global/command-prune-yarn4/snap.txt
+++ b/packages/cli/snap-tests-global/command-prune-yarn4/snap.txt
@@ -1,6 +1,4 @@
 > vp pm prune --help # should show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp pm prune [OPTIONS] [-- <PASS_THROUGH_ARGS>...]
 
 Remove unnecessary packages

--- a/packages/cli/snap-tests-global/command-publish-bun/snap.txt
+++ b/packages/cli/snap-tests-global/command-publish-bun/snap.txt
@@ -1,6 +1,4 @@
 > vp pm publish --help # should show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp pm publish [OPTIONS] [TARBALL|FOLDER] [-- <PASS_THROUGH_ARGS>...]
 
 Publish package to registry

--- a/packages/cli/snap-tests-global/command-publish-pnpm10/snap.txt
+++ b/packages/cli/snap-tests-global/command-publish-pnpm10/snap.txt
@@ -1,6 +1,4 @@
 > vp pm publish --help # should show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp pm publish [OPTIONS] [TARBALL|FOLDER] [-- <PASS_THROUGH_ARGS>...]
 
 Publish package to registry

--- a/packages/cli/snap-tests-global/command-remove-bun/snap.txt
+++ b/packages/cli/snap-tests-global/command-remove-bun/snap.txt
@@ -1,6 +1,4 @@
 > vp remove --help # should show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp remove [OPTIONS] <PACKAGES>... [-- <PASS_THROUGH_ARGS>...]
 
 Remove packages from dependencies

--- a/packages/cli/snap-tests-global/command-remove-pnpm10/snap.txt
+++ b/packages/cli/snap-tests-global/command-remove-pnpm10/snap.txt
@@ -1,6 +1,4 @@
 > vp remove --help # should show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp remove [OPTIONS] <PACKAGES>... [-- <PASS_THROUGH_ARGS>...]
 
 Remove packages from dependencies
@@ -106,8 +104,6 @@ Done in <variable>ms using pnpm v<semver>
 Failed to uninstall testnpm2: Configuration error: Package testnpm2 is not installed
 
 [2]> vp rm --stream foo && should show tips to use pass through arguments when options are not supported
-VITE+ - The Unified Toolchain for the Web
-
 error: Unexpected argument '--stream'
 
 Use `-- --stream` to pass the argument as a value

--- a/packages/cli/snap-tests-global/command-run-script-vite-program/snap.txt
+++ b/packages/cli/snap-tests-global/command-run-script-vite-program/snap.txt
@@ -1,35 +1,25 @@
 > node setup-bin.js
 > vp run dev # should run vite binary, not parse as vp subcommand
-VITE+ - The Unified Toolchain for the Web
-
 $ vite ⊘ cache disabled
 vite
 
 
 > vp run dev-help # should run vite -h, not parse as vp subcommand
-VITE+ - The Unified Toolchain for the Web
-
 $ vite -h ⊘ cache disabled
 vite -h
 
 
 > vp run dev-version # should run vite --version, not parse as vp subcommand
-VITE+ - The Unified Toolchain for the Web
-
 $ vite --version ⊘ cache disabled
 vite --version
 
 
 > vp run hello-vpr # vpr in script should be synthesized in-session
-VITE+ - The Unified Toolchain for the Web
-
 $ echo hello from script ⊘ cache disabled
 hello from script
 
 
 > vp run ready # chained vpr commands should both be synthesized
-VITE+ - The Unified Toolchain for the Web
-
 $ echo hello from script ⊘ cache disabled
 hello from script
 

--- a/packages/cli/snap-tests-global/command-run-without-vite-plus/snap.txt
+++ b/packages/cli/snap-tests-global/command-run-without-vite-plus/snap.txt
@@ -1,18 +1,12 @@
 > vp run hello # should execute via global vite-plus task runner
-VITE+ - The Unified Toolchain for the Web
-
 $ echo hello from script ⊘ cache disabled
 hello from script
 
 
 > vp run greet --arg1 value1 # should pass through args
-VITE+ - The Unified Toolchain for the Web
-
 $ echo greet --arg1 value1 ⊘ cache disabled
 greet --arg1 value1
 
 
 [1]> vp run nonexistent # should show task not found error
-VITE+ - The Unified Toolchain for the Web
-
 Task "nonexistent" not found.

--- a/packages/cli/snap-tests-global/command-staged-help/snap.txt
+++ b/packages/cli/snap-tests-global/command-staged-help/snap.txt
@@ -1,6 +1,4 @@
 > vp staged -h
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp staged [options]
 
 Run linters on staged files using staged config from vite.config.ts.
@@ -27,8 +25,6 @@ Documentation: https://viteplus.dev/guide/commit-hooks
 
 
 > vp staged --help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp staged [options]
 
 Run linters on staged files using staged config from vite.config.ts.
@@ -55,8 +51,6 @@ Documentation: https://viteplus.dev/guide/commit-hooks
 
 
 > vp help staged
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp staged [options]
 
 Run linters on staged files using staged config from vite.config.ts.

--- a/packages/cli/snap-tests-global/command-staged-no-config/snap.txt
+++ b/packages/cli/snap-tests-global/command-staged-no-config/snap.txt
@@ -1,6 +1,4 @@
 [1]> vp staged # should warn about missing staged config and exit with code 1
-VITE+ - The Unified Toolchain for the Web
-
 error: No "staged" config found in vite.config.ts. Please add a staged config:
 
   // vite.config.ts

--- a/packages/cli/snap-tests-global/command-unlink-pnpm10/snap.txt
+++ b/packages/cli/snap-tests-global/command-unlink-pnpm10/snap.txt
@@ -1,6 +1,4 @@
 > vp unlink -h # should show help message
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp unlink [OPTIONS] [PACKAGE|DIR] [ARGS]...
 
 Unlink packages

--- a/packages/cli/snap-tests-global/command-update-bun/snap.txt
+++ b/packages/cli/snap-tests-global/command-update-bun/snap.txt
@@ -1,6 +1,4 @@
 > vp update --help # should show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp update [OPTIONS] [PACKAGES]... [-- <PASS_THROUGH_ARGS>...]
 
 Update packages to their latest versions

--- a/packages/cli/snap-tests-global/command-update-pnpm10/snap.txt
+++ b/packages/cli/snap-tests-global/command-update-pnpm10/snap.txt
@@ -1,6 +1,4 @@
 > vp update --help # should show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp update [OPTIONS] [PACKAGES]... [-- <PASS_THROUGH_ARGS>...]
 
 Update packages to their latest versions

--- a/packages/cli/snap-tests-global/command-version-no-side-effects/snap.txt
+++ b/packages/cli/snap-tests-global/command-version-no-side-effects/snap.txt
@@ -1,6 +1,4 @@
 > vp --version # should print version
-VITE+ - The Unified Toolchain for the Web
-
 vp v<semver>
 
 Local vite-plus:

--- a/packages/cli/snap-tests-global/command-version-with-env/snap.txt
+++ b/packages/cli/snap-tests-global/command-version-with-env/snap.txt
@@ -1,6 +1,4 @@
 > vp --version
-VITE+ - The Unified Toolchain for the Web
-
 vp v<semver>
 
 Local vite-plus:

--- a/packages/cli/snap-tests-global/command-view-bun/snap.txt
+++ b/packages/cli/snap-tests-global/command-view-bun/snap.txt
@@ -1,6 +1,4 @@
 > vp pm view --help # should show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp pm view [OPTIONS] <PACKAGE> [FIELD] [-- <PASS_THROUGH_ARGS>...]
 
 View package information from the registry

--- a/packages/cli/snap-tests-global/command-view-pnpm10/snap.txt
+++ b/packages/cli/snap-tests-global/command-view-pnpm10/snap.txt
@@ -1,6 +1,4 @@
 > vp pm view --help # should show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp pm view [OPTIONS] <PACKAGE> [FIELD] [-- <PASS_THROUGH_ARGS>...]
 
 View package information from the registry

--- a/packages/cli/snap-tests-global/command-vpr/snap.txt
+++ b/packages/cli/snap-tests-global/command-vpr/snap.txt
@@ -1,6 +1,4 @@
 > vpr -h # should show vp run help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp run [OPTIONS] [TASK_SPECIFIER] [ADDITIONAL_ARGS]...
 
 Run tasks.

--- a/packages/cli/snap-tests-global/command-why-bun/snap.txt
+++ b/packages/cli/snap-tests-global/command-why-bun/snap.txt
@@ -1,6 +1,4 @@
 > vp why --help # should show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp why [OPTIONS] <PACKAGES>... [-- <PASS_THROUGH_ARGS>...]
 
 Show why a package is installed
@@ -29,8 +27,6 @@ Documentation: https://viteplus.dev/guide/install
 
 
 > vp install # should install packages first
-VITE+ - The Unified Toolchain for the Web
-
 bun install v<semver> (af24e281)
 
 + test-vite-plus-package@<semver>

--- a/packages/cli/snap-tests-global/command-why-npm10-with-workspace/snap.txt
+++ b/packages/cli/snap-tests-global/command-why-npm10-with-workspace/snap.txt
@@ -1,6 +1,4 @@
 > vp install
-VITE+ - The Unified Toolchain for the Web
-
 
 added 6 packages in <variable>ms
 

--- a/packages/cli/snap-tests-global/command-why-npm10/snap.txt
+++ b/packages/cli/snap-tests-global/command-why-npm10/snap.txt
@@ -1,6 +1,4 @@
 > vp install # should install packages first
-VITE+ - The Unified Toolchain for the Web
-
 
 added 3 packages in <variable>ms
 

--- a/packages/cli/snap-tests-global/command-why-pnpm10-with-workspace/snap.txt
+++ b/packages/cli/snap-tests-global/command-why-pnpm10-with-workspace/snap.txt
@@ -1,6 +1,4 @@
 > vp install
-VITE+ - The Unified Toolchain for the Web
-
 Scope: all <variable> workspace projects
 Packages: +<variable>
 +<repeat>

--- a/packages/cli/snap-tests-global/command-why-pnpm10/snap.txt
+++ b/packages/cli/snap-tests-global/command-why-pnpm10/snap.txt
@@ -1,6 +1,4 @@
 > vp why --help # should show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp why [OPTIONS] <PACKAGES>... [-- <PASS_THROUGH_ARGS>...]
 
 Show why a package is installed
@@ -29,8 +27,6 @@ Documentation: https://viteplus.dev/guide/install
 
 
 > vp install # should install packages first
-VITE+ - The Unified Toolchain for the Web
-
 Packages: +<variable>
 +<repeat>
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done

--- a/packages/cli/snap-tests-global/command-why-yarn4/snap.txt
+++ b/packages/cli/snap-tests-global/command-why-yarn4/snap.txt
@@ -1,6 +1,4 @@
 > vp install -- --mode=update-lockfile # should install packages first
-VITE+ - The Unified Toolchain for the Web
-
 ➤ YN0000: · Yarn <semver>
 ➤ YN0000: ┌ Resolution step
 ➤ YN0085: │ + test-vite-plus-package-optional@npm:1.0.0, test-vite-plus-package@npm:1.0.0, testnpm2@npm:1.0.1

--- a/packages/cli/snap-tests-global/create-framework-shim-astro/snap.txt
+++ b/packages/cli/snap-tests-global/create-framework-shim-astro/snap.txt
@@ -4,7 +4,5 @@
 
 > cd my-astro-app && vp install -- --no-frozen-lockfile # install dependencies
 > cd my-astro-app && vp check --fix # fix generated formatting and ensure no errors
-VITE+ - The Unified Toolchain for the Web
-
 pass: Formatting completed for checked files (<variable>ms)
 pass: Found no warnings, lint errors, or type errors in 6 files (<variable>ms, <variable> threads)

--- a/packages/cli/snap-tests-global/create-framework-shim-vue/snap.txt
+++ b/packages/cli/snap-tests-global/create-framework-shim-vue/snap.txt
@@ -8,7 +8,5 @@ declare module '*.vue' {
 
 > cd vite-plus-application && vp install # install dependencies
 > cd vite-plus-application && vp check --fix # fix generated formatting and ensure no errors
-VITE+ - The Unified Toolchain for the Web
-
 pass: Formatting completed for checked files (<variable>ms)
 pass: Found no warnings, lint errors, or type errors in 5 files (<variable>ms, <variable> threads)

--- a/packages/cli/snap-tests-global/delegate-respects-default-node-version/snap.txt
+++ b/packages/cli/snap-tests-global/delegate-respects-default-node-version/snap.txt
@@ -1,23 +1,15 @@
 > vp env default 22.12.0 # Set global default to 22.12.0
-VITE+ - The Unified Toolchain for the Web
-
 ✓ Default Node.js version set to <semver>
 
 > vp run check-node # Should also use 22.12.0
-VITE+ - The Unified Toolchain for the Web
-
 $ node -e "console.log(process.version)" ⊘ cache disabled
 v<semver>
 
 
 > vp exec node -e "console.log(process.version)" # Should also use 22.12.0
-VITE+ - The Unified Toolchain for the Web
-
-v<semver>
+v22.12.0
 
 > vp env which node # Should show 22.12.0 from 'default' source
-VITE+ - The Unified Toolchain for the Web
-
 <vite-plus-home>/js_runtime/node/<semver>/bin/node
   Version:    <semver>
   Source:     <vite-plus-home>/config.json

--- a/packages/cli/snap-tests-global/env-install-binary-conflict/snap.txt
+++ b/packages/cli/snap-tests-global/env-install-binary-conflict/snap.txt
@@ -1,6 +1,4 @@
 > vp install -g ./env-binary-conflict-pkg-a # Install pkg-a which provides env-binary-conflict-cli binary
-VITE+ - The Unified Toolchain for the Web
-
 Installing ./env-binary-conflict-pkg-a globally...
 Installed ./env-binary-conflict-pkg-a v<semver>
 Binaries: env-binary-conflict-cli
@@ -14,8 +12,6 @@ Binaries: env-binary-conflict-cli
   "source": "vp"
 }
 [1]> vp install -g ./env-binary-conflict-pkg-b # Try to install pkg-b without force - should fail
-VITE+ - The Unified Toolchain for the Web
-
 Installing ./env-binary-conflict-pkg-b globally...
 Failed to install ./env-binary-conflict-pkg-b: Executable 'env-binary-conflict-cli' is already installed by ./env-binary-conflict-pkg-a
 
@@ -30,8 +26,6 @@ Please remove ./env-binary-conflict-pkg-a before installing ./env-binary-conflic
   "source": "vp"
 }
 > vp install -g --force ./env-binary-conflict-pkg-b # Force install pkg-b - should auto-uninstall pkg-a
-VITE+ - The Unified Toolchain for the Web
-
 Installing ./env-binary-conflict-pkg-b globally...
 Uninstalling ./env-binary-conflict-pkg-a (conflicts with ./env-binary-conflict-pkg-b)...
 Uninstalled ./env-binary-conflict-pkg-a

--- a/packages/cli/snap-tests-global/fallback-all-invalid-to-user-default/snap.txt
+++ b/packages/cli/snap-tests-global/fallback-all-invalid-to-user-default/snap.txt
@@ -1,10 +1,6 @@
 > vp env default 22.12.0 # Set user default
-VITE+ - The Unified Toolchain for the Web
-
 ✓ Default Node.js version set to <semver>
 
 > vp exec node -e "console.log(process.version)" # Should use default 22.12.0, not LTS
-VITE+ - The Unified Toolchain for the Web
-
 warning: invalid version 'invalid' in engines.node, ignoring
 v<semver>

--- a/packages/cli/snap-tests-global/fallback-invalid-engines-to-dev-engines/snap.txt
+++ b/packages/cli/snap-tests-global/fallback-invalid-engines-to-dev-engines/snap.txt
@@ -1,13 +1,9 @@
 > vp exec node -e "console.log(process.version)" # Should use devEngines.runtime 22.12.0, not LTS
-VITE+ - The Unified Toolchain for the Web
-
 warning: invalid version 'invalid' in engines.node, ignoring
 warning: invalid version 'invalid' in engines.node, ignoring
 v<semver>
 
 > vp env which node # Should show devEngines.runtime source
-VITE+ - The Unified Toolchain for the Web
-
 warning: invalid version 'invalid' in engines.node, ignoring
 <vite-plus-home>/js_runtime/node/<semver>/bin/node
   Version:    <semver>

--- a/packages/cli/snap-tests-global/global-cli-fallback/snap.txt
+++ b/packages/cli/snap-tests-global/global-cli-fallback/snap.txt
@@ -1,6 +1,4 @@
 > vp build -h # should fall back to global vite-plus and show build help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp build [ROOT] [OPTIONS]
 
 Build for production.
@@ -28,8 +26,6 @@ Documentation: https://viteplus.dev/guide/build
 
 
 > vp dev -h # should fall back to global vite-plus and show dev help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp dev [ROOT] [OPTIONS]
 
 Run the development server.
@@ -57,8 +53,6 @@ Documentation: https://viteplus.dev/guide/dev
 
 
 > vp test -h # should fall back to global vite-plus and show test help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp test [COMMAND] [FILTERS] [OPTIONS]
 
 Run tests.

--- a/packages/cli/snap-tests-global/migration-add-git-hooks/snap.txt
+++ b/packages/cli/snap-tests-global/migration-add-git-hooks/snap.txt
@@ -1,7 +1,5 @@
 > git init
 > vp migrate --no-interactive # migration should add git hooks setup
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied

--- a/packages/cli/snap-tests-global/migration-agent-claude/snap.txt
+++ b/packages/cli/snap-tests-global/migration-agent-claude/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --agent claude --no-interactive # migration with --agent claude should write CLAUDE.md
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied

--- a/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-hookspath/snap.txt
+++ b/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-hookspath/snap.txt
@@ -1,8 +1,6 @@
 > git init
 > git config core.hooksPath .husky/_
 > vp migrate --no-interactive # should override husky's core.hooksPath and migrate hooks
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Updated .
 • Node <semver>  unknown latest
 • 2 config updates applied

--- a/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-lint-staged/snap.txt
@@ -1,7 +1,5 @@
 > git init
 > vp migrate --no-interactive # should still migrate husky/lint-staged even though vite-plus exists
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Updated .
 • Node <semver>  unknown latest
 • 2 config updates applied

--- a/packages/cli/snap-tests-global/migration-already-vite-plus/snap.txt
+++ b/packages/cli/snap-tests-global/migration-already-vite-plus/snap.txt
@@ -1,5 +1,3 @@
 > vp migrate --no-interactive # should detect existing vite-plus and exit
-VITE+ - The Unified Toolchain for the Web
-
 This project is already using Vite+! Happy coding!
 

--- a/packages/cli/snap-tests-global/migration-auto-create-vite-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-auto-create-vite-config/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive 2>&1 # migration should auto create vite.config.ts and remove oxlintrc and oxfmtrc
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 4 config updates applied

--- a/packages/cli/snap-tests-global/migration-baseurl-tsconfig/snap.txt
+++ b/packages/cli/snap-tests-global/migration-baseurl-tsconfig/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should skip typeAware/typeCheck when tsconfig has baseUrl
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 3 config updates applied

--- a/packages/cli/snap-tests-global/migration-chained-lint-staged-pre-commit/snap.txt
+++ b/packages/cli/snap-tests-global/migration-chained-lint-staged-pre-commit/snap.txt
@@ -1,7 +1,5 @@
 > git init
 > vp migrate --no-interactive # migration should preserve chained commands after lint-staged
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied

--- a/packages/cli/snap-tests-global/migration-check/snap.txt
+++ b/packages/cli/snap-tests-global/migration-check/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --help # show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp migrate [PATH] [OPTIONS]
 
 Migrate standalone Vite, Vitest, Oxlint, Oxfmt, and Prettier projects to unified Vite+.

--- a/packages/cli/snap-tests-global/migration-composed-husky-custom-dir/snap.txt
+++ b/packages/cli/snap-tests-global/migration-composed-husky-custom-dir/snap.txt
@@ -1,7 +1,5 @@
 > git init
 > vp migrate --no-interactive # migration should preserve custom husky dir in composed prepare
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied

--- a/packages/cli/snap-tests-global/migration-composed-husky-prepare/snap.txt
+++ b/packages/cli/snap-tests-global/migration-composed-husky-prepare/snap.txt
@@ -1,7 +1,5 @@
 > git init
 > vp migrate --no-interactive # migration should replace husky in composed prepare script
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied

--- a/packages/cli/snap-tests-global/migration-env-prefix-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-env-prefix-lint-staged/snap.txt
@@ -1,7 +1,5 @@
 > git init
 > vp migrate --no-interactive # migration should replace env-prefixed lint-staged in pre-commit
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied

--- a/packages/cli/snap-tests-global/migration-eslint-legacy-already-vite-plus/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-legacy-already-vite-plus/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # should show legacy config warning and already using Vite+
-VITE+ - The Unified Toolchain for the Web
-
 
 Legacy ESLint configuration detected (.eslintrc). Automatic migration to Oxlint requires ESLint v9+ with flat config format (eslint.config.*). Please upgrade to ESLint v9 first: https://eslint.org/docs/latest/use/migrate-to-9.0.0
 This project is already using Vite+! Happy coding!

--- a/packages/cli/snap-tests-global/migration-eslint-legacy/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-legacy/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # should show legacy eslint config warning
-VITE+ - The Unified Toolchain for the Web
-
 
 Legacy ESLint configuration detected (.eslintrc). Automatic migration to Oxlint requires ESLint v9+ with flat config format (eslint.config.*). Please upgrade to ESLint v9 first: https://eslint.org/docs/latest/use/migrate-to-9.0.0
 ◇ Migrated . to Vite+<repeat>

--- a/packages/cli/snap-tests-global/migration-eslint-lint-staged-mjs/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-lint-staged-mjs/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should warn about non-JSON lint-staged config
-VITE+ - The Unified Toolchain for the Web
-
 
 Migrating ESLint config to Oxlint...
 

--- a/packages/cli/snap-tests-global/migration-eslint-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-lint-staged/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should detect eslint and auto-migrate including lint-staged
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 4 config updates applied

--- a/packages/cli/snap-tests-global/migration-eslint-lintstagedrc/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-lintstagedrc/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should detect eslint and auto-migrate including lintstagedrc
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 5 config updates applied

--- a/packages/cli/snap-tests-global/migration-eslint-monorepo-package-only/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-monorepo-package-only/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should warn about package-only eslint
-VITE+ - The Unified Toolchain for the Web
-
 
 ESLint detected in workspace packages but no root config found. Package-level ESLint must be migrated manually.
 ◇ Migrated . to Vite+<repeat>

--- a/packages/cli/snap-tests-global/migration-eslint-monorepo/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-monorepo/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should detect eslint in monorepo and migrate all packages
-VITE+ - The Unified Toolchain for the Web
-
 
 ✔ Created vite.config.ts in vite.config.ts
 

--- a/packages/cli/snap-tests-global/migration-eslint-npx-wrapper/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-npx-wrapper/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should rewrite bare eslint but leave npx wrappers unchanged
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 4 config updates applied

--- a/packages/cli/snap-tests-global/migration-eslint-rerun-dual-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-rerun-dual-config/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # should detect vite-plus + eslint and auto-migrate eslint
-VITE+ - The Unified Toolchain for the Web
-
 
 Migrating ESLint config to Oxlint...
 

--- a/packages/cli/snap-tests-global/migration-eslint-rerun-mjs/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-rerun-mjs/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # should detect vite-plus + eslint and auto-migrate eslint
-VITE+ - The Unified Toolchain for the Web
-
 
 Migrating ESLint config to Oxlint...
 

--- a/packages/cli/snap-tests-global/migration-eslint-rerun/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-rerun/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # should detect vite-plus + eslint and auto-migrate eslint
-VITE+ - The Unified Toolchain for the Web
-
 
 Migrating ESLint config to Oxlint...
 

--- a/packages/cli/snap-tests-global/migration-eslint/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should detect eslint and auto-migrate
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 4 config updates applied

--- a/packages/cli/snap-tests-global/migration-existing-husky-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-husky-lint-staged/snap.txt
@@ -1,7 +1,5 @@
 > git init
 > vp migrate --no-interactive # migration should rewrite husky and lint-staged
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied

--- a/packages/cli/snap-tests-global/migration-existing-husky-v8-hooks/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-husky-v8-hooks/snap.txt
@@ -1,7 +1,5 @@
 > git init
 > vp migrate --no-interactive # should warn about husky v8 and skip hooks setup
-VITE+ - The Unified Toolchain for the Web
-
 
 ⚠ Detected husky <9.0.0 — please upgrade to husky v9+ first, then re-run migration.
 ◇ Migrated . to Vite+<repeat>

--- a/packages/cli/snap-tests-global/migration-existing-husky-v8-multi-hooks/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-husky-v8-multi-hooks/snap.txt
@@ -1,7 +1,5 @@
 > git init
 > vp migrate --no-interactive # should warn about husky v8 and skip hooks setup
-VITE+ - The Unified Toolchain for the Web
-
 
 ⚠ Detected husky <9.0.0 — please upgrade to husky v9+ first, then re-run migration.
 ◇ Migrated . to Vite+<repeat>

--- a/packages/cli/snap-tests-global/migration-existing-husky/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-husky/snap.txt
@@ -1,7 +1,5 @@
 > git init
 > vp migrate --no-interactive # migration should rewrite husky to vp config
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied

--- a/packages/cli/snap-tests-global/migration-existing-lint-staged-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-lint-staged-config/snap.txt
@@ -1,7 +1,5 @@
 > git init
 > vp migrate --no-interactive # migration should add prepare script, remove lint-staged from devDeps
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 3 config updates applied

--- a/packages/cli/snap-tests-global/migration-existing-pnpm-exec-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-pnpm-exec-lint-staged/snap.txt
@@ -1,7 +1,5 @@
 > git init
 > vp migrate --no-interactive # migration should strip pnpm exec lint-staged and add vp staged
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied

--- a/packages/cli/snap-tests-global/migration-existing-pre-commit/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-pre-commit/snap.txt
@@ -6,8 +6,6 @@ npm test
 secret-scan
 
 > vp migrate --no-interactive # migration should preserve existing pre-commit contents
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied

--- a/packages/cli/snap-tests-global/migration-existing-prepare-script/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-prepare-script/snap.txt
@@ -1,7 +1,5 @@
 > git init
 > vp migrate --no-interactive # migration should compose vp config with existing prepare script
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied

--- a/packages/cli/snap-tests-global/migration-framework-shim-astro-vue/snap.txt
+++ b/packages/cli/snap-tests-global/migration-framework-shim-astro-vue/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive --no-hooks # migration should add both Vue and Astro shims
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 ✓ Dependencies installed in <variable>ms

--- a/packages/cli/snap-tests-global/migration-framework-shim-astro/snap.txt
+++ b/packages/cli/snap-tests-global/migration-framework-shim-astro/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive --no-hooks # migration should add Astro shim when astro dependency is detected
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 ✓ Dependencies installed in <variable>ms

--- a/packages/cli/snap-tests-global/migration-framework-shim-vue/snap.txt
+++ b/packages/cli/snap-tests-global/migration-framework-shim-vue/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive --no-hooks # migration should add Vue shim when vue dependency is detected
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 ✓ Dependencies installed in <variable>ms

--- a/packages/cli/snap-tests-global/migration-from-tsdown-json-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-from-tsdown-json-config/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should rewrite imports to vite-plus
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
@@ -62,8 +60,6 @@ peerDependencyRules:
     vitest: '*'
 
 > vp migrate --no-interactive # run migration again to check if it is idempotent
-VITE+ - The Unified Toolchain for the Web
-
 This project is already using Vite+! Happy coding!
 
 

--- a/packages/cli/snap-tests-global/migration-from-tsdown/snap.txt
+++ b/packages/cli/snap-tests-global/migration-from-tsdown/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should rewrite imports to vite-plus
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 3 config updates applied, 1 file had imports rewritten
@@ -64,8 +62,6 @@ peerDependencyRules:
     vitest: '*'
 
 > vp migrate --no-interactive # run migration again to check if it is idempotent
-VITE+ - The Unified Toolchain for the Web
-
 This project is already using Vite+! Happy coding!
 
 

--- a/packages/cli/snap-tests-global/migration-from-vitest-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-from-vitest-config/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should rewrite imports to vite-plus
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied, 1 file had imports rewritten

--- a/packages/cli/snap-tests-global/migration-from-vitest-files/snap.txt
+++ b/packages/cli/snap-tests-global/migration-from-vitest-files/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should rewrite imports to vite-plus
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied, 1 file had imports rewritten

--- a/packages/cli/snap-tests-global/migration-hooks-skip-on-existing-hookspath/snap.txt
+++ b/packages/cli/snap-tests-global/migration-hooks-skip-on-existing-hookspath/snap.txt
@@ -1,8 +1,6 @@
 > git init
 > git config core.hooksPath .custom-hooks
 > vp migrate --no-interactive # should skip hooks because core.hooksPath is already set
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied

--- a/packages/cli/snap-tests-global/migration-husky-env-skip/snap.txt
+++ b/packages/cli/snap-tests-global/migration-husky-env-skip/snap.txt
@@ -1,7 +1,5 @@
 > git init
 > vp migrate --no-interactive # with HUSKY=0, vp config should skip and warn instead of reporting success
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied

--- a/packages/cli/snap-tests-global/migration-husky-latest-dist-tag-v9-installed/snap.txt
+++ b/packages/cli/snap-tests-global/migration-husky-latest-dist-tag-v9-installed/snap.txt
@@ -1,7 +1,5 @@
 > git init
 > vp migrate --no-interactive # should resolve husky v9 from node_modules, no warning
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied

--- a/packages/cli/snap-tests-global/migration-husky-latest-dist-tag/snap.txt
+++ b/packages/cli/snap-tests-global/migration-husky-latest-dist-tag/snap.txt
@@ -1,7 +1,5 @@
 > git init
 > vp migrate --no-interactive # should warn about uncoercible husky version
-VITE+ - The Unified Toolchain for the Web
-
 
 ⚠ Could not determine husky version from "latest" — please specify a semver-compatible version (e.g., "^9.0.0") and re-run migration.
 ◇ Migrated . to Vite+<repeat>

--- a/packages/cli/snap-tests-global/migration-husky-or-prepare/snap.txt
+++ b/packages/cli/snap-tests-global/migration-husky-or-prepare/snap.txt
@@ -1,7 +1,5 @@
 > git init
 > vp migrate --no-interactive # migration should preserve || fallback semantics
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied

--- a/packages/cli/snap-tests-global/migration-husky-semicolon-prepare/snap.txt
+++ b/packages/cli/snap-tests-global/migration-husky-semicolon-prepare/snap.txt
@@ -1,7 +1,5 @@
 > git init
 > vp migrate --no-interactive # migration should strip husky from semicolon-composed prepare script
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied

--- a/packages/cli/snap-tests-global/migration-husky-v8-preserves-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-husky-v8-preserves-lint-staged/snap.txt
@@ -1,7 +1,5 @@
 > git init
 > vp migrate --no-interactive # should warn about husky v8, preserve lint-staged config
-VITE+ - The Unified Toolchain for the Web
-
 
 ⚠ Detected husky <9.0.0 — please upgrade to husky v9+ first, then re-run migration.
 ◇ Migrated . to Vite+<repeat>

--- a/packages/cli/snap-tests-global/migration-lint-staged-in-scripts/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lint-staged-in-scripts/snap.txt
@@ -1,7 +1,5 @@
 > git init
 > vp migrate --no-interactive # migration should rewrite lint-staged commands in scripts
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied

--- a/packages/cli/snap-tests-global/migration-lint-staged-merge-fail/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lint-staged-merge-fail/snap.txt
@@ -1,7 +1,5 @@
 > git init
 > vp migrate --no-interactive # should handle merge failure gracefully
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 ! Warnings:

--- a/packages/cli/snap-tests-global/migration-lint-staged-ts-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lint-staged-ts-config/snap.txt
@@ -1,7 +1,5 @@
 > git init
 > vp migrate --no-interactive # migration should warn about unsupported TS lint-staged config
-VITE+ - The Unified Toolchain for the Web
-
 
 ⚠ Unsupported lint-staged config format — skipping git hooks setup. Please configure git hooks manually.
 ◇ Migrated . to Vite+<repeat>

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-json/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-json/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate -h # migration help message
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp migrate [PATH] [OPTIONS]
 
 Migrate standalone Vite, Vitest, Oxlint, Oxfmt, and Prettier projects to unified Vite+.
@@ -69,8 +67,6 @@ Documentation: https://viteplus.dev/guide/migrate
 
 
 > vp migrate --no-interactive # migration work with lintstagedrc.json
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-merge-fail/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-merge-fail/snap.txt
@@ -1,7 +1,5 @@
 > git init
 > vp migrate --no-interactive # should handle merge failure gracefully
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 ! Warnings:

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-not-support/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-not-support/snap.txt
@@ -1,7 +1,5 @@
 > git init
 > vp migrate --no-interactive # migration should not support non-json format lintstagedrc
-VITE+ - The Unified Toolchain for the Web
-
 
 ⚠ Unsupported lint-staged config format — skipping git hooks setup. Please configure git hooks manually.
 ◇ Migrated . to Vite+<repeat>

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-staged-exists/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-staged-exists/snap.txt
@@ -1,7 +1,5 @@
 > git init
 > vp migrate --no-interactive # should warn when staged already exists in vite.config.ts
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • Git hooks configured

--- a/packages/cli/snap-tests-global/migration-merge-vite-config-js/snap.txt
+++ b/packages/cli/snap-tests-global/migration-merge-vite-config-js/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should merge vite.config.js and remove oxlintrc
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied

--- a/packages/cli/snap-tests-global/migration-merge-vite-config-ts/snap.txt
+++ b/packages/cli/snap-tests-global/migration-merge-vite-config-ts/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should merge vite.config.ts and remove oxlintrc and oxfmtrc
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 3 config updates applied, 1 file had imports rewritten

--- a/packages/cli/snap-tests-global/migration-monorepo-bun/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-bun/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should work with bun object-form workspaces
-VITE+ - The Unified Toolchain for the Web
-
 
 ✔ Merged .oxlintrc.json into vite.config.ts
 ◇ Migrated . to Vite+<repeat>

--- a/packages/cli/snap-tests-global/migration-monorepo-husky-v8-preserves-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-husky-v8-preserves-lint-staged/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # should warn about husky v8, preserve all lint-staged config
-VITE+ - The Unified Toolchain for the Web
-
 
 ⚠ Detected husky <9.0.0 — please upgrade to husky v9+ first, then re-run migration.
 ◇ Migrated . to Vite+<repeat>

--- a/packages/cli/snap-tests-global/migration-monorepo-pnpm-overrides-dependency-selector/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-pnpm-overrides-dependency-selector/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should merge pnpm overrides with dependency selector
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 1 config update applied, 1 file had imports rewritten

--- a/packages/cli/snap-tests-global/migration-monorepo-pnpm/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-pnpm/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should merge vite.config.ts and remove oxlintrc and oxfmtrc
-VITE+ - The Unified Toolchain for the Web
-
 
 ✔ Merged .oxlintrc.json into vite.config.ts
 

--- a/packages/cli/snap-tests-global/migration-monorepo-skip-vite-peer-dependency/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-skip-vite-peer-dependency/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should check each package's peerDependencies
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied, 1 file had imports rewritten

--- a/packages/cli/snap-tests-global/migration-monorepo-yarn4/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-yarn4/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should merge vite.config.ts and remove oxlintrc
-VITE+ - The Unified Toolchain for the Web
-
 
 ✔ Merged .oxlintrc.json into vite.config.ts
 ◇ Migrated . to Vite+<repeat>

--- a/packages/cli/snap-tests-global/migration-no-agent/snap.txt
+++ b/packages/cli/snap-tests-global/migration-no-agent/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-agent --no-interactive # migration with --no-agent should skip agent instructions
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied

--- a/packages/cli/snap-tests-global/migration-no-git-repo/snap.txt
+++ b/packages/cli/snap-tests-global/migration-no-git-repo/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should create .vite-hooks/pre-commit even without .git
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied

--- a/packages/cli/snap-tests-global/migration-no-hooks-with-husky/snap.txt
+++ b/packages/cli/snap-tests-global/migration-no-hooks-with-husky/snap.txt
@@ -1,7 +1,5 @@
 > git init
 > vp migrate --no-hooks --no-interactive # --no-hooks should keep husky/lint-staged and preserve config
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 1 config update applied

--- a/packages/cli/snap-tests-global/migration-no-hooks/snap.txt
+++ b/packages/cli/snap-tests-global/migration-no-hooks/snap.txt
@@ -1,7 +1,5 @@
 > git init
 > vp migrate --no-hooks --no-interactive # migration with --no-hooks should skip hooks setup
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 1 config update applied

--- a/packages/cli/snap-tests-global/migration-not-supported-npm8.2/snap.txt
+++ b/packages/cli/snap-tests-global/migration-not-supported-npm8.2/snap.txt
@@ -1,6 +1,4 @@
 [1]> vp migrate --no-interactive # migration should fail because npm version is not supported
-VITE+ - The Unified Toolchain for the Web
-
 
 ✘ npm@<semver> is not supported by auto migration, please upgrade npm to >=8.3.0 first
 Vite+ cannot automatically migrate this project yet.

--- a/packages/cli/snap-tests-global/migration-not-supported-pnpm9.4/snap.txt
+++ b/packages/cli/snap-tests-global/migration-not-supported-pnpm9.4/snap.txt
@@ -1,6 +1,4 @@
 [1]> vp migrate --no-interactive # migration should fail because pnpm version is not supported
-VITE+ - The Unified Toolchain for the Web
-
 
 ✘ pnpm@<semver> is not supported by auto migration, please upgrade pnpm to >=9.5.0 first
 Vite+ cannot automatically migrate this project yet.

--- a/packages/cli/snap-tests-global/migration-not-supported-vite6/snap.txt
+++ b/packages/cli/snap-tests-global/migration-not-supported-vite6/snap.txt
@@ -1,7 +1,5 @@
 > vp install # install dependencies first
 [1]> vp migrate --no-interactive # migration should fail because vite version is not supported
-VITE+ - The Unified Toolchain for the Web
-
 
 ✘ vite@<semver> in package.json is not supported by auto migration
 

--- a/packages/cli/snap-tests-global/migration-not-supported-vitest3/snap.txt
+++ b/packages/cli/snap-tests-global/migration-not-supported-vitest3/snap.txt
@@ -1,7 +1,5 @@
 > vp install # install dependencies first
 [1]> vp migrate --no-interactive # migration should fail because vitest version is not supported
-VITE+ - The Unified Toolchain for the Web
-
 
 ✘ vitest@<semver> in package.json is not supported by auto migration
 

--- a/packages/cli/snap-tests-global/migration-nvmrc-lts/snap.txt
+++ b/packages/cli/snap-tests-global/migration-nvmrc-lts/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should detect .nvmrc with lts alias and auto-migrate
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied

--- a/packages/cli/snap-tests-global/migration-nvmrc-node-alias/snap.txt
+++ b/packages/cli/snap-tests-global/migration-nvmrc-node-alias/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # 'node' alias should be mapped to lts/* with an info message
-VITE+ - The Unified Toolchain for the Web
-
 
 "node" in .nvmrc is not a specific version; automatically mapping to "lts/*"
 ◇ Migrated . to Vite+<repeat>

--- a/packages/cli/snap-tests-global/migration-nvmrc/snap.txt
+++ b/packages/cli/snap-tests-global/migration-nvmrc/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should detect .nvmrc and auto-migrate to .node-version
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied

--- a/packages/cli/snap-tests-global/migration-other-hook-tool/snap.txt
+++ b/packages/cli/snap-tests-global/migration-other-hook-tool/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # hooks should be skipped due to simple-git-hooks
-VITE+ - The Unified Toolchain for the Web
-
 
 ⚠ Detected simple-git-hooks — skipping git hooks setup. Please configure git hooks manually.
 ◇ Migrated . to Vite+<repeat>

--- a/packages/cli/snap-tests-global/migration-oxlintrc-json-with-comments/snap.txt
+++ b/packages/cli/snap-tests-global/migration-oxlintrc-json-with-comments/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive 2>&1 # migration should handle .oxlintrc.json with JSONC comments
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 3 config updates applied

--- a/packages/cli/snap-tests-global/migration-oxlintrc-jsonc/snap.txt
+++ b/packages/cli/snap-tests-global/migration-oxlintrc-jsonc/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive 2>&1 # migration should detect .oxlintrc.jsonc and .oxfmtrc.jsonc
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 4 config updates applied

--- a/packages/cli/snap-tests-global/migration-partially-migrated-pre-commit/snap.txt
+++ b/packages/cli/snap-tests-global/migration-partially-migrated-pre-commit/snap.txt
@@ -1,7 +1,5 @@
 > git init
 > vp migrate --no-interactive # should warn about husky v8 and skip hooks setup
-VITE+ - The Unified Toolchain for the Web
-
 
 ⚠ Detected husky <9.0.0 — please upgrade to husky v9+ first, then re-run migration.
 ◇ Migrated . to Vite+<repeat>

--- a/packages/cli/snap-tests-global/migration-pre-commit-env-setup/snap.txt
+++ b/packages/cli/snap-tests-global/migration-pre-commit-env-setup/snap.txt
@@ -7,8 +7,6 @@ npx lint-staged
 npm test
 
 > vp migrate --no-interactive # migration should replace lint-staged in-place
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied

--- a/packages/cli/snap-tests-global/migration-prettier-eslint-combo/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier-eslint-combo/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should detect both eslint and prettier and auto-migrate
-VITE+ - The Unified Toolchain for the Web
-
 
 Prettier configuration detected. Auto-migrating to Oxfmt...
 ◇ Migrated . to Vite+<repeat>

--- a/packages/cli/snap-tests-global/migration-prettier-ignore-unknown/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier-ignore-unknown/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should strip --ignore-unknown and -u flags
-VITE+ - The Unified Toolchain for the Web
-
 
 Prettier configuration detected. Auto-migrating to Oxfmt...
 ◇ Migrated . to Vite+<repeat>

--- a/packages/cli/snap-tests-global/migration-prettier-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier-lint-staged/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should detect prettier and auto-migrate including lint-staged
-VITE+ - The Unified Toolchain for the Web
-
 
 Prettier configuration detected. Auto-migrating to Oxfmt...
 ◇ Migrated . to Vite+<repeat>

--- a/packages/cli/snap-tests-global/migration-prettier-pkg-json/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier-pkg-json/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should detect prettier in package.json and auto-migrate
-VITE+ - The Unified Toolchain for the Web
-
 
 Prettier configuration detected. Auto-migrating to Oxfmt...
 ◇ Migrated . to Vite+<repeat>

--- a/packages/cli/snap-tests-global/migration-prettier-rerun/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier-rerun/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # should detect vite-plus + prettier and auto-migrate prettier
-VITE+ - The Unified Toolchain for the Web
-
 
 Prettier configuration detected. Auto-migrating to Oxfmt...
 

--- a/packages/cli/snap-tests-global/migration-prettier/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should detect prettier and auto-migrate
-VITE+ - The Unified Toolchain for the Web
-
 
 Prettier configuration detected. Auto-migrating to Oxfmt...
 ◇ Migrated . to Vite+<repeat>

--- a/packages/cli/snap-tests-global/migration-rewrite-declare-module/snap.txt
+++ b/packages/cli/snap-tests-global/migration-rewrite-declare-module/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should rewrite imports to vite-plus
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied, 1 file had imports rewritten

--- a/packages/cli/snap-tests-global/migration-rewrite-reference-types/snap.txt
+++ b/packages/cli/snap-tests-global/migration-rewrite-reference-types/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration rewrites reference types
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied, 1 file had imports rewritten

--- a/packages/cli/snap-tests-global/migration-skip-vite-dependency/snap.txt
+++ b/packages/cli/snap-tests-global/migration-skip-vite-dependency/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should skip rewriting vite imports when vite is in dependencies
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied, 1 file had imports rewritten

--- a/packages/cli/snap-tests-global/migration-skip-vite-peer-dependency/snap.txt
+++ b/packages/cli/snap-tests-global/migration-skip-vite-peer-dependency/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should skip rewriting vite imports when vite is in peerDependencies
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied, 1 file had imports rewritten

--- a/packages/cli/snap-tests-global/migration-standalone-npm/snap.txt
+++ b/packages/cli/snap-tests-global/migration-standalone-npm/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive --no-hooks # migration should work with npm, add overrides, and update lockfile
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  npm <semver>
 ✓ Dependencies installed in <variable>ms

--- a/packages/cli/snap-tests-global/migration-standalone-pnpm/snap.txt
+++ b/packages/cli/snap-tests-global/migration-standalone-pnpm/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive --no-hooks --package-manager pnpm # migration should work with pnpm, write overrides and peerDependencyRules to pnpm-workspace.yaml
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 ✓ Dependencies installed in <variable>ms

--- a/packages/cli/snap-tests-global/migration-subpath/snap.txt
+++ b/packages/cli/snap-tests-global/migration-subpath/snap.txt
@@ -1,7 +1,5 @@
 > git init
 > vp migrate foo --no-interactive # migration work with subpath
-VITE+ - The Unified Toolchain for the Web
-
 
 ⚠ Subdirectory project detected — skipping git hooks setup. Configure hooks at the repository root.
 ◇ Migrated foo to Vite+<repeat>

--- a/packages/cli/snap-tests-global/migration-tsconfig-esmoduleinterop/snap.txt
+++ b/packages/cli/snap-tests-global/migration-tsconfig-esmoduleinterop/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # should remove esModuleInterop: false from tsconfig.json
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 4 config updates applied

--- a/packages/cli/snap-tests-global/migration-vite-version/snap.txt
+++ b/packages/cli/snap-tests-global/migration-vite-version/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should rewrite vite --version to vp --version
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied

--- a/packages/cli/snap-tests-global/migration-vitest-peer-dep/snap.txt
+++ b/packages/cli/snap-tests-global/migration-vitest-peer-dep/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # vitest should be added to devDeps when vitest-browser-svelte is present
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied

--- a/packages/cli/snap-tests-global/migration-volta-with-nvmrc/snap.txt
+++ b/packages/cli/snap-tests-global/migration-volta-with-nvmrc/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # .nvmrc should take priority over volta.node
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied

--- a/packages/cli/snap-tests-global/migration-volta/snap.txt
+++ b/packages/cli/snap-tests-global/migration-volta/snap.txt
@@ -1,6 +1,4 @@
 > vp migrate --no-interactive # migration should detect volta.node in package.json and migrate to .node-version
-VITE+ - The Unified Toolchain for the Web
-
 ◇ Migrated . to Vite+<repeat>
 • Node <semver>  pnpm <semver>
 • 2 config updates applied

--- a/packages/cli/snap-tests-global/new-check/snap.txt
+++ b/packages/cli/snap-tests-global/new-check/snap.txt
@@ -1,6 +1,4 @@
 > vp create --help # show help
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp create [TEMPLATE] [OPTIONS] [-- TEMPLATE_OPTIONS]
 
 Use any builtin, local or remote template with Vite+.
@@ -55,8 +53,6 @@ Documentation: https://viteplus.dev/guide/create
 
 
 > vp create --list # list templates
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp create --list
 
 List available builtin and popular project templates.

--- a/packages/cli/snap-tests-global/npm-global-install-already-linked/snap.txt
+++ b/packages/cli/snap-tests-global/npm-global-install-already-linked/snap.txt
@@ -2,8 +2,6 @@
 <cwd>/../npm-global-lib-for-snap-tests
 
 > vp install -g ./npm-global-linked-pkg # First install via vp (creates managed shim)
-VITE+ - The Unified Toolchain for the Web
-
 Installing ./npm-global-linked-pkg globally...
 Installed ./npm-global-linked-pkg v<semver>
 Binaries: npm-global-linked-cli

--- a/packages/cli/snap-tests-global/npm-global-uninstall-vp-managed/snap.txt
+++ b/packages/cli/snap-tests-global/npm-global-uninstall-vp-managed/snap.txt
@@ -1,6 +1,4 @@
 > vp install -g ./npm-global-vp-managed-pkg # Install via vp (creates managed shim)
-VITE+ - The Unified Toolchain for the Web
-
 Installing ./npm-global-vp-managed-pkg globally...
 Installed ./npm-global-vp-managed-pkg v<semver>
 Binaries: npm-global-vp-managed-cli

--- a/packages/cli/snap-tests-global/runtime-with-incompatible-env-node/snap.txt
+++ b/packages/cli/snap-tests-global/runtime-with-incompatible-env-node/snap.txt
@@ -1,7 +1,5 @@
 > vp env use 20.0.0
 [1]> vp exec node --version
-VITE+ - The Unified Toolchain for the Web
-
 error: Node.js <semver> is incompatible with Vite+ CLI.
 Required by Vite+: ^20.19.0 || >=22.12.0
 Resolved from: .session-node-version

--- a/packages/cli/snap-tests-global/runtime-with-incompatible-project-node/snap.txt
+++ b/packages/cli/snap-tests-global/runtime-with-incompatible-project-node/snap.txt
@@ -1,6 +1,4 @@
 [1]> vp check
-VITE+ - The Unified Toolchain for the Web
-
 error: Node.js <semver> is incompatible with Vite+ CLI.
 Required by Vite+: ^20.19.0 || >=22.12.0
 Resolved from: .node-version

--- a/packages/cli/snap-tests-global/shim-recursive-package-binary/snap.txt
+++ b/packages/cli/snap-tests-global/shim-recursive-package-binary/snap.txt
@@ -1,6 +1,4 @@
 > vp install -g ./recursive-cli-pkg # Install test package
-VITE+ - The Unified Toolchain for the Web
-
 Installing ./recursive-cli-pkg globally...
 Installed ./recursive-cli-pkg v<semver>
 Binaries: recursive-cli

--- a/packages/cli/snap-tests/cli-helper-message/snap.txt
+++ b/packages/cli/snap-tests/cli-helper-message/snap.txt
@@ -1,6 +1,4 @@
 > vp -h # show help message
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp <COMMAND>
 
 Core Commands:
@@ -25,8 +23,6 @@ Options:
   -h, --help  Print help
 
 > vp -V # show version
-VITE+ - The Unified Toolchain for the Web
-
 vp v<semver>
 
 Local vite-plus:

--- a/packages/cli/snap-tests/command-helper/snap.txt
+++ b/packages/cli/snap-tests/command-helper/snap.txt
@@ -1,6 +1,4 @@
 > vp -h # help message
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp <COMMAND>
 
 Core Commands:

--- a/packages/cli/snap-tests/command-version/snap.txt
+++ b/packages/cli/snap-tests/command-version/snap.txt
@@ -1,6 +1,4 @@
 > vp --version
-VITE+ - The Unified Toolchain for the Web
-
 vp v<semver>
 
 Local vite-plus:

--- a/packages/cli/snap-tests/command-vp-alias/snap.txt
+++ b/packages/cli/snap-tests/command-vp-alias/snap.txt
@@ -1,6 +1,4 @@
 > vp -h # vp should show help same as vite
-VITE+ - The Unified Toolchain for the Web
-
 Usage: vp <COMMAND>
 
 Core Commands:

--- a/packages/cli/src/config/bin.ts
+++ b/packages/cli/src/config/bin.ts
@@ -9,12 +9,11 @@ import { join } from 'node:path';
 
 import mri from 'mri';
 
-import { vitePlusHeader } from '../../binding/index.js';
 import { ensurePreCommitHook, hasStagedConfigInViteConfig } from '../migration/migrator.ts';
 import { updateExistingAgentInstructions } from '../utils/agent.ts';
 import { renderCliDoc } from '../utils/help.ts';
 import { defaultInteractive, promptGitHooks } from '../utils/prompts.ts';
-import { log } from '../utils/terminal.ts';
+import { log, printHeader } from '../utils/terminal.ts';
 import { install } from './hooks.ts';
 
 async function main() {
@@ -46,7 +45,7 @@ async function main() {
         },
       ],
     });
-    log(vitePlusHeader() + '\n');
+    printHeader();
     log(helpMessage);
     return;
   }

--- a/packages/cli/src/create/bin.ts
+++ b/packages/cli/src/create/bin.ts
@@ -32,7 +32,7 @@ import {
   runViteInstall,
   selectPackageManager,
 } from '../utils/prompts.ts';
-import { accent, muted, log, success } from '../utils/terminal.ts';
+import { accent, muted, log, printHeader, success } from '../utils/terminal.ts';
 import {
   detectWorkspace,
   updatePackageJsonWithDeps,
@@ -364,7 +364,7 @@ async function main() {
 
   // #region Handle help flag
   if (options.help) {
-    log(vitePlusHeader() + '\n');
+    printHeader();
     log(helpMessage);
     return;
   }
@@ -1005,7 +1005,7 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
 }
 
 async function showAvailableTemplates() {
-  log(vitePlusHeader() + '\n');
+  printHeader();
   log(listTemplatesMessage);
 }
 

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -5,7 +5,6 @@ import * as prompts from '@voidzero-dev/vite-plus-prompts';
 import mri from 'mri';
 import semver from 'semver';
 
-import { vitePlusHeader } from '../../binding/index.js';
 import {
   PackageManager,
   type WorkspaceInfo,
@@ -37,7 +36,7 @@ import {
   selectPackageManager,
   upgradeYarn,
 } from '../utils/prompts.ts';
-import { accent, log, muted } from '../utils/terminal.ts';
+import { accent, log, muted, printHeader } from '../utils/terminal.ts';
 import type { PackageDependencies } from '../utils/types.ts';
 import { detectWorkspace } from '../utils/workspace.ts';
 import {
@@ -910,12 +909,12 @@ async function main() {
   const { projectPath, options } = parseArgs();
 
   if (options.help) {
-    log(vitePlusHeader() + '\n');
+    printHeader();
     log(helpMessage);
     return;
   }
 
-  log(`${vitePlusHeader()}\n`);
+  printHeader();
 
   const workspaceInfoOptional = await detectWorkspace(projectPath);
   const resolvedPackageManager = workspaceInfoOptional.packageManager ?? 'unknown';

--- a/packages/cli/src/staged/bin.ts
+++ b/packages/cli/src/staged/bin.ts
@@ -13,10 +13,9 @@ import lintStaged from 'lint-staged';
 import type { Options } from 'lint-staged';
 import mri from 'mri';
 
-import { vitePlusHeader } from '../../binding/index.js';
 import { resolveViteConfig } from '../resolve-vite-config.ts';
 import { renderCliDoc } from '../utils/help.ts';
-import { errorMsg, log } from '../utils/terminal.ts';
+import { errorMsg, log, printHeader } from '../utils/terminal.ts';
 
 const args = mri(process.argv.slice(3), {
   alias: {
@@ -97,7 +96,7 @@ if (args.help) {
       },
     ],
   });
-  log(vitePlusHeader() + '\n');
+  printHeader();
   log(helpMessage);
 } else {
   const options: Options = {};
@@ -152,7 +151,7 @@ if (args.help) {
   if (stagedConfig) {
     options.config = stagedConfig;
   } else {
-    log(vitePlusHeader() + '\n');
+    printHeader();
     errorMsg('No "staged" config found in vite.config.ts. Please add a staged config:');
     log('');
     log('  // vite.config.ts');

--- a/packages/cli/src/utils/terminal.ts
+++ b/packages/cli/src/utils/terminal.ts
@@ -1,6 +1,6 @@
 import { styleText } from 'node:util';
 
-import { vitePlusHeader } from '../../binding/index.js';
+import { shouldPrintVitePlusHeader, vitePlusHeader } from '../../binding/index.js';
 
 export function log(message: string) {
   /* oxlint-disable-next-line no-console */
@@ -9,19 +9,11 @@ export function log(message: string) {
 
 /**
  * Emit the Vite+ banner (header line + trailing blank line) to stdout.
- *
- * Silent when:
- * - stdout is piped or redirected (lefthook/husky, `execSync`, CI, pagers) —
- *   the banner's ANSI styling renders inconsistently there.
- * - a git commit-flow hook is running. Direct shell hooks inherit the
- *   terminal for stdout, so the TTY check alone doesn't catch them; git
- *   sets `GIT_INDEX_FILE` for pre-commit / commit-msg / prepare-commit-msg.
+ * Gating (non-TTY, git hooks) lives in `shouldPrintVitePlusHeader` on the
+ * Rust side so both CLIs stay in sync.
  */
 export function printHeader() {
-  if (!process.stdout.isTTY) {
-    return;
-  }
-  if (process.env.GIT_INDEX_FILE) {
+  if (!shouldPrintVitePlusHeader()) {
     return;
   }
   log(vitePlusHeader());

--- a/packages/cli/src/utils/terminal.ts
+++ b/packages/cli/src/utils/terminal.ts
@@ -1,8 +1,31 @@
 import { styleText } from 'node:util';
 
+import { vitePlusHeader } from '../../binding/index.js';
+
 export function log(message: string) {
   /* oxlint-disable-next-line no-console */
   console.log(message);
+}
+
+/**
+ * Emit the Vite+ banner (header line + trailing blank line) to stdout.
+ *
+ * Silent when:
+ * - stdout is piped or redirected (lefthook/husky, `execSync`, CI, pagers) —
+ *   the banner's ANSI styling renders inconsistently there.
+ * - a git commit-flow hook is running. Direct shell hooks inherit the
+ *   terminal for stdout, so the TTY check alone doesn't catch them; git
+ *   sets `GIT_INDEX_FILE` for pre-commit / commit-msg / prepare-commit-msg.
+ */
+export function printHeader() {
+  if (!process.stdout.isTTY) {
+    return;
+  }
+  if (process.env.GIT_INDEX_FILE) {
+    return;
+  }
+  log(vitePlusHeader());
+  log('');
 }
 
 export function accent(text: string) {

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,12 +1,11 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { vitePlusHeader } from '../binding/index.js';
 import cliPkg from '../package.json' with { type: 'json' };
 import { VITE_PLUS_NAME } from './utils/constants.ts';
 import { renderCliDoc } from './utils/help.ts';
 import { detectPackageMetadata, hasVitePlusDependency } from './utils/package.ts';
-import { accent, log } from './utils/terminal.ts';
+import { accent, log, printHeader } from './utils/terminal.ts';
 
 /** Tool display names in the order shown by `vp --version`. */
 const TOOL_DISPLAY_ORDER = [
@@ -87,8 +86,7 @@ export async function printVersion(cwd: string) {
   const localVersion = localMetadata?.version ?? null;
   const vpVersion = globalVersion ?? cliVersion ?? localVersion ?? 'unknown';
 
-  log(vitePlusHeader());
-  log('');
+  printHeader();
   log(`vp v${vpVersion}\n`);
 
   const sections = [


### PR DESCRIPTION
The banner was printing from every `vp` invocation, cluttering captured
output (lefthook/husky, `execSync`, CI pipes, pagers) and the git commit
flow when a shell pre-commit hook runs `vp check --fix` — in the hook
the colour detection is unreliable, so the banner also rendered in a
degraded style.

Banner emission now gates on two signals at every call site:

- `stdout.is_terminal()` — catches piped/redirected contexts.
- `GIT_INDEX_FILE` env var — catches direct shell hooks that inherit
  the terminal for stdout. Git sets this for pre-commit, commit-msg,
  and prepare-commit-msg, which is where `vp check --fix` typically
  runs.

Centralised behind `vite_shared::header::print_header()` on the Rust
side and a new `printHeader()` helper in `packages/cli/src/utils/
terminal.ts` on the Node CLI side. The interactive `prompts.intro()` in
`vp create` and the interactive top-level command picker are left
alone — they only run when genuinely interactive.

Snap fixtures regenerated to reflect the removed banner lines.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily changes CLI stdout formatting, which may affect scripts/tests that assert exact output; the gating relies on TTY detection and `GIT_INDEX_FILE`, so edge environments could suppress (or unexpectedly show) the banner.
> 
> **Overview**
> Prevents the Vite+ banner from being emitted in non-interactive contexts by introducing `vite_shared::header::should_print_header()` (TTY + `GIT_INDEX_FILE` gating) and a centralized `print_header()` helper.
> 
> Updates the Rust global CLI to call `print_header()` (and to omit the header in clap help templates unless `should_print_header()` passes), and updates the Node CLI to use a new `printHeader()` helper that delegates the same gating via a newly-exposed N-API binding `shouldPrintVitePlusHeader()`.
> 
> Regenerates CLI snapshot fixtures to reflect the banner being absent in captured/help/test outputs where it’s now suppressed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 918c3db340b99b10f8443eecefe6d729accdd464. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->