### PR TITLE
test(cli): verify .gitignore and .yarnrc.yml in new-vite-monorepo snap

### DIFF
--- a/packages/cli/snap-tests-global/new-vite-monorepo/snap.txt
+++ b/packages/cli/snap-tests-global/new-vite-monorepo/snap.txt
@@ -68,6 +68,12 @@ peerDependencyRules:
     vite: "*"
     vitest: "*"
 
+> test -f vite-plus-monorepo/.gitignore && echo '.gitignore exists' || echo 'ERROR: .gitignore missing' # verify gitignore renamed from _gitignore
+.gitignore exists
+
+> test ! -f vite-plus-monorepo/.yarnrc.yml && echo 'No .yarnrc.yml' || echo 'ERROR: .yarnrc.yml exists' # verify no yarn config for pnpm
+No .yarnrc.yml
+
 > test -d vite-plus-monorepo/.git && echo 'Git initialized' || echo 'No git' # check git init
 Git initialized
 

--- a/packages/cli/snap-tests-global/new-vite-monorepo/steps.json
+++ b/packages/cli/snap-tests-global/new-vite-monorepo/steps.json
@@ -9,6 +9,8 @@
     "cat vite-plus-monorepo/package.json # check package.json",
     "cat vite-plus-monorepo/vite.config.ts # check vite config has cache enabled",
     "cat vite-plus-monorepo/pnpm-workspace.yaml # check workspace config",
+    "test -f vite-plus-monorepo/.gitignore && echo '.gitignore exists' || echo 'ERROR: .gitignore missing' # verify gitignore renamed from _gitignore",
+    "test ! -f vite-plus-monorepo/.yarnrc.yml && echo 'No .yarnrc.yml' || echo 'ERROR: .yarnrc.yml exists' # verify no yarn config for pnpm",
     "test -d vite-plus-monorepo/.git && echo 'Git initialized' || echo 'No git' # check git init",
     "ls vite-plus-monorepo/apps # check apps directory created",
     "ls vite-plus-monorepo/apps/website/package.json # check website package.json",


### PR DESCRIPTION
 ## Summary

`ls | sort` skips dotfiles, so the `new-vite-monorepo` snap test never noticed if:
- `_gitignore → .gitignore` rename failed
- pnpm-branch `.yarnrc.yml` cleanup broke — the bun snap covers the npm/bun branch but not pnpm

Adds two `test -f` / `test ! -f` assertions