### PR TITLE
feat(cli): prompt to migrate baseUrl if detected

### DIFF
--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -18,9 +18,12 @@ If you are migrating an existing project and it still depends on older Vite or V
 ## `vp check` does not run type-aware lint rules or type checks
 
 - Confirm that `lint.options.typeAware` and `lint.options.typeCheck` are enabled in `vite.config.ts`
-- Check whether your `tsconfig.json` uses `compilerOptions.baseUrl`
+- Check whether your `tsconfig.json` still uses `compilerOptions.baseUrl`
 
-The Oxlint type checker path powered by `tsgolint` does not support `baseUrl`, so Vite+ skips `typeAware` and `typeCheck` when that setting is present.
+The Oxlint type checker path powered by `tsgolint` does not support `baseUrl`.
+`vp migrate` and `vp lint --init` try to run the `@andrewbranch/ts5to6 --fixBaseUrl .`
+fix before enabling type-aware linting. If that fix fails or is declined, Vite+
+skips `typeAware` and `typeCheck`.
 
 ## `vp lint` / `vp fmt` may fail to read `vite.config.ts`
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -21,7 +21,7 @@ If you are migrating an existing project and it still depends on older Vite or V
 - Check whether your `tsconfig.json` still uses `compilerOptions.baseUrl`
 
 The Oxlint type checker path powered by `tsgolint` does not support `baseUrl`.
-`vp migrate` and `vp lint --init` try to run the `@andrewbranch/ts5to6 --fixBaseUrl .`
+`vp migrate` and `vp lint --init` try to run the `vp dlx @andrewbranch/ts5to6 --fixBaseUrl .`
 fix before enabling type-aware linting. If that fix fails or is declined, Vite+
 skips `typeAware` and `typeCheck`.
 

--- a/packages/cli/snap-tests-global/migration-baseurl-tsconfig/fix-baseurl.mjs
+++ b/packages/cli/snap-tests-global/migration-baseurl-tsconfig/fix-baseurl.mjs
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const target = process.argv.at(-1);
+if (!target || target.startsWith('-')) {
+  process.exit(1);
+}
+
+const filePath = path.resolve(process.cwd(), target);
+const text = fs.readFileSync(filePath, 'utf8');
+fs.writeFileSync(filePath, text.replace(/\n\s*"baseUrl": "\.",?/, ''));

