### PR TITLE
fix(check): remove redundant package tsconfigs to unblock single-file lint-staged

### DIFF
--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,9 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "experimentalDecorators": true
-  },
-  "files": [],
-  "include": [],
-  "exclude": ["**/*"]
-}

--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -91,7 +91,7 @@ await mergePackageJson();
 
 async function buildVite() {
   const newViteRolldownConfig = viteRolldownConfig.map((config) => {
-    config.tsconfig = join(projectDir, 'tsconfig.json');
+    config.tsconfig = join(projectDir, '..', '..', 'tsconfig.json');
     config.cwd = projectDir;
 
     if (Array.isArray(config.external)) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -100,7 +100,7 @@
     "./types/internal/*": null
   },
   "scripts": {
-    "build": "oxnode -C dev ./build.ts"
+    "build": "cross-env OXC_TSCONFIG_PATH=../../tsconfig.json oxnode -C dev ./build.ts"
   },
   "dependencies": {
     "@oxc-project/runtime": "catalog:",
@@ -116,6 +116,7 @@
     "@oxc-node/cli": "catalog:",
     "@oxc-node/core": "catalog:",
     "@vitejs/devtools": "^0.1.15",
+    "cross-env": "catalog:",
     "es-module-lexer": "^1.7.0",
     "hookable": "^6.0.1",
     "magic-string": "^0.30.21",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,9 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "experimentalDecorators": true
-  },
-  "files": [],
-  "include": [],
-  "exclude": ["**/*"]
-}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "experimentalDecorators": true
+  },
+  "files": [],
+  "include": [],
+  "exclude": ["**/*"]
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "experimentalDecorators": true
   },
-  "files": [],
-  "include": [],
-  "exclude": ["**/*"]
+  "include": ["build-support/**/*", "__tests__/**/*"],
+  "exclude": ["dist", "node_modules"]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "experimentalDecorators": true
-  },
-  "include": ["build-support/**/*", "__tests__/**/*"],
-  "exclude": ["dist", "node_modules"]
-}

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -272,7 +272,7 @@
     }
   },
   "scripts": {
-    "build": "oxnode -C dev ./build.ts"
+    "build": "cross-env OXC_TSCONFIG_PATH=../../tsconfig.json oxnode -C dev ./build.ts"
   },
   "dependencies": {
     "@standard-schema/spec": "^1.1.0",
@@ -306,6 +306,7 @@
     "@vitest/utils": "4.1.5",
     "chai": "^6.2.1",
     "convert-source-map": "^2.0.0",
+    "cross-env": "catalog:",
     "estree-walker": "^3.0.3",
     "expect-type": "^1.2.2",
     "magic-string": "^0.30.21",

--- a/packages/test/tsconfig.json
+++ b/packages/test/tsconfig.json
@@ -1,9 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "experimentalDecorators": true
-  },
-  "files": [],
-  "include": [],
-  "exclude": ["**/*"]
-}

--- a/packages/test/tsconfig.json
+++ b/packages/test/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "experimentalDecorators": true
+  },
+  "files": [],
+  "include": [],
+  "exclude": ["**/*"]
+}

--- a/packages/test/tsconfig.json
+++ b/packages/test/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "experimentalDecorators": true
   },
-  "files": [],
-  "include": [],
-  "exclude": ["**/*"]
+  "include": ["__tests__/**/*"],
+  "exclude": ["dist", "node_modules"]
 }

--- a/packages/test/tsconfig.json
+++ b/packages/test/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "experimentalDecorators": true
-  },
-  "include": ["__tests__/**/*"],
-  "exclude": ["dist", "node_modules"]
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12506,7 +12506,7 @@ snapshots:
       lightningcss: 1.32.0
       postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(yaml@2.8.2)
       rolldown: link:rolldown/packages/rolldown
