### PR TITLE
fix(cli): add managed bin to hook path

### DIFF
--- a/packages/cli/snap-tests-global/migration-add-git-hooks/snap.txt
+++ b/packages/cli/snap-tests-global/migration-add-git-hooks/snap.txt
@@ -59,6 +59,10 @@ i="${XDG_CONFIG_HOME:-$HOME/.config}/vite-plus/hooks-init.sh"
 
 { [ "${HUSKY-}" = "0" ] || [ "${VITE_GIT_HOOKS-}" = "0" ]; } && exit 0
 
+d="$(dirname "$(dirname "$(dirname "$0")")")"
+__vp_shell=/bin/sh
+[ -x "$__vp_shell" ] || __vp_shell=$(command -v sh)
+
 if [ -n "${VP_HOME-}" ]; then
   __vp_bin="$VP_HOME/bin"
 elif [ -n "${HOME-}" ]; then
@@ -66,11 +70,10 @@ elif [ -n "${HOME-}" ]; then
 else
   __vp_bin=""
 fi
-[ -n "$__vp_bin" ] && [ -d "$__vp_bin" ] && export PATH="$__vp_bin:$PATH"
+[ -n "$__vp_bin" ] && [ -d "$__vp_bin" ] && export PATH="$PATH:$__vp_bin"
 
-d="$(dirname "$(dirname "$(dirname "$0")")")"
 export PATH="$d/node_modules/.bin:$PATH"
-sh -e "$s" "$@"
+"$__vp_shell" -e "$s" "$@"
 c=$?
 
 [ $c != 0 ] && echo "VITE+ - $n script failed (code $c)"

--- a/packages/cli/snap-tests-global/migration-add-git-hooks/snap.txt
+++ b/packages/cli/snap-tests-global/migration-add-git-hooks/snap.txt
@@ -59,6 +59,15 @@ i="${XDG_CONFIG_HOME:-$HOME/.config}/vite-plus/hooks-init.sh"
 
 { [ "${HUSKY-}" = "0" ] || [ "${VITE_GIT_HOOKS-}" = "0" ]; } && exit 0
 
+if [ -n "${VP_HOME-}" ]; then
+  __vp_bin="$VP_HOME/bin"
+elif [ -n "${HOME-}" ]; then
+  __vp_bin="$HOME/.vite-plus/bin"
+else
+  __vp_bin=""
+fi
+[ -n "$__vp_bin" ] && [ -d "$__vp_bin" ] && export PATH="$__vp_bin:$PATH"
+
 d="$(dirname "$(dirname "$(dirname "$0")")")"
 export PATH="$d/node_modules/.bin:$PATH"
 sh -e "$s" "$@"

--- a/packages/cli/snap-tests-global/migration-composed-husky-custom-dir/snap.txt
+++ b/packages/cli/snap-tests-global/migration-composed-husky-custom-dir/snap.txt
@@ -51,6 +51,10 @@ i="${XDG_CONFIG_HOME:-$HOME/.config}/vite-plus/hooks-init.sh"
 
 { [ "${HUSKY-}" = "0" ] || [ "${VITE_GIT_HOOKS-}" = "0" ]; } && exit 0
 
+d="$(dirname "$(dirname "$(dirname "$(dirname "$0")")")")"
+__vp_shell=/bin/sh
+[ -x "$__vp_shell" ] || __vp_shell=$(command -v sh)
+
 if [ -n "${VP_HOME-}" ]; then
   __vp_bin="$VP_HOME/bin"
 elif [ -n "${HOME-}" ]; then
@@ -58,11 +62,10 @@ elif [ -n "${HOME-}" ]; then
 else
   __vp_bin=""
 fi
-[ -n "$__vp_bin" ] && [ -d "$__vp_bin" ] && export PATH="$__vp_bin:$PATH"
+[ -n "$__vp_bin" ] && [ -d "$__vp_bin" ] && export PATH="$PATH:$__vp_bin"
 
-d="$(dirname "$(dirname "$(dirname "$(dirname "$0")")")")"
 export PATH="$d/node_modules/.bin:$PATH"
-sh -e "$s" "$@"
+"$__vp_shell" -e "$s" "$@"
 c=$?
 
 [ $c != 0 ] && echo "VITE+ - $n script failed (code $c)"

--- a/packages/cli/snap-tests-global/migration-composed-husky-custom-dir/snap.txt
+++ b/packages/cli/snap-tests-global/migration-composed-husky-custom-dir/snap.txt
@@ -51,6 +51,15 @@ i="${XDG_CONFIG_HOME:-$HOME/.config}/vite-plus/hooks-init.sh"
 
 { [ "${HUSKY-}" = "0" ] || [ "${VITE_GIT_HOOKS-}" = "0" ]; } && exit 0
 
