### PR TITLE
docs: mention env doctor in agent instructions

### DIFF
--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -11,5 +11,6 @@ Docs are local at `node_modules/vite-plus/docs` or online at https://viteplus.de
 - [ ] Run `vp install` after pulling remote changes and before getting started.
 - [ ] Run `vp check` and `vp test` to format, lint, type check and test changes.
 - [ ] Check if there are `vite.config.ts` tasks or `package.json` scripts necessary for validation, run via `vp run <script>`.
+- [ ] If setup, runtime, or package-manager behavior looks wrong, run `vp env doctor` and include its output when asking for help.
 
 <!--VITE PLUS END-->


### PR DESCRIPTION
## Summary
- Add a short `vp env doctor` troubleshooting note to the generated agent instruction template.
- Keeps the AGENTS/CLAUDE-style generated guidance compact while covering setup/runtime/package-manager diagnostics.

Closes #1302

## Test Plan
- `git diff --check`
- `grep -n 'vp env doctor' packages/cli/AGENTS.md`
