### PR TITLE
docs(pack): document exe peer dependencies

### DIFF
--- a/docs/guide/pack.md
+++ b/docs/guide/pack.md
@@ -59,3 +59,13 @@ export default defineConfig({
 ```
 
 See the official [tsdown executable docs](https://tsdown.dev/options/exe#executable) for details about configuring custom file names, embedded assets, and cross-platform targets.
+
+### Executable dependencies
+
+The `exe` option loads `@tsdown/exe` at build time. Install it together with a matching top-level `tsdown` package; Vite+'s bundled tsdown is not exposed as a `tsdown` package that `@tsdown/exe` can resolve.
+
+```bash
+vp install -D @tsdown/exe@0.22.0 tsdown@0.22.0
+```
+
+Use the tsdown version shown by `vp env current` when installing these dependencies for newer Vite+ releases. Installing only `@tsdown/exe` can surface as `Failed to import module "@tsdown/exe"` because the underlying peer import `tsdown/internal` is unresolved.


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary

- Document that `vp pack` executable builds load `@tsdown/exe` at build time.
- Show that `@tsdown/exe` must be installed with a matching top-level `tsdown` package because Vite+'s bundled tsdown is not resolvable as the `tsdown` package peer.
- Call out that installing only `@tsdown/exe` can surface as `Failed to import module "@tsdown/exe"` when the underlying unresolved import is `tsdown/internal`.

Refs #1586

## Test Plan

- `npm view @tsdown/exe@0.22.0 peerDependencies --json` -> `{ "tsdown": "0.22.0" }`
- Source proof: `origin/main:docs/guide/pack.md` did not contain the actionable `@tsdown/exe@0.22.0 tsdown@0.22.0` note or `tsdown/internal`; patched docs contain both plus the `vp env current` version guidance.
- `git diff --no-index --check /tmp/viteplus-pack-md-original.md /tmp/viteplus-pack-md-patched.md` -> no whitespace errors
- `pnpm --dir docs build` -> build complete in 87.23s