+if [ -n "${VP_HOME-}" ]; then
+  __vp_bin="$VP_HOME/bin"
+elif [ -n "${HOME-}" ]; then
+  __vp_bin="$HOME/.vite-plus/bin"
+else
+  __vp_bin=""
+fi
+[ -n "$__vp_bin" ] && [ -d "$__vp_bin" ] && export PATH="$__vp_bin:$PATH"
+
 d="$(dirname "$(dirname "$(dirname "$(dirname "$0")")")")"
 export PATH="$d/node_modules/.bin:$PATH"
 sh -e "$s" "$@"

--- a/packages/cli/src/config/__tests__/hooks.spec.ts
+++ b/packages/cli/src/config/__tests__/hooks.spec.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'node:child_process';
-import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -73,4 +73,65 @@ describe('hookScript', () => {
     expect(countDirnameCalls(withDot)).toBe(countDirnameCalls(withoutDot));
     expect(countDirnameCalls(withDot)).toBe(3);
   });
+
+  it.skipIf(process.platform === 'win32')(
+    'should add Vite+ managed bin to PATH before running user hook',
+    () => {
+      const tmp = mkdtempSync(join(tmpdir(), 'hooks-path-test-'));
+      try {
+        const hooksDir = join(tmp, '.vite-hooks');
+        const internalHooksDir = join(hooksDir, '_');
+        const nodeModulesBin = join(tmp, 'node_modules', '.bin');
+        const vpHomeBin = join(tmp, 'vp-home', 'bin');
+        const systemBin = join(tmp, 'system-bin');
+
+        mkdirSync(internalHooksDir, { recursive: true });
+        mkdirSync(nodeModulesBin, { recursive: true });
+        mkdirSync(vpHomeBin, { recursive: true });
+        mkdirSync(systemBin, { recursive: true });
+
+        writeFileSync(join(internalHooksDir, 'h'), hookScript('.vite-hooks'), { mode: 0o755 });
+        writeFileSync(
+          join(internalHooksDir, 'pre-commit'),
+          '#!/usr/bin/env sh\n. "$(dirname "$0")/h"',
+          { mode: 0o755 },
+        );
+        writeFileSync(join(hooksDir, 'pre-commit'), 'vp staged\n');
+
+        writeFileSync(
+          join(nodeModulesBin, 'vp'),
+          '#!/bin/sh\nbasedir=$(dirname "$0")\nexec node "$basedir/../vite-plus/bin/vp" "$@"\n',
+          { mode: 0o755 },
+        );
+        writeFileSync(
+          join(vpHomeBin, 'node'),
+          '#!/bin/sh\necho "fake-node $*" > "$VP_HOME/node-used"\n',
+          { mode: 0o755 },
+        );
+
+        writeFileSync(join(systemBin, 'sh'), '#!/bin/sh\nexec /bin/sh "$@"\n', {
+          mode: 0o755,
+        });
+        writeFileSync(join(systemBin, 'dirname'), '#!/bin/sh\nexec /usr/bin/dirname "$@"\n', {
+          mode: 0o755,
+        });
+        writeFileSync(join(systemBin, 'basename'), '#!/bin/sh\nexec /usr/bin/basename "$@"\n', {
+          mode: 0o755,
+        });
+
+        execSync('sh .vite-hooks/_/pre-commit', {
+          cwd: tmp,
+          env: {
+            HOME: join(tmp, 'home'),
+            PATH: systemBin,
+            VP_HOME: join(tmp, 'vp-home'),
+          },
+        });
+
+        expect(existsSync(join(tmp, 'vp-home', 'node-used'))).toBe(true);
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    },
+  );
 });

