### PR TITLE
fix(install): use managed npm for global commands

### DIFF
--- a/crates/vite_command/src/lib.rs
+++ b/crates/vite_command/src/lib.rs
@@ -3,7 +3,6 @@ use std::os::fd::{BorrowedFd, RawFd};
 use std::{
     collections::HashMap,
     ffi::OsStr,
-    path::Path,
     process::{ExitStatus, Stdio},
 };
 
@@ -31,15 +30,6 @@ pub fn resolve_bin(
     path_env: Option<&OsStr>,
     cwd: impl AsRef<AbsolutePath>,
 ) -> Result<AbsolutePathBuf, Error> {
-    let candidate = Path::new(bin_name);
-    if candidate.is_absolute() {
-        if candidate.exists() {
-            return AbsolutePathBuf::new(candidate.to_path_buf())
-                .ok_or_else(|| Error::CannotFindBinaryPath(bin_name.into()));
-        }
-        return Err(Error::CannotFindBinaryPath(bin_name.into()));
-    }
-
     let current_path;
     let path_env = match path_env {
         Some(p) => p,
@@ -369,6 +359,33 @@ mod tests {
             let envs = HashMap::new();
             let result = run_command(&bin_path, &args, &envs, &temp_dir_path).await;
             assert!(result.is_ok(), "Should run absolute binary path, but got error: {:?}", result);
+        }
+
+        #[cfg(unix)]
+        #[tokio::test]
+        async fn test_run_command_rejects_non_executable_absolute_binary_path() {
+            let temp_dir = create_temp_dir();
+            let temp_dir_path =
+                AbsolutePathBuf::new(temp_dir.path().canonicalize().unwrap().to_path_buf())
+                    .unwrap();
+            let script_path = temp_dir_path.join("test-bin");
+            std::fs::write(&script_path, "#!/bin/sh\nexit 0\n").unwrap();
+            let envs = HashMap::new();
+            let result = run_command(
+                &script_path.as_path().display().to_string(),
+                &[] as &[&str],
+                &envs,
+                &temp_dir_path,
+            )
+            .await;
+            assert!(result.is_err(), "Should reject non-executable absolute binary path");
+            assert_eq!(
+                result.unwrap_err().to_string(),
+                format!(
+                    "Cannot find binary path for command '{}'",
+                    script_path.as_path().display()
+                )
+            );
         }
 
         #[tokio::test]

--- a/crates/vite_command/src/lib.rs
+++ b/crates/vite_command/src/lib.rs
@@ -340,14 +340,12 @@ mod tests {
 
             #[cfg(unix)]
             let (bin_path, args) = {
-                use std::os::unix::fs::PermissionsExt;
-
-                let script_path = temp_dir_path.join("test-bin");
-                std::fs::write(&script_path, "#!/bin/sh\nexit 0\n").unwrap();
-                let mut permissions = std::fs::metadata(&script_path).unwrap().permissions();
-                permissions.set_mode(0o755);
-                std::fs::set_permissions(&script_path, permissions).unwrap();
-                (script_path.as_path().display().to_string(), Vec::<&str>::new())
+                let true_path = if std::path::Path::new("/bin/true").exists() {
+                    "/bin/true"
+                } else {
+                    "/usr/bin/true"
+                };
+                (true_path.to_string(), Vec::<&str>::new())
             };
 
             #[cfg(not(unix))]

--- a/crates/vite_command/src/lib.rs
+++ b/crates/vite_command/src/lib.rs
@@ -3,6 +3,7 @@ use std::os::fd::{BorrowedFd, RawFd};
 use std::{
     collections::HashMap,
     ffi::OsStr,
+    path::Path,
     process::{ExitStatus, Stdio},
 };
 
@@ -30,6 +31,15 @@ pub fn resolve_bin(
     path_env: Option<&OsStr>,
     cwd: impl AsRef<AbsolutePath>,
 ) -> Result<AbsolutePathBuf, Error> {
+    let candidate = Path::new(bin_name);
+    if candidate.is_absolute() {
+        if candidate.exists() {
+            return AbsolutePathBuf::new(candidate.to_path_buf())
+                .ok_or_else(|| Error::CannotFindBinaryPath(bin_name.into()));
+        }
+        return Err(Error::CannotFindBinaryPath(bin_name.into()));
+    }
+
     let current_path;
     let path_env = match path_env {
         Some(p) => p,
@@ -329,6 +339,36 @@ mod tests {
             )]);
             let result = run_command("npm", &["--version"], &envs, &temp_dir_path).await;
             assert!(result.is_ok(), "Should run command successfully, but got error: {:?}", result);
+        }
+
+        #[tokio::test]
+        async fn test_run_command_with_absolute_binary_path() {
+            let temp_dir = create_temp_dir();
+            let temp_dir_path =
+                AbsolutePathBuf::new(temp_dir.path().canonicalize().unwrap().to_path_buf())
+                    .unwrap();
+
+            #[cfg(unix)]
+            let (bin_path, args) = {
+                use std::os::unix::fs::PermissionsExt;
+
+                let script_path = temp_dir_path.join("test-bin");
+                std::fs::write(&script_path, "#!/bin/sh\nexit 0\n").unwrap();
+                let mut permissions = std::fs::metadata(&script_path).unwrap().permissions();
+                permissions.set_mode(0o755);
+                std::fs::set_permissions(&script_path, permissions).unwrap();
+                (script_path.as_path().display().to_string(), Vec::<&str>::new())
+            };
+
+            #[cfg(not(unix))]
+            let (bin_path, args) = {
+                let current_exe = std::env::current_exe().unwrap();
+                (current_exe.to_string_lossy().to_string(), vec!["--help"])
+            };
+
+            let envs = HashMap::new();
+            let result = run_command(&bin_path, &args, &envs, &temp_dir_path).await;
+            assert!(result.is_ok(), "Should run absolute binary path, but got error: {:?}", result);
         }
 
         #[tokio::test]

--- a/crates/vite_global_cli/src/commands/add.rs
+++ b/crates/vite_global_cli/src/commands/add.rs
@@ -6,7 +6,7 @@ use vite_install::{
 };
 use vite_path::AbsolutePathBuf;
 
-use super::prepend_js_runtime_to_path_env;
+use super::{managed_npm_bin_for_global_command, prepend_js_runtime_to_path_env};
 use crate::error::Error;
 
 /// Add command for adding packages to dependencies.
@@ -35,7 +35,7 @@ impl AddCommand {
         allow_build: Option<&str>,
         pass_through_args: Option<&[String]>,
     ) -> Result<ExitStatus, Error> {
-        prepend_js_runtime_to_path_env(&self.cwd).await?;
+        let node_bin_prefix = prepend_js_runtime_to_path_env(&self.cwd).await?;
         super::ensure_package_json(&self.cwd).await?;
 
         let add_command_options = AddCommandOptions {
@@ -53,8 +53,15 @@ impl AddCommand {
 
         // Detect package manager
         let package_manager = PackageManager::builder(&self.cwd).build_with_default().await?;
+        let global_npm_bin_path = managed_npm_bin_for_global_command(global, &node_bin_prefix);
 
-        Ok(package_manager.run_add_command(&add_command_options, &self.cwd).await?)
+        Ok(package_manager
+            .run_add_command_with_global_npm_bin(
+                &add_command_options,
+                &self.cwd,
+                global_npm_bin_path.as_deref(),
+            )
+            .await?)
     }
 }
 

--- a/crates/vite_global_cli/src/commands/mod.rs
+++ b/crates/vite_global_cli/src/commands/mod.rs
@@ -120,12 +120,21 @@ pub(crate) fn managed_npm_bin_for_global_command(
     }
 
     let npm_bin = npm_bin_path_from_node_bin_prefix(node_bin_prefix);
-    vite_command::resolve_bin(
+    match vite_command::resolve_bin(
         npm_bin.as_path().as_os_str().to_string_lossy().as_ref(),
         None,
         node_bin_prefix,
-    )
-    .ok()
+    ) {
+        Ok(npm_bin) => Some(npm_bin),
+        Err(error) => {
+            tracing::debug!(
+                npm_bin = ?npm_bin,
+                ?error,
+                "Falling back to npm from PATH for global command"
+            );
+            None
+        }
+    }
 }
 
 /// Build a PackageManager, converting PackageJsonNotFound into a friendly error message.

--- a/crates/vite_global_cli/src/commands/mod.rs
+++ b/crates/vite_global_cli/src/commands/mod.rs
@@ -25,8 +25,10 @@
 
 use std::{collections::HashMap, io::BufReader};
 
-use vite_install::package_manager::{PackageManager, PackageManagerType};
-use vite_path::AbsolutePath;
+use vite_install::package_manager::{
+    PackageManager, PackageManagerType, npm_bin_path_from_node_bin_prefix,
+};
+use vite_path::{AbsolutePath, AbsolutePathBuf};
 use vite_shared::{PrependOptions, prepend_to_path_env};
 
 use crate::{error::Error, js_executor::JsExecutor};
@@ -86,7 +88,9 @@ pub async fn ensure_package_json(project_path: &AbsolutePath) -> Result<(), Erro
 ///
 /// If `project_path` contains a package.json, uses the project's runtime
 /// (based on devEngines.runtime). Otherwise, falls back to the CLI's runtime.
-pub async fn prepend_js_runtime_to_path_env(project_path: &AbsolutePath) -> Result<(), Error> {
+pub async fn prepend_js_runtime_to_path_env(
+    project_path: &AbsolutePath,
+) -> Result<AbsolutePathBuf, Error> {
     let mut executor = JsExecutor::new(None);
 
     // Use project runtime if package.json exists, otherwise use CLI runtime
@@ -104,7 +108,14 @@ pub async fn prepend_js_runtime_to_path_env(project_path: &AbsolutePath) -> Resu
         tracing::debug!("Set PATH to include {:?}", node_bin_prefix);
     }
 
-    Ok(())
+    Ok(node_bin_prefix)
+}
+
+pub(crate) fn managed_npm_bin_for_global_command(
+    global: bool,
+    node_bin_prefix: &AbsolutePath,
+) -> Option<AbsolutePathBuf> {
+    global.then(|| npm_bin_path_from_node_bin_prefix(node_bin_prefix))
 }
 
 /// Build a PackageManager, converting PackageJsonNotFound into a friendly error message.
@@ -200,6 +211,19 @@ mod tests {
     use vite_path::AbsolutePathBuf;
 
     use super::*;
+
+    #[test]
+    fn test_managed_npm_bin_for_global_command_only_when_global() {
+        let node_bin_prefix = if cfg!(windows) {
+            AbsolutePathBuf::new("C:\\node".into()).unwrap()
+        } else {
+            AbsolutePathBuf::new("/node/bin".into()).unwrap()
+        };
+        let npm_bin = managed_npm_bin_for_global_command(true, &node_bin_prefix).unwrap();
+        let expected = npm_bin_path_from_node_bin_prefix(&node_bin_prefix);
+        assert_eq!(npm_bin, expected);
+        assert!(managed_npm_bin_for_global_command(false, &node_bin_prefix).is_none());
+    }
 
     #[test]
     fn test_has_vite_plus_in_dev_dependencies() {

--- a/crates/vite_global_cli/src/commands/mod.rs
+++ b/crates/vite_global_cli/src/commands/mod.rs
@@ -120,7 +120,12 @@ pub(crate) fn managed_npm_bin_for_global_command(
     }
 
     let npm_bin = npm_bin_path_from_node_bin_prefix(node_bin_prefix);
-    npm_bin.as_path().exists().then_some(npm_bin)
+    vite_command::resolve_bin(
+        npm_bin.as_path().as_os_str().to_string_lossy().as_ref(),
+        None,
+        node_bin_prefix,
+    )
+    .ok()
 }
 
 /// Build a PackageManager, converting PackageJsonNotFound into a friendly error message.
@@ -218,15 +223,33 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_managed_npm_bin_for_global_command_uses_existing_adjacent_npm() {
+    fn test_managed_npm_bin_for_global_command_uses_executable_adjacent_npm() {
         let temp_dir = tempfile::tempdir().unwrap();
         let node_bin_prefix = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
         let expected = npm_bin_path_from_node_bin_prefix(&node_bin_prefix);
         std::fs::write(&expected, "").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = std::fs::metadata(&expected).unwrap().permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&expected, permissions).unwrap();
+        }
 
         let npm_bin = managed_npm_bin_for_global_command(true, &node_bin_prefix).unwrap();
         assert_eq!(npm_bin, expected);
         assert!(managed_npm_bin_for_global_command(false, &node_bin_prefix).is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_managed_npm_bin_for_global_command_falls_back_when_adjacent_npm_is_not_executable() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let node_bin_prefix = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        let npm_bin = npm_bin_path_from_node_bin_prefix(&node_bin_prefix);
+        std::fs::write(&npm_bin, "").unwrap();
+
+        assert!(managed_npm_bin_for_global_command(true, &node_bin_prefix).is_none());
     }
 
     #[test]

--- a/crates/vite_global_cli/src/commands/mod.rs
+++ b/crates/vite_global_cli/src/commands/mod.rs
@@ -115,7 +115,12 @@ pub(crate) fn managed_npm_bin_for_global_command(
     global: bool,
     node_bin_prefix: &AbsolutePath,
 ) -> Option<AbsolutePathBuf> {
-    global.then(|| npm_bin_path_from_node_bin_prefix(node_bin_prefix))
+    if !global {
+        return None;
+    }
+
+    let npm_bin = npm_bin_path_from_node_bin_prefix(node_bin_prefix);
+    npm_bin.as_path().exists().then_some(npm_bin)
 }
 
 /// Build a PackageManager, converting PackageJsonNotFound into a friendly error message.
@@ -213,16 +218,22 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_managed_npm_bin_for_global_command_only_when_global() {
-        let node_bin_prefix = if cfg!(windows) {
-            AbsolutePathBuf::new("C:\\node".into()).unwrap()
-        } else {
-            AbsolutePathBuf::new("/node/bin".into()).unwrap()
-        };
-        let npm_bin = managed_npm_bin_for_global_command(true, &node_bin_prefix).unwrap();
+    fn test_managed_npm_bin_for_global_command_uses_existing_adjacent_npm() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let node_bin_prefix = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
         let expected = npm_bin_path_from_node_bin_prefix(&node_bin_prefix);
+        std::fs::write(&expected, "").unwrap();
+
+        let npm_bin = managed_npm_bin_for_global_command(true, &node_bin_prefix).unwrap();
         assert_eq!(npm_bin, expected);
         assert!(managed_npm_bin_for_global_command(false, &node_bin_prefix).is_none());
+    }
+
+    #[test]
+    fn test_managed_npm_bin_for_global_command_falls_back_when_adjacent_npm_is_missing() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let node_bin_prefix = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        assert!(managed_npm_bin_for_global_command(true, &node_bin_prefix).is_none());
     }
 
     #[test]

--- a/crates/vite_global_cli/src/commands/outdated.rs
+++ b/crates/vite_global_cli/src/commands/outdated.rs
@@ -3,7 +3,9 @@ use std::process::ExitStatus;
 use vite_install::commands::outdated::{Format, OutdatedCommandOptions};
 use vite_path::AbsolutePathBuf;
 
-use super::{build_package_manager, prepend_js_runtime_to_path_env};
+use super::{
+    build_package_manager, managed_npm_bin_for_global_command, prepend_js_runtime_to_path_env,
+};
 use crate::error::Error;
 
 /// Outdated command for checking outdated packages.
@@ -36,7 +38,7 @@ impl OutdatedCommand {
         global: bool,
         pass_through_args: Option<&[String]>,
     ) -> Result<ExitStatus, Error> {
-        prepend_js_runtime_to_path_env(&self.cwd).await?;
+        let node_bin_prefix = prepend_js_runtime_to_path_env(&self.cwd).await?;
 
         let package_manager = build_package_manager(&self.cwd).await?;
 
@@ -55,7 +57,14 @@ impl OutdatedCommand {
             global,
             pass_through_args,
         };
-        Ok(package_manager.run_outdated_command(&outdated_command_options, &self.cwd).await?)
+        let global_npm_bin_path = managed_npm_bin_for_global_command(global, &node_bin_prefix);
+        Ok(package_manager
+            .run_outdated_command_with_global_npm_bin(
+                &outdated_command_options,
+                &self.cwd,
+                global_npm_bin_path.as_deref(),
+            )
+            .await?)
     }
 }
 

--- a/crates/vite_global_cli/src/commands/remove.rs
+++ b/crates/vite_global_cli/src/commands/remove.rs
@@ -3,7 +3,9 @@ use std::process::ExitStatus;
 use vite_install::commands::remove::RemoveCommandOptions;
 use vite_path::AbsolutePathBuf;
 
-use super::{build_package_manager, prepend_js_runtime_to_path_env};
+use super::{
+    build_package_manager, managed_npm_bin_for_global_command, prepend_js_runtime_to_path_env,
+};
 use crate::error::Error;
 
 /// Remove command for removing packages from dependencies.
@@ -31,7 +33,7 @@ impl RemoveCommand {
         global: bool,
         pass_through_args: Option<&[String]>,
     ) -> Result<ExitStatus, Error> {
-        prepend_js_runtime_to_path_env(&self.cwd).await?;
+        let node_bin_prefix = prepend_js_runtime_to_path_env(&self.cwd).await?;
 
         let package_manager = build_package_manager(&self.cwd).await?;
 
@@ -46,7 +48,14 @@ impl RemoveCommand {
             save_prod,
             pass_through_args,
         };
-        Ok(package_manager.run_remove_command(&remove_command_options, &self.cwd).await?)
+        let global_npm_bin_path = managed_npm_bin_for_global_command(global, &node_bin_prefix);
+        Ok(package_manager
+            .run_remove_command_with_global_npm_bin(
+                &remove_command_options,
+                &self.cwd,
+                global_npm_bin_path.as_deref(),
+            )
+            .await?)
     }
 }
 

