### PR TITLE
fix(cli): parse tsconfig as jsonc

### DIFF
--- a/packages/cli/src/__tests__/tsconfig.spec.ts
+++ b/packages/cli/src/__tests__/tsconfig.spec.ts
@@ -1,0 +1,56 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { hasBaseUrlInTsconfig } from '../utils/tsconfig.js';
+
+const tempDirs: string[] = [];
+
+function createTempDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vp-tsconfig-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0, tempDirs.length)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('hasBaseUrlInTsconfig', () => {
+  it('detects baseUrl in JSONC tsconfig files', () => {
+    const projectPath = createTempDir();
+    fs.writeFileSync(
+      path.join(projectPath, 'tsconfig.json'),
+      `{
+  "compilerOptions": {
+    // Laravel starter tsconfig files commonly keep generated comments.
+    "moduleResolution": "bundler",
+    "baseUrl": ".",
+  }
+}
+`,
+    );
+
+    expect(hasBaseUrlInTsconfig(projectPath)).toBe(true);
+  });
+
+  it('returns false when baseUrl is only present in a comment', () => {
+    const projectPath = createTempDir();
+    fs.writeFileSync(
+      path.join(projectPath, 'tsconfig.json'),
+      `{
+  "compilerOptions": {
+    // "baseUrl": ".",
+    "moduleResolution": "bundler"
+  }
+}
+`,
+    );
+
+    expect(hasBaseUrlInTsconfig(projectPath)).toBe(false);
+  });
+});

--- a/packages/cli/src/utils/tsconfig.ts
+++ b/packages/cli/src/utils/tsconfig.ts
@@ -10,9 +10,11 @@ import { applyEdits, modify, parse as parseJsonc } from 'jsonc-parser';
  */
 export function hasBaseUrlInTsconfig(projectPath: string): boolean {
   try {
-    const tsconfig = JSON.parse(
+    const tsconfig = parseJsonc(
       fs.readFileSync(path.join(projectPath, 'tsconfig.json'), 'utf-8'),
-    ) as { compilerOptions?: { baseUrl?: string } };
+    ) as {
+      compilerOptions?: { baseUrl?: string };
+    };
     return tsconfig?.compilerOptions?.baseUrl !== undefined;
   } catch {
     return false;


### PR DESCRIPTION
If tsconfig has comments, JSON.parse fails and we can't detect nor remove baseUrl!

This PR resolves this.

Related: https://github.com/voidzero-dev/vite-plus/pull/739