### PR TITLE
chore: bump vite-task to c945cc0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1906,7 +1906,7 @@ dependencies = [
 [[package]]
 name = "fspy"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c63db22ff0258e4e45f03205104838ab795161ac#c63db22ff0258e4e45f03205104838ab795161ac"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c945cc0c7bb5af478a68d4548db7f46e621b36b0#c945cc0c7bb5af478a68d4548db7f46e621b36b0"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -1942,7 +1942,7 @@ dependencies = [
 [[package]]
 name = "fspy_detours_sys"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c63db22ff0258e4e45f03205104838ab795161ac#c63db22ff0258e4e45f03205104838ab795161ac"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c945cc0c7bb5af478a68d4548db7f46e621b36b0#c945cc0c7bb5af478a68d4548db7f46e621b36b0"
 dependencies = [
  "cc",
  "winapi",
@@ -1951,7 +1951,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c63db22ff0258e4e45f03205104838ab795161ac#c63db22ff0258e4e45f03205104838ab795161ac"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c945cc0c7bb5af478a68d4548db7f46e621b36b0#c945cc0c7bb5af478a68d4548db7f46e621b36b0"
 dependencies = [
  "anyhow",
  "bstr",
@@ -1966,7 +1966,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_windows"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c63db22ff0258e4e45f03205104838ab795161ac#c63db22ff0258e4e45f03205104838ab795161ac"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c945cc0c7bb5af478a68d4548db7f46e621b36b0#c945cc0c7bb5af478a68d4548db7f46e621b36b0"
 dependencies = [
  "constcat",
  "fspy_detours_sys",
@@ -1982,7 +1982,7 @@ dependencies = [
 [[package]]
 name = "fspy_seccomp_unotify"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c63db22ff0258e4e45f03205104838ab795161ac#c63db22ff0258e4e45f03205104838ab795161ac"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c945cc0c7bb5af478a68d4548db7f46e621b36b0#c945cc0c7bb5af478a68d4548db7f46e621b36b0"
 dependencies = [
  "futures-util",
  "libc",
@@ -1999,7 +1999,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c63db22ff0258e4e45f03205104838ab795161ac#c63db22ff0258e4e45f03205104838ab795161ac"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c945cc0c7bb5af478a68d4548db7f46e621b36b0#c945cc0c7bb5af478a68d4548db7f46e621b36b0"
 dependencies = [
  "allocator-api2",
  "bitflags 2.11.0",
@@ -2018,7 +2018,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c63db22ff0258e4e45f03205104838ab795161ac#c63db22ff0258e4e45f03205104838ab795161ac"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c945cc0c7bb5af478a68d4548db7f46e621b36b0#c945cc0c7bb5af478a68d4548db7f46e621b36b0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3170,7 +3170,7 @@ dependencies = [
 [[package]]
 name = "materialized_artifact"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c63db22ff0258e4e45f03205104838ab795161ac#c63db22ff0258e4e45f03205104838ab795161ac"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c945cc0c7bb5af478a68d4548db7f46e621b36b0#c945cc0c7bb5af478a68d4548db7f46e621b36b0"
 dependencies = [
  "tempfile",
 ]
@@ -3178,7 +3178,7 @@ dependencies = [
 [[package]]
 name = "materialized_artifact_build"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c63db22ff0258e4e45f03205104838ab795161ac#c63db22ff0258e4e45f03205104838ab795161ac"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c945cc0c7bb5af478a68d4548db7f46e621b36b0#c945cc0c7bb5af478a68d4548db7f46e621b36b0"
 dependencies = [
  "xxhash-rust",
 ]
@@ -3392,7 +3392,7 @@ dependencies = [
 [[package]]
 name = "native_str"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c63db22ff0258e4e45f03205104838ab795161ac#c63db22ff0258e4e45f03205104838ab795161ac"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c945cc0c7bb5af478a68d4548db7f46e621b36b0#c945cc0c7bb5af478a68d4548db7f46e621b36b0"
 dependencies = [
  "allocator-api2",
  "bytemuck",
@@ -4818,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal_test_client"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c63db22ff0258e4e45f03205104838ab795161ac#c63db22ff0258e4e45f03205104838ab795161ac"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c945cc0c7bb5af478a68d4548db7f46e621b36b0#c945cc0c7bb5af478a68d4548db7f46e621b36b0"
 
 [[package]]
 name = "quote"
@@ -7529,7 +7529,7 @@ dependencies = [
 [[package]]
 name = "vite_glob"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c63db22ff0258e4e45f03205104838ab795161ac#c63db22ff0258e4e45f03205104838ab795161ac"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c945cc0c7bb5af478a68d4548db7f46e621b36b0#c945cc0c7bb5af478a68d4548db7f46e621b36b0"
 dependencies = [
  "thiserror 2.0.18",
  "vite_path",
@@ -7573,7 +7573,7 @@ dependencies = [
 [[package]]
 name = "vite_graph_ser"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c63db22ff0258e4e45f03205104838ab795161ac#c63db22ff0258e4e45f03205104838ab795161ac"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c945cc0c7bb5af478a68d4548db7f46e621b36b0#c945cc0c7bb5af478a68d4548db7f46e621b36b0"
 dependencies = [
  "petgraph 0.8.3",
  "serde",
@@ -7672,7 +7672,7 @@ dependencies = [
 [[package]]
 name = "vite_path"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c63db22ff0258e4e45f03205104838ab795161ac#c63db22ff0258e4e45f03205104838ab795161ac"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c945cc0c7bb5af478a68d4548db7f46e621b36b0#c945cc0c7bb5af478a68d4548db7f46e621b36b0"
 dependencies = [
  "diff-struct",
  "path-clean",
@@ -7703,7 +7703,7 @@ dependencies = [
 [[package]]
 name = "vite_powershell"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c63db22ff0258e4e45f03205104838ab795161ac#c63db22ff0258e4e45f03205104838ab795161ac"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c945cc0c7bb5af478a68d4548db7f46e621b36b0#c945cc0c7bb5af478a68d4548db7f46e621b36b0"
 dependencies = [
  "vite_path",
  "which",
@@ -7712,7 +7712,7 @@ dependencies = [
 [[package]]
 name = "vite_select"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c63db22ff0258e4e45f03205104838ab795161ac#c63db22ff0258e4e45f03205104838ab795161ac"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c945cc0c7bb5af478a68d4548db7f46e621b36b0#c945cc0c7bb5af478a68d4548db7f46e621b36b0"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -7762,7 +7762,7 @@ dependencies = [
 [[package]]
 name = "vite_shell"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c63db22ff0258e4e45f03205104838ab795161ac#c63db22ff0258e4e45f03205104838ab795161ac"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c945cc0c7bb5af478a68d4548db7f46e621b36b0#c945cc0c7bb5af478a68d4548db7f46e621b36b0"
 dependencies = [
  "brush-parser 0.3.0 (git+https://github.com/reubeno/brush?rev=dcb760933b10ee0433d7b740a5709b06f5c67c6b)",
  "diff-struct",
@@ -7789,7 +7789,7 @@ dependencies = [
 [[package]]
 name = "vite_str"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c63db22ff0258e4e45f03205104838ab795161ac#c63db22ff0258e4e45f03205104838ab795161ac"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c945cc0c7bb5af478a68d4548db7f46e621b36b0#c945cc0c7bb5af478a68d4548db7f46e621b36b0"
 dependencies = [
  "compact_str",
  "diff-struct",
@@ -7800,7 +7800,7 @@ dependencies = [
 [[package]]
 name = "vite_task"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c63db22ff0258e4e45f03205104838ab795161ac#c63db22ff0258e4e45f03205104838ab795161ac"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c945cc0c7bb5af478a68d4548db7f46e621b36b0#c945cc0c7bb5af478a68d4548db7f46e621b36b0"
 dependencies = [
  "anstream 0.6.21",
  "anyhow",
@@ -7843,7 +7843,7 @@ dependencies = [
 [[package]]
 name = "vite_task_graph"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c63db22ff0258e4e45f03205104838ab795161ac#c63db22ff0258e4e45f03205104838ab795161ac"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c945cc0c7bb5af478a68d4548db7f46e621b36b0#c945cc0c7bb5af478a68d4548db7f46e621b36b0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7865,7 +7865,7 @@ dependencies = [
 [[package]]
 name = "vite_task_plan"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c63db22ff0258e4e45f03205104838ab795161ac#c63db22ff0258e4e45f03205104838ab795161ac"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c945cc0c7bb5af478a68d4548db7f46e621b36b0#c945cc0c7bb5af478a68d4548db7f46e621b36b0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7897,7 +7897,7 @@ version = "0.0.0"
 [[package]]
 name = "vite_workspace"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c63db22ff0258e4e45f03205104838ab795161ac#c63db22ff0258e4e45f03205104838ab795161ac"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=c945cc0c7bb5af478a68d4548db7f46e621b36b0#c945cc0c7bb5af478a68d4548db7f46e621b36b0"
 dependencies = [
  "clap",
  "petgraph 0.8.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,7 +184,7 @@ dunce = "1.0.5"
 fast-glob = "1.0.0"
 flate2 = { version = "=1.1.9", features = ["zlib-rs"] }
 form_urlencoded = "1.2.1"
-fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c63db22ff0258e4e45f03205104838ab795161ac" }
+fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c945cc0c7bb5af478a68d4548db7f46e621b36b0" }
 futures = "0.3.31"
 futures-util = "0.3.31"
 glob = "0.3.2"
@@ -289,18 +289,18 @@ vfs = "0.13.0"
 vite_command = { path = "crates/vite_command" }
 vite_error = { path = "crates/vite_error" }
 vite_js_runtime = { path = "crates/vite_js_runtime" }
-vite_glob = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c63db22ff0258e4e45f03205104838ab795161ac" }
+vite_glob = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c945cc0c7bb5af478a68d4548db7f46e621b36b0" }
 vite_install = { path = "crates/vite_install" }
 vite_migration = { path = "crates/vite_migration" }
 vite_pm_cli = { path = "crates/vite_pm_cli" }
 vite_setup = { path = "crates/vite_setup" }
 vite_shared = { path = "crates/vite_shared" }
 vite_static_config = { path = "crates/vite_static_config" }
-vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c63db22ff0258e4e45f03205104838ab795161ac" }
-vite_powershell = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c63db22ff0258e4e45f03205104838ab795161ac" }
-vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c63db22ff0258e4e45f03205104838ab795161ac" }
-vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c63db22ff0258e4e45f03205104838ab795161ac" }
-vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c63db22ff0258e4e45f03205104838ab795161ac" }
+vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c945cc0c7bb5af478a68d4548db7f46e621b36b0" }
+vite_powershell = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c945cc0c7bb5af478a68d4548db7f46e621b36b0" }
+vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c945cc0c7bb5af478a68d4548db7f46e621b36b0" }
+vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c945cc0c7bb5af478a68d4548db7f46e621b36b0" }
+vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "c945cc0c7bb5af478a68d4548db7f46e621b36b0" }
 walkdir = "2.5.0"
 wax = "0.6.0"
 which = "8.0.0"

--- a/packages/cli/binding/src/cli/mod.rs
+++ b/packages/cli/binding/src/cli/mod.rs
@@ -152,10 +152,11 @@ async fn execute_vite_task_command(
         program_name: Str::from("vp"),
     })?;
 
-    // Main execution (consumes session)
-    let result = session.main(command).await.map_err(|e| Error::Anyhow(e));
+    // Main execution (consumes session). vite-task prints any errors itself
+    // and returns only an exit status.
+    let status = session.main(command).await;
 
-    result
+    Ok(status)
 }
 
 /// Main entry point for vite-plus CLI.


### PR DESCRIPTION
`https://github.com/voidzero-dev/vite-task/compare/c63db22ff0258e4e45f03205104838ab795161ac...c945cc0c7bb5af478a68d4548db7f46e621b36b0#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed`

Adopts the breaking `Session::main` signature change from voidzero-dev/vite-task#390 (now returns `ExitStatus` directly; vite-task prints its own errors).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGWZAzEb9KDWfXCshVD4NW)_