### PR TITLE
chore(ci): ensure no file changes after build-upstream step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,6 +243,16 @@ jobs:
         with:
           target: ${{ matrix.target }}
 
+      - name: Ensure no unexpected file changes after build
+        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "::error::Unexpected file changes detected after build"
+            git status
+            git diff
+            exit 1
+          fi
+
       - name: Check TypeScript types
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
         run: pnpm tsgo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5351,7 +5351,6 @@ name = "rolldown_devtools"
 version = "0.1.0"
 dependencies = [
  "blake3",
- "dashmap",
  "rolldown_devtools_action",
  "rustc-hash",
  "serde",


### PR DESCRIPTION
## Summary

- Add a `git status --porcelain` check immediately after the `Build with upstream` step in the `cli-e2e-test` job
- Fails the job with `git status` + `git diff` output if the build mutates any tracked files
- Gated to `x86_64-unknown-linux-gnu` only

Refs https://github.com/voidzero-dev/vite-plus/pull/1305#discussion_r3224753554

## Test plan

- [x] CI passes on this branch (no unexpected file changes from `build-upstream`)