### PR TITLE
ci(release): drop unused setup-node from version check job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,6 @@ jobs:
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 
-      - uses: oxc-project/setup-node@ab97f03642370d79a7e96dd286bd02a1be40e0ba # v1.3.0
-
       - name: Check version changes
         uses: EndBug/version-check@095362f3cd50f690c8fa0e6afeea81834bd8d320 # v3.0.0
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,6 @@ on:
     branches: [main]
     paths:
       - 'packages/cli/package.json'
-  # TEMP: remove before merge — validate the check job from PR #1600
-  pull_request:
-    paths:
-      - '.github/workflows/release.yml'
 
 permissions: {}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
     paths:
       - 'packages/cli/package.json'
+  # TEMP: remove before merge — validate the check job from PR #1600
+  pull_request:
+    paths:
+      - '.github/workflows/release.yml'
 
 permissions: {}
 


### PR DESCRIPTION
## Summary

- The `check` job in `.github/workflows/release.yml` only runs `EndBug/version-check`, a self-contained JS action that compares `packages/cli/package.json` against the version on unpkg. It needs neither this repo's `node_modules` nor pnpm.
- The `oxc-project/setup-node` step was running `pnpm install --frozen-lockfile --ignore-scripts`, which fails when the local-only `vite/patches/*` paths referenced from `pnpm-workspace.yaml` are missing on the runner — exactly what blew up in [run 25955706863](https://github.com/voidzero-dev/vite-plus/actions/runs/25955706863/job/76301884814).
- Removing the unused step unblocks the release check job. The underlying patch-path issue (`vite/` is gitignored) still affects any other workflow that needs a real `pnpm install` and should be addressed separately.

## Test plan

- [x] Release workflow's `Check version` job runs to completion without invoking pnpm.