--- a/crates/vite_global_cli/src/commands/update.rs
+++ b/crates/vite_global_cli/src/commands/update.rs
@@ -3,7 +3,9 @@ use std::process::ExitStatus;
 use vite_install::commands::update::UpdateCommandOptions;
 use vite_path::AbsolutePathBuf;
 
-use super::{build_package_manager, prepend_js_runtime_to_path_env};
+use super::{
+    build_package_manager, managed_npm_bin_for_global_command, prepend_js_runtime_to_path_env,
+};
 use crate::error::Error;
 
 /// Update command for updating packages to their latest versions.
@@ -36,7 +38,7 @@ impl UpdateCommand {
         workspace_only: bool,
         pass_through_args: Option<&[String]>,
     ) -> Result<ExitStatus, Error> {
-        prepend_js_runtime_to_path_env(&self.cwd).await?;
+        let node_bin_prefix = prepend_js_runtime_to_path_env(&self.cwd).await?;
 
         let package_manager = build_package_manager(&self.cwd).await?;
 
@@ -55,7 +57,14 @@ impl UpdateCommand {
             workspace_only,
             pass_through_args,
         };
-        Ok(package_manager.run_update_command(&update_command_options, &self.cwd).await?)
+        let global_npm_bin_path = managed_npm_bin_for_global_command(global, &node_bin_prefix);
+        Ok(package_manager
+            .run_update_command_with_global_npm_bin(
+                &update_command_options,
+                &self.cwd,
+                global_npm_bin_path.as_deref(),
+            )
+            .await?)
     }
 }
 

