### PR TITLE
ci: gate release publish on environment approval with Discord notice

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,9 +60,19 @@ jobs:
       version: ${{ needs.prepare.outputs.version }}
       cache-key: release
 
-  Release:
+  request-approval:
     runs-on: ubuntu-latest
     needs: [prepare, build-rust]
+    steps:
+      - uses: tsickert/discord-webhook@b217a69502f52803de774ded2b1ab7c282e99645 # v7.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_RELEASES_WEBHOOK_URL }}
+          content: "Requesting approval: ${{ github.server_url }}/${{ github.repository }}/actions/workflows/release.yml"
+
+  Release:
+    runs-on: ubuntu-latest
+    environment: release
+    needs: [prepare, build-rust, request-approval]
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: tsickert/discord-webhook@b217a69502f52803de774ded2b1ab7c282e99645 # v7.0.0
         with:
           webhook-url: ${{ secrets.DISCORD_RELEASES_WEBHOOK_URL }}
-          content: "Requesting approval: ${{ github.server_url }}/${{ github.repository }}/actions/workflows/release.yml"
+          content: 'Requesting approval: ${{ github.server_url }}/${{ github.repository }}/actions/workflows/release.yml'
 
   Release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `environment: release` to the `Release` job so npm publishing is gated by a manual approval on the `release` environment.
- Introduce a `request-approval` job that fires before the `Release` job and posts a Discord message with a link to the workflow run, so reviewers know an approval is waiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)