### PR TITLE
fix(ci): publish release as draft to support immutable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,7 +205,7 @@ jobs:
         id: release
         with:
           body_path: ./RELEASE_BODY.md
-          draft: false
+          draft: true
           make_latest: ${{ inputs.npm_tag == 'latest' }}
           prerelease: ${{ inputs.npm_tag == 'alpha' }}
           name: vite-plus v${{ env.VERSION }}
@@ -213,6 +213,11 @@ jobs:
           target_commitish: ${{ github.sha }}
           files: |
             installer-release/vp-setup-*.exe
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "v${VERSION}" --draft=false --repo "${{ github.repository }}"
 
       - name: Send Discord notification
         if: ${{ inputs.npm_tag == 'latest' }}


### PR DESCRIPTION
## Summary

The release workflow fails on the asset-upload step on repos with GitHub's [immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases) feature enabled. Failing run: https://github.com/voidzero-dev/vite-plus/actions/runs/25673521844/job/75370568926

```
Cannot upload asset vp-setup-x86_64-pc-windows-msvc.exe to an immutable release.
GitHub only allows asset uploads before a release is published, but draft
prereleases publish with the release.published event instead of release.prereleased.
```

`softprops/action-gh-release` creates `prerelease: true, draft: false` in a single API call, so the release is already published by the time assets upload. On immutable repos that's rejected.

## Fix

- Create the release as a **draft** so assets attach while it's still mutable.
- Add a follow-up `gh release edit ... --draft=false` step to publish it.

The single `release.published` event still fires once, after assets are in place. `GITHUB_TOKEN` already has `contents: write` on the Release job, which is all `gh release edit` needs.

## Test plan

- [x] Trigger a manual `Release` workflow run with `npm_tag: alpha` and verify both the `Create GitHub Release` (draft) and `Publish GitHub Release` steps succeed
- [x] Confirm assets (`vp-setup-*.exe`) appear on the published release
- [x] Confirm the GitHub release transitions from draft to published prerelease