### PR TITLE
docs: add filename labels to configuration code blocks

### DIFF
--- a/docs/config/build.md
+++ b/docs/config/build.md
@@ -4,7 +4,7 @@
 
 ## Example
 
-```ts
+```ts [vite.config.ts]
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({

--- a/docs/config/fmt.md
+++ b/docs/config/fmt.md
@@ -4,7 +4,7 @@
 
 ## Example
 
-```ts
+```ts [vite.config.ts]
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -2,7 +2,7 @@
 
 Vite+ keeps project configuration in one place: `vite.config.ts`, allowing you to consolidate many top-level configuration files in a single file. You can keep using your Vite configuration such as `server` or `build`, and add Vite+ blocks for the rest of your workflow:
 
-```ts
+```ts [vite.config.ts]
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({

--- a/docs/config/lint.md
+++ b/docs/config/lint.md
@@ -4,7 +4,7 @@
 
 ## Example
 
-```ts
+```ts [vite.config.ts]
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({

--- a/docs/config/pack.md
+++ b/docs/config/pack.md
@@ -4,7 +4,7 @@
 
 ## Example
 
-```ts
+```ts [vite.config.ts]
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({

--- a/docs/config/run.md
+++ b/docs/config/run.md
@@ -2,7 +2,7 @@
 
 You can configure Vite Task under the `run` field in `vite.config.ts`. Check out [`vp run`](/guide/run) to learn more about running scripts and tasks with Vite+.
 
-```ts
+```ts [vite.config.ts]
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({
@@ -27,7 +27,7 @@ Whether to automatically run `preX`/`postX` package.json scripts as lifecycle ho
 
 When enabled (the default), running a script like `test` will automatically run `pretest` before it and `posttest` after it, if they exist in `package.json`.
 
-```ts
+```ts [vite.config.ts]
 export default defineConfig({
   run: {
     enablePrePostScripts: false, // Disable pre/post lifecycle hooks
@@ -46,7 +46,7 @@ This option can only be set in the workspace root's `vite.config.ts`. Setting it
 
 Controls whether task results are cached and replayed on subsequent runs.
 
-```ts
+```ts [vite.config.ts]
 export default defineConfig({
   run: {
     cache: {
@@ -71,7 +71,7 @@ Defines tasks that can be run with `vp run <task>`.
 
 Defines the shell command to run for the task.
 
-```ts
+```ts [vite.config.ts]
 tasks: {
   build: {
     command: 'vp build',
@@ -90,7 +90,7 @@ Commands joined with `&&` are automatically split into independently cached sub-
 
 Tasks that must complete successfully before this one starts.
 
-```ts
+```ts [vite.config.ts]
 tasks: {
   deploy: {
     command: 'deploy-script --prod',
@@ -101,7 +101,7 @@ tasks: {
 
 Dependencies can reference tasks in other packages using the `package#task` format:
 
-```ts
+```ts [vite.config.ts]
 dependsOn: ['@my/core#build', '@my/utils#lint'];
 ```
 
@@ -114,7 +114,7 @@ See [Task Dependencies](/guide/run#task-dependencies) for details on how explici
 
 Whether to cache this task's output. Set to `false` for tasks that should never be cached, like dev servers:
 
-```ts
+```ts [vite.config.ts]
 tasks: {
   dev: {
     command: 'vp dev',
@@ -130,7 +130,7 @@ tasks: {
 
 Environment variables included in the cache fingerprint. When any listed variable's value changes, the cache is invalidated.
 
-```ts
+```ts [vite.config.ts]
 tasks: {
   build: {
     command: 'vp build',
@@ -153,7 +153,7 @@ $ NODE_ENV=production vp run build     # cache miss: variable changed
 
 Environment variables passed to the task process but **not** included in the cache fingerprint. Changing these values won't invalidate the cache.
 
-```ts
+```ts [vite.config.ts]
 tasks: {
   build: {
     command: 'vp build',
@@ -178,7 +178,7 @@ Vite Task automatically detects which files are used by a command (see [Automati
 
 **Exclude files** from automatic tracking:
 
-```ts
+```ts [vite.config.ts]
 tasks: {
   build: {
     command: 'vp build',
@@ -190,7 +190,7 @@ tasks: {
 
 **Specify explicit files** only without automatic tracking:
 
-```ts
+```ts [vite.config.ts]
 tasks: {
   build: {
     command: 'vp build',
@@ -201,7 +201,7 @@ tasks: {
 
 **Resolve patterns relative to the workspace root** using the object form:
 
-```ts
+```ts [vite.config.ts]
 tasks: {
   build: {
     command: 'vp build',
@@ -219,7 +219,7 @@ The `base` field is required and controls how the glob pattern is resolved:
 
 **Disable file tracking** entirely and cache only on command/env changes:
 
-```ts
+```ts [vite.config.ts]
 tasks: {
   greet: {
     command: 'node greet.mjs',
@@ -239,7 +239,7 @@ String glob patterns are resolved relative to the package directory by default. 
 
 Working directory for the task, relative to the package root.
 
-```ts
+```ts [vite.config.ts]
 tasks: {
   'test-e2e': {
     command: 'vp test',

--- a/docs/config/staged.md
+++ b/docs/config/staged.md
@@ -4,7 +4,7 @@
 
 ## Example
 
-```ts
+```ts [vite.config.ts]
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({

--- a/docs/config/test.md
+++ b/docs/config/test.md
@@ -4,7 +4,7 @@
 
 ## Example
 
-```ts
+```ts [vite.config.ts]
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({

--- a/docs/guide/cache.md
+++ b/docs/guide/cache.md
@@ -65,7 +65,7 @@ Automatic tracking can sometimes include more files than necessary, causing unne
 
 Use the [`input`](/config/run#input) option to exclude files or to replace automatic tracking with explicit file patterns:
 
-```ts
+```ts [vite.config.ts]
 tasks: {
   build: {
     command: 'tsc',
@@ -80,7 +80,7 @@ By default, tasks run in a clean environment. Only a small set of common variabl
 
 To add an environment variable to the cache key, add it to [`env`](/config/run#env). Changing its value then invalidates the cache:
 
-```ts
+```ts [vite.config.ts]
 tasks: {
   build: {
     command: 'webpack --mode production',

--- a/docs/guide/ci.md
+++ b/docs/guide/ci.md
@@ -10,7 +10,7 @@ That means you usually do not need separate `setup-node`, package-manager setup,
 
 ## GitHub Actions
 
-```yaml
+```yaml [.github/workflows/ci.yml]
 - uses: voidzero-dev/setup-vp@v1
   with:
     node-version: '22'
@@ -29,7 +29,7 @@ If you are migrating an existing GitHub Actions workflow, you can often replace 
 
 #### Before:
 
-```yaml
+```yaml [.github/workflows/ci.yml]
 - uses: actions/setup-node@v4
   with:
     node-version: '24'
@@ -52,7 +52,7 @@ If you are migrating an existing GitHub Actions workflow, you can often replace 
 
 #### After:
 
-```yaml
+```yaml [.github/workflows/ci.yml]
 - uses: voidzero-dev/setup-vp@v1
   with:
     node-version: '24'

--- a/docs/guide/run.md
+++ b/docs/guide/run.md
@@ -104,7 +104,7 @@ See [Run Config](/config/run) for the full `run` block reference.
 
 Use [`dependsOn`](#depends-on) to run tasks in the right order. Running `vp run deploy` with the config above runs `build` and `test` first. Dependencies can also target other packages in the same project with the `package#task` notation:
 
-```ts
+```ts [vite.config.ts]
 dependsOn: ['@my/core#build', '@my/utils#lint'];
 ```
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -79,7 +79,7 @@ If `vp staged` fails or your pre-commit hook does not run:
 
 A minimal staged config looks like this:
 
-```ts
+```ts [vite.config.ts]
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({
@@ -95,7 +95,7 @@ When `vite.config.ts` imports heavy plugins at the top level, every `import` is 
 
 Use `lazyPlugins` to wrap plugin loading. Plugins are only loaded for commands that need them (`dev`, `build`, `test`, `preview`), and skipped for everything else:
 
-```ts
+```ts [vite.config.ts]
 import { defineConfig, lazyPlugins } from 'vite-plus';
 import myPlugin from 'vite-plugin-foo';
 
@@ -106,7 +106,7 @@ export default defineConfig({
 
 For heavy plugins that should be lazily imported, combine with dynamic `import()`:
 
-```ts
+```ts [vite.config.ts]
 import { defineConfig, lazyPlugins } from 'vite-plus';
 
 export default defineConfig({


### PR DESCRIPTION
Apply the `vitepress-plugin-group-icons` filename-label convention from
#1487 to remaining configuration code blocks across config and guide
pages so each block clearly shows where it belongs.