### PR TITLE
fix(cli): vp create tracking for generated VS Code settings

### DIFF
--- a/packages/cli/snap-tests-global/new-create-vite/snap.txt
+++ b/packages/cli/snap-tests-global/new-create-vite/snap.txt
@@ -1,6 +1,18 @@
-> vp create vite:application --no-interactive # create vite app with default values
+> vp create vite:application --no-interactive --git --editor vscode # create vite app with default values
 > ls vite-plus-application/package.json # check package.json
 vite-plus-application/package.json
+
+> test -f vite-plus-application/.vscode/settings.json && echo '.vscode/settings.json exists' # check VS Code settings created
+.vscode/settings.json exists
+
+> test -f vite-plus-application/.vscode/extensions.json && echo '.vscode/extensions.json exists' # check VS Code extensions created
+.vscode/extensions.json exists
+
+> node -e "const { spawnSync } = require('node:child_process'); const file = '.vscode/settings.json'; const result = spawnSync('git', ['-C', 'vite-plus-application', 'check-ignore', '--no-index', file], { stdio: 'ignore' }); const status = result.status; if (status === 1) { console.log(file + ' trackable'); } else { console.log(status === 0 ? 'ERROR: ' + file + ' ignored' : 'ERROR: git check-ignore failed with status ' + status); process.exit(status || 1); }" # check VS Code settings are trackable
+.vscode/settings.json trackable
+
+> node -e "const { spawnSync } = require('node:child_process'); const file = '.vscode/extensions.json'; const result = spawnSync('git', ['-C', 'vite-plus-application', 'check-ignore', '--no-index', file], { stdio: 'ignore' }); const status = result.status; if (status === 1) { console.log(file + ' trackable'); } else { console.log(status === 0 ? 'ERROR: ' + file + ' ignored' : 'ERROR: git check-ignore failed with status ' + status); process.exit(status || 1); }" # check VS Code extensions are trackable
+.vscode/extensions.json trackable
 
 > test ! -f vite-plus-application/.github/workflows/copilot-setup-steps.yml # default create should not add Copilot setup workflow
 > vp create vite:application --no-interactive --directory claude-app --agent claude # create vite app with non-Copilot agent

