### PR TITLE
ci(release): attach per-target vp binary archives to GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,6 +145,13 @@ jobs:
           echo "Installer binaries:"
           ls -la installer-release/ || echo "No installer binaries found"
 
+      - name: Download release archives
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: binary-release
+          pattern: vp-release-archive-*
+          merge-multiple: true
+
       - name: 'Setup npm'
         run: npm install -g npm@latest
 
@@ -203,6 +210,8 @@ jobs:
           target_commitish: ${{ github.sha }}
           files: |
             installer-release/vp-setup-*.exe
+            binary-release/vp-*.tar.gz
+            binary-release/vp-*.zip
 
       - name: Publish GitHub Release
         env:

--- a/.github/workflows/reusable-release-build.yml
+++ b/.github/workflows/reusable-release-build.yml
@@ -102,6 +102,25 @@ jobs:
             ./target/${{ matrix.settings.target }}/release/vp-shim.exe
           if-no-files-found: error
 
+      - name: Package release archive
+        shell: bash
+        working-directory: ./target/${{ matrix.settings.target }}/release
+        run: |
+          if [ -f vp.exe ]; then
+            7z a "vp-${{ matrix.settings.target }}.zip" vp.exe vp-shim.exe
+          else
+            tar -czf "vp-${{ matrix.settings.target }}.tar.gz" vp
+          fi
+
+      - name: Upload release archive
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vp-release-archive-${{ matrix.settings.target }}
+          path: |
+            ./target/${{ matrix.settings.target }}/release/vp-*.tar.gz
+            ./target/${{ matrix.settings.target }}/release/vp-*.zip
+          if-no-files-found: error
+
       - name: Upload installer binary artifact (Windows only)
         if: contains(matrix.settings.target, 'windows')
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Summary

- Package the existing `vite-global-cli-<target>` matrix artifacts into per-platform `.tar.gz` (unix) / `.zip` (windows) archives inside `reusable-release-build.yml`, and attach them to the GitHub Release alongside the existing `vp-setup-*.exe` installers.
- Asset names use the Rust target triple verbatim (`vp-x86_64-unknown-linux-gnu.tar.gz`, `vp-x86_64-pc-windows-msvc.zip`, ...) so no name-mapping table is needed on the CI side.
- Permissions are preserved because the archive is produced inside the same matrix job that builds the binary (no upload/download round-trip strip).

## Why

The release pipeline already cross-compiles `vp` for 8 targets, but only the Windows `vp-setup.exe` installer ever reaches the GitHub Release. Tools like mise (`aqua:` backend) and aqua itself expect to consume binaries from GitHub Releases rather than npm tarballs — see [#943](https://github.com/voidzero-dev/vite-plus/issues/943).

This is the minimal CI plumbing for that. Out of scope: aqua-registry PR, `jdx/mise` `registry/viteplus.toml` update, and resolving the runtime JS-sidecar dependency in `crates/vite_global_cli/src/js_executor.rs` — those are tracked separately on #943.

🤖 Generated with [Claude Code](https://claude.com/claude-code)