### PR TITLE
ci(docs): add Void deploy workflows for docs site

### DIFF
--- a/.github/workflows/deploy-docs-preview.yml
+++ b/.github/workflows/deploy-docs-preview.yml
@@ -1,0 +1,69 @@
+name: Deploy Docs Preview
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'packages/cli/install.sh'
+      - 'packages/cli/install.ps1'
+      - '.github/workflows/deploy-docs-preview.yml'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: deploy-docs-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  staging-deploy:
+    if: github.repository == 'voidzero-dev/vite-plus'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+
+      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
+        with:
+          cache: true
+          working-directory: docs
+
+      - run: vp run build
+        working-directory: docs
+
+      - run: vpx void deploy --dir docs/.vitepress/dist
+        env:
+          VOID_TOKEN: ${{ secrets.VOID_TOKEN }}
+          VOID_PROJECT: viteplus-staging
+
+      - name: Comment on PR
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const marker = '<!-- staging-deploy -->';
+            const body = `${marker}\n✅ Staging deployment successful!\n\nPreview: https://viteplus-staging.void.app/\nCommit: ${context.sha}`;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/deploy-docs-preview.yml
+++ b/.github/workflows/deploy-docs-preview.yml
@@ -1,5 +1,7 @@
 name: Deploy Docs Preview
 
+permissions: {}
+
 on:
   pull_request:
     paths:
@@ -7,10 +9,6 @@ on:
       - 'packages/cli/install.sh'
       - 'packages/cli/install.ps1'
       - '.github/workflows/deploy-docs-preview.yml'
-
-permissions:
-  contents: read
-  pull-requests: write
 
 concurrency:
   group: deploy-docs-preview-${{ github.event.pull_request.number }}
@@ -24,6 +22,12 @@ jobs:
   staging-deploy:
     if: github.repository == 'voidzero-dev/vite-plus'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      VOID_PROJECT: viteplus-staging
+      PREVIEW_URL: https://viteplus-staging.void.app/
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 
@@ -31,6 +35,7 @@ jobs:
         with:
           cache: true
           working-directory: docs
+          cache-dependency-path: docs/pnpm-lock.yaml
 
       - run: vp run build
         working-directory: docs
@@ -38,14 +43,15 @@ jobs:
       - run: vpx void deploy --dir docs/.vitepress/dist
         env:
           VOID_TOKEN: ${{ secrets.VOID_TOKEN }}
-          VOID_PROJECT: viteplus-staging
 
       - name: Comment on PR
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          PREVIEW_URL: ${{ env.PREVIEW_URL }}
         with:
           script: |
             const marker = '<!-- staging-deploy -->';
-            const body = `${marker}\n✅ Staging deployment successful!\n\nPreview: https://viteplus-staging.void.app/\nCommit: ${context.sha}`;
+            const body = `${marker}\n✅ Staging deployment successful!\n\nPreview: ${process.env.PREVIEW_URL}\nCommit: ${context.payload.pull_request.head.sha}`;
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,42 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'packages/cli/install.sh'
+      - 'packages/cli/install.ps1'
+      - '.github/workflows/deploy-docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-docs-${{ github.ref }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  deploy:
+    if: github.repository == 'voidzero-dev/vite-plus'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+
+      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
+        with:
+          cache: true
+          working-directory: docs
+
+      - run: vp run build
+        working-directory: docs
+
+      - run: vpx void deploy --dir docs/.vitepress/dist
+        env:
+          VOID_TOKEN: ${{ secrets.VOID_TOKEN }}
+          VOID_PROJECT: viteplus

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,5 +1,7 @@
 name: Deploy Docs
 
+permissions: {}
+
 on:
   push:
     branches: [main]
@@ -10,11 +12,8 @@ on:
       - '.github/workflows/deploy-docs.yml'
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 concurrency:
-  group: deploy-docs-${{ github.ref }}
+  group: deploy-docs
   cancel-in-progress: false
 
 defaults:
@@ -25,6 +24,10 @@ jobs:
   deploy:
     if: github.repository == 'voidzero-dev/vite-plus'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      VOID_PROJECT: viteplus
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 
@@ -32,6 +35,7 @@ jobs:
         with:
           cache: true
           working-directory: docs
+          cache-dependency-path: docs/pnpm-lock.yaml
 
       - run: vp run build
         working-directory: docs
@@ -39,4 +43,3 @@ jobs:
       - run: vpx void deploy --dir docs/.vitepress/dist
         env:
           VOID_TOKEN: ${{ secrets.VOID_TOKEN }}
-          VOID_PROJECT: viteplus

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ rolldown
 rolldown-vite
 vite
 /crates/vite_global_cli/vp
+.void/


### PR DESCRIPTION
## Summary

Add two GitHub workflows that deploy the VitePress docs site to void.cloud, mirroring the pattern used in [voidzero-dev/setup.viteplus.dev](https://github.com/voidzero-dev/setup.viteplus.dev/tree/main/.github/workflows):

- **`deploy-docs.yml`** — push to `main` (or `workflow_dispatch`) deploys to the `viteplus` production project.
- **`deploy-docs-preview.yml`** — pull requests deploy to the `viteplus-staging` project and a sticky comment is posted on the PR with the preview URL.

Both build via `vp run build` inside `docs/` and upload the pre-built static directory with `vpx void deploy --dir docs/.vitepress/dist` (the `--dir` flag skips Void's auto-build, which is the correct mode for a VitePress SSG site — see [void.cloud/guide/deployment](https://void.cloud/guide/deployment)).

Triggered only when these paths change:
- `docs/**`
- `packages/cli/install.sh`
- `packages/cli/install.ps1` *(the docs build script copies both into `docs/public/`)*
- the workflow file itself

Also ignores the local `.void/` directory created by `void deploy` (holds `project.json` linking the working tree to a void project).

## Prerequisites before merge

- [x] Provision `viteplus` and `viteplus-staging` projects on void.cloud
- [x] Add `VOID_TOKEN` as a repo secret

## Test plan

- [ ] Open a PR touching only `docs/**` → Deploy Docs Preview runs, sticky comment with `https://viteplus-staging.void.app/`
- [ ] Open a PR touching only Rust code → neither workflow runs (path filter excludes it)
- [ ] Merge a docs PR to `main` → Deploy Docs runs and production URL serves the new build
- [ ] Trigger Deploy Docs via Actions → workflow_dispatch path works

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new GitHub Actions workflows that automatically build and deploy docs to Void using a repository secret; risk is mainly around CI configuration and potential misconfiguration/exposure of deployment credentials.
> 
> **Overview**
> Adds automated Void deployments for the VitePress docs site.
> 
> `deploy-docs.yml` deploys docs on `main` pushes (and manual dispatch) to the `viteplus` Void project, while `deploy-docs-preview.yml` deploys PR changes to `viteplus-staging` and posts/updates a sticky PR comment with the preview URL.
> 
> Also updates `.gitignore` to exclude the local `.void/` directory created by `void deploy`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d35424a4bd1decb3a53b521f94cd60507057821. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->