### PR TITLE
ci: add codiff to ecosystem-ci

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -337,6 +337,9 @@ jobs:
           - name: codiff
             node-version: 24
             command: |
+              # vp migrate rewrites package.json without reformatting,
+              # so format first before running the project's `vp check && vp test` task.
+              vp fmt
               vp run test:all
         exclude:
           # frm-stack uses Docker (testcontainers) which doesn't work the same way on Windows

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -334,6 +334,10 @@ jobs:
               node scripts/bootstrap.mjs
               vp run lint
               vp run test:coverage
+          - name: codiff
+            node-version: 24
+            command: |
+              vp run test:all
         exclude:
           # frm-stack uses Docker (testcontainers) which doesn't work the same way on Windows
           - os: windows-latest
@@ -359,6 +363,10 @@ jobs:
           - os: windows-latest
             project:
               name: varlet
+          # codiff is an Electron app; upstream CI is ubuntu-only
+          - os: windows-latest
+            project:
+              name: codiff
 
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2

--- a/ecosystem-ci/repo.json
+++ b/ecosystem-ci/repo.json
@@ -131,5 +131,11 @@
     "branch": "dev",
     "hash": "83f6c6a418ab9319e07d719d86d4fa952f99e266",
     "forceFreshMigration": true
+  },
+  "codiff": {
+    "repository": "https://github.com/nkzw-tech/codiff.git",
+    "branch": "main",
+    "hash": "613f822eed07ee16b07875f635a9bbaf8eab4181",
+    "forceFreshMigration": true
   }
 }


### PR DESCRIPTION
## Summary

- Add [nkzw-tech/codiff](https://github.com/nkzw-tech/codiff) (an Electron-based fast local diff viewer) to ecosystem-ci.
- Runs `vp run test:all` (which expands to `vp check && vp test` via the task defined in codiff's `vite.config.ts`) on ubuntu-latest only — matching upstream's `test.yml` workflow.
- Codiff already depends on `vite-plus` (via catalog), so `forceFreshMigration: true` is set so `vp migrate` performs a full dependency rewrite rather than skipping.

## Test plan

- [ ] e2e-test workflow passes for the new `codiff` matrix entry on ubuntu-latest