### PR TITLE
chore: gate pkg.pr.new publish on label only

### DIFF
--- a/.github/workflows/publish-to-pkg.pr.new.yml
+++ b/.github/workflows/publish-to-pkg.pr.new.yml
@@ -5,10 +5,6 @@ name: Publish to pkg.pr.new
 permissions: {}
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - ci/pkg-pr-new
   pull_request:
     types: [labeled]
 
@@ -20,9 +16,7 @@ jobs:
   prepare:
     if: >-
       github.repository == 'voidzero-dev/vite-plus' &&
-      (github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'pkg.pr.new')))
+      contains(github.event.pull_request.labels.*.name, 'pkg.pr.new')
     name: Compute snapshot version
     runs-on: ubuntu-latest
     permissions:
@@ -45,9 +39,7 @@ jobs:
     name: Build bindings and binaries
     if: >-
       github.repository == 'voidzero-dev/vite-plus' &&
-      (github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'pkg.pr.new')))
+      contains(github.event.pull_request.labels.*.name, 'pkg.pr.new')
     needs: prepare
     permissions:
       contents: read
@@ -59,9 +51,7 @@ jobs:
   publish:
     if: >-
       github.repository == 'voidzero-dev/vite-plus' &&
-      (github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'pkg.pr.new')))
+      contains(github.event.pull_request.labels.*.name, 'pkg.pr.new')
     name: Pkg Preview
     runs-on: ubuntu-latest
     needs:

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -1,0 +1,13 @@
+# Maintenance
+
+## Publishing Preview Packages
+
+Publish to https://pkg.pr.new/~/voidzero-dev/vite-plus
+
+Add the `pkg.pr.new` label to the PR.
+
+Use the commit sha, e.g.:
+
+```sh
+pnpm add https://pkg.pr.new/voidzero-dev/vite-plus@sha
+```


### PR DESCRIPTION
## Summary
- Add `MAINTENANCE.md` documenting how to publish a preview build (label PR with `pkg.pr.new`, install via `pnpm add https://pkg.pr.new/voidzero-dev/vite-plus@sha`).
- Drop the `workflow_dispatch` and `ci/pkg-pr-new` push triggers from `.github/workflows/publish-to-pkg.pr.new.yml`; the preview publish now runs only when a PR is labeled `pkg.pr.new`.
- Simplify the per-job `if:` conditions accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)