--- a/crates/vite_install/src/commands/add.rs
+++ b/crates/vite_install/src/commands/add.rs
@@ -7,6 +7,7 @@ use vite_shared::output;
 
 use crate::package_manager::{
     PackageManager, PackageManagerType, ResolveCommandResult, format_path_env,
+    resolve_global_npm_bin_path,
 };
 
 /// The type of dependency to save.
@@ -46,7 +47,22 @@ impl PackageManager {
         options: &AddCommandOptions<'_>,
         cwd: impl AsRef<AbsolutePath>,
     ) -> Result<ExitStatus, Error> {
-        let resolve_command = self.resolve_add_command(options);
+        let resolve_command = self.resolve_add_command_with_global_npm_bin(options, None);
+        run_command(&resolve_command.bin_path, &resolve_command.args, &resolve_command.envs, cwd)
+            .await
+    }
+
+    /// Run the add command with an explicit npm binary for global installs.
+    /// Return the exit status of the command.
+    #[must_use]
+    pub async fn run_add_command_with_global_npm_bin(
+        &self,
+        options: &AddCommandOptions<'_>,
+        cwd: impl AsRef<AbsolutePath>,
+        global_npm_bin_path: Option<&AbsolutePath>,
+    ) -> Result<ExitStatus, Error> {
+        let resolve_command =
+            self.resolve_add_command_with_global_npm_bin(options, global_npm_bin_path);
         run_command(&resolve_command.bin_path, &resolve_command.args, &resolve_command.envs, cwd)
             .await
     }