-      tsdown: 0.21.10(@arethetypeswrong/core@0.18.2)(@tsdown/css@0.21.10)(@tsdown/exe@0.21.10)(@typescript/native-preview@7.0.0-dev.20260122.2)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(typescript@6.0.2)(vite@packages+core))(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(publint@0.3.18)(typescript@6.0.2)(unplugin-unused@0.5.6)
+      tsdown: 0.21.10(@arethetypeswrong/core@0.18.2)(@tsdown/css@0.21.10)(@tsdown/exe@0.21.10)(@typescript/native-preview@7.0.0-dev.20260122.2)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(typescript@6.0.2)(vite@packages+core))(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(publint@0.3.18)(typescript@6.0.2)(unplugin-unused@0.5.6)
     optionalDependencies:
       postcss: 8.5.10
       postcss-import: 16.1.1(postcss@8.5.10)
@@ -12541,7 +12541,7 @@ snapshots:
       obug: 2.1.1
       semver: 7.7.4
       tinyexec: 1.1.1
-      tsdown: 0.21.10(@arethetypeswrong/core@0.18.2)(@tsdown/css@0.21.10)(@tsdown/exe@0.21.10)(@typescript/native-preview@7.0.0-dev.20260122.2)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(typescript@6.0.2)(vite@packages+core))(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(publint@0.3.18)(typescript@6.0.2)(unplugin-unused@0.5.6)
+      tsdown: 0.21.10(@arethetypeswrong/core@0.18.2)(@tsdown/css@0.21.10)(@tsdown/exe@0.21.10)(@typescript/native-preview@7.0.0-dev.20260122.2)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(typescript@6.0.2)(vite@packages+core))(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(publint@0.3.18)(typescript@6.0.2)(unplugin-unused@0.5.6)
 
   '@tsdown/exe@0.21.4(tsdown@0.21.4)':
     dependencies:
@@ -16353,7 +16353,7 @@ snapshots:
       '@babel/types': 8.0.0-rc.3
       ast-kit: 3.0.0-beta.1
       birpc: 4.0.0
-      dts-resolver: 2.1.3(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))
+      dts-resolver: 2.1.3(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))
       get-tsconfig: 4.13.7
       obug: 2.1.1
       picomatch: 4.0.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ catalogs:
     consola:
       specifier: ^3.4.2
       version: 3.4.2
+    cross-env:
+      specifier: ^10.1.0
+      version: 10.1.0
     cross-spawn:
       specifier: ^7.0.5
       version: 7.0.6
@@ -507,6 +510,9 @@ importers:
       '@vitejs/devtools':
         specifier: ^0.1.15
         version: 0.1.15(@pnpm/logger@1001.0.1)(typescript@6.0.2)(vite@packages+core)
+      cross-env:
+        specifier: 'catalog:'
+        version: 10.1.0
       es-module-lexer:
         specifier: ^1.7.0
         version: 1.7.0
@@ -705,6 +711,9 @@ importers:
       convert-source-map:
         specifier: ^2.0.0
         version: 2.0.0
+      cross-env:
+        specifier: 'catalog:'
+        version: 10.1.0
       estree-walker:
         specifier: ^3.0.3
         version: 3.0.3
@@ -2162,6 +2171,9 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@epic-web/invariant@1.0.0':
+    resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
 
   '@esbuild/aix-ppc64@0.27.4':
     resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
@@ -6237,6 +6249,11 @@ packages:
   crc32-stream@6.0.0:
     resolution: {integrity: sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==}
     engines: {node: '>= 14'}
+
+  cross-env@10.1.0:
+    resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -10428,6 +10445,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@epic-web/invariant@1.0.0': {}
+
   '@esbuild/aix-ppc64@0.27.4':
     optional: true
 
@@ -12487,7 +12506,7 @@ snapshots:
       lightningcss: 1.32.0
       postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(yaml@2.8.2)
       rolldown: link:rolldown/packages/rolldown