--- a/packages/cli/snap-tests-global/migration-baseurl-tsconfig/snap.txt
+++ b/packages/cli/snap-tests-global/migration-baseurl-tsconfig/snap.txt
@@ -35,7 +35,7 @@ export default defineConfig({
   "compilerOptions": {
     // JSONC comments should not prevent baseUrl detection.
     "target": "ES2023",
-    "module": "NodeNext",
+    "module": "NodeNext"
   }
 }
 

--- a/packages/cli/snap-tests-global/migration-baseurl-tsconfig/snap.txt
+++ b/packages/cli/snap-tests-global/migration-baseurl-tsconfig/snap.txt
@@ -1,12 +1,10 @@
-> vp migrate --no-interactive # migration should skip typeAware/typeCheck when tsconfig has baseUrl
+> chmod +x fix-baseurl.mjs # setup baseUrl fixer
+> vp migrate --no-interactive # migration should auto-fix tsconfig baseUrl
 ◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 3 config updates applied
-! Warnings:
-  - Skipped typeAware/typeCheck: tsconfig.json contains baseUrl which is not yet supported by the oxlint type checker.
-  Run `npx @andrewbranch/ts5to6 --fixBaseUrl .` to remove baseUrl from your tsconfig.
 
-> cat vite.config.ts # check vite.config.ts — should NOT have typeAware or typeCheck
+> cat vite.config.ts # check vite.config.ts has typeAware and typeCheck
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({
@@ -19,7 +17,10 @@ export default defineConfig({
       "no-unused-vars": "error",
       "vite-plus/prefer-vite-plus-imports": "error"
     },
-    "options": {},
+    "options": {
+      "typeAware": true,
+      "typeCheck": true
+    },
     "jsPlugins": [
       {
         "name": "vite-plus",
@@ -28,6 +29,15 @@ export default defineConfig({
     ]
   },
 });
+
+> cat tsconfig.json # check baseUrl was removed
+{
+  "compilerOptions": {
+    // JSONC comments should not prevent baseUrl detection.
+    "target": "ES2023",
+    "module": "NodeNext",
+  }
+}
 
 > test ! -f .oxlintrc.json # check .oxlintrc.json is removed
 > cat package.json # check package.json

--- a/packages/cli/snap-tests-global/migration-baseurl-tsconfig/steps.json
+++ b/packages/cli/snap-tests-global/migration-baseurl-tsconfig/steps.json
@@ -1,7 +1,12 @@
 {
+  "env": {
+    "VP_CLI_BIN": "./fix-baseurl.mjs"
+  },
   "commands": [
-    "vp migrate --no-interactive # migration should skip typeAware/typeCheck when tsconfig has baseUrl",
-    "cat vite.config.ts # check vite.config.ts \u2014 should NOT have typeAware or typeCheck",
+    "chmod +x fix-baseurl.mjs # setup baseUrl fixer",
+    "vp migrate --no-interactive # migration should auto-fix tsconfig baseUrl",
+    "cat vite.config.ts # check vite.config.ts has typeAware and typeCheck",
+    "cat tsconfig.json # check baseUrl was removed",
     "test ! -f .oxlintrc.json # check .oxlintrc.json is removed",
     "cat package.json # check package.json",
     "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog"

--- a/packages/cli/snap-tests-global/migration-baseurl-tsconfig/tsconfig.json
+++ b/packages/cli/snap-tests-global/migration-baseurl-tsconfig/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    // JSONC comments should not prevent baseUrl detection.
     "target": "ES2023",
     "module": "NodeNext",
     "baseUrl": "."

--- a/packages/cli/src/__tests__/init-config.spec.ts
+++ b/packages/cli/src/__tests__/init-config.spec.ts
@@ -8,6 +8,7 @@ import { vi } from 'vitest';
 import { applyToolInitConfigToViteConfig, inspectInitCommand } from '../init-config.js';
 
 const tempDirs: string[] = [];
+const originalVpCliBin = process.env.VP_CLI_BIN;
 
 function createTempDir() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vp-init-config-'));
@@ -24,6 +25,11 @@ function createTempDir() {
 afterEach(() => {
   for (const dir of tempDirs.splice(0, tempDirs.length)) {
     fs.rmSync(dir, { recursive: true, force: true });
+  }
+  if (originalVpCliBin === undefined) {
+    delete process.env.VP_CLI_BIN;
+  } else {
+    process.env.VP_CLI_BIN = originalVpCliBin;
   }
   vi.clearAllMocks();
 });
@@ -66,6 +72,46 @@ describe('applyToolInitConfigToViteConfig', () => {
     expect(content).toContain('typeAware');
     expect(content).toContain('typeCheck');
     expect(fs.existsSync(path.join(projectPath, '.oxlintrc.json'))).toBe(false);
+  });
+
+  it('auto-fixes tsconfig baseUrl before writing type-aware lint defaults', async () => {
+    const projectPath = createTempDir();
+    const fixerPath = path.join(projectPath, 'fix-baseurl.mjs');
+    fs.writeFileSync(
+      fixerPath,
+      `#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const tsconfigPath = path.join(process.cwd(), 'tsconfig.json');
+const text = fs.readFileSync(tsconfigPath, 'utf8');
+fs.writeFileSync(tsconfigPath, text.replace(/\\n\\s*"baseUrl": "\\.",?/, ''));
+`,
+    );
+    fs.chmodSync(fixerPath, 0o755);
+    process.env.VP_CLI_BIN = fixerPath;
+    fs.writeFileSync(
+      path.join(projectPath, 'tsconfig.json'),
+      `{
+  "compilerOptions": {
+    // comments require JSONC parsing
+    "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "paths": { "@/*": ["./src/*"] }
+  }
+}
+`,
+    );
+
+    const result = await applyToolInitConfigToViteConfig('lint', ['--init'], projectPath);
+    expect(result.handled).toBe(true);
+    expect(result.action).toBe('added');
+
+    const viteConfig = fs.readFileSync(path.join(projectPath, 'vite.config.ts'), 'utf8');
+    expect(viteConfig).toContain('typeAware');
+    expect(viteConfig).toContain('typeCheck');
+    const tsconfig = fs.readFileSync(path.join(projectPath, 'tsconfig.json'), 'utf8');
+    expect(tsconfig).not.toContain('"baseUrl"');
   });
 
   it('ignores generated lint init defaults and still writes lint with options', async () => {

--- a/packages/cli/src/__tests__/tsconfig.spec.ts
+++ b/packages/cli/src/__tests__/tsconfig.spec.ts
@@ -4,9 +4,14 @@ import path from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { hasBaseUrlInTsconfig } from '../utils/tsconfig.js';
+import {
+  findTsconfigFilesWithBaseUrl,
+  fixBaseUrlInTsconfig,
+  hasBaseUrlInTsconfig,
+} from '../utils/tsconfig.js';
 
 const tempDirs: string[] = [];
+const originalVpCliBin = process.env.VP_CLI_BIN;
 
 function createTempDir() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vp-tsconfig-'));
@@ -17,6 +22,11 @@ function createTempDir() {
 afterEach(() => {
   for (const dir of tempDirs.splice(0, tempDirs.length)) {
     fs.rmSync(dir, { recursive: true, force: true });
+  }
+  if (originalVpCliBin === undefined) {
+    delete process.env.VP_CLI_BIN;
+  } else {
+    process.env.VP_CLI_BIN = originalVpCliBin;
   }
 });
 
@@ -51,6 +61,110 @@ describe('hasBaseUrlInTsconfig', () => {
 `,
     );
 
+    expect(hasBaseUrlInTsconfig(projectPath)).toBe(false);
+  });
+
+  it('treats null baseUrl as absent', () => {
+    const projectPath = createTempDir();
+    fs.writeFileSync(
+      path.join(projectPath, 'tsconfig.json'),
+      JSON.stringify({ compilerOptions: { baseUrl: null } }),
+    );
+
+    expect(hasBaseUrlInTsconfig(projectPath)).toBe(false);
+    expect(findTsconfigFilesWithBaseUrl(projectPath)).toEqual([]);
+  });
+
+  it('detects baseUrl in secondary tsconfig files', () => {
+    const projectPath = createTempDir();
+    fs.writeFileSync(
+      path.join(projectPath, 'tsconfig.json'),
+      JSON.stringify({ compilerOptions: { moduleResolution: 'bundler' } }),
+    );
+    fs.writeFileSync(
+      path.join(projectPath, 'tsconfig.app.json'),
+      JSON.stringify({ compilerOptions: { baseUrl: '.' } }),
+    );
+
+    expect(hasBaseUrlInTsconfig(projectPath)).toBe(true);
+  });
+
+  it('returns tsconfig files that contain baseUrl', () => {
+    const projectPath = createTempDir();
+    fs.writeFileSync(
+      path.join(projectPath, 'tsconfig.json'),
+      JSON.stringify({ compilerOptions: { moduleResolution: 'bundler' } }),
+    );
+    fs.writeFileSync(
+      path.join(projectPath, 'tsconfig.app.json'),
+      JSON.stringify({ compilerOptions: { baseUrl: '.' } }),
+    );
+
+    expect(findTsconfigFilesWithBaseUrl(projectPath)).toEqual([
+      path.join(projectPath, 'tsconfig.app.json'),
+    ]);
+  });
+
+  it('fixes every tsconfig file that contains baseUrl', async () => {
+    const projectPath = createTempDir();
+    const fixerPath = path.join(projectPath, 'fix-baseurl.mjs');
+    const invocationsPath = path.join(projectPath, 'fix-invocations.json');
+    fs.writeFileSync(
+      fixerPath,
+      `#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const target = process.argv.at(-1);
+const invocationsPath = path.join(process.cwd(), 'fix-invocations.json');
+const invocations = fs.existsSync(invocationsPath)
+  ? JSON.parse(fs.readFileSync(invocationsPath, 'utf8'))
+  : [];
+invocations.push(target);
+fs.writeFileSync(invocationsPath, JSON.stringify(invocations));
+
+const tsconfigPath = path.resolve(process.cwd(), target);
+const text = fs.readFileSync(tsconfigPath, 'utf8');
+fs.writeFileSync(tsconfigPath, text.replace(/\\n\\s*"baseUrl": "\\.",?/, ''));
+`,
+    );
+    fs.chmodSync(fixerPath, 0o755);
+    process.env.VP_CLI_BIN = fixerPath;
+    fs.writeFileSync(
+      path.join(projectPath, 'tsconfig.json'),
+      `{
+  "compilerOptions": {
+    "moduleResolution": "bundler"
+  }
+}
+`,
+    );
+    fs.writeFileSync(
+      path.join(projectPath, 'tsconfig.app.json'),
+      `{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": { "@/*": ["./src/*"] }
+  }
+}
+`,
+    );
+    fs.writeFileSync(
+      path.join(projectPath, 'tsconfig.node.json'),
+      `{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "types": ["node"]
+  }
+}
+`,
+    );
+
+    await expect(fixBaseUrlInTsconfig(projectPath)).resolves.toBe('fixed');
+
+    const invocations = JSON.parse(fs.readFileSync(invocationsPath, 'utf8')) as string[];
+    expect(new Set(invocations)).toEqual(new Set(['tsconfig.app.json', 'tsconfig.node.json']));
+    expect(invocations).toHaveLength(2);
     expect(hasBaseUrlInTsconfig(projectPath)).toBe(false);
   });
 });

--- a/packages/cli/src/__tests__/tsconfig.spec.ts
+++ b/packages/cli/src/__tests__/tsconfig.spec.ts
@@ -1,0 +1,56 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { hasBaseUrlInTsconfig } from '../utils/tsconfig.js';
+
+const tempDirs: string[] = [];
+
+function createTempDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vp-tsconfig-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0, tempDirs.length)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('hasBaseUrlInTsconfig', () => {
+  it('detects baseUrl in JSONC tsconfig files', () => {
+    const projectPath = createTempDir();
+    fs.writeFileSync(
+      path.join(projectPath, 'tsconfig.json'),
+      `{
+  "compilerOptions": {
+    // Laravel starter tsconfig files commonly keep generated comments.
+    "moduleResolution": "bundler",
+    "baseUrl": ".",
+  }
+}
+`,
+    );
+
+    expect(hasBaseUrlInTsconfig(projectPath)).toBe(true);
+  });
+
+  it('returns false when baseUrl is only present in a comment', () => {
+    const projectPath = createTempDir();
+    fs.writeFileSync(
+      path.join(projectPath, 'tsconfig.json'),
+      `{
+  "compilerOptions": {
+    // "baseUrl": ".",
+    "moduleResolution": "bundler"
+  }
+}
+`,
+    );
+
+    expect(hasBaseUrlInTsconfig(projectPath)).toBe(false);
+  });
+});

--- a/packages/cli/src/init-config.ts
+++ b/packages/cli/src/init-config.ts
@@ -7,7 +7,7 @@ import { fmt as resolveFmt } from './resolve-fmt.ts';
 import { runCommandSilently } from './utils/command.ts';
 import { BASEURL_TSCONFIG_WARNING, VITE_PLUS_NAME } from './utils/constants.ts';
 import { warnMsg } from './utils/terminal.ts';
-import { hasBaseUrlInTsconfig } from './utils/tsconfig.ts';
+import { fixBaseUrlInTsconfig, hasBaseUrlInTsconfig } from './utils/tsconfig.ts';
 
 interface InitCommandSpec {
   configKey: 'lint' | 'fmt';
@@ -227,7 +227,8 @@ export async function applyToolInitConfigToViteConfig(
 
   if (spec.configKey === 'lint' && hasTriggerFlag(args, ['--init'])) {
     const lintInitConfigPath = path.join(projectPath, '.vite-plus-lint-init.oxlintrc.json');
-    // Skip typeAware/typeCheck when tsconfig.json has baseUrl (unsupported by tsgolint)
+    await fixBaseUrlInTsconfig(projectPath);
+    // Skip typeAware/typeCheck when tsconfig still has baseUrl (unsupported by tsgolint)
     const hasBaseUrl = hasBaseUrlInTsconfig(projectPath);
     const initConfig = createDefaultVitePlusLintConfig({
       includeTypeAwareDefaults: !hasBaseUrl,

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -37,6 +37,11 @@ import {
   upgradeYarn,
 } from '../utils/prompts.ts';
 import { accent, log, muted, printHeader } from '../utils/terminal.ts';
+import {
+  confirmBaseUrlFix,
+  fixBaseUrlInTsconfig,
+  hasBaseUrlInTsconfig,
+} from '../utils/tsconfig.ts';
 import type { PackageDependencies } from '../utils/types.ts';
 import { detectWorkspace } from '../utils/workspace.ts';
 import {
@@ -50,6 +55,7 @@ import {
   detectNodeVersionManagerFile,
   detectPrettierProject,
   hasFrameworkShim,
+  injectLintTypeCheckDefaults,
   installGitHooks,
   mergeViteConfigFiles,
   migrateEslintToOxlint,
@@ -66,7 +72,7 @@ import {
   type Framework,
   type NodeVersionManagerDetection,
 } from './migrator.ts';
-import { createMigrationReport, type MigrationReport } from './report.ts';
+import { addMigrationWarning, createMigrationReport, type MigrationReport } from './report.ts';
 
 async function confirmNodeVersionFileMigration(
   interactive: boolean,
@@ -110,6 +116,70 @@ async function confirmFrameworkShim(framework: Framework, interactive: boolean):
     return confirmed;
   }
   return true;
+}
+
+async function fixBaseUrlForWorkspace(
+  workspaceInfo: { rootDir: string; packages?: WorkspacePackage[] },
+  fixBaseUrl: boolean,
+  updateProgress?: (message: string) => void,
+  report?: MigrationReport,
+): Promise<string[]> {
+  if (!fixBaseUrl) {
+    return [];
+  }
+
+  const fixedProjectPaths: string[] = [];
+  for (const projectPath of getWorkspaceProjectPaths(workspaceInfo)) {
+    if (!hasBaseUrlInTsconfig(projectPath)) {
+      continue;
+    }
+    updateProgress?.(
+      `Fixing tsconfig baseUrl${
+        projectPath === workspaceInfo.rootDir
+          ? ''
+          : ` in ${displayRelative(projectPath, workspaceInfo.rootDir)}`
+      }`,
+    );
+    const status = await fixBaseUrlInTsconfig(projectPath, {
+      confirmed: true,
+      silent: true,
+    });
+    if (status === 'failed') {
+      const projectLabel = displayRelative(projectPath, workspaceInfo.rootDir) || '.';
+      addMigrationWarning(
+        report,
+        `Failed to remove tsconfig baseUrl in ${projectLabel}. ` +
+          'Run `npx @andrewbranch/ts5to6 --fixBaseUrl <tsconfig path>` manually and re-run the migration.',
+      );
+    }
+    if (status === 'fixed') {
+      fixedProjectPaths.push(projectPath);
+    }
+  }
+  return fixedProjectPaths;
+}
+
+function getWorkspaceProjectPaths(workspaceInfo: {
+  rootDir: string;
+  packages?: WorkspacePackage[];
+}): string[] {
+  return [
+    workspaceInfo.rootDir,
+    ...(workspaceInfo.packages ?? []).map((pkg) => path.join(workspaceInfo.rootDir, pkg.path)),
+  ];
+}
+
+function hasBaseUrlInWorkspace(workspaceInfo: {
+  rootDir: string;
+  packages?: WorkspacePackage[];
+}): boolean {
+  for (const projectPath of getWorkspaceProjectPaths(workspaceInfo)) {
+    if (!hasBaseUrlInTsconfig(projectPath)) {
+      continue;
+    }
+    return true;
+  }
+  return false;
 }
 
 const helpMessage = renderCliDoc({
@@ -262,6 +332,7 @@ interface MigrationPlan {
   eslintConfigFile?: string;
   migratePrettier: boolean;
   prettierConfigFile?: string;
+  fixBaseUrl: boolean;
   migrateNodeVersionFile: boolean;
   nodeVersionDetection?: NodeVersionManagerDetection;
   frameworkShimFrameworks?: Framework[];
@@ -383,7 +454,7 @@ async function collectMigrationPlan(
     warnPackageLevelEslint();
   }
 
-  // 9. Prettier detection + prompt
+  // 8. Prettier detection + prompt
   const prettierProject = detectPrettierProject(rootDir, packages);
   let migratePrettier = false;
   if (prettierProject.hasDependency && prettierProject.configFile) {
@@ -391,6 +462,11 @@ async function collectMigrationPlan(
   } else if (prettierProject.hasDependency) {
     warnPackageLevelPrettier();
   }
+
+  // 9. tsconfig baseUrl prompt
+  const fixBaseUrl = hasBaseUrlInWorkspace({ rootDir, packages })
+    ? await confirmBaseUrlFix(options.interactive)
+    : false;
 
   // 10. Node version manager file detection + prompt
   const nodeVersionDetection = detectNodeVersionManagerFile(rootDir);
@@ -439,6 +515,7 @@ async function collectMigrationPlan(
     eslintConfigFile: eslintProject.configFile,
     migratePrettier,
     prettierConfigFile: prettierProject.configFile,
+    fixBaseUrl,
     migrateNodeVersionFile,
     nodeVersionDetection,
     frameworkShimFrameworks:
@@ -672,6 +749,8 @@ async function executeMigrationPlan(
     }
   }
 
+  await fixBaseUrlForWorkspace(workspaceInfo, plan.fixBaseUrl, updateMigrationProgress, report);
+
   // 6. ESLint → Oxlint migration (before main rewrite so .oxlintrc.json gets picked up)
   if (plan.migrateEslint) {
     updateMigrationProgress('Migrating ESLint');
@@ -840,7 +919,26 @@ async function main() {
       }
     };
 
-    // Check if ESLint migration is needed
+    const fixBaseUrl = hasBaseUrlInWorkspace(workspaceInfoOptional)
+      ? await confirmBaseUrlFix(options.interactive)
+      : false;
+
+    // Check if tsconfig baseUrl migration is needed
+    const fixedBaseUrlProjectPaths = await fixBaseUrlForWorkspace(
+      workspaceInfoOptional,
+      fixBaseUrl,
+      updateMigrationProgress,
+      report,
+    );
+    if (fixedBaseUrlProjectPaths.length > 0) {
+      updateMigrationProgress('Updating lint defaults');
+      for (const projectPath of fixedBaseUrlProjectPaths) {
+        injectLintTypeCheckDefaults(projectPath, true, report);
+      }
+      didMigrate = true;
+    }
+    clearMigrationProgress();
+
     const eslintMigrated = await promptEslintMigration(
       workspaceInfoOptional.rootDir,
       options.interactive,

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -149,7 +149,7 @@ async function fixBaseUrlForWorkspace(
       addMigrationWarning(
         report,
         `Failed to remove tsconfig baseUrl in ${projectLabel}. ` +
-          'Run `npx @andrewbranch/ts5to6 --fixBaseUrl <tsconfig path>` manually and re-run the migration.',
+          'Run `vp dlx @andrewbranch/ts5to6 --fixBaseUrl <tsconfig path>` manually and re-run the migration.',
       );
     }
     if (status === 'fixed') {

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -262,6 +262,12 @@ export async function migrateEslintToOxlint(
     // @ts-expect-error — resolved at runtime from dist/ → dist/versions.js
     const { versions } = await import('../versions.js');
     const migratePackage = `@oxlint/migrate@${versions.oxlint}`;
+    const migrateArgs = [
+      '--merge',
+      ...(!hasBaseUrlInTsconfig(projectPath) ? ['--type-aware'] : []),
+      '--with-nursery',
+      '--details',
+    ];
 
     // Step 1: Generate .oxlintrc.json from ESLint config
     spinner.start('Migrating ESLint config to Oxlint...');
@@ -269,10 +275,10 @@ export async function migrateEslintToOxlint(
       vpBin,
       projectPath,
       migratePackage,
-      ['--merge', '--type-aware', '--with-nursery', '--details'],
+      migrateArgs,
       spinner,
       'ESLint migration failed',
-      `You can run \`vp dlx ${migratePackage} --merge --type-aware --with-nursery --details\` manually later`,
+      `You can run \`vp dlx ${migratePackage} ${migrateArgs.join(' ')}\` manually later`,
     );
     if (!migrateOk) {
       return false;
@@ -1999,6 +2005,7 @@ export function injectLintTypeCheckDefaults(
   report?: MigrationReport,
 ): void {
   if (hasBaseUrlInTsconfig(projectPath)) {
+    warnMigration(BASEURL_TSCONFIG_WARNING, report);
     return;
   }
   injectConfigDefaults(

--- a/packages/cli/src/utils/constants.ts
+++ b/packages/cli/src/utils/constants.ts
@@ -28,8 +28,16 @@ export function resolve(path: string) {
 }
 
 export const BASEURL_TSCONFIG_WARNING =
-  'Skipped typeAware/typeCheck: tsconfig.json contains baseUrl which is not yet supported by the oxlint type checker.\n' +
-  '  Run `npx @andrewbranch/ts5to6 --fixBaseUrl .` to remove baseUrl from your tsconfig.';
+  'Skipped typeAware/typeCheck: a tsconfig file contains baseUrl which is not yet supported by the oxlint type checker.\n' +
+  '  Run `npx @andrewbranch/ts5to6 --fixBaseUrl <tsconfig path>` to remove baseUrl from your tsconfig.';
+
+export const BASEURL_TSCONFIG_FIX_PACKAGE = '@andrewbranch/ts5to6';
+export const BASEURL_TSCONFIG_FIX_FLAG = '--fixBaseUrl';
+export const BASEURL_TSCONFIG_FIX_DEFAULT_TARGET = '.';
+
+export function createBaseUrlTsconfigFixArgs(target = BASEURL_TSCONFIG_FIX_DEFAULT_TARGET) {
+  return [BASEURL_TSCONFIG_FIX_FLAG, target] as const;
+}
 
 export const DEFAULT_ENVS = {
   // Provide Node.js runtime information for oxfmt's telemetry/compatibility

--- a/packages/cli/src/utils/constants.ts
+++ b/packages/cli/src/utils/constants.ts
@@ -29,7 +29,7 @@ export function resolve(path: string) {
 
 export const BASEURL_TSCONFIG_WARNING =
   'Skipped typeAware/typeCheck: a tsconfig file contains baseUrl which is not yet supported by the oxlint type checker.\n' +
-  '  Run `npx @andrewbranch/ts5to6 --fixBaseUrl <tsconfig path>` to remove baseUrl from your tsconfig.';
+  '  Run `vp dlx @andrewbranch/ts5to6 --fixBaseUrl <tsconfig path>` to remove baseUrl from your tsconfig.';
 
 export const BASEURL_TSCONFIG_FIX_PACKAGE = '@andrewbranch/ts5to6';
 export const BASEURL_TSCONFIG_FIX_FLAG = '--fixBaseUrl';

--- a/packages/cli/src/utils/tsconfig.ts
+++ b/packages/cli/src/utils/tsconfig.ts
@@ -6,10 +6,7 @@ import * as prompts from '@voidzero-dev/vite-plus-prompts';
 import { applyEdits, modify, parse as parseJsonc } from 'jsonc-parser';
 
 import { runCommandSilently } from './command.ts';
-import {
-  BASEURL_TSCONFIG_FIX_PACKAGE,
-  createBaseUrlTsconfigFixArgs,
-} from './constants.ts';
+import { BASEURL_TSCONFIG_FIX_PACKAGE, createBaseUrlTsconfigFixArgs } from './constants.ts';
 import { cancelAndExit } from './prompts.ts';
 
 export type BaseUrlFixStatus = 'not-needed' | 'fixed' | 'declined' | 'failed';
@@ -44,15 +41,11 @@ export function findTsconfigFiles(projectPath: string): string[] {
 }
 
 export function hasBaseUrlInTsconfig(projectPath: string): boolean {
-  return findTsconfigFiles(projectPath).some((filePath) =>
-    hasBaseUrlInTsconfigFile(filePath),
-  );
+  return findTsconfigFiles(projectPath).some((filePath) => hasBaseUrlInTsconfigFile(filePath));
 }
 
 export function findTsconfigFilesWithBaseUrl(projectPath: string): string[] {
-  return findTsconfigFiles(projectPath).filter((filePath) =>
-    hasBaseUrlInTsconfigFile(filePath),
-  );
+  return findTsconfigFiles(projectPath).filter((filePath) => hasBaseUrlInTsconfigFile(filePath));
 }
 
 export async function confirmBaseUrlFix(interactive: boolean): Promise<boolean> {
@@ -95,8 +88,7 @@ export async function fixBaseUrlInTsconfig(
     return 'not-needed';
   }
 
-  const confirmed =
-    options?.confirmed ?? (await confirmBaseUrlFix(options?.interactive ?? false));
+  const confirmed = options?.confirmed ?? (await confirmBaseUrlFix(options?.interactive ?? false));
   if (!confirmed) {
     options?.onStatus?.('declined', projectPath);
     return 'declined';

--- a/packages/cli/src/utils/tsconfig.ts
+++ b/packages/cli/src/utils/tsconfig.ts
@@ -1,21 +1,30 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { styleText } from 'node:util';
 
+import * as prompts from '@voidzero-dev/vite-plus-prompts';
 import { applyEdits, modify, parse as parseJsonc } from 'jsonc-parser';
+
+import { runCommandSilently } from './command.ts';
+import {
+  BASEURL_TSCONFIG_FIX_PACKAGE,
+  createBaseUrlTsconfigFixArgs,
+} from './constants.ts';
+import { cancelAndExit } from './prompts.ts';
+
+export type BaseUrlFixStatus = 'not-needed' | 'fixed' | 'declined' | 'failed';
 
 /**
  * Check if tsconfig.json has compilerOptions.baseUrl set.
  * oxlint's TypeScript checker (tsgolint) does not support baseUrl,
  * so typeAware/typeCheck must be disabled when it is present.
  */
-export function hasBaseUrlInTsconfig(projectPath: string): boolean {
+export function hasBaseUrlInTsconfigFile(filePath: string): boolean {
   try {
-    const tsconfig = parseJsonc(
-      fs.readFileSync(path.join(projectPath, 'tsconfig.json'), 'utf-8'),
-    ) as {
-      compilerOptions?: { baseUrl?: string };
+    const tsconfig = parseJsonc(fs.readFileSync(filePath, 'utf-8')) as {
+      compilerOptions?: { baseUrl?: string | null };
     };
-    return tsconfig?.compilerOptions?.baseUrl !== undefined;
+    return tsconfig?.compilerOptions?.baseUrl != null;
   } catch {
     return false;
   }
@@ -32,6 +41,106 @@ export function findTsconfigFiles(projectPath: string): string[] {
   } catch {
     return [];
   }
+}
+
+export function hasBaseUrlInTsconfig(projectPath: string): boolean {
+  return findTsconfigFiles(projectPath).some((filePath) => hasBaseUrlInTsconfigFile(filePath));
+}
+
+export function findTsconfigFilesWithBaseUrl(projectPath: string): string[] {
+  return findTsconfigFiles(projectPath).filter((filePath) => hasBaseUrlInTsconfigFile(filePath));
+}
+
+export async function confirmBaseUrlFix(interactive: boolean): Promise<boolean> {
+  if (!interactive) {
+    return true;
+  }
+
+  const command = [
+    BASEURL_TSCONFIG_FIX_PACKAGE,
+    ...createBaseUrlTsconfigFixArgs('<tsconfig path>'),
+  ].join(' ');
+  const confirmed = await prompts.confirm({
+    message:
+      'Your tsconfig contains `baseUrl`, which prevents enabling type-aware linting.\n  ' +
+      styleText(
+        'gray',
+        '`baseUrl` is deprecated in TypeScript 6.0 and removed in TypeScript 7.0.',
+      ) +
+      `\n  Download and run the external \`${BASEURL_TSCONFIG_FIX_PACKAGE}\` fixer now?\n  ` +
+      styleText('gray', `Equivalent command: \`npx ${command}\``),
+    initialValue: true,
+  });
+  if (prompts.isCancel(confirmed)) {
+    cancelAndExit();
+  }
+  return confirmed;
+}
+
+export async function fixBaseUrlInTsconfig(
+  projectPath: string,
+  options?: {
+    interactive?: boolean;
+    confirmed?: boolean;
+    silent?: boolean;
+    onStatus?: (status: BaseUrlFixStatus, projectPath: string) => void;
+  },
+): Promise<BaseUrlFixStatus> {
+  const files = findTsconfigFilesWithBaseUrl(projectPath);
+  if (files.length === 0) {
+    return 'not-needed';
+  }
+
+  const confirmed =
+    options?.confirmed ?? (await confirmBaseUrlFix(options?.interactive ?? false));
+  if (!confirmed) {
+    options?.onStatus?.('declined', projectPath);
+    return 'declined';
+  }
+
+  try {
+    for (const filePath of files) {
+      const target = path.relative(projectPath, filePath) || filePath;
+      const fixArgs = createBaseUrlTsconfigFixArgs(target);
+      if (!options?.silent) {
+        prompts.log.info(`Running vp dlx ${BASEURL_TSCONFIG_FIX_PACKAGE} ${fixArgs.join(' ')}`);
+      }
+      const result = await runCommandSilently({
+        command: process.env.VP_CLI_BIN ?? 'vp',
+        args: ['dlx', BASEURL_TSCONFIG_FIX_PACKAGE, ...fixArgs],
+        cwd: projectPath,
+        envs: process.env,
+      });
+
+      if (result.exitCode !== 0) {
+        if (!options?.silent) {
+          const output = `${result.stdout.toString()}${result.stderr.toString()}`.trim();
+          if (output) {
+            prompts.log.warn(output);
+          }
+        }
+        options?.onStatus?.('failed', projectPath);
+        return 'failed';
+      }
+    }
+
+    if (hasBaseUrlInTsconfig(projectPath)) {
+      if (!options?.silent) {
+        prompts.log.warn('tsconfig still contains baseUrl after running the fixer.');
+      }
+      options?.onStatus?.('failed', projectPath);
+      return 'failed';
+    }
+  } catch (error) {
+    if (!options?.silent && error instanceof Error) {
+      prompts.log.warn(error.message);
+    }
+    options?.onStatus?.('failed', projectPath);
+    return 'failed';
+  }
+
+  options?.onStatus?.('fixed', projectPath);
+  return 'fixed';
 }
 
 // jsonc-parser is in dependencies (not devDependencies) so it's available at

--- a/packages/cli/src/utils/tsconfig.ts
+++ b/packages/cli/src/utils/tsconfig.ts
@@ -68,7 +68,7 @@ export async function confirmBaseUrlFix(interactive: boolean): Promise<boolean> 
         '`baseUrl` is deprecated in TypeScript 6.0 and removed in TypeScript 7.0.',
       ) +
       `\n  Download and run the external \`${BASEURL_TSCONFIG_FIX_PACKAGE}\` fixer now?\n  ` +
-      styleText('gray', `Equivalent command: \`npx ${command}\``),
+      styleText('gray', `Equivalent command: \`vp dlx ${command}\``),
     initialValue: true,
   });
   if (prompts.isCancel(confirmed)) {

--- a/packages/cli/src/utils/tsconfig.ts
+++ b/packages/cli/src/utils/tsconfig.ts
@@ -44,11 +44,15 @@ export function findTsconfigFiles(projectPath: string): string[] {
 }
 
 export function hasBaseUrlInTsconfig(projectPath: string): boolean {
-  return findTsconfigFiles(projectPath).some((filePath) => hasBaseUrlInTsconfigFile(filePath));
+  return findTsconfigFiles(projectPath).some((filePath) =>
+    hasBaseUrlInTsconfigFile(filePath),
+  );
 }
 
 export function findTsconfigFilesWithBaseUrl(projectPath: string): string[] {
-  return findTsconfigFiles(projectPath).filter((filePath) => hasBaseUrlInTsconfigFile(filePath));
+  return findTsconfigFiles(projectPath).filter((filePath) =>
+    hasBaseUrlInTsconfigFile(filePath),
+  );
 }
 
 export async function confirmBaseUrlFix(interactive: boolean): Promise<boolean> {

--- a/packages/cli/src/utils/tsconfig.ts
+++ b/packages/cli/src/utils/tsconfig.ts
@@ -10,9 +10,11 @@ import { applyEdits, modify, parse as parseJsonc } from 'jsonc-parser';
  */
 export function hasBaseUrlInTsconfig(projectPath: string): boolean {
   try {
-    const tsconfig = JSON.parse(
+    const tsconfig = parseJsonc(
       fs.readFileSync(path.join(projectPath, 'tsconfig.json'), 'utf-8'),
-    ) as { compilerOptions?: { baseUrl?: string } };
+    ) as {
+      compilerOptions?: { baseUrl?: string };
+    };
     return tsconfig?.compilerOptions?.baseUrl !== undefined;
   } catch {
     return false;

--- a/rfcs/migration-command.md
+++ b/rfcs/migration-command.md
@@ -329,7 +329,7 @@ export default defineConfig({
 });
 ```
 
-> **Note**: If `tsconfig.json` contains `compilerOptions.baseUrl`, Vite+ runs the `@andrewbranch/ts5to6 --fixBaseUrl .` fix before enabling `typeAware` and `typeCheck`. If that fix fails or is declined, Vite+ skips those options because oxlint's TypeScript checker does not yet support `baseUrl`.
+> **Note**: If `tsconfig.json` contains `compilerOptions.baseUrl`, Vite+ runs `vp dlx @andrewbranch/ts5to6 --fixBaseUrl .` before enabling `typeAware` and `typeCheck`. If that fix fails or is declined, Vite+ skips those options because oxlint's TypeScript checker does not yet support `baseUrl`.
 
 ### Oxfmt Configuration
 

--- a/rfcs/migration-command.md
+++ b/rfcs/migration-command.md
@@ -329,7 +329,7 @@ export default defineConfig({
 });
 ```
 
-> **Note**: If `tsconfig.json` contains `compilerOptions.baseUrl`, `typeAware` and `typeCheck` are not injected because oxlint's TypeScript checker does not yet support `baseUrl`. Run `npx @andrewbranch/ts5to6 --fixBaseUrl .` to migrate away from `baseUrl`.
+> **Note**: If `tsconfig.json` contains `compilerOptions.baseUrl`, Vite+ runs the `@andrewbranch/ts5to6 --fixBaseUrl .` fix before enabling `typeAware` and `typeCheck`. If that fix fails or is declined, Vite+ skips those options because oxlint's TypeScript checker does not yet support `baseUrl`.
 
 ### Oxfmt Configuration
 


### PR DESCRIPTION
Based on #1688.

---

This PR allows the user to remove `baseUrl` from `tsconfig.json` before applying type-aware lint defaults. When run in non-interactive mode, this will simply be applied

Internally `vp dlx @andrewbranch/ts5to6 --fixBaseUrl .` is being run.