### PR TITLE
chore: update handle branchseer -> wan9chi

### DIFF
--- a/docs/_data/team.ts
+++ b/docs/_data/team.ts
@@ -10,11 +10,11 @@ export const core: DefaultTheme.TeamMember[] = [
     ],
   },
   {
-    avatar: 'https://github.com/branchseer.png',
+    avatar: 'https://github.com/wan9chi.png',
     name: 'Wang Chi',
     links: [
-      { icon: 'github', link: 'https://github.com/branchseer' },
-      { icon: 'x', link: 'https://x.com/branchseer' },
+      { icon: 'github', link: 'https://github.com/wan9chi' },
+      { icon: 'x', link: 'https://x.com/wan9chi' },
     ],
   },
   {


### PR DESCRIPTION
Updates my GitHub/X handle from `branchseer` to `wan9chi` following the account rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)