### PR TITLE
docs: add Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,13 @@ Vite+ is fully open-source under the MIT license.
 
 Install Vite+ globally as `vp`:
 
-For Linux or macOS:
+For macOS (Homebrew):
+
+```bash
+brew install vite-plus
+```
+
+For macOS / Linux:
 
 ```bash
 curl -fsSL https://vite.plus | bash

--- a/docs/.vitepress/theme/components/home/InstallCommand.vue
+++ b/docs/.vitepress/theme/components/home/InstallCommand.vue
@@ -10,6 +10,11 @@ type CommandCard = {
 
 const commandCards: CommandCard[] = [
   {
+    id: 'macos-homebrew',
+    label: 'macOS (Homebrew)',
+    command: 'brew install vite-plus',
+  },
+  {
     id: 'unix',
     label: 'macOS / Linux',
     command: 'curl -fsSL https://vite.plus | bash',

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -6,6 +6,12 @@ Vite+ ships in two parts: `vp`, the global command-line tool, and `vite-plus`, t
 
 ## Install `vp`
 
+### macOS (Homebrew)
+
+```bash
+brew install vite-plus
+```
+
 ### macOS / Linux
 
 ```bash

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -26,7 +26,13 @@ Vite+ is fully open-source under the MIT license.
 
 Install Vite+ globally as `vp`:
 
-For Linux or macOS:
+For macOS (Homebrew):
+
+```bash
+brew install vite-plus
+```
+
+For macOS / Linux:
 
 ```bash
 curl -fsSL https://vite.plus | bash


### PR DESCRIPTION
There's now a formula for [`vite-plus`](https://formulae.brew.sh/formula/vite-plus) on Homebrew.

<img width="1474" height="726" alt="CleanShot 2026-05-05 at 12 28 08@2x" src="https://github.com/user-attachments/assets/14955af4-dbdc-4728-818c-ec5bf44ea2c8" />
