### PR TITLE
test(cli): add --help case to config snap tests for npm10/yarn1/yarn4

### DIFF
--- a/packages/cli/snap-tests-global/command-config-npm10/snap.txt
+++ b/packages/cli/snap-tests-global/command-config-npm10/snap.txt
@@ -1,3 +1,20 @@
+> vp pm config --help # should show help
+Usage: vp pm config <COMMAND>
+
+Manage package manager configuration
+
+Commands:
+  list    List all configuration
+  get     Get configuration value
+  set     Set configuration value
+  delete  Delete configuration key
+
+Options:
+  -h, --help  Print help
+
+Documentation: https://viteplus.dev/guide/install
+
+
 > # vp pm config set vite-plus-pm-config-test-key test-value --location project # npm set will check valid keys start from npm v9, see https://github.com/npm/cli/issues/5852
 > vp pm config get vite-plus-pm-config-test-key --location project # should get config value from project scope
 test-value

--- a/packages/cli/snap-tests-global/command-config-npm10/steps.json
+++ b/packages/cli/snap-tests-global/command-config-npm10/steps.json
@@ -1,5 +1,6 @@
 {
   "commands": [
+    "vp pm config --help # should show help",
     "# vp pm config set vite-plus-pm-config-test-key test-value --location project # npm set will check valid keys start from npm v9, see https://github.com/npm/cli/issues/5852",
     "vp pm config get vite-plus-pm-config-test-key --location project # should get config value from project scope",
     "vp pm config delete vite-plus-pm-config-test-key --location project && cat .npmrc # should delete config key from project scope"

--- a/packages/cli/snap-tests-global/command-config-yarn1/snap.txt
+++ b/packages/cli/snap-tests-global/command-config-yarn1/snap.txt
@@ -1,3 +1,20 @@
+> vp pm config --help # should show help
+Usage: vp pm config <COMMAND>
+
+Manage package manager configuration
+
+Commands:
+  list    List all configuration
+  get     Get configuration value
+  set     Set configuration value
+  delete  Delete configuration key
+
+Options:
+  -h, --help  Print help
+
+Documentation: https://viteplus.dev/guide/install
+
+
 > vp pm config set vite-plus-pm-config-test-key test-value --location project # should set config value in project scope (shows warning for yarn@1)
 warn: yarn@1 does not support --location, ignoring flag
 yarn config v<semver>

--- a/packages/cli/snap-tests-global/command-config-yarn1/steps.json
+++ b/packages/cli/snap-tests-global/command-config-yarn1/steps.json
@@ -3,6 +3,7 @@
     "NODE_OPTIONS": "--no-deprecation"
   },
   "commands": [
+    "vp pm config --help # should show help",
     "vp pm config set vite-plus-pm-config-test-key test-value --location project # should set config value in project scope (shows warning for yarn@1)",
     "vp pm config get vite-plus-pm-config-test-key --location project # should get config value from project scope (shows warning for yarn@1)",
     "vp pm config delete vite-plus-pm-config-test-key --location project # should delete config key from project scope (shows warning for yarn@1)"

--- a/packages/cli/snap-tests-global/command-config-yarn4/snap.txt
+++ b/packages/cli/snap-tests-global/command-config-yarn4/snap.txt
@@ -1,3 +1,20 @@
+> vp pm config --help # should show help
+Usage: vp pm config <COMMAND>
+
+Manage package manager configuration
+
+Commands:
+  list    List all configuration
+  get     Get configuration value
+  set     Set configuration value
+  delete  Delete configuration key
+
+Options:
+  -h, --help  Print help
+
+Documentation: https://viteplus.dev/guide/install
+
+
 [1]> vp pm config set vite-plus-pm-config-test-key test-value --location project # should set config value in project scope
 Usage Error: Couldn't find a configuration settings named "vite-plus-pm-config-test-key"
 

--- a/packages/cli/snap-tests-global/command-config-yarn4/steps.json
+++ b/packages/cli/snap-tests-global/command-config-yarn4/steps.json
@@ -1,5 +1,6 @@
 {
   "commands": [
+    "vp pm config --help # should show help",
     "vp pm config set vite-plus-pm-config-test-key test-value --location project # should set config value in project scope",
     "vp pm config get vite-plus-pm-config-test-key --location project # should get config value from project scope",
     "vp pm config delete vite-plus-pm-config-test-key --location project # should delete config key from project scope (uses yarn config unset)"


### PR DESCRIPTION
## Summary

Align the `vp pm config` snap matrix by adding a `--help` case to `command-config-npm10`, `command-config-yarn1`, and `command-config-yarn4` — previously only `bun`, `pnpm10`, and `pnpm11` captured it.

clap-generated help is deterministic, so this gives a cheap regression signal whenever the `vp pm config` command surface (flags, descriptions, ordering) changes, and forces every PM fixture to flag the same regression in lockstep.

## Changes                          

For each of the three fixtures:
- `steps.json`: prepend `vp pm config --help` ahead of the existing `--dry-run` step
- `snap.txt`: regenerated with the 17-line help block; existing `set`/`get`/`delete` output unchanged