### PR TITLE
fix: use fmt.configPath for Zed oxfmt settings

### DIFF
--- a/docs/guide/ide-integration.md
+++ b/docs/guide/ide-integration.md
@@ -71,7 +71,7 @@ You can also manually set up the Zed config:
     "oxfmt": {
       "initialization_options": {
         "settings": {
-          "configPath": "./vite.config.ts",
+          "fmt.configPath": "./vite.config.ts",
           "run": "onSave"
         }
       }
@@ -98,4 +98,4 @@ You can also manually set up the Zed config:
 }
 ```
 
-Setting `oxfmt.configPath` to `./vite.config.ts` keeps editor format-on-save aligned with the `fmt` block in your Vite+ config. The full generated config covers additional languages (CSS, HTML, JSON, Markdown, etc.) — run `vp create` or `vp migrate` to get the complete file written automatically.
+Setting `oxfmt.fmt.configPath` to `./vite.config.ts` keeps editor format-on-save aligned with the `fmt` block in your Vite+ config. The full generated config covers additional languages (CSS, HTML, JSON, Markdown, etc.) — run `vp create` or `vp migrate` to get the complete file written automatically.

--- a/packages/cli/src/utils/__tests__/editor.spec.ts
+++ b/packages/cli/src/utils/__tests__/editor.spec.ts
@@ -250,14 +250,14 @@ describe('writeEditorConfigs', () => {
         oxfmt?: {
           initialization_options?: {
             settings?: {
-              configPath?: string;
+              'fmt.configPath'?: string;
             };
           };
         };
       };
     };
 
-    expect(settings.lsp?.oxfmt?.initialization_options?.settings?.configPath).toBe(
+    expect(settings.lsp?.oxfmt?.initialization_options?.settings?.['fmt.configPath']).toBe(
       './vite.config.ts',
     );
   });

--- a/packages/cli/src/utils/editor.ts
+++ b/packages/cli/src/utils/editor.ts
@@ -46,7 +46,7 @@ const ZED_SETTINGS = {
     oxfmt: {
       initialization_options: {
         settings: {
-          configPath: './vite.config.ts',
+          'fmt.configPath': './vite.config.ts',
           run: 'onSave',
         },
       },


### PR DESCRIPTION
According to the [Zed OXC extension example](https://github.com/oxc-project/oxc-zed/blob/main/examples/oxfmt/.zed/settings.json), the `configPath` should be `fmt.configPath` instead, and I verified it myself.