### PR TITLE
fix(cli): default git init prompt to true on scaffold

### DIFF
--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -228,7 +228,7 @@ export async function promptGitInit(options: {
   if (options.interactive) {
     const selected = await prompts.confirm({
       message: 'Initialize a git repository with an initial commit?',
-      initialValue: false,
+      initialValue: true,
     });
     if (prompts.isCancel(selected)) {
       cancelAndExit();


### PR DESCRIPTION
## Summary

- Flip the default for the `Initialize a git repository with an initial commit?` prompt from `false` to `true`, matching the pre-commit hooks prompt and the typical expectation that scaffolded projects start as a git repo.

Follow-up to #1484 (review comment: https://github.com/voidzero-dev/vite-plus/pull/1484#discussion_r3252537764).

<img width="1576" height="736" alt="image" src="https://github.com/user-attachments/assets/1edce33e-b559-40f4-826f-6f35bc77fe48" />


## Test plan

- [x] Scaffold a new project interactively and confirm the git-init prompt is preselected as Yes.