### PR TITLE
chore: remove dead global logic for update command

### DIFF
--- a/crates/vite_global_cli/src/cli.rs
+++ b/crates/vite_global_cli/src/cli.rs
@@ -1840,7 +1840,6 @@ pub async fn run_command_with_options(
                 .execute(
                     &packages,
                     latest,
-                    global,
                     recursive,
                     filter.as_deref(),
                     workspace_root,

--- a/crates/vite_global_cli/src/commands/update.rs
+++ b/crates/vite_global_cli/src/commands/update.rs
@@ -24,7 +24,6 @@ impl UpdateCommand {
         self,
         packages: &[String],
         latest: bool,
-        global: bool,
         recursive: bool,
         filters: Option<&[String]>,
         workspace_root: bool,
@@ -43,7 +42,6 @@ impl UpdateCommand {
         let update_command_options = UpdateCommandOptions {
             packages,
             latest,
-            global,
             recursive,
             filters,
             workspace_root,

--- a/crates/vite_install/src/commands/update.rs
+++ b/crates/vite_install/src/commands/update.rs
@@ -48,19 +48,6 @@ impl PackageManager {
         let envs = HashMap::from([("PATH".to_string(), format_path_env(self.get_bin_prefix()))]);
         let mut args: Vec<String> = Vec::new();
 
-        // global packages should use npm cli only
-        if options.global {
-            bin_name = "npm".into();
-            args.push("update".into());
-            args.push("--global".into());
-            if let Some(pass_through_args) = options.pass_through_args {
-                args.extend_from_slice(pass_through_args);
-            }
-            args.extend_from_slice(options.packages);
-
-            return ResolveCommandResult { bin_path: bin_name, args, envs };
-        }
-
         match self.client {
             PackageManagerType::Pnpm => {
                 bin_name = "pnpm".into();

--- a/crates/vite_install/src/commands/update.rs
+++ b/crates/vite_install/src/commands/update.rs
@@ -14,7 +14,6 @@ use crate::package_manager::{
 pub struct UpdateCommandOptions<'a> {
     pub packages: &'a [String],
     pub latest: bool,
-    pub global: bool,
     pub recursive: bool,
     pub filters: Option<&'a [String]>,
     pub workspace_root: bool,
@@ -236,7 +235,6 @@ mod tests {
         let result = pm.resolve_update_command(&UpdateCommandOptions {
             packages: &["react".to_string()],
             latest: false,
-            global: false,
             recursive: false,
             filters: None,
             workspace_root: false,
@@ -523,18 +521,6 @@ mod tests {
             ..Default::default()
         });
         assert_eq!(result.args, vec!["update", "--no-save", "react"]);
-        assert_eq!(result.bin_path, "npm");
-    }
-
-    #[test]
-    fn test_global_update() {
-        let pm = create_mock_package_manager(PackageManagerType::Pnpm, "10.0.0");
-        let result = pm.resolve_update_command(&UpdateCommandOptions {
-            packages: &["typescript".to_string()],
-            global: true,
-            ..Default::default()
-        });
-        assert_eq!(result.args, vec!["update", "--global", "typescript"]);
         assert_eq!(result.bin_path, "npm");
     }
 


### PR DESCRIPTION
There is a part of unreachable code in `update.rs`. It is used to run `npm update -g` when running `vp update -g`.

It was added in #238, the first implementation of `vp update`. But it became dead code after #524 got merged (the PR which introduces `vp env`).

The following code in `cli.rs` makes it unreachable.

https://github.com/voidzero-dev/vite-plus/blob/a2876b6a3ef096c9b5b1ab79aced73dc72d0c8ce/crates/vite_global_cli/src/cli.rs#L1816-L1817

This PR clears the logic about it, including related tests

It was found by Claude Code while I was writing #1477.