### PR TITLE
ci: switch mac runners back to namespace-profile-mac-default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-          - os: macos-latest
+          - os: namespace-profile-mac-default
             target: aarch64-apple-darwin
     runs-on: ${{ matrix.os }}
     steps:
@@ -208,7 +208,7 @@ jobs:
         include:
           - os: namespace-profile-linux-x64-default
             target: x86_64-unknown-linux-gnu
-          - os: macos-latest
+          - os: namespace-profile-mac-default
             target: aarch64-apple-darwin
           - os: windows-latest
             target: x86_64-pc-windows-msvc
@@ -646,15 +646,15 @@ jobs:
             target: x86_64-unknown-linux-gnu
             shard: 3
             shardTotal: 3
-          - os: macos-latest
+          - os: namespace-profile-mac-default
             target: aarch64-apple-darwin
             shard: 1
             shardTotal: 3
-          - os: macos-latest
+          - os: namespace-profile-mac-default
             target: aarch64-apple-darwin
             shard: 2
             shardTotal: 3
-          - os: macos-latest
+          - os: namespace-profile-mac-default
             target: aarch64-apple-darwin
             shard: 3
             shardTotal: 3


### PR DESCRIPTION
## Summary

Reverts #1432. The `namespace-profile-mac-default` runner pool now has adequate resources, so move the 5 mac matrix entries in `.github/workflows/ci.yml` back from `macos-latest`.

Affected jobs:
- `build` (line 81)
- `cli-e2e-test` (line 211)
- sharded test matrix (lines 649, 653, 657)

## Test plan

- [ ] CI dispatches mac jobs to `namespace-profile-mac-default` without queueing
- [ ] `build`, `cli-e2e-test`, and sharded test jobs pass on the namespace runner