### PR TITLE
ci(e2e): remove vinext vp check workaround

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -265,14 +265,8 @@ jobs:
             node-version: 24
             command: |
               vp run build
-              # Report-only: oxlint 1.63 drops the `eslint-` prefix from plugin names
-              # (https://github.com/oxc-project/oxc/pull/21806), invalidating vinext's existing
-              # `oxlint-disable-next-line eslint-plugin-react-hooks/...` directive, and tightens
-              # a couple of unused-import checks. vinext can only update its source after a
-              # vite-plus release ships these oxlint changes, so don't fail the matrix on the
-              # surfaced errors yet.
-              vp check --fix || true
-              vp run check || true
+              vp check --fix
+              vp run check
               vp run test
           - name: reactive-resume
             node-version: 24

--- a/ecosystem-ci/repo.json
+++ b/ecosystem-ci/repo.json
@@ -71,7 +71,7 @@
   "vinext": {
     "repository": "https://github.com/cloudflare/vinext.git",
     "branch": "main",
-    "hash": "d558923fde85fab11b8cf9329c9d6eea367758ce",
+    "hash": "c483253b58aa51ece5ae61e8d3df827de64baa5f",
     "forceFreshMigration": true
   },
   "reactive-resume": {

--- a/ecosystem-ci/repo.json
+++ b/ecosystem-ci/repo.json
@@ -71,7 +71,7 @@
   "vinext": {
     "repository": "https://github.com/cloudflare/vinext.git",
     "branch": "main",
-    "hash": "a1d2b6103469cb181e3d097cb16c272004f2d6b1",
+    "hash": "d558923fde85fab11b8cf9329c9d6eea367758ce",
     "forceFreshMigration": true
   },
   "reactive-resume": {


### PR DESCRIPTION
## Summary

- vinext upstream main now reflects oxlint 1.63's `eslint-` prefix removal ([oxc-project/oxc#21806](https://github.com/oxc-project/oxc/pull/21806)), so `vp check --fix` and `vp run check` no longer need the `|| true` report-only escape hatch in the ecosystem-ci matrix.
- Bumps the pinned vinext hash (`a1d2b610` → `d558923f`) to pick up the source-side fix.
- After this lands, a regression in `vp check` against vinext will fail the e2e matrix instead of being silently swallowed.

## Test plan

- [ ] E2E Test workflow passes the `vinext` job without `|| true`.