### PR TITLE
fix(test): preserve string-literal tabs in convertTabsToSpaces

### DIFF
--- a/packages/cli/snap-tests/test-inline-snapshot-indent/package.json
+++ b/packages/cli/snap-tests/test-inline-snapshot-indent/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "test-inline-snapshot-indent",
+  "private": true
+}

--- a/packages/cli/snap-tests/test-inline-snapshot-indent/snap.txt
+++ b/packages/cli/snap-tests/test-inline-snapshot-indent/snap.txt
@@ -1,0 +1,23 @@
+> vp test run -u src/inline-snapshot.test.ts # write inline snapshot via --update (regression test for #1553)
+ RUN  <cwd>
+
+ ✓ src/inline-snapshot.test.ts (1 test) <variable>ms
+
+  Snapshots  1 written
+ Test Files  1 passed (1)
+      Tests  1 passed (1)
+   Start at  <date>
+   Duration  <variable>ms (transform <variable>ms, setup <variable>ms, import <variable>ms, tests <variable>ms, environment <variable>ms)
+
+
+> cat src/inline-snapshot.test.ts # snapshot must use 2-space indentation, not tabs
+import { describe, expect, it } from 'vite-plus/test';
+
+describe('inline snapshot indentation', () => {
+  it('writes multiline snapshots using the surrounding file indentation style', () => {
+    expect('alpha\nbeta').toMatchInlineSnapshot(`
+      "alpha
+      beta"
+    `);
+  });
+});

--- a/packages/cli/snap-tests/test-inline-snapshot-indent/src/inline-snapshot.test.ts
+++ b/packages/cli/snap-tests/test-inline-snapshot-indent/src/inline-snapshot.test.ts
@@ -1,0 +1,7 @@
+import { describe, expect, it } from 'vite-plus/test';
+
+describe('inline snapshot indentation', () => {
+  it('writes multiline snapshots using the surrounding file indentation style', () => {
+    expect('alpha\nbeta').toMatchInlineSnapshot();
+  });
+});

