### PR TITLE
chore: fix bootstrap cli on Windows

### DIFF
--- a/justfile
+++ b/justfile
@@ -74,8 +74,13 @@ check:
 watch-check:
   just watch "'cargo check; cargo clippy'"
 
+[unix]
 test:
-  cargo test
+  cargo test $(for d in crates/*/; do echo -n "-p $(basename $d) "; done) -p vite-plus-cli
+
+[windows]
+test:
+  $packages = Get-ChildItem -Path crates -Directory | ForEach-Object { '-p'; $_.Name }; $Env:__COMPAT_LAYER='RunAsInvoker'; cargo test @packages -p vite-plus-cli
 
 lint:
   cargo clippy --workspace --all-targets --all-features -- --deny warnings

--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -16,6 +16,7 @@ import { dts } from 'rolldown-plugin-dts';
 import { glob } from 'tinyglobby';
 
 import { generateLicenseFile } from '../../scripts/generate-license.js';
+import viteRolldownConfig from '../../vite/packages/vite/rolldown.config.js';
 import { buildCjsDeps } from './build-support/build-cjs-deps.js';
 import { replaceThirdPartyCjsRequires } from './build-support/find-create-require.js';
 import { RewriteImportsPlugin } from './build-support/rewrite-imports.js';
@@ -26,7 +27,6 @@ import {
   type ReplacementRule,
 } from './build-support/rewrite-module-specifiers.js';
 import pkgJson from './package.json' with { type: 'json' };
-import viteRolldownConfig from '../../vite/packages/vite/rolldown.config.js';
 
 const projectDir = join(fileURLToPath(import.meta.url), '..');
 

--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -26,7 +26,7 @@ import {
   type ReplacementRule,
 } from './build-support/rewrite-module-specifiers.js';
 import pkgJson from './package.json' with { type: 'json' };
-import viteRolldownConfig from './vite-rolldown.config.js';
+import viteRolldownConfig from '../../vite/packages/vite/rolldown.config.js';
 
 const projectDir = join(fileURLToPath(import.meta.url), '..');
 

--- a/packages/core/rollupLicensePlugin.ts
+++ b/packages/core/rollupLicensePlugin.ts
@@ -1,1 +1,0 @@
-../../vite/packages/vite/rollupLicensePlugin.ts

--- a/packages/core/vite-rolldown.config.ts
+++ b/packages/core/vite-rolldown.config.ts
@@ -1,1 +1,0 @@
-../../vite/packages/vite/rolldown.config.ts

--- a/packages/tools/src/install-global-cli.ts
+++ b/packages/tools/src/install-global-cli.ts
@@ -226,7 +226,10 @@ function isWindowsLockedExecutableError(err: unknown): boolean {
   }
 
   const code = (err as NodeJS.ErrnoException).code;
-  return code === 'EPERM' && err.message.includes(`${path.sep}bin${path.sep}vp.exe`);
+  return (
+    (code === 'EPERM' || code === 'EBUSY') &&
+    err.message.includes(`${path.sep}bin${path.sep}vp.exe`)
+  );
 }
 
 function removeWindowsPath(targetPath: string) {

--- a/packages/tools/src/install-global-cli.ts
+++ b/packages/tools/src/install-global-cli.ts
@@ -233,11 +233,16 @@ function isWindowsLockedExecutableError(err: unknown): boolean {
 }
 
 function removeWindowsPath(targetPath: string) {
-  if (!existsSync(targetPath)) {
-    return;
+  let stat;
+  try {
+    stat = lstatSync(targetPath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return;
+    }
+    throw err;
   }
 
-  const stat = lstatSync(targetPath);
   if (!stat.isDirectory() || stat.isSymbolicLink()) {
     rmSync(targetPath, { force: true });
     return;

--- a/packages/tools/src/install-global-cli.ts
+++ b/packages/tools/src/install-global-cli.ts
@@ -217,9 +217,7 @@ function pathsEqual(a: string, b: string | undefined): boolean {
 
   const resolvedA = path.resolve(a);
   const resolvedB = path.resolve(b);
-  return isWindows
-    ? resolvedA.toLowerCase() === resolvedB.toLowerCase()
-    : resolvedA === resolvedB;
+  return isWindows ? resolvedA.toLowerCase() === resolvedB.toLowerCase() : resolvedA === resolvedB;
 }
 
 function isWindowsLockedExecutableError(err: unknown): boolean {

--- a/packages/tools/src/install-global-cli.ts
+++ b/packages/tools/src/install-global-cli.ts
@@ -1,11 +1,14 @@
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
+  realpathSync,
   rmSync,
+  rmdirSync,
   symlinkSync,
   writeFileSync,
 } from 'node:fs';
@@ -105,11 +108,20 @@ export function installGlobalCli() {
 
     // Clean up old local-dev directories to avoid accumulation
     if (existsSync(installDir)) {
+      const currentInstallPath = getCurrentInstallPath(installDir);
       for (const entry of readdirSync(installDir)) {
         if (entry.startsWith(LOCAL_DEV_PREFIX)) {
+          const entryPath = path.join(installDir, entry);
+          if (pathsEqual(entryPath, currentInstallPath)) {
+            continue;
+          }
           try {
-            rmSync(path.join(installDir, entry), { recursive: true, force: true });
+            removeInstallPath(entryPath);
           } catch (err) {
+            if (isWindowsLockedExecutableError(err)) {
+              console.log(`Skipping old ${entry} because its vp.exe is still running.`);
+              continue;
+            }
             console.warn(`Warning: failed to remove old ${entry}: ${(err as Error).message}`);
           }
         }
@@ -132,12 +144,17 @@ export function installGlobalCli() {
     // Run platform-specific install script (use absolute paths)
     const installScriptDir = path.join(repoRoot, 'packages/cli');
     if (isWindows) {
-      // Use pwsh (PowerShell Core) for better UTF-8 handling
+      // Prefer PowerShell Core for better UTF-8 handling, but fall back to
+      // Windows PowerShell because pwsh is not available on every Windows host.
       const ps1Path = path.join(installScriptDir, 'install.ps1');
-      execSync(`pwsh -ExecutionPolicy Bypass -File "${ps1Path}"`, {
-        stdio: 'inherit',
-        env,
-      });
+      execFileSync(
+        getWindowsPowerShellCommand(),
+        ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', ps1Path],
+        {
+          stdio: 'inherit',
+          env,
+        },
+      );
     } else {
       const shPath = path.join(installScriptDir, 'install.sh');
       execSync(`bash "${shPath}"`, {
@@ -171,6 +188,67 @@ function getTargetDirs(): string[] {
   return dirs;
 }
 
+function removeInstallPath(targetPath: string) {
+  if (!isWindows) {
+    rmSync(targetPath, { recursive: true, force: true });
+    return;
+  }
+
+  removeWindowsPath(targetPath);
+}
+
+function getCurrentInstallPath(installDir: string): string | undefined {
+  const currentPath = path.join(installDir, 'current');
+  if (!existsSync(currentPath)) {
+    return undefined;
+  }
+
+  try {
+    return realpathSync(currentPath);
+  } catch {
+    return undefined;
+  }
+}
+
+function pathsEqual(a: string, b: string | undefined): boolean {
+  if (!b) {
+    return false;
+  }
+
+  const resolvedA = path.resolve(a);
+  const resolvedB = path.resolve(b);
+  return isWindows
+    ? resolvedA.toLowerCase() === resolvedB.toLowerCase()
+    : resolvedA === resolvedB;
+}
+
+function isWindowsLockedExecutableError(err: unknown): boolean {
+  if (!isWindows || !(err instanceof Error)) {
+    return false;
+  }
+
+  const code = (err as NodeJS.ErrnoException).code;
+  return code === 'EPERM' && err.message.includes(`${path.sep}bin${path.sep}vp.exe`);
+}
+
+function removeWindowsPath(targetPath: string) {
+  if (!existsSync(targetPath)) {
+    return;
+  }
+
+  const stat = lstatSync(targetPath);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    rmSync(targetPath, { force: true });
+    return;
+  }
+
+  for (const entry of readdirSync(targetPath)) {
+    removeWindowsPath(path.join(targetPath, entry));
+  }
+
+  rmdirSync(targetPath);
+}
+
 // Find the vp binary in the target directory.
 // Checks target/release/ first (local builds), then target/<triple>/release/ (cross-compiled CI builds).
 function findVpBinary(binaryName: string) {
@@ -193,6 +271,26 @@ function findVpBinary(binaryName: string) {
   }
 
   return null;
+}
+
+function getWindowsPowerShellCommand(): string {
+  for (const command of ['pwsh', 'powershell.exe', 'powershell']) {
+    try {
+      const resolved = execFileSync('where.exe', [command], {
+        encoding: 'utf-8',
+        stdio: 'pipe',
+      })
+        .split(/\r?\n/)
+        .find(Boolean);
+      if (resolved) {
+        return resolved;
+      }
+    } catch {
+      // Try the next candidate.
+    }
+  }
+
+  return 'powershell.exe';
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,11 +19,8 @@
     "packages/cli/docs",
     "packages/cli/snap-tests",
     "packages/cli/snap-tests-global",
-    // Symlinks to vite submodule files that don't use .js extensions;
-    // excluding build.ts too because it imports vite-rolldown.config.ts
+    // build.ts imports vite/packages/vite/rolldown.config.ts which doesn't use .js extensions
     "packages/core/build.ts",
-    "packages/core/rollupLicensePlugin.ts",
-    "packages/core/vite-rolldown.config.ts",
     "vite",
     "rolldown",
     "target"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -70,6 +70,8 @@ export default defineConfig({
       'packages/cli/snap-tests/fmt-ignore-patterns/src/ignored',
       'packages/cli/snap-tests-global/migration-lint-staged-ts-config',
       'ecosystem-ci/*/**',
+      'packages/core/rollupLicensePlugin.ts',
+      'packages/core/vite-rolldown.config.ts',
       'packages/test/**.cjs',
       'packages/test/**.cts',
       'packages/test/**.d.mjs',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,8 +28,6 @@ export default defineConfig({
           'bench/**/*.ts',
           'ecosystem-ci/**/*',
           'packages/*/build.ts',
-          'packages/core/rollupLicensePlugin.ts',
-          'packages/core/vite-rolldown.config.ts',
           'packages/tools/**/*.ts',
         ],
         rules: {
@@ -48,8 +46,6 @@ export default defineConfig({
       '**/snap-tests-global/**',
       '**/snap-tests-todo/**',
       'packages/*/binding/**',
-      'packages/core/rollupLicensePlugin.ts',
-      'packages/core/vite-rolldown.config.ts',
     ],
   },
   test: {
@@ -70,8 +66,6 @@ export default defineConfig({
       'packages/cli/snap-tests/fmt-ignore-patterns/src/ignored',
       'packages/cli/snap-tests-global/migration-lint-staged-ts-config',
       'ecosystem-ci/*/**',
-      'packages/core/rollupLicensePlugin.ts',
-      'packages/core/vite-rolldown.config.ts',
       'packages/test/**.cjs',
       'packages/test/**.cts',
       'packages/test/**.d.mjs',


### PR DESCRIPTION
## Summary
- import Vite's Rolldown config directly from the real source path so Windows checkouts do not try to parse symlink placeholder text
- fall back from `pwsh` to Windows PowerShell when launching `install.ps1`
- make local-dev cleanup handle Windows junctions and locked `vp.exe` installs gracefully

## Verification
- `pnpm bootstrap-cli`
- `pnpm install-global-cli`
- `vp --version`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the Windows install/bootstrap path and cleanup behavior for global CLI installs, which could break developer setup on Windows if edge cases are missed; runtime product code is not affected.
> 
> **Overview**
> Fixes Windows bootstrap issues by **removing symlink-placeholder TypeScript configs** in `packages/core` and having `packages/core/build.ts` import Vite’s `rolldown.config` directly from the upstream `vite/` submodule path.
> 
> Improves `install-global-cli` on Windows by **falling back from `pwsh` to Windows PowerShell**, and by making local-dev install cleanup skip the active `current` install, correctly delete junction/symlink trees, and tolerate locked `vp.exe` binaries.
> 
> Updates developer tooling to run Rust tests per-crate (including `vite-plus-cli`) on both Unix and Windows, and trims TS/lint excludes now that the placeholder symlink files are gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39ebb629e45d73c52a4dcf0d0e6e0f844a2a54a4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->