### PR TITLE
ci: warm-up monorepo cache test under npm

### DIFF
--- a/.github/workflows/test-vp-create.yml
+++ b/.github/workflows/test-vp-create.yml
@@ -322,10 +322,24 @@ jobs:
         if: matrix.template.name == 'monorepo'
         working-directory: ${{ runner.temp }}/test-project
         run: |
+          # Under npm, `vp run ready` reaches 100% cache hit only on the
+          # third invocation (#1638): vite-task's directory-listing
+          # fingerprint and fspy read/write tracking surface false-positive
+          # misses on run #2 because `packages/utils/node_modules/` is born
+          # during run #1. pnpm/yarn/bun pre-create per-package
+          # `node_modules/` at install time and reach 100% on run #2.
+          # The preceding `Verify project builds` step already invoked
+          # `vp run ready` once (verify-command for monorepo), so one
+          # extra warm-up here is enough under npm.
+          if [ "${{ matrix.package-manager }}" = "npm" ]; then
+            vp run ready >/dev/null 2>&1
+          fi
           output=$(vp run ready 2>&1)
           echo "$output"
           if ! echo "$output" | grep -q 'cache hit (100%)'; then
-            echo "✗ Expected 100% cache hit on second run"
+            echo "✗ Expected 100% cache hit"
+            echo "--- vp run --last-details (cache-miss diagnostics) ---"
+            vp run --last-details || true
             exit 1
           fi
           echo "✓ 100% cache hit verified"


### PR DESCRIPTION
## Summary

- Test-side band-aid for #1638: under npm, `vp run ready` requires three invocations before reaching 100% cache hit. The `Verify cache (monorepo only)` step previously asserted on what was effectively the second run and failed on the `vp create monorepo (npm)` matrix entry.
- The preceding `Verify project builds` step already invokes `vp run ready` once (it's the monorepo template's `verify-command` at line 125 of this file), so we add **one** extra warm-up under npm — that lands the assertion on the third invocation, the first to reach 100%. pnpm/yarn/bun keep the original single-run assertion since they already pass.
- On assertion failure, dump `vp run --last-details` so per-task cache-miss reasons surface directly in the CI log.

## Why npm only

Under npm with full hoisting, `packages/utils/node_modules/` does not exist until run #1 — vitest's deps optimizer + tsdown's temp dir create it. Two distinct vite-task bugs then trip on run #2:
1. Directory-listing fingerprint of `packages/utils/` sees `node_modules` as an added entry.
2. fspy classifies vitest's reads/writes inside `node_modules/.vite/` as a read-write overlap → `CacheNotUpdatedReason::InputModified`, no cache entry written.

pnpm/yarn/bun pre-create per-package `node_modules/` during install, so neither bug triggers there.

This is the "test-side band-aid" path called out in #1638. The proper vite-task fix (ignore `node_modules` in directory fingerprints + filter `node_modules/.vite{,-temp}/` and `node_modules/.cache/` from fspy tracking) can be filed as a new follow-up issue if/when desired.

## Test plan

- [ ] `test-vp-create` matrix: `vp create monorepo (npm)` turns green
- [ ] pnpm / yarn / bun monorepo jobs stay green (single-run assertion unchanged)
- [ ] On a deliberately-broken cache, the failure log shows `vp run --last-details` output with the per-task cache-miss reasons

Closes #1638