-      tsdown: 0.21.10(@arethetypeswrong/core@0.18.2)(@tsdown/css@0.21.10)(@tsdown/exe@0.21.10)(@typescript/native-preview@7.0.0-dev.20260122.2)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(typescript@6.0.2)(vite@packages+core))(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(publint@0.3.18)(typescript@6.0.2)(unplugin-unused@0.5.6)
+      tsdown: 0.21.10(@arethetypeswrong/core@0.18.2)(@tsdown/css@0.21.10)(@tsdown/exe@0.21.10)(@typescript/native-preview@7.0.0-dev.20260122.2)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(typescript@6.0.2)(vite@packages+core))(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(publint@0.3.18)(typescript@6.0.2)(unplugin-unused@0.5.6)
     optionalDependencies:
       postcss: 8.5.10
       postcss-import: 16.1.1(postcss@8.5.10)
@@ -12522,7 +12541,7 @@ snapshots:
       obug: 2.1.1
       semver: 7.7.4
       tinyexec: 1.1.1
-      tsdown: 0.21.10(@arethetypeswrong/core@0.18.2)(@tsdown/css@0.21.10)(@tsdown/exe@0.21.10)(@typescript/native-preview@7.0.0-dev.20260122.2)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(typescript@6.0.2)(vite@packages+core))(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(publint@0.3.18)(typescript@6.0.2)(unplugin-unused@0.5.6)
+      tsdown: 0.21.10(@arethetypeswrong/core@0.18.2)(@tsdown/css@0.21.10)(@tsdown/exe@0.21.10)(@typescript/native-preview@7.0.0-dev.20260122.2)(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(typescript@6.0.2)(vite@packages+core))(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(publint@0.3.18)(typescript@6.0.2)(unplugin-unused@0.5.6)
 
   '@tsdown/exe@0.21.4(tsdown@0.21.4)':
     dependencies:
@@ -13941,6 +13960,11 @@ snapshots:
     dependencies:
       crc-32: 1.2.2
       readable-stream: 4.7.0
+
+  cross-env@10.1.0:
+    dependencies:
+      '@epic-web/invariant': 1.0.0
+      cross-spawn: 7.0.6
 
   cross-spawn@7.0.6:
     dependencies:
@@ -16329,7 +16353,7 @@ snapshots:
       '@babel/types': 8.0.0-rc.3
       ast-kit: 3.0.0-beta.1
       birpc: 4.0.0
-      dts-resolver: 2.1.3(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))
+      dts-resolver: 2.1.3(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))
       get-tsconfig: 4.13.7
       obug: 2.1.1
       picomatch: 4.0.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -56,6 +56,7 @@ catalog:
   change-case: ^5.4.4
   connect: ^3.7.0
   consola: ^3.4.2
+  cross-env: ^10.1.0
   cross-spawn: ^7.0.5
   debug: ^4.4.3
   dedent: ^1.5.3

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "strict": true,
     "target": "esnext",
     "types": ["node"],
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
+    "experimentalDecorators": true
   },
   "exclude": [
     "ecosystem-ci",


### PR DESCRIPTION
## Summary

Per @cpojer's [comment](https://github.com/voidzero-dev/vite-plus/issues/1443#issuecomment-4309644867), all three redundant `packages/{cli,core,test}/tsconfig.json` files are removed. They were leftovers from the pre-`oxnode` `tsc` build era — empty-include shells whose only role was setting `experimentalDecorators: true`. The single migration step needed:

- Move `experimentalDecorators: true` to the root `tsconfig.json`.
- For the build path: `@oxc-node/core`'s `OxcTransformer` reads compilerOptions only from `cwd/tsconfig.json` and does not walk up to ancestor tsconfigs (verified empirically + by binary inspection — there's no CLI flag, only the `OXC_TSCONFIG_PATH` env var). Wire it through `cross-env` in `packages/{core,test}` build scripts so oxnode finds the root tsconfig: `cross-env OXC_TSCONFIG_PATH=../../tsconfig.json oxnode -C dev ./build.ts`.
- `packages/core/build.ts:94` also passed `join(projectDir, 'tsconfig.json')` to rolldown's bundler API; repoint that to the root tsconfig too.
- `packages/cli/build.ts` doesn't import `rolldown`, so its build path needs no decorator handling — its tsconfig was the easiest to remove and was the original cause of #1443.

## Why this fixes #1443

`vp check --fix <one-file>` forwards the path to oxlint→tsgolint with no tsconfig. tsgolint walks up from the file looking for the nearest ancestor tsconfig. With the empty-include `packages/{cli,core,test}/tsconfig.json` files in place, that ancestor matched no files and tsgolint built a "loose" program — dropping the parent's `types: ["node"]` and emitting spurious `TS2591: Cannot find name 'node:util'` on `node:*` imports.

After deletion, tsgolint walks all the way up to the project root `tsconfig.json`, which declares `types: ["node"]`, and `@types/node` is loaded as expected. Same fix automatically resolves equivalent failures for files under `packages/core/build-support/` and `packages/{core,test}/__tests__/`.

## Test plan

- [x] `vp check --fix packages/cli/src/utils/{terminal,help,agent}.ts packages/cli/src/version.ts` — was FAIL (TS2591), now PASS
- [x] `vp lint packages/core/build-support/{find-create-require,build-cjs-deps,rewrite-imports,rewrite-module-specifiers}.ts` — all PASS
- [x] `vp lint packages/core/__tests__/build-artifacts.spec.ts` — PASS
- [x] `vp lint packages/test/__tests__/build-artifacts.spec.ts` — was FAIL (TS2591 + TS7006), now PASS
- [x] `vp check` (full project) — PASS (1234 files formatted, 137 lint/type clean)
- [x] `pnpm bootstrap-cli` — PASS

Closes #1443