--- a/packages/cli/snap-tests/test-inline-snapshot-indent/steps.json
+++ b/packages/cli/snap-tests/test-inline-snapshot-indent/steps.json
@@ -1,4 +1,5 @@
 {
+  "ignoredPlatforms": ["win32"],
   "commands": [
     "vp test run -u src/inline-snapshot.test.ts # write inline snapshot via --update (regression test for #1553)",
     "cat src/inline-snapshot.test.ts # snapshot must use 2-space indentation, not tabs"

--- a/packages/cli/snap-tests/test-inline-snapshot-indent/steps.json
+++ b/packages/cli/snap-tests/test-inline-snapshot-indent/steps.json
@@ -1,0 +1,6 @@
+{
+  "commands": [
+    "vp test run -u src/inline-snapshot.test.ts # write inline snapshot via --update (regression test for #1553)",
+    "cat src/inline-snapshot.test.ts # snapshot must use 2-space indentation, not tabs"
+  ]
+}

--- a/packages/test/__tests__/build-artifacts.spec.ts
+++ b/packages/test/__tests__/build-artifacts.spec.ts
@@ -66,6 +66,30 @@ describe('build artifacts', () => {
   });
 
   /**
+   * `convertTabsToSpaces()` in build.ts must not touch tabs inside string
+   * literals. Upstream `@vitest/snapshot` decides multi-line snapshot
+   * indentation via `indent.includes("\t")` — where `"\t"` is a literal
+   * tab byte in the bundled source. A blanket tab→spaces rewrite turned
+   * this into `indent.includes("  ")`, so every 2-space indent matched
+   * and the tab-appending branch always ran, producing tab-indented
+   * snapshots in 2-space files.
+   *
+   * See: https://github.com/voidzero-dev/vite-plus/issues/1553
+   */
+  describe('snapshot indent check (regression test for #1553)', () => {
+    const snapshotIndexPath = path.join(distDir, '@vitest/snapshot/index.js');
+
+    it('preserves the literal tab byte inside the indent.includes string', () => {
+      const content = fs.readFileSync(snapshotIndexPath, 'utf-8');
+      // The bundled snapshot logic must still test for a tab character.
+      // If the string argument is "  " instead of "\t", every 2-space
+      // indent matches and snapshots get tab-indented.
+      expect(content).toContain('indent.includes("\t")');
+      expect(content).not.toMatch(/indent\.includes\("  "\)/);
+    });
+  });
+
+  /**
    * Third-party packages that call `expect.extend()` internally
    * (e.g., @testing-library/jest-dom) break under npm override because
    * the vitest module instance is split, causing matchers to be registered

--- a/packages/test/__tests__/build-artifacts.spec.ts
+++ b/packages/test/__tests__/build-artifacts.spec.ts
@@ -81,9 +81,6 @@ describe('build artifacts', () => {
 
     it('preserves the literal tab byte inside the indent.includes string', () => {
       const content = fs.readFileSync(snapshotIndexPath, 'utf-8');
-      // The bundled snapshot logic must still test for a tab character.
-      // If the string argument is "  " instead of "\t", every 2-space
-      // indent matches and snapshots get tab-indented.
       expect(content).toContain('indent.includes("\t")');
       expect(content).not.toMatch(/indent\.includes\("  "\)/);
     });

--- a/packages/test/build.ts
+++ b/packages/test/build.ts
@@ -1383,9 +1383,6 @@ async function convertTabsToSpaces() {
 
   for await (const file of fsGlob(resolve(distDir, '**/*.js'))) {
     const content = await readFile(file, 'utf-8');
-    if (!/^\t/m.test(content)) {
-      continue;
-    }
     const converted = content.replace(/^\t+/gm, (match) => '  '.repeat(match.length));
     if (converted !== content) {
       await writeFile(file, converted);

--- a/packages/test/build.ts
+++ b/packages/test/build.ts
@@ -1365,18 +1365,29 @@ async function patchVitestCoreResolver() {
 }
 
 /**
- * Convert tabs to spaces in all JS files in dist/ for consistent formatting.
- * This allows our patching code to use space-based patterns instead of tabs.
+ * Convert leading tabs to spaces in all JS files in dist/ for consistent
+ * formatting. This allows our patching code to use space-based patterns
+ * instead of tabs.
+ *
+ * Only leading whitespace is rewritten — tabs inside string or template
+ * literals are semantically meaningful (e.g. `indent.includes("\t")` in
+ * @vitest/snapshot picks the snapshot indent style by checking for a
+ * literal tab byte) and must be preserved.
+ *
+ * See: https://github.com/voidzero-dev/vite-plus/issues/1553
  */
 async function convertTabsToSpaces() {
-  console.log('\nConverting tabs to spaces in dist/...');
+  console.log('\nConverting leading tabs to spaces in dist/...');
 
   let convertedCount = 0;
 
   for await (const file of fsGlob(resolve(distDir, '**/*.js'))) {
     const content = await readFile(file, 'utf-8');
-    if (content.includes('\t')) {
-      const converted = content.replace(/\t/g, '  ');
+    if (!/^\t/m.test(content)) {
+      continue;
+    }
+    const converted = content.replace(/^\t+/gm, (match) => '  '.repeat(match.length));
+    if (converted !== content) {
       await writeFile(file, converted);
       convertedCount++;
     }


### PR DESCRIPTION
## Summary

- `convertTabsToSpaces()` in `packages/test/build.ts` did a blanket `\t` → 2-space rewrite over every dist `.js` file. Upstream `@vitest/snapshot` decides multi-line inline snapshot indentation with `indent.includes("\t")` where the `"\t"` is a literal tab byte in the bundled source. The blanket replace turned that into `indent.includes("  ")`, so any 2+ space indent matched and the tab-appending branch always ran — producing tab-indented snapshots inside 2-space-indented test files.
- Restrict the replacement to leading tabs only via `/^\t+/gm`. Indentation is still normalized (downstream patches that rely on space indent keep working), but tabs inside string and template literals are now preserved.

## Root cause (byte-level)

Upstream `@vitest/snapshot/dist/index.js:369`:
```
\t const indentNext = indent.includes("<TAB>") ? `${indent}\t` : `${indent}  `;
```
The `<TAB>` inside the `includes(...)` string is a real 0x09 byte. The `\t` in the template literal is the 2-char escape sequence (`\` + `t`).

Before the fix, `convertTabsToSpaces` rewrote both the leading tab AND the literal tab byte inside the string to two spaces. The escape sequence was untouched. Result at runtime:
- `indent.includes("  ")` is true for any 2+ space indent
- Snapshot lines get appended with `${indent}\t` → a real tab byte

After the fix only leading tabs are rewritten; the string-literal tab survives.

## Test plan

- [x] Unit regression test in `packages/test/__tests__/build-artifacts.spec.ts` asserts the bundled snapshot file preserves `indent.includes("\t")` with a literal tab byte (passes after fix, fails before).
- [x] Snap test in `packages/cli/snap-tests/test-inline-snapshot-indent/` reproduces the issue's exact reproduction steps (`vp test run -u` on a 2-space-indented file) and captures the rewritten file content. Verified that reverting the fix produces a `snap.txt` containing real tabs (`<4 spaces><TAB>"alpha`) while the fixed build produces 6-space indentation.
- [x] All 6 `packages/test` unit tests pass.
- [x] `vp check --fix` is clean.

Closes #1553

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the test package build post-processing (`convertTabsToSpaces`) which rewrites generated dist artifacts; a regex mistake could subtly change bundled code semantics beyond formatting, but the change is narrowly scoped and covered by new regression tests.
> 
> **Overview**
> Fixes a dist-build formatting step so it **only converts leading tab indentation to spaces**, instead of rewriting *all* tab bytes and accidentally altering string/template literal contents.
> 
> Adds regression coverage for inline snapshot indentation: a new build-artifact assertion ensures `@vitest/snapshot` still contains `indent.includes("\t")`, and a new CLI snap-test reproduces `vp test run -u` updating an inline snapshot in a 2-space-indented file to verify the written snapshot stays space-indented (not tab-indented).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eb4ed17cb471ac10981cc9ef6ca5641346f83b4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->