@@ -54,13 +70,23 @@ impl PackageManager {
     /// Resolve the add command.
     #[must_use]
     pub fn resolve_add_command(&self, options: &AddCommandOptions) -> ResolveCommandResult {
+        self.resolve_add_command_with_global_npm_bin(options, None)
+    }
+
+    /// Resolve the add command with an explicit npm binary for global installs.
+    #[must_use]
+    pub fn resolve_add_command_with_global_npm_bin(
+        &self,
+        options: &AddCommandOptions,
+        global_npm_bin_path: Option<&AbsolutePath>,
+    ) -> ResolveCommandResult {
         let bin_name: String;
         let envs = HashMap::from([("PATH".to_string(), format_path_env(self.get_bin_prefix()))]);
         let mut args: Vec<String> = Vec::new();
 
         // global packages should use npm cli only
         if options.global {
-            bin_name = "npm".into();
+            bin_name = resolve_global_npm_bin_path(global_npm_bin_path);
             args.push("install".into());
             args.push("--global".into());
             if let Some(pass_through_args) = options.pass_through_args {
@@ -599,5 +625,25 @@ mod tests {
         });
         assert_eq!(result.args, vec!["add", "--allow-build=react,napi", "react"]);
         assert_eq!(result.bin_path, "pnpm");
+    }
+
+    #[test]
+    fn test_global_add_uses_explicit_npm_bin() {
+        let pm = create_mock_package_manager(PackageManagerType::Pnpm);
+        let npm_bin = if cfg!(windows) {
+            AbsolutePathBuf::new("C:\\node\\npm.cmd".into()).unwrap()
+        } else {
+            AbsolutePathBuf::new("/node/bin/npm".into()).unwrap()
+        };
+        let result = pm.resolve_add_command_with_global_npm_bin(
+            &AddCommandOptions {
+                packages: &["typescript".to_string()],
+                global: true,
+                ..Default::default()
+            },
+            Some(&npm_bin),
+        );
+        assert_eq!(result.args, vec!["install", "--global", "typescript"]);
+        assert_eq!(result.bin_path, npm_bin.as_path().display().to_string());
     }
 }

--- a/crates/vite_install/src/commands/list.rs
+++ b/crates/vite_install/src/commands/list.rs
@@ -7,7 +7,6 @@ use vite_shared::output;
 
 use crate::package_manager::{
     PackageManager, PackageManagerType, ResolveCommandResult, format_path_env,
-    resolve_global_npm_bin_path,
 };
 
 /// Options for the list command.
@@ -39,27 +38,8 @@ impl PackageManager {
         options: &ListCommandOptions<'_>,
         cwd: impl AsRef<AbsolutePath>,
     ) -> Result<ExitStatus, Error> {
-        let Some(resolve_command) = self.resolve_list_command_with_global_npm_bin(options, None)
-        else {
+        let Some(resolve_command) = self.resolve_list_command(options) else {
             // Command not supported, return success
-            return Ok(ExitStatus::default());
-        };
-        run_command(&resolve_command.bin_path, &resolve_command.args, &resolve_command.envs, cwd)
-            .await
-    }
-
-    /// Run the list command with an explicit npm binary for global lists.
-    /// Returns ExitStatus with success (0) if the command is not supported.
-    #[must_use]
-    pub async fn run_list_command_with_global_npm_bin(
-        &self,
-        options: &ListCommandOptions<'_>,
-        cwd: impl AsRef<AbsolutePath>,
-        global_npm_bin_path: Option<&AbsolutePath>,
-    ) -> Result<ExitStatus, Error> {
-        let Some(resolve_command) =
-            self.resolve_list_command_with_global_npm_bin(options, global_npm_bin_path)
-        else {
             return Ok(ExitStatus::default());
         };
         run_command(&resolve_command.bin_path, &resolve_command.args, &resolve_command.envs, cwd)
@@ -73,17 +53,6 @@ impl PackageManager {
         &self,
         options: &ListCommandOptions,
     ) -> Option<ResolveCommandResult> {
-        self.resolve_list_command_with_global_npm_bin(options, None)
-    }
-
-    /// Resolve the list command with an explicit npm binary for global lists.
-    /// Returns None if the command is not supported by the package manager.
-    #[must_use]
-    pub fn resolve_list_command_with_global_npm_bin(
-        &self,
-        options: &ListCommandOptions,
-        global_npm_bin_path: Option<&AbsolutePath>,
-    ) -> Option<ResolveCommandResult> {
         // yarn@2+ does not support list command
         if self.client == PackageManagerType::Yarn && !self.version.starts_with("1.") {
             output::warn("yarn@2+ does not support 'list' command");
@@ -96,7 +65,7 @@ impl PackageManager {
         // Global packages should use npm cli only (since global installs use npm)
         let bin_name: String;
         if options.global {
-            bin_name = resolve_global_npm_bin_path(global_npm_bin_path);
+            bin_name = "npm".into();
             Self::format_npm_list_args(&mut args, options);
             args.push("-g".into());
 
@@ -509,24 +478,6 @@ mod tests {
         let result = result.unwrap();
         assert_eq!(result.bin_path, "npm");
         assert_eq!(result.args, vec!["list", "--depth", "0", "-g"]);
-    }
-
-    #[test]
-    fn test_global_list_uses_explicit_npm_bin() {
-        let pm = create_mock_package_manager(PackageManagerType::Pnpm, "10.0.0");
-        let npm_bin = if cfg!(windows) {
-            AbsolutePathBuf::new("C:\\node\\npm.cmd".into()).unwrap()
-        } else {
-            AbsolutePathBuf::new("/node/bin/npm".into()).unwrap()
-        };
-        let result = pm
-            .resolve_list_command_with_global_npm_bin(
-                &ListCommandOptions { global: true, ..Default::default() },
-                Some(&npm_bin),
-            )
-            .unwrap();
-        assert_eq!(result.bin_path, npm_bin.as_path().display().to_string());
-        assert_eq!(result.args, vec!["list", "-g"]);
     }
 
     #[test]

--- a/crates/vite_install/src/commands/list.rs
+++ b/crates/vite_install/src/commands/list.rs
@@ -7,6 +7,7 @@ use vite_shared::output;
 
 use crate::package_manager::{
     PackageManager, PackageManagerType, ResolveCommandResult, format_path_env,
+    resolve_global_npm_bin_path,
 };
 
 /// Options for the list command.
@@ -38,8 +39,27 @@ impl PackageManager {
         options: &ListCommandOptions<'_>,
         cwd: impl AsRef<AbsolutePath>,
     ) -> Result<ExitStatus, Error> {
-        let Some(resolve_command) = self.resolve_list_command(options) else {
+        let Some(resolve_command) = self.resolve_list_command_with_global_npm_bin(options, None)
+        else {
             // Command not supported, return success
+            return Ok(ExitStatus::default());
+        };
+        run_command(&resolve_command.bin_path, &resolve_command.args, &resolve_command.envs, cwd)
+            .await
+    }
+
+    /// Run the list command with an explicit npm binary for global lists.
+    /// Returns ExitStatus with success (0) if the command is not supported.
+    #[must_use]
+    pub async fn run_list_command_with_global_npm_bin(
+        &self,
+        options: &ListCommandOptions<'_>,
+        cwd: impl AsRef<AbsolutePath>,
+        global_npm_bin_path: Option<&AbsolutePath>,
+    ) -> Result<ExitStatus, Error> {
+        let Some(resolve_command) =
+            self.resolve_list_command_with_global_npm_bin(options, global_npm_bin_path)
+        else {
             return Ok(ExitStatus::default());
         };
         run_command(&resolve_command.bin_path, &resolve_command.args, &resolve_command.envs, cwd)
@@ -53,6 +73,17 @@ impl PackageManager {
         &self,
         options: &ListCommandOptions,
     ) -> Option<ResolveCommandResult> {
+        self.resolve_list_command_with_global_npm_bin(options, None)
+    }
+
+    /// Resolve the list command with an explicit npm binary for global lists.
+    /// Returns None if the command is not supported by the package manager.
+    #[must_use]
+    pub fn resolve_list_command_with_global_npm_bin(
+        &self,
+        options: &ListCommandOptions,
+        global_npm_bin_path: Option<&AbsolutePath>,
+    ) -> Option<ResolveCommandResult> {
         // yarn@2+ does not support list command
         if self.client == PackageManagerType::Yarn && !self.version.starts_with("1.") {
             output::warn("yarn@2+ does not support 'list' command");
@@ -65,7 +96,7 @@ impl PackageManager {
         // Global packages should use npm cli only (since global installs use npm)
         let bin_name: String;
         if options.global {
-            bin_name = "npm".into();
+            bin_name = resolve_global_npm_bin_path(global_npm_bin_path);
             Self::format_npm_list_args(&mut args, options);
             args.push("-g".into());
 
@@ -478,6 +509,24 @@ mod tests {
         let result = result.unwrap();
         assert_eq!(result.bin_path, "npm");
         assert_eq!(result.args, vec!["list", "--depth", "0", "-g"]);
+    }
+
+    #[test]
+    fn test_global_list_uses_explicit_npm_bin() {
+        let pm = create_mock_package_manager(PackageManagerType::Pnpm, "10.0.0");
+        let npm_bin = if cfg!(windows) {
+            AbsolutePathBuf::new("C:\\node\\npm.cmd".into()).unwrap()
+        } else {
+            AbsolutePathBuf::new("/node/bin/npm".into()).unwrap()
+        };
+        let result = pm
+            .resolve_list_command_with_global_npm_bin(
+                &ListCommandOptions { global: true, ..Default::default() },
+                Some(&npm_bin),
+            )
+            .unwrap();
+        assert_eq!(result.bin_path, npm_bin.as_path().display().to_string());
+        assert_eq!(result.args, vec!["list", "-g"]);
     }
 
     #[test]

--- a/crates/vite_install/src/commands/outdated.rs
+++ b/crates/vite_install/src/commands/outdated.rs
@@ -7,6 +7,7 @@ use vite_shared::output;
 
 use crate::package_manager::{
     PackageManager, PackageManagerType, ResolveCommandResult, format_path_env,
+    resolve_global_npm_bin_path,
 };
 
 /// Output format for the outdated command.
@@ -77,7 +78,22 @@ impl PackageManager {
         options: &OutdatedCommandOptions<'_>,
         cwd: impl AsRef<AbsolutePath>,
     ) -> Result<ExitStatus, Error> {
-        let resolve_command = self.resolve_outdated_command(options);
+        let resolve_command = self.resolve_outdated_command_with_global_npm_bin(options, None);
+        run_command(&resolve_command.bin_path, &resolve_command.args, &resolve_command.envs, cwd)
+            .await
+    }
+
+    /// Run the outdated command with an explicit npm binary for global checks.
+    /// Return the exit status of the command.
+    #[must_use]
+    pub async fn run_outdated_command_with_global_npm_bin(
+        &self,
+        options: &OutdatedCommandOptions<'_>,
+        cwd: impl AsRef<AbsolutePath>,
+        global_npm_bin_path: Option<&AbsolutePath>,
+    ) -> Result<ExitStatus, Error> {
+        let resolve_command =
+            self.resolve_outdated_command_with_global_npm_bin(options, global_npm_bin_path);
         run_command(&resolve_command.bin_path, &resolve_command.args, &resolve_command.envs, cwd)
             .await
     }
@@ -88,13 +104,23 @@ impl PackageManager {
         &self,
         options: &OutdatedCommandOptions,
     ) -> ResolveCommandResult {
+        self.resolve_outdated_command_with_global_npm_bin(options, None)
+    }
+
+    /// Resolve the outdated command with an explicit npm binary for global checks.
+    #[must_use]
+    pub fn resolve_outdated_command_with_global_npm_bin(
+        &self,
+        options: &OutdatedCommandOptions,
+        global_npm_bin_path: Option<&AbsolutePath>,
+    ) -> ResolveCommandResult {
         let bin_name: String;
         let envs = HashMap::from([("PATH".to_string(), format_path_env(self.get_bin_prefix()))]);
         let mut args: Vec<String> = Vec::new();
 
         // Global packages should use npm cli only
         if options.global {
-            bin_name = "npm".into();
+            bin_name = resolve_global_npm_bin_path(global_npm_bin_path);
             Self::format_npm_outdated_args(&mut args, options);
             args.push("-g".into());
         } else {
@@ -481,6 +507,22 @@ mod tests {
             ..Default::default()
         });
         assert_eq!(result.bin_path, "npm");
+        assert_eq!(result.args, vec!["outdated", "-g"]);
+    }
+
+    #[test]
+    fn test_global_outdated_uses_explicit_npm_bin() {
+        let pm = create_mock_package_manager(PackageManagerType::Pnpm, "10.0.0");
+        let npm_bin = if cfg!(windows) {
+            AbsolutePathBuf::new("C:\\node\\npm.cmd".into()).unwrap()
+        } else {
+            AbsolutePathBuf::new("/node/bin/npm".into()).unwrap()
+        };
+        let result = pm.resolve_outdated_command_with_global_npm_bin(
+            &OutdatedCommandOptions { global: true, ..Default::default() },
+            Some(&npm_bin),
+        );
+        assert_eq!(result.bin_path, npm_bin.as_path().display().to_string());
         assert_eq!(result.args, vec!["outdated", "-g"]);
     }
 

--- a/crates/vite_install/src/commands/remove.rs
+++ b/crates/vite_install/src/commands/remove.rs
@@ -7,6 +7,7 @@ use vite_shared::output;
 
 use crate::package_manager::{
     PackageManager, PackageManagerType, ResolveCommandResult, format_path_env,
+    resolve_global_npm_bin_path,
 };
 
 /// Options for the remove command.
@@ -32,7 +33,22 @@ impl PackageManager {
         options: &RemoveCommandOptions<'_>,
         cwd: impl AsRef<AbsolutePath>,
     ) -> Result<ExitStatus, Error> {
-        let resolve_command = self.resolve_remove_command(options);
+        let resolve_command = self.resolve_remove_command_with_global_npm_bin(options, None);
+        run_command(&resolve_command.bin_path, &resolve_command.args, &resolve_command.envs, cwd)
+            .await
+    }
+
+    /// Run the remove command with an explicit npm binary for global installs.
+    /// Return the exit status of the command.
+    #[must_use]
+    pub async fn run_remove_command_with_global_npm_bin(
+        &self,
+        options: &RemoveCommandOptions<'_>,
+        cwd: impl AsRef<AbsolutePath>,
+        global_npm_bin_path: Option<&AbsolutePath>,
+    ) -> Result<ExitStatus, Error> {
+        let resolve_command =
+            self.resolve_remove_command_with_global_npm_bin(options, global_npm_bin_path);
         run_command(&resolve_command.bin_path, &resolve_command.args, &resolve_command.envs, cwd)
             .await
     }
@@ -40,14 +56,23 @@ impl PackageManager {
     /// Resolve the remove command.
     #[must_use]
     pub fn resolve_remove_command(&self, options: &RemoveCommandOptions) -> ResolveCommandResult {
+        self.resolve_remove_command_with_global_npm_bin(options, None)
+    }
+
+    /// Resolve the remove command with an explicit npm binary for global installs.
+    #[must_use]
+    pub fn resolve_remove_command_with_global_npm_bin(
+        &self,
+        options: &RemoveCommandOptions,
+        global_npm_bin_path: Option<&AbsolutePath>,
+    ) -> ResolveCommandResult {
         let bin_name: String;
         let envs = HashMap::from([("PATH".to_string(), format_path_env(self.get_bin_prefix()))]);
         let mut args: Vec<String> = Vec::new();
 
         // global packages should use npm cli only
         if options.global {
-            // TODO(@fengmk2): Need to handle the case where the npm CLI does not exist in the PATH
-            bin_name = "npm".into();
+            bin_name = resolve_global_npm_bin_path(global_npm_bin_path);
             args.push("uninstall".into());
             args.push("--global".into());
             if let Some(pass_through_args) = options.pass_through_args {
@@ -441,6 +466,26 @@ mod tests {
         });
         assert_eq!(result.args, vec!["uninstall", "--global", "typescript"]);
         assert_eq!(result.bin_path, "npm");
+    }
+
+    #[test]
+    fn test_global_remove_uses_explicit_npm_bin() {
+        let pm = create_mock_package_manager(PackageManagerType::Pnpm);
+        let npm_bin = if cfg!(windows) {
+            AbsolutePathBuf::new("C:\\node\\npm.cmd".into()).unwrap()
+        } else {
+            AbsolutePathBuf::new("/node/bin/npm".into()).unwrap()
+        };
+        let result = pm.resolve_remove_command_with_global_npm_bin(
+            &RemoveCommandOptions {
+                packages: &["typescript".to_string()],
+                global: true,
+                ..Default::default()
+            },
+            Some(&npm_bin),
+        );
+        assert_eq!(result.args, vec!["uninstall", "--global", "typescript"]);
+        assert_eq!(result.bin_path, npm_bin.as_path().display().to_string());
     }
 
     #[test]

--- a/crates/vite_install/src/commands/update.rs
+++ b/crates/vite_install/src/commands/update.rs
@@ -7,6 +7,7 @@ use vite_shared::output;
 
 use crate::package_manager::{
     PackageManager, PackageManagerType, ResolveCommandResult, format_path_env,
+    resolve_global_npm_bin_path,
 };
 
 /// Options for the update command.
@@ -36,7 +37,22 @@ impl PackageManager {
         options: &UpdateCommandOptions<'_>,
         cwd: impl AsRef<AbsolutePath>,
     ) -> Result<ExitStatus, Error> {
-        let resolve_command = self.resolve_update_command(options);
+        let resolve_command = self.resolve_update_command_with_global_npm_bin(options, None);
+        run_command(&resolve_command.bin_path, &resolve_command.args, &resolve_command.envs, cwd)
+            .await
+    }
+
+    /// Run the update command with an explicit npm binary for global installs.
+    /// Return the exit status of the command.
+    #[must_use]
+    pub async fn run_update_command_with_global_npm_bin(
+        &self,
+        options: &UpdateCommandOptions<'_>,
+        cwd: impl AsRef<AbsolutePath>,
+        global_npm_bin_path: Option<&AbsolutePath>,
+    ) -> Result<ExitStatus, Error> {
+        let resolve_command =
+            self.resolve_update_command_with_global_npm_bin(options, global_npm_bin_path);
         run_command(&resolve_command.bin_path, &resolve_command.args, &resolve_command.envs, cwd)
             .await
     }
@@ -44,13 +60,23 @@ impl PackageManager {
     /// Resolve the update command.
     #[must_use]
     pub fn resolve_update_command(&self, options: &UpdateCommandOptions) -> ResolveCommandResult {
+        self.resolve_update_command_with_global_npm_bin(options, None)
+    }
+
+    /// Resolve the update command with an explicit npm binary for global installs.
+    #[must_use]
+    pub fn resolve_update_command_with_global_npm_bin(
+        &self,
+        options: &UpdateCommandOptions,
+        global_npm_bin_path: Option<&AbsolutePath>,
+    ) -> ResolveCommandResult {
         let bin_name: String;
         let envs = HashMap::from([("PATH".to_string(), format_path_env(self.get_bin_prefix()))]);
         let mut args: Vec<String> = Vec::new();
 
         // global packages should use npm cli only
         if options.global {
-            bin_name = "npm".into();
+            bin_name = resolve_global_npm_bin_path(global_npm_bin_path);
             args.push("update".into());
             args.push("--global".into());
             if let Some(pass_through_args) = options.pass_through_args {
@@ -549,6 +575,26 @@ mod tests {
         });
         assert_eq!(result.args, vec!["update", "--global", "typescript"]);
         assert_eq!(result.bin_path, "npm");
+    }
+
+    #[test]
+    fn test_global_update_uses_explicit_npm_bin() {
+        let pm = create_mock_package_manager(PackageManagerType::Pnpm, "10.0.0");
+        let npm_bin = if cfg!(windows) {
+            AbsolutePathBuf::new("C:\\node\\npm.cmd".into()).unwrap()
+        } else {
+            AbsolutePathBuf::new("/node/bin/npm".into()).unwrap()
+        };
+        let result = pm.resolve_update_command_with_global_npm_bin(
+            &UpdateCommandOptions {
+                packages: &["typescript".to_string()],
+                global: true,
+                ..Default::default()
+            },
+            Some(&npm_bin),
+        );
+        assert_eq!(result.args, vec!["update", "--global", "typescript"]);
+        assert_eq!(result.bin_path, npm_bin.as_path().display().to_string());
     }
 
     #[test]

--- a/crates/vite_install/src/package_manager.rs
+++ b/crates/vite_install/src/package_manager.rs
@@ -66,6 +66,18 @@ pub struct ResolveCommandResult {
     pub envs: HashMap<String, String>,
 }
 
+#[must_use]
+pub fn npm_bin_path_from_node_bin_prefix(node_bin_prefix: &AbsolutePath) -> AbsolutePathBuf {
+    if cfg!(windows) { node_bin_prefix.join("npm.cmd") } else { node_bin_prefix.join("npm") }
+}
+
+#[must_use]
+pub(crate) fn resolve_global_npm_bin_path(global_npm_bin_path: Option<&AbsolutePath>) -> String {
+    global_npm_bin_path
+        .map(|path| path.as_path().display().to_string())
+        .unwrap_or_else(|| "npm".into())
+}
+
 /// The package manager.
 /// Use `PackageManager::builder()` to create a package manager.
 /// Then use `PackageManager::resolve_command()` to resolve the command result.
@@ -1012,6 +1024,22 @@ mod tests {
     fn create_pnpm_workspace_yaml(dir: &AbsolutePath, content: &str) {
         fs::write(dir.join("pnpm-workspace.yaml"), content)
             .expect("Failed to write pnpm-workspace.yaml");
+    }
+
+    #[test]
+    fn test_npm_bin_path_from_node_bin_prefix() {
+        let node_bin_prefix = if cfg!(windows) {
+            AbsolutePathBuf::new("C:\\node".into()).unwrap()
+        } else {
+            AbsolutePathBuf::new("/node/bin".into()).unwrap()
+        };
+        let npm_bin = npm_bin_path_from_node_bin_prefix(&node_bin_prefix);
+        let expected = if cfg!(windows) {
+            node_bin_prefix.join("npm.cmd")
+        } else {
+            node_bin_prefix.join("npm")
+        };
+        assert_eq!(npm_bin, expected);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Use the resolved managed npm binary for global add/remove/update/outdated commands when the adjacent npm is executable.
- Fall back to npm on PATH when the adjacent managed npm is missing or not executable, with debug logging for diagnostics.
- Keep existing vite_install APIs compatible by falling back to `npm` when no explicit binary is provided.
- Add coverage for absolute binary resolution and managed npm fallback behavior.

## Why

Global npm commands previously depended on PATH being prepared by the caller. This makes the managed npm path explicit when it is safe to do so, while preserving PATH-based fallback for system runtimes and unchanged command arguments.

## Tests

- `cargo test -p vite_command --no-fail-fast`
- `cargo test -p vite_install --no-fail-fast`
- `cargo test -p vite_global_cli --no-fail-fast`