--- a/packages/cli/src/config/__tests__/hooks.spec.ts
+++ b/packages/cli/src/config/__tests__/hooks.spec.ts
@@ -75,7 +75,7 @@ describe('hookScript', () => {
   });
 
   it.skipIf(process.platform === 'win32')(
-    'should add Vite+ managed bin to PATH before running user hook',
+    'should add Vite+ managed bin to PATH as a fallback before running user hook',
     () => {
       const tmp = mkdtempSync(join(tmpdir(), 'hooks-path-test-'));
       try {
@@ -108,6 +108,16 @@ describe('hookScript', () => {
           '#!/bin/sh\necho "fake-node $*" > "$VP_HOME/node-used"\n',
           { mode: 0o755 },
         );
+        writeFileSync(
+          join(vpHomeBin, 'dirname'),
+          '#!/bin/sh\necho "wrong dirname" > "$VP_HOME/dirname-used"\nexit 1\n',
+          { mode: 0o755 },
+        );
+        writeFileSync(
+          join(vpHomeBin, 'sh'),
+          '#!/bin/sh\necho "wrong sh" > "$VP_HOME/sh-used"\nexit 1\n',
+          { mode: 0o755 },
+        );
 
         writeFileSync(join(systemBin, 'sh'), '#!/bin/sh\nexec /bin/sh "$@"\n', {
           mode: 0o755,
@@ -129,9 +139,20 @@ describe('hookScript', () => {
         });
 
         expect(existsSync(join(tmp, 'vp-home', 'node-used'))).toBe(true);
+        expect(existsSync(join(tmp, 'vp-home', 'dirname-used'))).toBe(false);
+        expect(existsSync(join(tmp, 'vp-home', 'sh-used'))).toBe(false);
       } finally {
         rmSync(tmp, { recursive: true, force: true });
       }
     },
   );
+
+  it('should compute root and shell before appending Vite+ managed bin', () => {
+    const script = hookScript('.vite-hooks');
+    expect(script.indexOf('d=')).toBeLessThan(script.indexOf('export PATH="$PATH:$__vp_bin"'));
+    expect(script.indexOf('__vp_shell=')).toBeLessThan(
+      script.indexOf('export PATH="$PATH:$__vp_bin"'),
+    );
+    expect(script).toContain('"$__vp_shell" -e "$s" "$@"');
+  });
 });

--- a/packages/cli/src/config/hooks.ts
+++ b/packages/cli/src/config/hooks.ts
@@ -49,6 +49,10 @@ i="\${XDG_CONFIG_HOME:-$HOME/.config}/vite-plus/hooks-init.sh"
 
 { [ "\${HUSKY-}" = "0" ] || [ "\${VITE_GIT_HOOKS-}" = "0" ]; } && exit 0
 
+d=${rootExpr}
+__vp_shell=/bin/sh
+[ -x "$__vp_shell" ] || __vp_shell=$(command -v sh)
+
 if [ -n "\${VP_HOME-}" ]; then
   __vp_bin="$VP_HOME/bin"
 elif [ -n "\${HOME-}" ]; then
@@ -56,11 +60,10 @@ elif [ -n "\${HOME-}" ]; then
 else
   __vp_bin=""
 fi
-[ -n "$__vp_bin" ] && [ -d "$__vp_bin" ] && export PATH="$__vp_bin:$PATH"
+[ -n "$__vp_bin" ] && [ -d "$__vp_bin" ] && export PATH="$PATH:$__vp_bin"
 
-d=${rootExpr}
 export PATH="$d/node_modules/.bin:$PATH"
-sh -e "$s" "$@"
+"$__vp_shell" -e "$s" "$@"
 c=$?
 
 [ $c != 0 ] && echo "VITE+ - $n script failed (code $c)"

--- a/packages/cli/src/config/hooks.ts
+++ b/packages/cli/src/config/hooks.ts
@@ -49,6 +49,15 @@ i="\${XDG_CONFIG_HOME:-$HOME/.config}/vite-plus/hooks-init.sh"
 
 { [ "\${HUSKY-}" = "0" ] || [ "\${VITE_GIT_HOOKS-}" = "0" ]; } && exit 0
 
+if [ -n "\${VP_HOME-}" ]; then
+  __vp_bin="$VP_HOME/bin"
+elif [ -n "\${HOME-}" ]; then
+  __vp_bin="$HOME/.vite-plus/bin"
+else
+  __vp_bin=""
+fi
+[ -n "$__vp_bin" ] && [ -d "$__vp_bin" ] && export PATH="$__vp_bin:$PATH"
+
 d=${rootExpr}
 export PATH="$d/node_modules/.bin:$PATH"
 sh -e "$s" "$@"


### PR DESCRIPTION
When committing via VS Code on MacOS I hit the error

```bash
./node_modules/.bin/vp: line 20: exec: node: not found
VITE+ - pre-commit script failed (code 127)
VITE+ - command not found in PATH=./node_modules/.bin:/Library/Developer/CommandLineTools/usr/libexec/git-core:/usr/bin:/bin:/usr/sbin:/sbin
```

But node was installed and `vp env doctor` was happy.
The issues seemed that the managed Node is not available in the Git hook.

I learned that Git hooks often run with a much smaller, non-interactive `PATH`, possibly not including the shims.
In my case, path was limited to what is shared in the error above. That included the local `vp` bin but not `node`, leading to the error.

The PR fixes that by making generated hooks add Vite+’s managed bin directory before running the user hook. Then `vp staged` can start even when Git launches the hook with a restricted PATH.