### PR TITLE
chore(global_cli): clarify `--help` for `vp env` default/pin/use/exec

### DIFF
--- a/crates/vite_global_cli/src/cli.rs
+++ b/crates/vite_global_cli/src/cli.rs
@@ -395,11 +395,14 @@ Examples:
     },
 
     /// Execute a command with a specific Node.js version
-    #[command(visible_alias = "run", after_help = "\
+    #[command(
+        visible_alias = "run",
+        after_help = "\
 Examples:
   vp env exec --node lts npm install        # Run npm install with latest LTS
   vp env exec --node 20.18.0 node script.js # Run with a specific version
-  vp env exec node -v                       # Shim mode: version auto-resolved")]
+  vp env exec node -v                       # Shim mode: version auto-resolved"
+    )]
     Exec {
         /// Node.js version to use (e.g., "20.18.0", "lts", "^20.0.0").
         /// If omitted and command is node/npm/npx or a global package binary,

--- a/crates/vite_global_cli/src/cli.rs
+++ b/crates/vite_global_cli/src/cli.rs
@@ -298,9 +298,14 @@ pub enum EnvSubcommands {
     Print,
 
     /// Set or show the global default Node.js version
+    #[command(after_help = "\
+Examples:
+  vp env default              # Show the current default
+  vp env default lts          # Set the default to latest LTS
+  vp env default 20.18.0      # Set a specific version")]
     Default {
-        /// Version to set as default (e.g., "20.18.0", "lts", "latest")
-        /// If not provided, shows the current default
+        /// Version to set as default (e.g., "20.18.0", "lts", "latest").
+        /// If omitted, prints the current default.
         version: Option<String>,
     },
 
@@ -330,9 +335,16 @@ pub enum EnvSubcommands {
     },
 
     /// Pin a Node.js version in the current directory (creates .node-version)
+    #[command(after_help = "\
+Examples:
+  vp env pin                    # Show the currently pinned version
+  vp env pin lts                # Pin to latest LTS
+  vp env pin 20.18.0            # Pin a specific version
+  vp env pin \"^20.0.0\" --force  # Pin a range, overwriting existing file
+  vp env pin --unpin            # Remove .node-version")]
     Pin {
-        /// Version to pin (e.g., "20.18.0", "lts", "latest", "^20.0.0")
-        /// If not provided, shows the current pinned version
+        /// Version to pin (e.g., "20.18.0", "lts", "latest", "^20.0.0").
+        /// If omitted, prints the currently pinned version.
         version: Option<String>,
 
         /// Remove the .node-version file from current directory
@@ -383,11 +395,15 @@ pub enum EnvSubcommands {
     },
 
     /// Execute a command with a specific Node.js version
-    #[command(visible_alias = "run")]
+    #[command(visible_alias = "run", after_help = "\
+Examples:
+  vp env exec --node lts npm install        # Run npm install with latest LTS
+  vp env exec --node 20.18.0 node script.js # Run with a specific version
+  vp env exec node -v                       # Shim mode: version auto-resolved")]
     Exec {
-        /// Node.js version to use (e.g., "20.18.0", "lts", "^20.0.0")
-        /// If not provided and command is node/npm/npx or a global package binary,
-        /// version is resolved automatically (same as shim behavior)
+        /// Node.js version to use (e.g., "20.18.0", "lts", "^20.0.0").
+        /// If omitted and command is node/npm/npx or a global package binary,
+        /// version is resolved automatically (same as shim behavior).
         #[arg(long)]
         node: Option<String>,
 
@@ -417,9 +433,15 @@ pub enum EnvSubcommands {
     },
 
     /// Use a specific Node.js version for this shell session
+    #[command(after_help = "\
+Examples:
+  vp env use            # Use the version from .node-version / package.json
+  vp env use 20         # Override the session with Node 20
+  vp env use lts        # Use latest LTS for this session
+  vp env use --unset    # Clear the session override")]
     Use {
-        /// Version to use (e.g., "20", "20.18.0", "lts", "latest")
-        /// If not provided, reads from .node-version or package.json
+        /// Version to use (e.g., "20", "20.18.0", "lts", "latest").
+        /// If omitted, reads from .node-version or package.json.
         version: Option<String>,
 
         /// Remove session override (revert to file-based resolution)

--- a/crates/vite_global_cli/src/cli.rs
+++ b/crates/vite_global_cli/src/cli.rs
@@ -298,11 +298,10 @@ pub enum EnvSubcommands {
     Print,
 
     /// Set or show the global default Node.js version
-    #[command(after_help = "\
+    #[command(after_long_help = "\
 Examples:
-  vp env default              # Show the current default
-  vp env default lts          # Set the default to latest LTS
-  vp env default 20.18.0      # Set a specific version")]
+  vp env default          # Show the current default
+  vp env default lts      # Set the default")]
     Default {
         /// Version to set as default (e.g., "20.18.0", "lts", "latest").
         /// If omitted, prints the current default.
@@ -335,13 +334,11 @@ Examples:
     },
 
     /// Pin a Node.js version in the current directory (creates .node-version)
-    #[command(after_help = "\
+    #[command(after_long_help = "\
 Examples:
-  vp env pin                    # Show the currently pinned version
-  vp env pin lts                # Pin to latest LTS
-  vp env pin 20.18.0            # Pin a specific version
-  vp env pin \"^20.0.0\" --force  # Pin a range, overwriting existing file
-  vp env pin --unpin            # Remove .node-version")]
+  vp env pin lts                  # Pin to latest LTS
+  vp env pin --unpin              # Remove .node-version
+  vp env pin \"^20.0.0\" --force    # Overwrite existing pin")]
     Pin {
         /// Version to pin (e.g., "20.18.0", "lts", "latest", "^20.0.0").
         /// If omitted, prints the currently pinned version.
@@ -397,11 +394,10 @@ Examples:
     /// Execute a command with a specific Node.js version
     #[command(
         visible_alias = "run",
-        after_help = "\
+        after_long_help = "\
 Examples:
-  vp env exec --node lts npm install        # Run npm install with latest LTS
-  vp env exec --node 20.18.0 node script.js # Run with a specific version
-  vp env exec node -v                       # Shim mode: version auto-resolved"
+  vp env exec --node lts npm install  # Pin version for this invocation
+  vp env exec node -v                 # Shim mode: version auto-resolved"
     )]
     Exec {
         /// Node.js version to use (e.g., "20.18.0", "lts", "^20.0.0").
@@ -436,11 +432,9 @@ Examples:
     },
 
     /// Use a specific Node.js version for this shell session
-    #[command(after_help = "\
+    #[command(after_long_help = "\
 Examples:
-  vp env use            # Use the version from .node-version / package.json
-  vp env use 20         # Override the session with Node 20
-  vp env use lts        # Use latest LTS for this session
+  vp env use lts        # Override session with latest LTS
   vp env use --unset    # Clear the session override")]
     Use {
         /// Version to use (e.g., "20", "20.18.0", "lts", "latest").

--- a/packages/cli/snap-tests-global/command-env-use/snap.txt
+++ b/packages/cli/snap-tests-global/command-env-use/snap.txt
@@ -4,13 +4,19 @@ Usage: vp env use [OPTIONS] [VERSION]
 Use a specific Node.js version for this shell session
 
 Arguments:
-  [VERSION]  Version to use (e.g., "20", "20.18.0", "lts", "latest") If not provided, reads from .node-version or package.json
+  [VERSION]  Version to use (e.g., "20", "20.18.0", "lts", "latest"). If omitted, reads from .node-version or package.json
 
 Options:
   --unset                Remove session override (revert to file-based resolution)
   --no-install           Skip auto-installation if version not present
   --silent-if-unchanged  Suppress output if version is already active
   -h, --help             Print help
+
+Examples:
+  vp env use            # Use the version from .node-version / package.json
+  vp env use 20         # Override the session with Node 20
+  vp env use lts        # Use latest LTS for this session
+  vp env use --unset    # Clear the session override
 
 Documentation: https://viteplus.dev/guide/env
 

--- a/packages/cli/snap-tests-global/command-env-use/snap.txt
+++ b/packages/cli/snap-tests-global/command-env-use/snap.txt
@@ -13,9 +13,7 @@ Options:
   -h, --help             Print help
 
 Examples:
-  vp env use            # Use the version from .node-version / package.json
-  vp env use 20         # Override the session with Node 20
-  vp env use lts        # Use latest LTS for this session
+  vp env use lts        # Override session with latest LTS
   vp env use --unset    # Clear the session override
 
 Documentation: https://viteplus.dev/guide/env

--- a/packages/cli/snap-tests-global/command-env-use/snap.txt
+++ b/packages/cli/snap-tests-global/command-env-use/snap.txt
@@ -10,7 +10,7 @@ Options:
   --unset                Remove session override (revert to file-based resolution)
   --no-install           Skip auto-installation if version not present
   --silent-if-unchanged  Suppress output if version is already active
-  -h, --help             Print help
+  -h, --help             Print help (see a summary with '-h')
 
 Examples:
   vp env use lts        # Override session with latest LTS


### PR DESCRIPTION
## Summary

Closes #949.

Adds `Examples:` blocks (via clap `after_help`) to the four `vp env` subcommands flagged in the issue, so the intended invocation modes are visible directly from `--help`:

- `vp env default` — show vs. set (with/without `<version>`)
- `vp env pin` — show / pin / range / `--unpin`
- `vp env use` — default / override `<version>` / `--unset`
- `vp env exec` — explicit `--node <version>` vs. shim mode

Also tightens per-argument doc comments ("If not provided" → "If omitted", missing period).

No behavior changes. The clap auto-generated `Usage:` line is unchanged.

The `command-env-use` snap was regenerated to capture the new `--help` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)