### PR TITLE
chore(build): drop `@rolldown/pluginutils` build step

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -102,7 +102,6 @@ export default defineConfig({
     tasks: {
       'build:src': {
         command: [
-          'vp run @rolldown/pluginutils#build',
           'vp run rolldown#build-binding:release',
           'vp run rolldown#build-node',
           'vp run vite#build-types',


### PR DESCRIPTION
## Summary
- `@rolldown/pluginutils` has been extracted from the rolldown repo into a standalone package (rolldown/rolldown#9317), so it is no longer a workspace member.
- Remove the `vp run @rolldown/pluginutils#build` step from the `build:src` task in `vite.config.ts` to keep it aligned with the root `pnpm build` script.