### PR TITLE
feat(docs): add Copy Prompt button for AI assistants

### DIFF
--- a/docs/.vitepress/theme/components/CopyPrompt.vue
+++ b/docs/.vitepress/theme/components/CopyPrompt.vue
@@ -78,11 +78,7 @@ onBeforeUnmount(() => {
   >
     <Icon
       :icon="
-        state === 'copied'
-          ? 'lucide:check'
-          : state === 'error'
-            ? 'lucide:x'
-            : 'lucide:clipboard'
+        state === 'copied' ? 'lucide:check' : state === 'error' ? 'lucide:x' : 'lucide:clipboard'
       "
       class="size-4"
       aria-hidden="true"

--- a/docs/.vitepress/theme/components/CopyPrompt.vue
+++ b/docs/.vitepress/theme/components/CopyPrompt.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+import { Icon } from '@iconify/vue';
+import { onBeforeUnmount, ref } from 'vue';
+
+// Default getting-started prompt handed to an AI coding assistant. Every
+// command and URL here is verified against the Getting Started guide and the
+// live llms-full.txt docs dump.
+const DEFAULT_PROMPT = `I want to use Vite+ in my project. Vite+ is the unified toolchain for the web behind the \`vp\` CLI — one tool combining Vite, Rolldown, Vitest, tsdown, Oxlint, Oxfmt, and Vite Task, plus runtime and package-manager management.
+
+First, read https://viteplus.dev/llms-full.txt to learn Vite+'s commands and configuration.
+
+Install the \`vp\` CLI:
+- macOS / Linux: curl -fsSL https://vite.plus | bash
+- Windows (PowerShell): irm https://vite.plus/ps1 | iex
+
+Then open a new terminal and run \`vp help\`. To scaffold a new project run \`vp create\`; to move an existing Vite project onto Vite+ run \`vp migrate\`.
+
+Day-to-day commands: \`vp install\` (dependencies), \`vp dev\` (dev server), \`vp check\` (format + lint + type-check), \`vp test\` (tests), and \`vp build\` (production build).
+
+Help me get set up and explain anything I should know.`;
+
+const props = withDefaults(
+  defineProps<{
+    prompt?: string;
+    label?: string;
+  }>(),
+  {
+    prompt: DEFAULT_PROMPT,
+    label: 'Copy Prompt',
+  },
+);
+
+const state = ref<'idle' | 'copied' | 'error'>('idle');
+let resetTimer: ReturnType<typeof setTimeout> | null = null;
+
+const flash = (next: 'copied' | 'error') => {
+  state.value = next;
+  if (resetTimer) {
+    clearTimeout(resetTimer);
+  }
+  resetTimer = setTimeout(() => {
+    state.value = 'idle';
+    resetTimer = null;
+  }, 1600);
+};
+
+const copyPrompt = async (event: MouseEvent) => {
+  // The theme draws the `.button` border with an `outline`, but a global reset
+  // (`button:focus:not(:focus-visible) { outline: none !important }`) strips it
+  // after a mouse click. The theme only ever uses `.button` on <a> tags, so this
+  // bites only real <button> elements. For pointer activation (event.detail > 0)
+  // drop focus so the button returns to its resting state and keeps its border;
+  // keyboard activation (detail === 0) keeps focus so the a11y focus ring shows.
+  if (event.detail > 0) {
+    (event.currentTarget as HTMLElement | null)?.blur();
+  }
+  try {
+    await navigator.clipboard.writeText(props.prompt);
+    flash('copied');
+  } catch {
+    flash('error');
+  }
+};
+
+onBeforeUnmount(() => {
+  if (resetTimer) {
+    clearTimeout(resetTimer);
+  }
+});
+</script>
+
+<template>
+  <button
+    type="button"
+    class="button"
+    :aria-label="`${label} for setting up Vite+ with an AI assistant`"
+    @click="copyPrompt"
+  >
+    <Icon
+      :icon="
+        state === 'copied'
+          ? 'lucide:check'
+          : state === 'error'
+            ? 'lucide:x'
+            : 'lucide:clipboard'
+      "
+      class="size-4"
+      aria-hidden="true"
+    />
+    <span>{{ state === 'copied' ? 'Copied!' : state === 'error' ? 'Could not copy' : label }}</span>
+  </button>
+</template>
+
+<style scoped>
+.button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+</style>

--- a/docs/.vitepress/theme/components/home/Hero.vue
+++ b/docs/.vitepress/theme/components/home/Hero.vue
@@ -12,7 +12,7 @@
         </p>
         <p class="text-sm text-grey">Free and open source under the MIT license.</p>
       </div>
-      <div class="flex items-center gap-5">
+      <div class="flex flex-wrap items-center justify-center gap-5">
         <a href="/guide" target="_self" class="button button--primary"> Get started </a>
         <a
           href="https://voidzero.dev/posts/announcing-vite-plus-alpha"
@@ -22,6 +22,7 @@
         >
           Read the Announcement
         </a>
+        <CopyPrompt />
       </div>
     </div>
   </div>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -2,6 +2,7 @@
 import BaseTheme from '@voidzero-dev/vitepress-theme/src/viteplus';
 import type { Theme } from 'vitepress';
 
+import CopyPrompt from './components/CopyPrompt.vue';
 import Layout from './Layout.vue';
 import './styles.css';
 import 'virtual:group-icons.css';
@@ -9,4 +10,8 @@ import 'virtual:group-icons.css';
 export default {
   extends: BaseTheme,
   Layout,
+  enhanceApp({ app }) {
+    // Globally available so Markdown pages can use <CopyPrompt /> without an import.
+    app.component('CopyPrompt', CopyPrompt);
+  },
 } satisfies Theme;

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -4,6 +4,10 @@ Vite+ is the unified toolchain and entry point for web development. It manages y
 
 Vite+ ships in two parts: `vp`, the global command-line tool, and `vite-plus`, the local package installed in each project. If you already have a Vite project, use [`vp migrate`](/guide/migrate) to migrate it to Vite+, or paste our [migration prompt](/guide/migrate#migration-prompt) into your coding agent.
 
+Building with an AI assistant? Copy a ready-made setup prompt:
+
+<CopyPrompt />
+
 ## Install `vp`
 
 ### macOS / Linux


### PR DESCRIPTION
## What

Adds a reusable **Copy Prompt** button to the Vite+ docs. It copies a ready-made, AI-friendly getting-started prompt to the clipboard so users can hand it straight to their coding agent.

The prompt introduces Vite+, points the agent at `https://viteplus.dev/llms-full.txt`, gives the platform-specific install commands, and lists the core `vp` commands.

## Where it appears

- **Front page** — in the hero CTA row, beside *Get started* / *Read the Announcement* (`docs/.vitepress/theme/components/home/Hero.vue`). The row is now `flex-wrap` so three buttons don't overflow on narrow screens.
- **Getting Started** — right after the intro paragraph (`docs/guide/index.md`).

## Implementation

- New `docs/.vitepress/theme/components/CopyPrompt.vue` — a single themed `.button` with `prompt` / `label` props (defaults to a shared `DEFAULT_PROMPT` and `"Copy Prompt"`). Clipboard + flash-feedback logic models the existing `InstallCommand.vue`; shows **Copied!** on success and **Could not copy** on failure.
- Registered globally via `enhanceApp` in `docs/.vitepress/theme/index.ts` so any Markdown page can use `<CopyPrompt />` without an import.
- Pointer clicks drop focus so the theme's `outline`-based `.button` border isn't stripped by the global `button:focus:not(:focus-visible) { outline: none !important }` reset — that reset only bites real `<button>` elements, since the theme otherwise uses `.button` on `<a>` tags. Keyboard activation keeps focus so the a11y focus ring still shows.

Scope: main `docs/` site only; the duplicate `packages/cli/docs/` guide tree is intentionally left unchanged.

## Verification

- `cd docs && pnpm build` — clean production build; the button renders into both `index.html` and `guide/index.html`, and the prompt is bundled.
- Previewed in `pnpm dev`: button reads **Copy Prompt**, flashes **Copied!**, and keeps its border through the click on both pages.
- Fact-checked the copied prompt end-to-end: both install URLs resolve to the real installers, `llms-full.txt` is live and documents every command named, and a fresh `vp create → install → check → dev → build` workflow all succeed. (`vp test` exits non-zero only because a bare scaffold has no test files yet — expected Vitest behavior.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)