### PR TITLE
chore: align package metadata across workspace

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "vite-plus-benches"
 version = "0.1.0"
-edition = "2024"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+rust-version.workspace = true
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/crates/vite_command/Cargo.toml
+++ b/crates/vite_command/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 rust-version.workspace = true
 
 [dependencies]

--- a/crates/vite_migration/Cargo.toml
+++ b/crates/vite_migration/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false
 rust-version.workspace = true
 
 [dependencies]

--- a/crates/vite_static_config/Cargo.toml
+++ b/crates/vite_static_config/Cargo.toml
@@ -5,7 +5,9 @@ authors.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
+publish = false
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 oxc_allocator = { workspace = true }

--- a/crates/vite_trampoline/Cargo.toml
+++ b/crates/vite_trampoline/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 publish = false
+rust-version.workspace = true
 description = "Minimal Windows trampoline exe for vite-plus shims"
 
 [[bin]]

--- a/packages/cli/binding/Cargo.toml
+++ b/packages/cli/binding/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "vite-plus-cli"
 version = "0.0.0"
+authors.workspace = true
 edition.workspace = true
+license.workspace = true
+publish = false
+rust-version.workspace = true
 
 [features]
 rolldown = ["dep:rolldown_binding"]


### PR DESCRIPTION
Align `Cargo.toml` metadata across the workspace (inherit `authors` / `license` / `rust-version` from `[workspace.package]`, add `publish = false` on internal crates). No functional changes.