--- a/packages/cli/snap-tests-global/new-create-vite/steps.json
+++ b/packages/cli/snap-tests-global/new-create-vite/steps.json
@@ -1,10 +1,14 @@
 {
   "commands": [
     {
-      "command": "vp create vite:application --no-interactive # create vite app with default values",
+      "command": "vp create vite:application --no-interactive --git --editor vscode # create vite app with default values",
       "ignoreOutput": true
     },
     "ls vite-plus-application/package.json # check package.json",
+    "test -f vite-plus-application/.vscode/settings.json && echo '.vscode/settings.json exists' # check VS Code settings created",
+    "test -f vite-plus-application/.vscode/extensions.json && echo '.vscode/extensions.json exists' # check VS Code extensions created",
+    "node -e \"const { spawnSync } = require('node:child_process'); const file = '.vscode/settings.json'; const result = spawnSync('git', ['-C', 'vite-plus-application', 'check-ignore', '--no-index', file], { stdio: 'ignore' }); const status = result.status; if (status === 1) { console.log(file + ' trackable'); } else { console.log(status === 0 ? 'ERROR: ' + file + ' ignored' : 'ERROR: git check-ignore failed with status ' + status); process.exit(status || 1); }\" # check VS Code settings are trackable",
+    "node -e \"const { spawnSync } = require('node:child_process'); const file = '.vscode/extensions.json'; const result = spawnSync('git', ['-C', 'vite-plus-application', 'check-ignore', '--no-index', file], { stdio: 'ignore' }); const status = result.status; if (status === 1) { console.log(file + ' trackable'); } else { console.log(status === 0 ? 'ERROR: ' + file + ' ignored' : 'ERROR: git check-ignore failed with status ' + status); process.exit(status || 1); }\" # check VS Code extensions are trackable",
     "test ! -f vite-plus-application/.github/workflows/copilot-setup-steps.yml # default create should not add Copilot setup workflow",
     {
       "command": "vp create vite:application --no-interactive --directory claude-app --agent claude # create vite app with non-Copilot agent",

--- a/packages/cli/snap-tests-global/new-vite-monorepo/snap.txt
+++ b/packages/cli/snap-tests-global/new-vite-monorepo/snap.txt
@@ -1,4 +1,4 @@
-> vp create vite:monorepo --no-interactive --git # create monorepo with default values
+> vp create vite:monorepo --no-interactive --git --editor vscode # create monorepo with default values
 > ls vite-plus-monorepo | LC_ALL=C sort # check files created
 AGENTS.md
 README.md
@@ -80,6 +80,18 @@ No .yarnrc.yml
 
 > test -d vite-plus-monorepo/.git && echo 'Git initialized' # check git init
 Git initialized
+
+> test -f vite-plus-monorepo/.vscode/settings.json && echo '.vscode/settings.json exists' # check VS Code settings created
+.vscode/settings.json exists
+
+> test -f vite-plus-monorepo/.vscode/extensions.json && echo '.vscode/extensions.json exists' # check VS Code extensions created
+.vscode/extensions.json exists
+
+> node -e "const { spawnSync } = require('node:child_process'); const file = '.vscode/settings.json'; const result = spawnSync('git', ['-C', 'vite-plus-monorepo', 'check-ignore', '--no-index', file], { stdio: 'ignore' }); const status = result.status; if (status === 1) { console.log(file + ' trackable'); } else { console.log(status === 0 ? 'ERROR: ' + file + ' ignored' : 'ERROR: git check-ignore failed with status ' + status); process.exit(status || 1); }" # check VS Code settings are trackable
+.vscode/settings.json trackable
+
+> node -e "const { spawnSync } = require('node:child_process'); const file = '.vscode/extensions.json'; const result = spawnSync('git', ['-C', 'vite-plus-monorepo', 'check-ignore', '--no-index', file], { stdio: 'ignore' }); const status = result.status; if (status === 1) { console.log(file + ' trackable'); } else { console.log(status === 0 ? 'ERROR: ' + file + ' ignored' : 'ERROR: git check-ignore failed with status ' + status); process.exit(status || 1); }" # check VS Code extensions are trackable
+.vscode/extensions.json trackable
 
 > ls vite-plus-monorepo/apps # check apps directory created
 website

--- a/packages/cli/snap-tests-global/new-vite-monorepo/steps.json
+++ b/packages/cli/snap-tests-global/new-vite-monorepo/steps.json
@@ -2,7 +2,7 @@
   "ignoredPlatforms": ["win32"],
   "commands": [
     {
-      "command": "vp create vite:monorepo --no-interactive --git # create monorepo with default values",
+      "command": "vp create vite:monorepo --no-interactive --git --editor vscode # create monorepo with default values",
       "ignoreOutput": true
     },
     "ls vite-plus-monorepo | LC_ALL=C sort # check files created",
@@ -12,6 +12,10 @@
     "test -f vite-plus-monorepo/.gitignore && echo '.gitignore exists' || echo 'ERROR: .gitignore missing' # verify gitignore renamed from _gitignore",
     "test ! -f vite-plus-monorepo/.yarnrc.yml && echo 'No .yarnrc.yml' || echo 'ERROR: .yarnrc.yml exists' # verify no yarn config for pnpm",
     "test -d vite-plus-monorepo/.git && echo 'Git initialized' # check git init",
+    "test -f vite-plus-monorepo/.vscode/settings.json && echo '.vscode/settings.json exists' # check VS Code settings created",
+    "test -f vite-plus-monorepo/.vscode/extensions.json && echo '.vscode/extensions.json exists' # check VS Code extensions created",
+    "node -e \"const { spawnSync } = require('node:child_process'); const file = '.vscode/settings.json'; const result = spawnSync('git', ['-C', 'vite-plus-monorepo', 'check-ignore', '--no-index', file], { stdio: 'ignore' }); const status = result.status; if (status === 1) { console.log(file + ' trackable'); } else { console.log(status === 0 ? 'ERROR: ' + file + ' ignored' : 'ERROR: git check-ignore failed with status ' + status); process.exit(status || 1); }\" # check VS Code settings are trackable",
+    "node -e \"const { spawnSync } = require('node:child_process'); const file = '.vscode/extensions.json'; const result = spawnSync('git', ['-C', 'vite-plus-monorepo', 'check-ignore', '--no-index', file], { stdio: 'ignore' }); const status = result.status; if (status === 1) { console.log(file + ' trackable'); } else { console.log(status === 0 ? 'ERROR: ' + file + ' ignored' : 'ERROR: git check-ignore failed with status ' + status); process.exit(status || 1); }\" # check VS Code extensions are trackable",
     "ls vite-plus-monorepo/apps # check apps directory created",
     "ls vite-plus-monorepo/apps/website/package.json # check website package.json",
     {

--- a/packages/cli/src/create/__tests__/utils.spec.ts
+++ b/packages/cli/src/create/__tests__/utils.spec.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   deriveDefaultPackageName,
   ensureGitignoreNodeModules,
+  ensureGitignoreVsCodeEditorConfigs,
   formatTargetDir,
   getProjectDirFromPackageName,
   renameFiles,
@@ -157,6 +158,129 @@ describe('ensureGitignoreNodeModules', () => {
     fs.writeFileSync(path.join(projectDir, '.gitignore'), '!node_modules\n');
     ensureGitignoreNodeModules(projectDir);
     expect(gitignore()).toBe('!node_modules\nnode_modules\n');
+  });
+});
+
+describe('ensureGitignoreVsCodeEditorConfigs', () => {
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vp-vscode-gitignore-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  function gitignore(): string {
+    return fs.readFileSync(path.join(projectDir, '.gitignore'), 'utf-8');
+  }
+
+  function writeGitignore(content: string): void {
+    fs.writeFileSync(path.join(projectDir, '.gitignore'), content);
+  }
+
+  function writeVsCodeSettings(): void {
+    fs.mkdirSync(path.join(projectDir, '.vscode'), { recursive: true });
+    fs.writeFileSync(path.join(projectDir, '.vscode', 'settings.json'), '{}\n');
+  }
+
+  it('unignores VS Code settings when `.vscode/*` is ignored', () => {
+    writeVsCodeSettings();
+    writeGitignore('.vscode/*\n!.vscode/extensions.json\n');
+    ensureGitignoreVsCodeEditorConfigs(projectDir);
+    expect(gitignore()).toBe('.vscode/*\n!.vscode/extensions.json\n!.vscode/settings.json\n');
+  });
+
+  it('unignores generated VS Code config files for root-anchored contents ignores', () => {
+    writeVsCodeSettings();
+    writeGitignore('/.vscode/*\n');
+    ensureGitignoreVsCodeEditorConfigs(projectDir);
+    expect(gitignore()).toBe('/.vscode/*\n!.vscode/settings.json\n!.vscode/extensions.json\n');
+  });
+
+  it('appends VS Code config unignores for directory-level VS Code ignores', () => {
+    writeVsCodeSettings();
+    writeGitignore('.vscode/\n');
+    ensureGitignoreVsCodeEditorConfigs(projectDir);
+    expect(gitignore()).toBe('.vscode/\n!.vscode/settings.json\n!.vscode/extensions.json\n');
+  });
+
+  it('appends VS Code config unignores for root-anchored directory-level VS Code ignores', () => {
+    writeVsCodeSettings();
+    writeGitignore('/.vscode\n');
+    ensureGitignoreVsCodeEditorConfigs(projectDir);
+    expect(gitignore()).toBe('/.vscode\n!.vscode/settings.json\n!.vscode/extensions.json\n');
+  });
+
+  it('appends VS Code config unignores after explicit VS Code settings ignores', () => {
+    writeVsCodeSettings();
+    writeGitignore('.vscode/*\n.vscode/settings.json\n');
+    ensureGitignoreVsCodeEditorConfigs(projectDir);
+    expect(gitignore()).toBe(
+      '.vscode/*\n.vscode/settings.json\n!.vscode/settings.json\n!.vscode/extensions.json\n',
+    );
+  });
+
+  it('appends VS Code config unignores after explicit VS Code extensions ignores', () => {
+    writeVsCodeSettings();
+    writeGitignore('.vscode/*\n/.vscode/extensions.json\n');
+    ensureGitignoreVsCodeEditorConfigs(projectDir);
+    expect(gitignore()).toBe(
+      '.vscode/*\n/.vscode/extensions.json\n!.vscode/settings.json\n!.vscode/extensions.json\n',
+    );
+  });
+
+  it('appends VS Code config unignores when all generated config files are explicitly ignored', () => {
+    writeVsCodeSettings();
+    writeGitignore('.vscode/*\n.vscode/settings.json\n.vscode/extensions.json\n');
+    ensureGitignoreVsCodeEditorConfigs(projectDir);
+    expect(gitignore()).toBe(
+      '.vscode/*\n.vscode/settings.json\n.vscode/extensions.json\n!.vscode/settings.json\n!.vscode/extensions.json\n',
+    );
+  });
+
+  it('appends extensions when settings are already unignored', () => {
+    writeVsCodeSettings();
+    writeGitignore('.vscode/*\n!.vscode/settings.json\n');
+    ensureGitignoreVsCodeEditorConfigs(projectDir);
+    expect(gitignore()).toBe('.vscode/*\n!.vscode/settings.json\n!.vscode/extensions.json\n');
+  });
+
+  it('appends VS Code config unignores even without a broad VS Code ignore', () => {
+    writeVsCodeSettings();
+    writeGitignore('dist\n');
+    ensureGitignoreVsCodeEditorConfigs(projectDir);
+    expect(gitignore()).toBe('dist\n!.vscode/settings.json\n!.vscode/extensions.json\n');
+  });
+
+  it('does not create `.gitignore` when none exists', () => {
+    writeVsCodeSettings();
+    ensureGitignoreVsCodeEditorConfigs(projectDir);
+    expect(fs.existsSync(path.join(projectDir, '.gitignore'))).toBe(false);
+  });
+
+  it('does not change `.gitignore` when VS Code settings do not exist', () => {
+    const existing = '.vscode/*\n';
+    writeGitignore(existing);
+    ensureGitignoreVsCodeEditorConfigs(projectDir);
+    expect(gitignore()).toBe(existing);
+  });
+
+  it('terminates the last line before appending VS Code config unignores', () => {
+    writeVsCodeSettings();
+    writeGitignore('.vscode/*');
+    ensureGitignoreVsCodeEditorConfigs(projectDir);
+    expect(gitignore()).toBe('.vscode/*\n!.vscode/settings.json\n!.vscode/extensions.json\n');
+  });
+
+  it('is idempotent', () => {
+    writeVsCodeSettings();
+    writeGitignore('.vscode/*\n');
+    ensureGitignoreVsCodeEditorConfigs(projectDir);
+    const afterFirstRun = gitignore();
+    ensureGitignoreVsCodeEditorConfigs(projectDir);
+    expect(gitignore()).toBe(afterFirstRun);
   });
 });
 

--- a/packages/cli/src/create/__tests__/utils.spec.ts
+++ b/packages/cli/src/create/__tests__/utils.spec.ts
@@ -199,18 +199,22 @@ describe('ensureGitignoreVsCodeEditorConfigs', () => {
     expect(gitignore()).toBe('/.vscode/*\n!.vscode/settings.json\n!.vscode/extensions.json\n');
   });
 
-  it('appends VS Code config unignores for directory-level VS Code ignores', () => {
+  it('appends VS Code directory and config unignores for directory-level VS Code ignores', () => {
     writeVsCodeSettings();
     writeGitignore('.vscode/\n');
     ensureGitignoreVsCodeEditorConfigs(projectDir);
-    expect(gitignore()).toBe('.vscode/\n!.vscode/settings.json\n!.vscode/extensions.json\n');
+    expect(gitignore()).toBe(
+      '.vscode/\n!.vscode/\n!.vscode/settings.json\n!.vscode/extensions.json\n',
+    );
   });
 
-  it('appends VS Code config unignores for root-anchored directory-level VS Code ignores', () => {
+  it('appends VS Code directory and config unignores for root-anchored directory-level VS Code ignores', () => {
     writeVsCodeSettings();
     writeGitignore('/.vscode\n');
     ensureGitignoreVsCodeEditorConfigs(projectDir);
-    expect(gitignore()).toBe('/.vscode\n!.vscode/settings.json\n!.vscode/extensions.json\n');
+    expect(gitignore()).toBe(
+      '/.vscode\n!.vscode/\n!.vscode/settings.json\n!.vscode/extensions.json\n',
+    );
   });
 
   it('appends VS Code config unignores after explicit VS Code settings ignores', () => {

--- a/packages/cli/src/create/__tests__/utils.spec.ts
+++ b/packages/cli/src/create/__tests__/utils.spec.ts
@@ -185,54 +185,48 @@ describe('ensureGitignoreVsCodeEditorConfigs', () => {
     fs.writeFileSync(path.join(projectDir, '.vscode', 'settings.json'), '{}\n');
   }
 
+  const vscodeUnignoreBlock = '!.vscode/\n!.vscode/settings.json\n!.vscode/extensions.json\n';
+
   it('unignores VS Code settings when `.vscode/*` is ignored', () => {
     writeVsCodeSettings();
     writeGitignore('.vscode/*\n!.vscode/extensions.json\n');
     ensureGitignoreVsCodeEditorConfigs(projectDir);
-    expect(gitignore()).toBe('.vscode/*\n!.vscode/extensions.json\n!.vscode/settings.json\n');
+    expect(gitignore()).toBe(`.vscode/*\n!.vscode/extensions.json\n${vscodeUnignoreBlock}`);
   });
 
   it('unignores generated VS Code config files for root-anchored contents ignores', () => {
     writeVsCodeSettings();
     writeGitignore('/.vscode/*\n');
     ensureGitignoreVsCodeEditorConfigs(projectDir);
-    expect(gitignore()).toBe('/.vscode/*\n!.vscode/settings.json\n!.vscode/extensions.json\n');
+    expect(gitignore()).toBe(`/.vscode/*\n${vscodeUnignoreBlock}`);
   });
 
   it('appends VS Code directory and config unignores for directory-level VS Code ignores', () => {
     writeVsCodeSettings();
     writeGitignore('.vscode/\n');
     ensureGitignoreVsCodeEditorConfigs(projectDir);
-    expect(gitignore()).toBe(
-      '.vscode/\n!.vscode/\n!.vscode/settings.json\n!.vscode/extensions.json\n',
-    );
+    expect(gitignore()).toBe(`.vscode/\n${vscodeUnignoreBlock}`);
   });
 
   it('appends VS Code directory and config unignores for root-anchored directory-level VS Code ignores', () => {
     writeVsCodeSettings();
     writeGitignore('/.vscode\n');
     ensureGitignoreVsCodeEditorConfigs(projectDir);
-    expect(gitignore()).toBe(
-      '/.vscode\n!.vscode/\n!.vscode/settings.json\n!.vscode/extensions.json\n',
-    );
+    expect(gitignore()).toBe(`/.vscode\n${vscodeUnignoreBlock}`);
   });
 
   it('appends VS Code config unignores after explicit VS Code settings ignores', () => {
     writeVsCodeSettings();
     writeGitignore('.vscode/*\n.vscode/settings.json\n');
     ensureGitignoreVsCodeEditorConfigs(projectDir);
-    expect(gitignore()).toBe(
-      '.vscode/*\n.vscode/settings.json\n!.vscode/settings.json\n!.vscode/extensions.json\n',
-    );
+    expect(gitignore()).toBe(`.vscode/*\n.vscode/settings.json\n${vscodeUnignoreBlock}`);
   });
 
   it('appends VS Code config unignores after explicit VS Code extensions ignores', () => {
     writeVsCodeSettings();
     writeGitignore('.vscode/*\n/.vscode/extensions.json\n');
     ensureGitignoreVsCodeEditorConfigs(projectDir);
-    expect(gitignore()).toBe(
-      '.vscode/*\n/.vscode/extensions.json\n!.vscode/settings.json\n!.vscode/extensions.json\n',
-    );
+    expect(gitignore()).toBe(`.vscode/*\n/.vscode/extensions.json\n${vscodeUnignoreBlock}`);
   });
 
   it('appends VS Code config unignores when all generated config files are explicitly ignored', () => {
@@ -240,23 +234,23 @@ describe('ensureGitignoreVsCodeEditorConfigs', () => {
     writeGitignore('.vscode/*\n.vscode/settings.json\n.vscode/extensions.json\n');
     ensureGitignoreVsCodeEditorConfigs(projectDir);
     expect(gitignore()).toBe(
-      '.vscode/*\n.vscode/settings.json\n.vscode/extensions.json\n!.vscode/settings.json\n!.vscode/extensions.json\n',
+      `.vscode/*\n.vscode/settings.json\n.vscode/extensions.json\n${vscodeUnignoreBlock}`,
     );
   });
 
-  it('appends extensions when settings are already unignored', () => {
+  it('appends the full block when settings are already unignored without the EOF block', () => {
     writeVsCodeSettings();
     writeGitignore('.vscode/*\n!.vscode/settings.json\n');
     ensureGitignoreVsCodeEditorConfigs(projectDir);
-    expect(gitignore()).toBe('.vscode/*\n!.vscode/settings.json\n!.vscode/extensions.json\n');
+    expect(gitignore()).toBe(`.vscode/*\n!.vscode/settings.json\n${vscodeUnignoreBlock}`);
   });
 
-  it('re-appends VS Code config unignores when later ignore rules override them', () => {
+  it('re-appends the full block when later ignore rules override generated config unignores', () => {
     writeVsCodeSettings();
     writeGitignore('!.vscode/settings.json\n!.vscode/extensions.json\n.vscode/*\n');
     ensureGitignoreVsCodeEditorConfigs(projectDir);
     expect(gitignore()).toBe(
-      '!.vscode/settings.json\n!.vscode/extensions.json\n.vscode/*\n!.vscode/settings.json\n!.vscode/extensions.json\n',
+      `!.vscode/settings.json\n!.vscode/extensions.json\n.vscode/*\n${vscodeUnignoreBlock}`,
     );
   });
 
@@ -264,7 +258,7 @@ describe('ensureGitignoreVsCodeEditorConfigs', () => {
     writeVsCodeSettings();
     writeGitignore('dist\n');
     ensureGitignoreVsCodeEditorConfigs(projectDir);
-    expect(gitignore()).toBe('dist\n!.vscode/settings.json\n!.vscode/extensions.json\n');
+    expect(gitignore()).toBe(`dist\n${vscodeUnignoreBlock}`);
   });
 
   it('does not create `.gitignore` when none exists', () => {
@@ -284,7 +278,7 @@ describe('ensureGitignoreVsCodeEditorConfigs', () => {
     writeVsCodeSettings();
     writeGitignore('.vscode/*');
     ensureGitignoreVsCodeEditorConfigs(projectDir);
-    expect(gitignore()).toBe('.vscode/*\n!.vscode/settings.json\n!.vscode/extensions.json\n');
+    expect(gitignore()).toBe(`.vscode/*\n${vscodeUnignoreBlock}`);
   });
 
   it('is idempotent', () => {

--- a/packages/cli/src/create/__tests__/utils.spec.ts
+++ b/packages/cli/src/create/__tests__/utils.spec.ts
@@ -247,6 +247,15 @@ describe('ensureGitignoreVsCodeEditorConfigs', () => {
     expect(gitignore()).toBe('.vscode/*\n!.vscode/settings.json\n!.vscode/extensions.json\n');
   });
 
+  it('re-appends VS Code config unignores when later ignore rules override them', () => {
+    writeVsCodeSettings();
+    writeGitignore('!.vscode/settings.json\n!.vscode/extensions.json\n.vscode/*\n');
+    ensureGitignoreVsCodeEditorConfigs(projectDir);
+    expect(gitignore()).toBe(
+      '!.vscode/settings.json\n!.vscode/extensions.json\n.vscode/*\n!.vscode/settings.json\n!.vscode/extensions.json\n',
+    );
+  });
+
   it('appends VS Code config unignores even without a broad VS Code ignore', () => {
     writeVsCodeSettings();
     writeGitignore('dist\n');

--- a/packages/cli/src/create/bin.ts
+++ b/packages/cli/src/create/bin.ts
@@ -73,7 +73,12 @@ import {
   executeRemoteTemplate,
 } from './templates/index.ts';
 import { BuiltinTemplate, TemplateType } from './templates/types.ts';
-import { deriveDefaultPackageName, ensureGitignoreNodeModules, formatTargetDir } from './utils.ts';
+import {
+  deriveDefaultPackageName,
+  ensureGitignoreNodeModules,
+  ensureGitignoreVsCodeEditorConfigs,
+  formatTargetDir,
+} from './utils.ts';
 
 const helpMessage = renderCliDoc({
   usage: 'vp create [TEMPLATE] [OPTIONS] [-- TEMPLATE_OPTIONS]',
@@ -949,6 +954,9 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
       silent: compactOutput,
       extraVsCodeSettings: { 'npm.scriptRunner': 'vp' },
     });
+    if (selectedEditors?.includes('vscode')) {
+      ensureGitignoreVsCodeEditorConfigs(fullPath);
+    }
     resumeCreateProgress();
     workspaceInfo.rootDir = fullPath;
     updateCreateProgress('Integrating monorepo');
@@ -1077,6 +1085,9 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
     silent: compactOutput,
     extraVsCodeSettings: { 'npm.scriptRunner': 'vp' },
   });
+  if (selectedEditors?.includes('vscode')) {
+    ensureGitignoreVsCodeEditorConfigs(fullPath);
+  }
   resumeCreateProgress();
 
   // The migrate-before-rewrite reorder is only needed when the template

--- a/packages/cli/src/create/utils.ts
+++ b/packages/cli/src/create/utils.ts
@@ -151,6 +151,51 @@ export function ensureGitignoreNodeModules(projectDir: string): void {
   fs.appendFileSync(gitignorePath, `${prefix}node_modules\n`);
 }
 
+const VSCODE_SETTINGS_PATH = '.vscode/settings.json';
+const VSCODE_EXTENSIONS_PATH = '.vscode/extensions.json';
+const VSCODE_CONFIG_UNIGNORE_LINES = [
+  `!${VSCODE_SETTINGS_PATH}`,
+  `!${VSCODE_EXTENSIONS_PATH}`,
+] as const;
+
+/**
+ * Make generated VS Code workspace config trackable when `vp create` writes VS Code config.
+ */
+export function ensureGitignoreVsCodeEditorConfigs(projectDir: string): void {
+  if (!fs.existsSync(path.join(projectDir, VSCODE_SETTINGS_PATH))) {
+    return;
+  }
+
+  const gitignorePath = path.join(projectDir, '.gitignore');
+  let content: string;
+  try {
+    content = fs.readFileSync(gitignorePath, 'utf-8');
+  } catch {
+    return;
+  }
+
+  const linesToAppend = VSCODE_CONFIG_UNIGNORE_LINES.filter(
+    (line) => !hasStandaloneGitignorePattern(content, line),
+  );
+  appendGitignoreLines(gitignorePath, content, linesToAppend);
+}
+
+function hasStandaloneGitignorePattern(content: string, pattern: string): boolean {
+  return content.split(/\r?\n/).some((line) => line.trim() === pattern);
+}
+
+function appendGitignoreLines(
+  gitignorePath: string,
+  content: string,
+  lines: readonly string[],
+): void {
+  if (lines.length === 0) {
+    return;
+  }
+  const prefix = content === '' || content.endsWith('\n') ? '' : '\n';
+  fs.appendFileSync(gitignorePath, `${prefix}${lines.join('\n')}\n`);
+}
+
 export function formatDisplayTargetDir(targetDir: string) {
   const normalized = targetDir.split(path.sep).join('/');
   if (normalized === '' || normalized === '.') {

--- a/packages/cli/src/create/utils.ts
+++ b/packages/cli/src/create/utils.ts
@@ -151,10 +151,10 @@ export function ensureGitignoreNodeModules(projectDir: string): void {
   fs.appendFileSync(gitignorePath, `${prefix}node_modules\n`);
 }
 
-const VSCODE_DIRECTORY_UNIGNORE_LINE = '!.vscode/';
 const VSCODE_SETTINGS_PATH = '.vscode/settings.json';
 const VSCODE_EXTENSIONS_PATH = '.vscode/extensions.json';
-const VSCODE_CONFIG_UNIGNORE_LINES = [
+const VSCODE_CONFIG_UNIGNORE_BLOCK = [
+  '!.vscode/',
   `!${VSCODE_SETTINGS_PATH}`,
   `!${VSCODE_EXTENSIONS_PATH}`,
 ] as const;
@@ -175,54 +175,14 @@ export function ensureGitignoreVsCodeEditorConfigs(projectDir: string): void {
     return;
   }
 
-  const linesToAppend = [
-    ...(shouldAppendVsCodeDirectoryUnignore(content) ? [VSCODE_DIRECTORY_UNIGNORE_LINE] : []),
-    ...VSCODE_CONFIG_UNIGNORE_LINES.filter((line) => shouldAppendGitignoreUnignore(content, line)),
-  ];
-  appendGitignoreLines(gitignorePath, content, linesToAppend);
+  appendGitignoreVsCodeEditorConfigsBlock(gitignorePath, content);
 }
 
-function shouldAppendVsCodeDirectoryUnignore(content: string): boolean {
-  const lines = content.split(/\r?\n/).map((line) => line.trim());
-  const lastDirectoryUnignoreIndex = lines.findLastIndex(isVsCodeDirectoryUnignorePattern);
-  const lastDirectoryIgnoreIndex = lines.findLastIndex(isVsCodeDirectoryIgnorePattern);
-  return lastDirectoryIgnoreIndex !== -1 && lastDirectoryIgnoreIndex > lastDirectoryUnignoreIndex;
-}
-
-function shouldAppendGitignoreUnignore(content: string, pattern: string): boolean {
-  const lines = content.split(/\r?\n/).map((line) => line.trim());
-  const lastUnignoreIndex = lines.findLastIndex((line) => line === pattern);
-  if (lastUnignoreIndex === -1) {
-    return true;
+function appendGitignoreVsCodeEditorConfigsBlock(gitignorePath: string, content: string): void {
+  if (content.trimEnd().endsWith(VSCODE_CONFIG_UNIGNORE_BLOCK.join('\n'))) {
+    return;
   }
-
-  const targetPath = pattern.slice(1);
-  const lastOverrideIndex = lines.findLastIndex((line) =>
-    isVsCodeConfigIgnorePattern(line, targetPath),
-  );
-  return lastOverrideIndex > lastUnignoreIndex;
-}
-
-function isVsCodeConfigIgnorePattern(pattern: string, targetPath: string): boolean {
-  if (pattern === '' || pattern.startsWith('#') || pattern.startsWith('!')) {
-    return false;
-  }
-
-  return (
-    pattern === targetPath ||
-    pattern === `/${targetPath}` ||
-    pattern === '.vscode/*' ||
-    pattern === '/.vscode/*' ||
-    isVsCodeDirectoryIgnorePattern(pattern)
-  );
-}
-
-function isVsCodeDirectoryUnignorePattern(pattern: string): boolean {
-  return ['!.vscode', '!.vscode/', '!/.vscode', '!/.vscode/'].includes(pattern);
-}
-
-function isVsCodeDirectoryIgnorePattern(pattern: string): boolean {
-  return ['.vscode', '.vscode/', '/.vscode', '/.vscode/'].includes(pattern);
+  appendGitignoreLines(gitignorePath, content, VSCODE_CONFIG_UNIGNORE_BLOCK);
 }
 
 function appendGitignoreLines(

--- a/packages/cli/src/create/utils.ts
+++ b/packages/cli/src/create/utils.ts
@@ -174,14 +174,37 @@ export function ensureGitignoreVsCodeEditorConfigs(projectDir: string): void {
     return;
   }
 
-  const linesToAppend = VSCODE_CONFIG_UNIGNORE_LINES.filter(
-    (line) => !hasStandaloneGitignorePattern(content, line),
+  const linesToAppend = VSCODE_CONFIG_UNIGNORE_LINES.filter((line) =>
+    shouldAppendGitignoreUnignore(content, line),
   );
   appendGitignoreLines(gitignorePath, content, linesToAppend);
 }
 
-function hasStandaloneGitignorePattern(content: string, pattern: string): boolean {
-  return content.split(/\r?\n/).some((line) => line.trim() === pattern);
+function shouldAppendGitignoreUnignore(content: string, pattern: string): boolean {
+  const lines = content.split(/\r?\n/).map((line) => line.trim());
+  const lastUnignoreIndex = lines.findLastIndex((line) => line === pattern);
+  if (lastUnignoreIndex === -1) {
+    return true;
+  }
+
+  const targetPath = pattern.slice(1);
+  const lastOverrideIndex = lines.findLastIndex((line) =>
+    isVsCodeConfigIgnorePattern(line, targetPath),
+  );
+  return lastOverrideIndex > lastUnignoreIndex;
+}
+
+function isVsCodeConfigIgnorePattern(pattern: string, targetPath: string): boolean {
+  if (pattern === '' || pattern.startsWith('#') || pattern.startsWith('!')) {
+    return false;
+  }
+
+  return (
+    pattern === targetPath ||
+    pattern === `/${targetPath}` ||
+    pattern === '.vscode/*' ||
+    pattern === '/.vscode/*'
+  );
 }
 
 function appendGitignoreLines(

--- a/packages/cli/src/create/utils.ts
+++ b/packages/cli/src/create/utils.ts
@@ -151,6 +151,7 @@ export function ensureGitignoreNodeModules(projectDir: string): void {
   fs.appendFileSync(gitignorePath, `${prefix}node_modules\n`);
 }
 
+const VSCODE_DIRECTORY_UNIGNORE_LINE = '!.vscode/';
 const VSCODE_SETTINGS_PATH = '.vscode/settings.json';
 const VSCODE_EXTENSIONS_PATH = '.vscode/extensions.json';
 const VSCODE_CONFIG_UNIGNORE_LINES = [
@@ -174,10 +175,18 @@ export function ensureGitignoreVsCodeEditorConfigs(projectDir: string): void {
     return;
   }
 
-  const linesToAppend = VSCODE_CONFIG_UNIGNORE_LINES.filter((line) =>
-    shouldAppendGitignoreUnignore(content, line),
-  );
+  const linesToAppend = [
+    ...(shouldAppendVsCodeDirectoryUnignore(content) ? [VSCODE_DIRECTORY_UNIGNORE_LINE] : []),
+    ...VSCODE_CONFIG_UNIGNORE_LINES.filter((line) => shouldAppendGitignoreUnignore(content, line)),
+  ];
   appendGitignoreLines(gitignorePath, content, linesToAppend);
+}
+
+function shouldAppendVsCodeDirectoryUnignore(content: string): boolean {
+  const lines = content.split(/\r?\n/).map((line) => line.trim());
+  const lastDirectoryUnignoreIndex = lines.findLastIndex(isVsCodeDirectoryUnignorePattern);
+  const lastDirectoryIgnoreIndex = lines.findLastIndex(isVsCodeDirectoryIgnorePattern);
+  return lastDirectoryIgnoreIndex !== -1 && lastDirectoryIgnoreIndex > lastDirectoryUnignoreIndex;
 }
 
 function shouldAppendGitignoreUnignore(content: string, pattern: string): boolean {
@@ -203,8 +212,17 @@ function isVsCodeConfigIgnorePattern(pattern: string, targetPath: string): boole
     pattern === targetPath ||
     pattern === `/${targetPath}` ||
     pattern === '.vscode/*' ||
-    pattern === '/.vscode/*'
+    pattern === '/.vscode/*' ||
+    isVsCodeDirectoryIgnorePattern(pattern)
   );
+}
+
+function isVsCodeDirectoryUnignorePattern(pattern: string): boolean {
+  return ['!.vscode', '!.vscode/', '!/.vscode', '!/.vscode/'].includes(pattern);
+}
+
+function isVsCodeDirectoryIgnorePattern(pattern: string): boolean {
+  return ['.vscode', '.vscode/', '/.vscode', '/.vscode/'].includes(pattern);
 }
 
 function appendGitignoreLines(

--- a/packages/cli/templates/monorepo/_gitignore
+++ b/packages/cli/templates/monorepo/_gitignore
@@ -14,6 +14,7 @@ dist-ssr
 
 # Editor directories and files
 .vscode/*
+!.vscode/settings.json
 !.vscode/extensions.json
 .idea
 .DS_Store


### PR DESCRIPTION
## Summary

Fixes #1641.

This updates `vp create` so generated VS Code workspace config files remain trackable when the VS Code editor option is selected.
                                                         
Previously, templates such as `create-vite` could generate `.vscode/settings.json` while also including a `.gitignore` pattern like:                                                                    
   ```gitignore                                                
   .vscode/*
   !.vscode/extensions.json
 ```                                                                    
That left .vscode/settings.json ignored even though Vite+ generated it. vp create now post-processes the generated `.gitignore` after writing VS Code editor config and appends unignore rules for:
 - `.vscode/settings.json`
 - `.vscode/extensions.json`

The fix is intentionally scoped to vp create; vp migrate behavior is unchanged.

## Changes

 Adds ensureGitignoreVsCodeEditorConfigs() for create-time .gitignore post-processing.
 - Wires the helper after writeEditorConfigs() when VS Code is selected.
- Updates the monorepo template `.gitignore` to include `!.vscode/settings.json.`