### PR TITLE
chore(tools): prevent false-positive `<repeat>` replacement on trailing plus

### DIFF
--- a/packages/cli/snap-tests-global/cli-helper-message/snap.txt
+++ b/packages/cli/snap-tests-global/cli-helper-message/snap.txt
@@ -4,7 +4,7 @@ Usage: vp [COMMAND]
 
 Start:
   create      Create a new project from a template
-  migrate     Migrate an existing project to Vite+<repeat>
+  migrate     Migrate an existing project to Vite+
   config      Configure hooks and agent integration
   staged      Run linters on staged files
   install, i  Install all dependencies, or add packages if package names are provided

--- a/packages/cli/snap-tests-global/command-add-pnpm10-with-workspace/snap.txt
+++ b/packages/cli/snap-tests-global/command-add-pnpm10-with-workspace/snap.txt
@@ -5,7 +5,7 @@ devDependencies:
 + testnpm2 ^1.0.1
 
 Packages: +<variable>
-+<repeat>
++
 Done in <variable>ms using pnpm v<semver>
 {
   "name": "command-add-pnpm10-with-workspace",
@@ -38,7 +38,7 @@ Done in <variable>ms using pnpm v<semver>
 
 > vp add testnpm2 test-vite-plus-install@1.0.0 --filter app && cat package.json packages/app/package.json packages/utils/package.json # should add packages to packages/app
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
-.                                        |   +1 +<repeat>
+.                                        |   +1 +
 Done in <variable>ms using pnpm v<semver>
 {
   "name": "command-add-pnpm10-with-workspace",
@@ -125,7 +125,7 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp install test-vite-plus-package@1.0.0 --filter "*" --workspace-root --save-catalog && cat package.json packages/app/package.json packages/utils/package.json pnpm-workspace.yaml # should install packages alias for add command
-.                                        |   +1 +<repeat>
+.                                        |   +1 +
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 Done in <variable>ms using pnpm v<semver>
 {
@@ -167,7 +167,7 @@ catalog:
 
 > vp add --filter app test-vite-plus-package-optional --save-catalog-name v1 && cat packages/app/package.json pnpm-workspace.yaml # should add with save-catalog-name
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
-.                                        |   +1 +<repeat>
+.                                        |   +1 +
 Done in <variable>ms using pnpm v<semver>
 {
   "name": "app",

--- a/packages/cli/snap-tests-global/command-add-pnpm10/snap.txt
+++ b/packages/cli/snap-tests-global/command-add-pnpm10/snap.txt
@@ -36,7 +36,7 @@ For more information, try '--help'.
 
 > vp add testnpm2 -D -- --loglevel=verbose --verbose && cat package.json # should add package as dev dependencies
 Packages: +<variable>
-+<repeat>
++
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
 devDependencies:
@@ -54,7 +54,7 @@ Done in <variable>ms using pnpm v<semver>
 
 > vp add testnpm2 test-vite-plus-install --allow-build=test-vite-plus-install && cat package.json # should add packages to dependencies
 Packages: +<variable>
-+<repeat>
++
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
 dependencies:
@@ -75,7 +75,7 @@ Done in <variable>ms using pnpm v<semver>
 
 > vp install test-vite-plus-package@1.0.0 --save-peer && cat package.json # should install package alias for add
 Packages: +<variable>
-+<repeat>
++
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
 peerDependencies:
@@ -103,7 +103,7 @@ Done in <variable>ms using pnpm v<semver>
 
 > vp add test-vite-plus-package-optional -O && cat package.json # should add package as optional dependencies
 Packages: +<variable>
-+<repeat>
++
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
 optionalDependencies:

--- a/packages/cli/snap-tests-global/command-add-pnpm11-with-workspace/snap.txt
+++ b/packages/cli/snap-tests-global/command-add-pnpm11-with-workspace/snap.txt
@@ -5,7 +5,7 @@ devDependencies:
 + testnpm2 ^1.0.1
 
 Packages: +<variable>
-+<repeat>
++
 Done in <variable>ms using pnpm v<semver>
 {
   "name": "command-add-pnpm11-with-workspace",
@@ -38,7 +38,7 @@ Done in <variable>ms using pnpm v<semver>
 
 > vp add testnpm2 test-vite-plus-install@1.0.0 --filter app && cat package.json packages/app/package.json packages/utils/package.json # should add packages to packages/app
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
-.                                        |   +1 +<repeat>
+.                                        |   +1 +
 Done in <variable>ms using pnpm v<semver>
 {
   "name": "command-add-pnpm11-with-workspace",
@@ -126,7 +126,7 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp install test-vite-plus-package@1.0.0 --filter "*" --workspace-root --save-catalog && cat package.json packages/app/package.json packages/utils/package.json pnpm-workspace.yaml # should install packages alias for add command
-.                                        |   +1 +<repeat>
+.                                        |   +1 +
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 Done in <variable>ms using pnpm v<semver>
 {
@@ -168,7 +168,7 @@ catalog:
 
 > vp add --filter app test-vite-plus-package-optional --save-catalog-name v1 && cat packages/app/package.json pnpm-workspace.yaml # should add with save-catalog-name
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
-.                                        |   +1 +<repeat>
+.                                        |   +1 +
 Done in <variable>ms using pnpm v<semver>
 {
   "name": "app",

--- a/packages/cli/snap-tests-global/command-add-pnpm11/snap.txt
+++ b/packages/cli/snap-tests-global/command-add-pnpm11/snap.txt
@@ -36,7 +36,7 @@ For more information, try '--help'.
 
 > vp add testnpm2 -D -- --loglevel=verbose --verbose && cat package.json # should add package as dev dependencies
 Packages: +<variable>
-+<repeat>
++
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
 devDependencies:
@@ -54,7 +54,7 @@ Done in <variable>ms using pnpm v<semver>
 
 > vp add testnpm2 test-vite-plus-install --allow-build=test-vite-plus-install && cat package.json # should add packages to dependencies
 Packages: +<variable>
-+<repeat>
++
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
 dependencies:
@@ -75,7 +75,7 @@ Done in <variable>ms using pnpm v<semver>
 
 > vp install test-vite-plus-package@1.0.0 --save-peer && cat package.json # should install package alias for add
 Packages: +<variable>
-+<repeat>
++
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
 peerDependencies:
@@ -103,7 +103,7 @@ Done in <variable>ms using pnpm v<semver>
 
 > vp add test-vite-plus-package-optional -O && cat package.json # should add package as optional dependencies
 Packages: +<variable>
-+<repeat>
++
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
 optionalDependencies:

--- a/packages/cli/snap-tests-global/command-add-pnpm9-with-workspace/snap.txt
+++ b/packages/cli/snap-tests-global/command-add-pnpm9-with-workspace/snap.txt
@@ -5,7 +5,7 @@ devDependencies:
 + testnpm2 ^1.0.1
 
 Packages: +<variable>
-+<repeat>
++
 Done in <variable>ms using pnpm v<semver>
 {
   "name": "command-add-pnpm9-with-workspace",
@@ -22,7 +22,7 @@ Done in <variable>ms using pnpm v<semver>
 > vp add testnpm2 test-vite-plus-install@1.0.0 --filter app && cat package.json packages/app/package.json packages/utils/package.json # should add packages to packages/app
 .                                        |  WARN  `node_modules` is present. Lockfile only installation will make it out-of-date
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
-.                                        |   +1 +<repeat>
+.                                        |   +1 +
 Done in <variable>ms using pnpm v<semver>
 {
   "name": "command-add-pnpm9-with-workspace",
@@ -101,7 +101,7 @@ Done in <variable>ms using pnpm v<semver>
 }
 
 > vp install test-vite-plus-package@1.0.0 --filter "*" --workspace-root && cat package.json packages/app/package.json packages/utils/package.json pnpm-workspace.yaml # should install packages alias for add command
-.                                        |   +1 +<repeat>
+.                                        |   +1 +
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 Done in <variable>ms using pnpm v<semver>
 {

--- a/packages/cli/snap-tests-global/command-add-pnpm9/snap.txt
+++ b/packages/cli/snap-tests-global/command-add-pnpm9/snap.txt
@@ -28,7 +28,7 @@ Documentation: https://viteplus.dev/guide/install
 
 > vp add testnpm2 -D && cat package.json # should add package as dev dependencies
 Packages: +<variable>
-+<repeat>
++
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
 devDependencies:
@@ -46,7 +46,7 @@ Done in <variable>ms using pnpm v<semver>
 
 > vp add testnpm2 test-vite-plus-install && cat package.json # should add packages to dependencies
 Packages: +<variable>
-+<repeat>
++
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
 dependencies:
@@ -71,7 +71,7 @@ For help, run: pnpm help add
 
 > vp install test-vite-plus-package@1.0.0 --save-peer && cat package.json # should install package alias for add
 Packages: +<variable>
-+<repeat>
++
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
 peerDependencies:
@@ -99,7 +99,7 @@ Done in <variable>ms using pnpm v<semver>
 
 > vp add test-vite-plus-package-optional -O && cat package.json # should add package as optional dependencies
 Packages: +<variable>
-+<repeat>
++
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
 optionalDependencies:

--- a/packages/cli/snap-tests-global/command-install-auto-create-package-json/snap.txt
+++ b/packages/cli/snap-tests-global/command-install-auto-create-package-json/snap.txt
@@ -8,7 +8,7 @@ no package.json
 }
 > vp add testnpm2 -D && cat package.json # should add package to auto-created package.json
 Packages: +<variable>
-+<repeat>
++
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
 devDependencies:

--- a/packages/cli/snap-tests-global/command-link-pnpm10/snap.txt
+++ b/packages/cli/snap-tests-global/command-link-pnpm10/snap.txt
@@ -15,7 +15,7 @@ Documentation: https://viteplus.dev/guide/install
 
 > vp install # install initial dependencies
 Packages: +<variable>
-+<repeat>
++
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
 dependencies:

--- a/packages/cli/snap-tests-global/command-link-pnpm11/snap.txt
+++ b/packages/cli/snap-tests-global/command-link-pnpm11/snap.txt
@@ -15,7 +15,7 @@ Documentation: https://viteplus.dev/guide/install
 
 > vp install # install initial dependencies
 Packages: +<variable>
-+<repeat>
++
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
 dependencies:

--- a/packages/cli/snap-tests-global/command-remove-pnpm10-with-workspace/snap.txt
+++ b/packages/cli/snap-tests-global/command-remove-pnpm10-with-workspace/snap.txt
@@ -1,11 +1,11 @@
 > vp add testnpm2 -D -w --filter=* && vp add test-vite-plus-install -w --filter=* && vp add test-vite-plus-package-optional -O --filter=* && cat package.json packages/app/package.json packages/utils/package.json # prepare packages
-.                                        |   +1 +<repeat>
+.                                        |   +1 +
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 Done in <variable>ms using pnpm v<semver>
-.                                        |   +1 +<repeat>
+.                                        |   +1 +
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 Done in <variable>ms using pnpm v<semver>
-.                                        |   +1 +<repeat>
+.                                        |   +1 +
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 Done in <variable>ms using pnpm v<semver>
 {

--- a/packages/cli/snap-tests-global/command-remove-pnpm10/snap.txt
+++ b/packages/cli/snap-tests-global/command-remove-pnpm10/snap.txt
@@ -34,7 +34,7 @@ For more information, try '--help'.
 
 > vp add testnpm2 && vp add -D test-vite-plus-install && vp add -O test-vite-plus-package-optional && cat package.json # should add packages to dependencies
 Packages: +<variable>
-+<repeat>
++
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
 dependencies:
@@ -42,7 +42,7 @@ dependencies:
 
 Done in <variable>ms using pnpm v<semver>
 Packages: +<variable>
-+<repeat>
++
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
 devDependencies:
@@ -50,7 +50,7 @@ devDependencies:
 
 Done in <variable>ms using pnpm v<semver>
 Packages: +<variable>
-+<repeat>
++
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
 optionalDependencies:

--- a/packages/cli/snap-tests-global/command-remove-pnpm11-with-workspace/snap.txt
+++ b/packages/cli/snap-tests-global/command-remove-pnpm11-with-workspace/snap.txt
@@ -1,11 +1,11 @@
 > vp add testnpm2 -D -w --filter=* && vp add test-vite-plus-install -w --filter=* && vp add test-vite-plus-package-optional -O --filter=* && cat package.json packages/app/package.json packages/utils/package.json # prepare packages
-.                                        |   +1 +<repeat>
+.                                        |   +1 +
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 Done in <variable>ms using pnpm v<semver>
-.                                        |   +1 +<repeat>
+.                                        |   +1 +
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 Done in <variable>ms using pnpm v<semver>
-.                                        |   +1 +<repeat>
+.                                        |   +1 +
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 Done in <variable>ms using pnpm v<semver>
 {

--- a/packages/cli/snap-tests-global/command-remove-pnpm11/snap.txt
+++ b/packages/cli/snap-tests-global/command-remove-pnpm11/snap.txt
@@ -34,7 +34,7 @@ For more information, try '--help'.
 
 > vp add testnpm2 && vp add -D test-vite-plus-install && vp add -O test-vite-plus-package-optional && cat package.json # should add packages to dependencies
 Packages: +<variable>
-+<repeat>
++
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
 dependencies:
@@ -42,7 +42,7 @@ dependencies:
 
 Done in <variable>ms using pnpm v<semver>
 Packages: +<variable>
-+<repeat>
++
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
 devDependencies:
@@ -50,7 +50,7 @@ devDependencies:
 
 Done in <variable>ms using pnpm v<semver>
 Packages: +<variable>
-+<repeat>
++
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
 optionalDependencies:

--- a/packages/cli/snap-tests-global/command-update-pnpm10-with-workspace/snap.txt
+++ b/packages/cli/snap-tests-global/command-update-pnpm10-with-workspace/snap.txt
@@ -2,7 +2,7 @@
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
 Packages: +<variable>
-+<repeat>
++
 Done in <variable>ms using pnpm v<semver>
 {
   "name": "command-update-pnpm10-with-workspace",
@@ -16,7 +16,7 @@ Done in <variable>ms using pnpm v<semver>
 > vp update testnpm2 --latest --filter app && cat packages/app/package.json # should update in specific package
 .                                        |  WARN  `node_modules` is present. Lockfile only installation will make it out-of-date
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
-.                                        |   +2 +<repeat>
+.                                        |   +2 +
 Done in <variable>ms using pnpm v<semver>
 {
   "name": "app",

--- a/packages/cli/snap-tests-global/command-update-pnpm10/snap.txt
+++ b/packages/cli/snap-tests-global/command-update-pnpm10/snap.txt
@@ -123,7 +123,7 @@ Done in <variable>ms using pnpm v<semver>
 > vp rm testnpm2 # should remove package from dependencies for the next test
 > vp add testnpm2@1.0.0 -O && vp update --no-optional --latest && cat package.json # should skip optional dependencies
 Packages: +<variable>
-+<repeat>
++
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
 optionalDependencies:

--- a/packages/cli/snap-tests-global/command-update-pnpm11-with-workspace/snap.txt
+++ b/packages/cli/snap-tests-global/command-update-pnpm11-with-workspace/snap.txt
@@ -2,7 +2,7 @@
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
 Packages: +<variable>
-+<repeat>
++
 Done in <variable>ms using pnpm v<semver>
 {
   "name": "command-update-pnpm11-with-workspace",
@@ -15,7 +15,7 @@ Done in <variable>ms using pnpm v<semver>
 
 > vp update testnpm2 --latest --filter app && cat packages/app/package.json # should update in specific package
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
-.                                        |   +2 +<repeat>
+.                                        |   +2 +
 Done in <variable>ms using pnpm v<semver>
 {
   "name": "app",

--- a/packages/cli/snap-tests-global/command-update-pnpm11/snap.txt
+++ b/packages/cli/snap-tests-global/command-update-pnpm11/snap.txt
@@ -123,7 +123,7 @@ Done in <variable>ms using pnpm v<semver>
 > vp rm testnpm2 # should remove package from dependencies for the next test
 > vp add testnpm2@1.0.0 -O && vp update --no-optional --latest && cat package.json # should skip optional dependencies
 Packages: +<variable>
-+<repeat>
++
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
 optionalDependencies:

--- a/packages/cli/snap-tests-global/migration-add-git-hooks/snap.txt
+++ b/packages/cli/snap-tests-global/migration-add-git-hooks/snap.txt
@@ -1,6 +1,6 @@
 > git init
 > vp migrate --no-interactive # migration should add git hooks setup
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 • Git hooks configured

--- a/packages/cli/snap-tests-global/migration-agent-claude/snap.txt
+++ b/packages/cli/snap-tests-global/migration-agent-claude/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --agent claude --no-interactive # migration with --agent claude should write CLAUDE.md
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 

--- a/packages/cli/snap-tests-global/migration-auto-create-vite-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-auto-create-vite-config/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive 2>&1 # migration should auto create vite.config.ts and remove oxlintrc and oxfmtrc
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 4 config updates applied
 

--- a/packages/cli/snap-tests-global/migration-baseurl-tsconfig/snap.txt
+++ b/packages/cli/snap-tests-global/migration-baseurl-tsconfig/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive # migration should skip typeAware/typeCheck when tsconfig has baseUrl
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 3 config updates applied
 ! Warnings:

--- a/packages/cli/snap-tests-global/migration-chained-lint-staged-pre-commit/snap.txt
+++ b/packages/cli/snap-tests-global/migration-chained-lint-staged-pre-commit/snap.txt
@@ -1,6 +1,6 @@
 > git init
 > vp migrate --no-interactive # migration should preserve chained commands after lint-staged
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 • Git hooks configured

--- a/packages/cli/snap-tests-global/migration-composed-husky-custom-dir/snap.txt
+++ b/packages/cli/snap-tests-global/migration-composed-husky-custom-dir/snap.txt
@@ -1,6 +1,6 @@
 > git init
 > vp migrate --no-interactive # migration should preserve custom husky dir in composed prepare
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 • Git hooks configured

--- a/packages/cli/snap-tests-global/migration-composed-husky-prepare/snap.txt
+++ b/packages/cli/snap-tests-global/migration-composed-husky-prepare/snap.txt
@@ -1,6 +1,6 @@
 > git init
 > vp migrate --no-interactive # migration should replace husky in composed prepare script
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 • Git hooks configured

--- a/packages/cli/snap-tests-global/migration-env-prefix-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-env-prefix-lint-staged/snap.txt
@@ -1,6 +1,6 @@
 > git init
 > vp migrate --no-interactive # migration should replace env-prefixed lint-staged in pre-commit
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 • Git hooks configured

--- a/packages/cli/snap-tests-global/migration-eslint-legacy/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-legacy/snap.txt
@@ -1,6 +1,6 @@
 > vp migrate --no-interactive # should show legacy eslint config warning
 
 Legacy ESLint configuration detected (.eslintrc). Automatic migration to Oxlint requires ESLint v9+ with flat config format (eslint.config.*). Please upgrade to ESLint v9 first: https://eslint.org/docs/latest/use/migrate-to-9.0.0
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied

--- a/packages/cli/snap-tests-global/migration-eslint-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-lint-staged/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive # migration should detect eslint and auto-migrate including lint-staged
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 4 config updates applied
 • ESLint rules migrated to Oxlint

--- a/packages/cli/snap-tests-global/migration-eslint-lintstagedrc/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-lintstagedrc/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive # migration should detect eslint and auto-migrate including lintstagedrc
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 5 config updates applied
 • ESLint rules migrated to Oxlint

--- a/packages/cli/snap-tests-global/migration-eslint-monorepo-package-only/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-monorepo-package-only/snap.txt
@@ -1,7 +1,7 @@
 > vp migrate --no-interactive # migration should warn about package-only eslint
 
 ESLint detected in workspace packages but no root config found. Package-level ESLint must be migrated manually.
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 

--- a/packages/cli/snap-tests-global/migration-eslint-monorepo/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-monorepo/snap.txt
@@ -3,7 +3,7 @@
 ✔ Created vite.config.ts in vite.config.ts
 
 ✔ Merged .oxlintrc.json into vite.config.ts
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 • ESLint rules migrated to Oxlint

--- a/packages/cli/snap-tests-global/migration-eslint-npx-wrapper/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-npx-wrapper/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive # migration should rewrite bare eslint but leave npx wrappers unchanged
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 4 config updates applied
 • ESLint rules migrated to Oxlint

--- a/packages/cli/snap-tests-global/migration-eslint/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive # migration should detect eslint and auto-migrate
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 4 config updates applied
 • ESLint rules migrated to Oxlint

--- a/packages/cli/snap-tests-global/migration-existing-husky-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-husky-lint-staged/snap.txt
@@ -1,6 +1,6 @@
 > git init
 > vp migrate --no-interactive # migration should rewrite husky and lint-staged
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 • Git hooks configured

--- a/packages/cli/snap-tests-global/migration-existing-husky-v8-hooks/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-husky-v8-hooks/snap.txt
@@ -2,7 +2,7 @@
 > vp migrate --no-interactive # should warn about husky v8 and skip hooks setup
 
 ⚠ Detected husky <9.0.0 — please upgrade to husky v9+ first, then re-run migration.
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 1 config update applied
 

--- a/packages/cli/snap-tests-global/migration-existing-husky-v8-multi-hooks/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-husky-v8-multi-hooks/snap.txt
@@ -2,7 +2,7 @@
 > vp migrate --no-interactive # should warn about husky v8 and skip hooks setup
 
 ⚠ Detected husky <9.0.0 — please upgrade to husky v9+ first, then re-run migration.
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 1 config update applied
 

--- a/packages/cli/snap-tests-global/migration-existing-husky/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-husky/snap.txt
@@ -1,6 +1,6 @@
 > git init
 > vp migrate --no-interactive # migration should rewrite husky to vp config
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 • Git hooks configured

--- a/packages/cli/snap-tests-global/migration-existing-lint-staged-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-lint-staged-config/snap.txt
@@ -1,6 +1,6 @@
 > git init
 > vp migrate --no-interactive # migration should add prepare script, remove lint-staged from devDeps
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 3 config updates applied
 • Git hooks configured

--- a/packages/cli/snap-tests-global/migration-existing-pnpm-exec-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-pnpm-exec-lint-staged/snap.txt
@@ -1,6 +1,6 @@
 > git init
 > vp migrate --no-interactive # migration should strip pnpm exec lint-staged and add vp staged
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 • Git hooks configured

--- a/packages/cli/snap-tests-global/migration-existing-pre-commit/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-pre-commit/snap.txt
@@ -6,7 +6,7 @@ npm test
 secret-scan
 
 > vp migrate --no-interactive # migration should preserve existing pre-commit contents
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 • Git hooks configured

--- a/packages/cli/snap-tests-global/migration-existing-prepare-script/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-prepare-script/snap.txt
@@ -1,6 +1,6 @@
 > git init
 > vp migrate --no-interactive # migration should compose vp config with existing prepare script
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 • Git hooks configured

--- a/packages/cli/snap-tests-global/migration-framework-shim-astro-vue/snap.txt
+++ b/packages/cli/snap-tests-global/migration-framework-shim-astro-vue/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive --no-hooks # migration should add both Vue and Astro shims
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 ✓ Dependencies installed in <variable>ms
 • 1 config update applied

--- a/packages/cli/snap-tests-global/migration-framework-shim-astro/snap.txt
+++ b/packages/cli/snap-tests-global/migration-framework-shim-astro/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive --no-hooks # migration should add Astro shim when astro dependency is detected
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 ✓ Dependencies installed in <variable>ms
 • 1 config update applied

--- a/packages/cli/snap-tests-global/migration-framework-shim-vue/snap.txt
+++ b/packages/cli/snap-tests-global/migration-framework-shim-vue/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive --no-hooks # migration should add Vue shim when vue dependency is detected
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 ✓ Dependencies installed in <variable>ms
 • 1 config update applied

--- a/packages/cli/snap-tests-global/migration-from-tsdown-json-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-from-tsdown-json-config/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive # migration should rewrite imports to vite-plus
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 

--- a/packages/cli/snap-tests-global/migration-from-tsdown/snap.txt
+++ b/packages/cli/snap-tests-global/migration-from-tsdown/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive # migration should rewrite imports to vite-plus
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 3 config updates applied, 1 file had imports rewritten
 → Manual follow-up:

--- a/packages/cli/snap-tests-global/migration-from-vitest-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-from-vitest-config/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive # migration should rewrite imports to vite-plus
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied, 1 file had imports rewritten
 

--- a/packages/cli/snap-tests-global/migration-from-vitest-files/snap.txt
+++ b/packages/cli/snap-tests-global/migration-from-vitest-files/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive # migration should rewrite imports to vite-plus
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied, 1 file had imports rewritten
 

--- a/packages/cli/snap-tests-global/migration-hooks-skip-on-existing-hookspath/snap.txt
+++ b/packages/cli/snap-tests-global/migration-hooks-skip-on-existing-hookspath/snap.txt
@@ -1,7 +1,7 @@
 > git init
 > git config core.hooksPath .custom-hooks
 > vp migrate --no-interactive # should skip hooks because core.hooksPath is already set
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 ! Warnings:

--- a/packages/cli/snap-tests-global/migration-husky-env-skip/snap.txt
+++ b/packages/cli/snap-tests-global/migration-husky-env-skip/snap.txt
@@ -1,6 +1,6 @@
 > git init
 > vp migrate --no-interactive # with HUSKY=0, vp config should skip and warn instead of reporting success
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 ! Warnings:

--- a/packages/cli/snap-tests-global/migration-husky-latest-dist-tag-v9-installed/snap.txt
+++ b/packages/cli/snap-tests-global/migration-husky-latest-dist-tag-v9-installed/snap.txt
@@ -1,6 +1,6 @@
 > git init
 > vp migrate --no-interactive # should resolve husky v9 from node_modules, no warning
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 • Git hooks configured

--- a/packages/cli/snap-tests-global/migration-husky-latest-dist-tag/snap.txt
+++ b/packages/cli/snap-tests-global/migration-husky-latest-dist-tag/snap.txt
@@ -2,7 +2,7 @@
 > vp migrate --no-interactive # should warn about uncoercible husky version
 
 ⚠ Could not determine husky version from "latest" — please specify a semver-compatible version (e.g., "^9.0.0") and re-run migration.
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 1 config update applied
 

--- a/packages/cli/snap-tests-global/migration-husky-or-prepare/snap.txt
+++ b/packages/cli/snap-tests-global/migration-husky-or-prepare/snap.txt
@@ -1,6 +1,6 @@
 > git init
 > vp migrate --no-interactive # migration should preserve || fallback semantics
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 • Git hooks configured

--- a/packages/cli/snap-tests-global/migration-husky-semicolon-prepare/snap.txt
+++ b/packages/cli/snap-tests-global/migration-husky-semicolon-prepare/snap.txt
@@ -1,6 +1,6 @@
 > git init
 > vp migrate --no-interactive # migration should strip husky from semicolon-composed prepare script
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 • Git hooks configured

--- a/packages/cli/snap-tests-global/migration-husky-v8-preserves-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-husky-v8-preserves-lint-staged/snap.txt
@@ -2,7 +2,7 @@
 > vp migrate --no-interactive # should warn about husky v8, preserve lint-staged config
 
 ⚠ Detected husky <9.0.0 — please upgrade to husky v9+ first, then re-run migration.
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 1 config update applied
 

--- a/packages/cli/snap-tests-global/migration-lint-staged-in-scripts/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lint-staged-in-scripts/snap.txt
@@ -1,6 +1,6 @@
 > git init
 > vp migrate --no-interactive # migration should rewrite lint-staged commands in scripts
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 • Git hooks configured

--- a/packages/cli/snap-tests-global/migration-lint-staged-merge-fail/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lint-staged-merge-fail/snap.txt
@@ -1,6 +1,6 @@
 > git init
 > vp migrate --no-interactive # should handle merge failure gracefully
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 ! Warnings:
   - Failed to merge staged config into vite.config.ts

--- a/packages/cli/snap-tests-global/migration-lint-staged-ts-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lint-staged-ts-config/snap.txt
@@ -2,7 +2,7 @@
 > vp migrate --no-interactive # migration should warn about unsupported TS lint-staged config
 
 ⚠ Unsupported lint-staged config format — skipping git hooks setup. Please configure git hooks manually.
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 1 config update applied
 

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-json/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-json/snap.txt
@@ -67,7 +67,7 @@ Documentation: https://viteplus.dev/guide/migrate
 
 
 > vp migrate --no-interactive # migration work with lintstagedrc.json
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 ! Warnings:

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-merge-fail/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-merge-fail/snap.txt
@@ -1,6 +1,6 @@
 > git init
 > vp migrate --no-interactive # should handle merge failure gracefully
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 ! Warnings:
   - Failed to merge staged config into vite.config.ts

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-not-support/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-not-support/snap.txt
@@ -2,7 +2,7 @@
 > vp migrate --no-interactive # migration should not support non-json format lintstagedrc
 
 ⚠ Unsupported lint-staged config format — skipping git hooks setup. Please configure git hooks manually.
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 1 config update applied
 

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-staged-exists/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-staged-exists/snap.txt
@@ -1,6 +1,6 @@
 > git init
 > vp migrate --no-interactive # should warn when staged already exists in vite.config.ts
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • Git hooks configured
 ! Warnings:

--- a/packages/cli/snap-tests-global/migration-merge-vite-config-js/snap.txt
+++ b/packages/cli/snap-tests-global/migration-merge-vite-config-js/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive # migration should merge vite.config.js and remove oxlintrc
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 

--- a/packages/cli/snap-tests-global/migration-merge-vite-config-ts/snap.txt
+++ b/packages/cli/snap-tests-global/migration-merge-vite-config-ts/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive # migration should merge vite.config.ts and remove oxlintrc and oxfmtrc
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 3 config updates applied, 1 file had imports rewritten
 

--- a/packages/cli/snap-tests-global/migration-monorepo-bun/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-bun/snap.txt
@@ -1,7 +1,7 @@
 > vp migrate --no-interactive # migration should work with bun object-form workspaces
 
 ✔ Merged .oxlintrc.json into vite.config.ts
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  bun <semver>
 • 1 config update applied, 1 file had imports rewritten
 

--- a/packages/cli/snap-tests-global/migration-monorepo-husky-v8-preserves-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-husky-v8-preserves-lint-staged/snap.txt
@@ -1,7 +1,7 @@
 > vp migrate --no-interactive # should warn about husky v8, preserve all lint-staged config
 
 ⚠ Detected husky <9.0.0 — please upgrade to husky v9+ first, then re-run migration.
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 1 config update applied
 

--- a/packages/cli/snap-tests-global/migration-monorepo-pnpm-overrides-dependency-selector/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-pnpm-overrides-dependency-selector/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive # migration should merge pnpm overrides with dependency selector
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 1 config update applied, 1 file had imports rewritten
 

--- a/packages/cli/snap-tests-global/migration-monorepo-pnpm/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-pnpm/snap.txt
@@ -3,7 +3,7 @@
 ✔ Merged .oxlintrc.json into vite.config.ts
 
 ✔ Merged .oxfmtrc.json into vite.config.ts
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 3 config updates applied, 1 file had imports rewritten
 

--- a/packages/cli/snap-tests-global/migration-monorepo-skip-vite-peer-dependency/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-skip-vite-peer-dependency/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive # migration should preserve vite peer contracts in workspace packages
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied, 1 file had imports rewritten
 

--- a/packages/cli/snap-tests-global/migration-monorepo-yarn4/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-yarn4/snap.txt
@@ -1,7 +1,7 @@
 > vp migrate --no-interactive # migration should merge vite.config.ts and remove oxlintrc
 
 ✔ Merged .oxlintrc.json into vite.config.ts
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  yarn <semver>
 • 1 config update applied, 1 file had imports rewritten
 

--- a/packages/cli/snap-tests-global/migration-no-agent/snap.txt
+++ b/packages/cli/snap-tests-global/migration-no-agent/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-agent --no-interactive # migration with --no-agent should skip agent instructions
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 

--- a/packages/cli/snap-tests-global/migration-no-git-repo/snap.txt
+++ b/packages/cli/snap-tests-global/migration-no-git-repo/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive # migration should create .vite-hooks/pre-commit even without .git
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 

--- a/packages/cli/snap-tests-global/migration-no-hooks-with-husky/snap.txt
+++ b/packages/cli/snap-tests-global/migration-no-hooks-with-husky/snap.txt
@@ -1,6 +1,6 @@
 > git init
 > vp migrate --no-hooks --no-interactive # --no-hooks should keep husky/lint-staged and preserve config
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 1 config update applied
 

--- a/packages/cli/snap-tests-global/migration-no-hooks/snap.txt
+++ b/packages/cli/snap-tests-global/migration-no-hooks/snap.txt
@@ -1,6 +1,6 @@
 > git init
 > vp migrate --no-hooks --no-interactive # migration with --no-hooks should skip hooks setup
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 1 config update applied
 

--- a/packages/cli/snap-tests-global/migration-nvmrc-lts/snap.txt
+++ b/packages/cli/snap-tests-global/migration-nvmrc-lts/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive # migration should detect .nvmrc with lts alias and auto-migrate
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 • Node version manager file migrated to .node-version

--- a/packages/cli/snap-tests-global/migration-nvmrc-node-alias/snap.txt
+++ b/packages/cli/snap-tests-global/migration-nvmrc-node-alias/snap.txt
@@ -1,7 +1,7 @@
 > vp migrate --no-interactive # 'node' alias should be mapped to lts/* with an info message
 
 "node" in .nvmrc is not a specific version; automatically mapping to "lts/*"
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 • Node version manager file migrated to .node-version

--- a/packages/cli/snap-tests-global/migration-nvmrc/snap.txt
+++ b/packages/cli/snap-tests-global/migration-nvmrc/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive # migration should detect .nvmrc and auto-migrate to .node-version
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 • Node version manager file migrated to .node-version

--- a/packages/cli/snap-tests-global/migration-other-hook-tool/snap.txt
+++ b/packages/cli/snap-tests-global/migration-other-hook-tool/snap.txt
@@ -1,7 +1,7 @@
 > vp migrate --no-interactive # hooks should be skipped due to simple-git-hooks
 
 ⚠ Detected simple-git-hooks — skipping git hooks setup. Please configure git hooks manually.
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 1 config update applied
 

--- a/packages/cli/snap-tests-global/migration-oxlintrc-json-with-comments/snap.txt
+++ b/packages/cli/snap-tests-global/migration-oxlintrc-json-with-comments/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive 2>&1 # migration should handle .oxlintrc.json with JSONC comments
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 3 config updates applied
 

--- a/packages/cli/snap-tests-global/migration-oxlintrc-jsonc/snap.txt
+++ b/packages/cli/snap-tests-global/migration-oxlintrc-jsonc/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive 2>&1 # migration should detect .oxlintrc.jsonc and .oxfmtrc.jsonc
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 4 config updates applied
 

--- a/packages/cli/snap-tests-global/migration-partially-migrated-pre-commit/snap.txt
+++ b/packages/cli/snap-tests-global/migration-partially-migrated-pre-commit/snap.txt
@@ -2,7 +2,7 @@
 > vp migrate --no-interactive # should warn about husky v8 and skip hooks setup
 
 ⚠ Detected husky <9.0.0 — please upgrade to husky v9+ first, then re-run migration.
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 1 config update applied
 

--- a/packages/cli/snap-tests-global/migration-pre-commit-env-setup/snap.txt
+++ b/packages/cli/snap-tests-global/migration-pre-commit-env-setup/snap.txt
@@ -7,7 +7,7 @@ npx lint-staged
 npm test
 
 > vp migrate --no-interactive # migration should replace lint-staged in-place
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 • Git hooks configured

--- a/packages/cli/snap-tests-global/migration-prettier-eslint-combo/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier-eslint-combo/snap.txt
@@ -1,7 +1,7 @@
 > vp migrate --no-interactive # migration should detect both eslint and prettier and auto-migrate
 
 Prettier configuration detected. Auto-migrating to Oxfmt...
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 4 config updates applied
 • ESLint rules migrated to Oxlint

--- a/packages/cli/snap-tests-global/migration-prettier-ignore-unknown/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier-ignore-unknown/snap.txt
@@ -1,7 +1,7 @@
 > vp migrate --no-interactive # migration should strip --ignore-unknown and -u flags
 
 Prettier configuration detected. Auto-migrating to Oxfmt...
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 • Prettier migrated to Oxfmt

--- a/packages/cli/snap-tests-global/migration-prettier-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier-lint-staged/snap.txt
@@ -1,7 +1,7 @@
 > vp migrate --no-interactive # migration should detect prettier and auto-migrate including lint-staged
 
 Prettier configuration detected. Auto-migrating to Oxfmt...
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 • Prettier migrated to Oxfmt

--- a/packages/cli/snap-tests-global/migration-prettier-pkg-json/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier-pkg-json/snap.txt
@@ -1,7 +1,7 @@
 > vp migrate --no-interactive # migration should detect prettier in package.json and auto-migrate
 
 Prettier configuration detected. Auto-migrating to Oxfmt...
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 1 config update applied
 • Prettier migrated to Oxfmt

--- a/packages/cli/snap-tests-global/migration-prettier/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier/snap.txt
@@ -1,7 +1,7 @@
 > vp migrate --no-interactive # migration should detect prettier and auto-migrate
 
 Prettier configuration detected. Auto-migrating to Oxfmt...
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 • Prettier migrated to Oxfmt

--- a/packages/cli/snap-tests-global/migration-rewrite-declare-module/snap.txt
+++ b/packages/cli/snap-tests-global/migration-rewrite-declare-module/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive # migration should rewrite imports to vite-plus
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied, 1 file had imports rewritten
 

--- a/packages/cli/snap-tests-global/migration-rewrite-reference-types/snap.txt
+++ b/packages/cli/snap-tests-global/migration-rewrite-reference-types/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive # migration rewrites reference types
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied, 1 file had imports rewritten
 

--- a/packages/cli/snap-tests-global/migration-skip-vite-dependency/snap.txt
+++ b/packages/cli/snap-tests-global/migration-skip-vite-dependency/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive # migration should skip rewriting vite imports when vite is in dependencies
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied, 1 file had imports rewritten
 

--- a/packages/cli/snap-tests-global/migration-skip-vite-peer-dependency/snap.txt
+++ b/packages/cli/snap-tests-global/migration-skip-vite-peer-dependency/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive # migration should preserve vite peer contracts
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied, 1 file had imports rewritten
 

--- a/packages/cli/snap-tests-global/migration-standalone-npm/snap.txt
+++ b/packages/cli/snap-tests-global/migration-standalone-npm/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive --no-hooks # migration should work with npm, add overrides, and update lockfile
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  npm <semver>
 ✓ Dependencies installed in <variable>ms
 • 1 config update applied

--- a/packages/cli/snap-tests-global/migration-standalone-pnpm/snap.txt
+++ b/packages/cli/snap-tests-global/migration-standalone-pnpm/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive --no-hooks --package-manager pnpm # migration should work with pnpm, write overrides and peerDependencyRules to pnpm-workspace.yaml
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 ✓ Dependencies installed in <variable>ms
 • 1 config update applied

--- a/packages/cli/snap-tests-global/migration-subpath/snap.txt
+++ b/packages/cli/snap-tests-global/migration-subpath/snap.txt
@@ -2,7 +2,7 @@
 > vp migrate foo --no-interactive # migration work with subpath
 
 ⚠ Subdirectory project detected — skipping git hooks setup. Configure hooks at the repository root.
-◇ Migrated foo to Vite+<repeat>
+◇ Migrated foo to Vite+
 • Node <semver>  pnpm <semver>
 • 1 config update applied
 

--- a/packages/cli/snap-tests-global/migration-tsconfig-esmoduleinterop/snap.txt
+++ b/packages/cli/snap-tests-global/migration-tsconfig-esmoduleinterop/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive # should remove esModuleInterop: false from tsconfig.json
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 4 config updates applied
 ! Warnings:

--- a/packages/cli/snap-tests-global/migration-vite-version/snap.txt
+++ b/packages/cli/snap-tests-global/migration-vite-version/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive # migration should rewrite vite --version to vp --version
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 

--- a/packages/cli/snap-tests-global/migration-vitest-peer-dep/snap.txt
+++ b/packages/cli/snap-tests-global/migration-vitest-peer-dep/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive # vitest should be added to devDeps when vitest-browser-svelte is present
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 

--- a/packages/cli/snap-tests-global/migration-volta-with-nvmrc/snap.txt
+++ b/packages/cli/snap-tests-global/migration-volta-with-nvmrc/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive # .nvmrc should take priority over volta.node
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 • Node version manager file migrated to .node-version

--- a/packages/cli/snap-tests-global/migration-volta/snap.txt
+++ b/packages/cli/snap-tests-global/migration-volta/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive # migration should detect volta.node in package.json and migrate to .node-version
-◇ Migrated . to Vite+<repeat>
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 • Node version manager file migrated to .node-version

--- a/packages/cli/snap-tests/command-install-shortcut/snap.txt
+++ b/packages/cli/snap-tests/command-install-shortcut/snap.txt
@@ -1,7 +1,7 @@
 > vp run install # install shortcut
 $ vp install
 Packages: +<variable>
-+<repeat>
++
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done
 
 dependencies:

--- a/packages/tools/src/__tests__/__snapshots__/utils.spec.ts.snap
+++ b/packages/tools/src/__tests__/__snapshots__/utils.spec.ts.snap
@@ -52,6 +52,13 @@ exports[`replaceUnstableOutput() > replace ignore tarball download average speed
  WARN  Tarball download average speed 34 KiB/s (size 347 KiB) is below 50 KiB/s: https://registry.<domain>/undici/-/undici-7.16.0.tgz (GET)"
 `;
 
+exports[`replaceUnstableOutput() > replace pnpm progress plus markers with <repeat> 1`] = `
+"Scope: all <variable> workspace projects
+Packages: +<variable>
++<repeat>
+Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done"
+`;
+
 exports[`replaceUnstableOutput() > replace pnpm registry request error warning log 1`] = `"Progress: resolved"`;
 
 exports[`replaceUnstableOutput() > replace tsdown output 1`] = `

--- a/packages/tools/src/__tests__/utils.spec.ts
+++ b/packages/tools/src/__tests__/utils.spec.ts
@@ -292,13 +292,8 @@ Progress: resolved 316, reused 316, downloaded 0, added 316, done
   });
 
   test('preserve trailing plus in text like Vite+', () => {
-    const output = `
-  migrate        Migrate an existing project to Vite+
-  dev            Run the development server
-    `;
-    expect(replaceUnstableOutput(output.trim())).toBe(
-      '  migrate        Migrate an existing project to Vite+\n  dev            Run the development server',
-    );
+    const output = 'Migrate an existing project to Vite+';
+    expect(replaceUnstableOutput(output)).toBe('Migrate an existing project to Vite+');
   });
 });
 

--- a/packages/tools/src/__tests__/utils.spec.ts
+++ b/packages/tools/src/__tests__/utils.spec.ts
@@ -280,6 +280,26 @@ hello world
     `;
     expect(replaceUnstableOutput(output.trim())).toMatchSnapshot();
   });
+
+  test('replace pnpm progress plus markers with <repeat>', () => {
+    const output = `
+Scope: all 6 workspace projects
+Packages: +312
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Progress: resolved 316, reused 316, downloaded 0, added 316, done
+    `;
+    expect(replaceUnstableOutput(output.trim())).toMatchSnapshot();
+  });
+
+  test('preserve trailing plus in text like Vite+', () => {
+    const output = `
+  migrate        Migrate an existing project to Vite+
+  dev            Run the development server
+    `;
+    expect(replaceUnstableOutput(output.trim())).toBe(
+      '  migrate        Migrate an existing project to Vite+\n  dev            Run the development server',
+    );
+  });
 });
 
 describe('isPassThroughEnv()', () => {

--- a/packages/tools/src/utils.ts
+++ b/packages/tools/src/utils.ts
@@ -83,7 +83,7 @@ export function replaceUnstableOutput(output: string, cwd?: string) {
       .replaceAll(/ ?WARN\s+Skip\s+adding .+?\n/g, '')
       .replaceAll(/ ?WARN\s+Request\s+took .+?\n/g, '')
       .replaceAll(/Scope: all \d+ workspace projects/g, 'Scope: all <variable> workspace projects')
-      .replaceAll(/\++\n/g, '+<repeat>\n')
+      .replaceAll(/\+{2,}\n/g, '+<repeat>\n')
       // ignore pnpm registry request error warning log
       .replaceAll(/ ?WARN\s+GET\s+https:\/\/registry\..+?\n/g, '')
       // ignore bun resolution progress (appears intermittently depending on cache state)


### PR DESCRIPTION
Discovered while reviewing CI results after approving #1508.

The regex `/\++\n/g` was overly aggressive and matched any line ending with a single `+`, including legitimate text like "Vite+" in the CLI help output.

Changed to `/\+{2,}\n/g` to only match pnpm's actual repeated `+` progress indicators (e.g., `+++`).
