### PR TITLE
fix(cli): auto-pass --ignore-scripts when pnpm >=11 in migrate/create

### DIFF
--- a/packages/cli/src/create/bin.ts
+++ b/packages/cli/src/create/bin.ts
@@ -917,6 +917,8 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
     updateCreateProgress('Installing dependencies');
     const installSummary = await runViteInstall(fullPath, options.interactive, installArgs, {
       silent: compactOutput,
+      packageManager: workspaceInfo.packageManager,
+      packageManagerVersion: workspaceInfo.downloadPackageManager.version,
     });
     updateCreateProgress('Formatting code');
     await runViteFmt(fullPath, options.interactive, undefined, { silent: compactOutput });
@@ -1038,6 +1040,8 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
     updateCreateProgress('Installing dependencies');
     installSummary = await runViteInstall(installCwd, options.interactive, installArgs, {
       silent: compactOutput,
+      packageManager: workspaceInfo.packageManager,
+      packageManagerVersion: workspaceInfo.downloadPackageManager.version,
     });
     if (installSummary.status !== 'installed') {
       return;
@@ -1126,6 +1130,8 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
     updateCreateProgress('Installing dependencies');
     installSummary = await runViteInstall(workspaceInfo.rootDir, options.interactive, installArgs, {
       silent: compactOutput,
+      packageManager: workspaceInfo.packageManager,
+      packageManagerVersion: workspaceInfo.downloadPackageManager.version,
     });
     updateCreateProgress('Formatting code');
     await runViteFmt(workspaceInfo.rootDir, options.interactive, [projectDir], {
@@ -1148,6 +1154,8 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
     updateCreateProgress('Installing dependencies');
     installSummary = await runViteInstall(fullPath, options.interactive, installArgs, {
       silent: compactOutput,
+      packageManager: workspaceInfo.packageManager,
+      packageManagerVersion: workspaceInfo.downloadPackageManager.version,
     });
     updateCreateProgress('Formatting code');
     await runViteFmt(fullPath, options.interactive, undefined, { silent: compactOutput });

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -649,6 +649,8 @@ async function executeMigrationPlan(
     undefined,
     {
       silent: true,
+      packageManager: workspaceInfo.packageManager,
+      packageManagerVersion: workspaceInfo.downloadPackageManager.version,
     },
   );
 
@@ -778,7 +780,11 @@ async function executeMigrationPlan(
     workspaceInfo.rootDir,
     interactive,
     installArgs,
-    { silent: true },
+    {
+      silent: true,
+      packageManager: workspaceInfo.packageManager,
+      packageManagerVersion: workspaceInfo.downloadPackageManager.version,
+    },
   );
 
   clearMigrationProgress();
@@ -868,12 +874,30 @@ async function main() {
       updateMigrationProgress('Rewriting configs');
       mergeViteConfigFiles(workspaceInfoOptional.rootDir, true, report);
       updateMigrationProgress('Installing dependencies');
+      // Resolve the actual pnpm version that `vp install` will use so the
+      // auto-install can opt into `--ignore-scripts` on pnpm v11 (which fails
+      // unapproved build scripts with `ERR_PNPM_IGNORED_BUILDS`).
+      let resolvedVersion = workspaceInfoOptional.packageManagerVersion;
+      if (
+        workspaceInfoOptional.packageManager &&
+        !semver.valid(semver.coerce(resolvedVersion) ?? '')
+      ) {
+        const resolved = await downloadPackageManager(
+          workspaceInfoOptional.packageManager,
+          resolvedVersion,
+          options.interactive,
+          true,
+        );
+        resolvedVersion = resolved.version;
+      }
       const installSummary = await runViteInstall(
         workspaceInfoOptional.rootDir,
         options.interactive,
         undefined,
         {
           silent: true,
+          packageManager: workspaceInfoOptional.packageManager,
+          packageManagerVersion: resolvedVersion,
         },
       );
       installDurationMs += installSummary.durationMs;

--- a/packages/cli/src/utils/__tests__/prompts.spec.ts
+++ b/packages/cli/src/utils/__tests__/prompts.spec.ts
@@ -21,7 +21,7 @@ describe('shouldIgnoreScriptsForAutoInstall', () => {
     expect(shouldIgnoreScriptsForAutoInstall(PackageManager.bun, '11.0.0')).toBe(false);
   });
 
-  it('returns false when version is unknown or unparseable', () => {
+  it('returns false when version is unknown or unparsable', () => {
     expect(shouldIgnoreScriptsForAutoInstall(PackageManager.pnpm, undefined)).toBe(false);
     expect(shouldIgnoreScriptsForAutoInstall(PackageManager.pnpm, 'latest')).toBe(false);
     expect(shouldIgnoreScriptsForAutoInstall(PackageManager.pnpm, '')).toBe(false);

--- a/packages/cli/src/utils/__tests__/prompts.spec.ts
+++ b/packages/cli/src/utils/__tests__/prompts.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { PackageManager } from '../../types/index.ts';
+import { shouldIgnoreScriptsForAutoInstall } from '../prompts.ts';
+
+describe('shouldIgnoreScriptsForAutoInstall', () => {
+  it('returns true for pnpm >= 11.0.0', () => {
+    expect(shouldIgnoreScriptsForAutoInstall(PackageManager.pnpm, '11.0.0')).toBe(true);
+    expect(shouldIgnoreScriptsForAutoInstall(PackageManager.pnpm, '11.0.8')).toBe(true);
+    expect(shouldIgnoreScriptsForAutoInstall(PackageManager.pnpm, '12.0.0')).toBe(true);
+  });
+
+  it('returns false for pnpm < 11.0.0', () => {
+    expect(shouldIgnoreScriptsForAutoInstall(PackageManager.pnpm, '10.33.2')).toBe(false);
+    expect(shouldIgnoreScriptsForAutoInstall(PackageManager.pnpm, '9.5.0')).toBe(false);
+  });
+
+  it('returns false for non-pnpm package managers', () => {
+    expect(shouldIgnoreScriptsForAutoInstall(PackageManager.npm, '11.0.0')).toBe(false);
+    expect(shouldIgnoreScriptsForAutoInstall(PackageManager.yarn, '11.0.0')).toBe(false);
+    expect(shouldIgnoreScriptsForAutoInstall(PackageManager.bun, '11.0.0')).toBe(false);
+  });
+
+  it('returns false when version is unknown or unparseable', () => {
+    expect(shouldIgnoreScriptsForAutoInstall(PackageManager.pnpm, undefined)).toBe(false);
+    expect(shouldIgnoreScriptsForAutoInstall(PackageManager.pnpm, 'latest')).toBe(false);
+    expect(shouldIgnoreScriptsForAutoInstall(PackageManager.pnpm, '')).toBe(false);
+  });
+
+  it('returns false when packageManager is undefined', () => {
+    expect(shouldIgnoreScriptsForAutoInstall(undefined, '11.0.0')).toBe(false);
+  });
+
+  it('coerces non-strict semver pnpm versions', () => {
+    expect(shouldIgnoreScriptsForAutoInstall(PackageManager.pnpm, 'v11.0.0')).toBe(true);
+    expect(shouldIgnoreScriptsForAutoInstall(PackageManager.pnpm, '11')).toBe(true);
+    expect(shouldIgnoreScriptsForAutoInstall(PackageManager.pnpm, '10')).toBe(false);
+  });
+});

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -1,4 +1,5 @@
 import * as prompts from '@voidzero-dev/vite-plus-prompts';
+import semver from 'semver';
 
 import { downloadPackageManager as downloadPackageManagerBinding } from '../../binding/index.js';
 import { PackageManager } from '../types/index.ts';
@@ -9,6 +10,28 @@ export interface CommandRunSummary {
   durationMs: number;
   exitCode?: number;
   status: 'installed' | 'formatted' | 'failed' | 'skipped';
+}
+
+/**
+ * pnpm v11 promoted `ERR_PNPM_IGNORED_BUILDS` from a warning to a hard
+ * exit-1. Auto-installs run by `vp migrate` / `vp create` happen before the
+ * user has a chance to approve build scripts via `pnpm.onlyBuiltDependencies`,
+ * so transitive deps like `esbuild` would fail the install. Pass
+ * `--ignore-scripts` in that window so the orchestration succeeds; the user's
+ * own subsequent `vp install` keeps default pnpm behavior.
+ */
+export function shouldIgnoreScriptsForAutoInstall(
+  packageManager: PackageManager | undefined,
+  packageManagerVersion: string | undefined,
+): boolean {
+  if (packageManager !== PackageManager.pnpm) {
+    return false;
+  }
+  const coerced = packageManagerVersion ? semver.coerce(packageManagerVersion)?.version : undefined;
+  if (!coerced) {
+    return false;
+  }
+  return semver.gte(coerced, '11.0.0');
 }
 
 export function cancelAndExit(message = 'Operation cancelled', exitCode = 0): never {
@@ -63,11 +86,23 @@ export async function runViteInstall(
   cwd: string,
   interactive?: boolean,
   extraArgs?: string[],
-  options?: { silent?: boolean },
+  options?: {
+    silent?: boolean;
+    packageManager?: PackageManager;
+    packageManagerVersion?: string;
+  },
 ) {
   // install dependencies on non-CI environment
   if (process.env.VP_SKIP_INSTALL) {
     return { durationMs: 0, status: 'skipped' } satisfies CommandRunSummary;
+  }
+
+  const installArgs = [...(extraArgs ?? [])];
+  if (
+    shouldIgnoreScriptsForAutoInstall(options?.packageManager, options?.packageManagerVersion) &&
+    !installArgs.includes('--ignore-scripts')
+  ) {
+    installArgs.push('--ignore-scripts');
   }
 
   const spinner = options?.silent ? getSilentSpinner() : getSpinner(interactive);
@@ -75,7 +110,7 @@ export async function runViteInstall(
   spinner.start(`Installing dependencies...`);
   const { exitCode, stderr, stdout } = await runCommandSilently({
     command: process.env.VP_CLI_BIN ?? 'vp',
-    args: ['install', ...(extraArgs ?? [])],
+    args: ['install', ...installArgs],
     cwd,
     envs: process.env,
   });


### PR DESCRIPTION
pnpm v11 promoted ERR_PNPM_IGNORED_BUILDS from a warning to a hard exit-1
on unapproved build scripts. The auto-install run by `vp migrate` /
`vp create` happens before the user has a chance to add packages to
`pnpm.onlyBuiltDependencies`, so transitive deps like esbuild and
@parcel/watcher fail the install — breaking the tanstack-start-helloworld
and viteplus-ws-repro ecosystem-ci jobs.

When the resolved package manager is pnpm and the version is >=11.0.0,
inject `--ignore-scripts` into the auto-triggered install. User-invoked
`vp install` is unchanged. The migrate early-return (eslint/prettier-only)
path resolves a `latest` version through downloadPackageManager so the
check applies there too.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dependency installation behavior in `vp create`/`vp migrate` by conditionally adding `--ignore-scripts` for pnpm v11+, which could mask legitimate install-script failures during the automated install step (though user-invoked installs remain unchanged).
> 
> **Overview**
> **Fixes pnpm v11 auto-install failures during scaffolding/migration.** `runViteInstall` now detects pnpm `>=11` and automatically appends `--ignore-scripts` for the *auto-triggered* install to avoid `ERR_PNPM_IGNORED_BUILDS`.
> 
> `vp create` and `vp migrate` now pass the resolved package manager + version into `runViteInstall`, including the migrate “already Vite+” early-return path which resolves non-semver versions (e.g. `latest`) before deciding. Adds unit tests for the new `shouldIgnoreScriptsForAutoInstall` helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20784c573592cf0acc0d4c16d5df0507aaf0d494. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->