### PR TITLE
chore: exclude vitest config inside snap tests for VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,6 @@
   "typescript.preferences.importModuleSpecifierEnding": "js",
   "typescript.reportStyleChecksAsWarnings": false,
   "typescript.updateImportsOnFileMove.enabled": "always",
-  "typescript.experimental.useTsgo": true
+  "typescript.experimental.useTsgo": true,
+  "vitest.configSearchPatternExclude": "{**/node_modules/**,**/vendor/**,**/.*/**,**/*.d.ts,{**/packages/cli/snap-tests*/**}}"
 }


### PR DESCRIPTION
I found that my git usually reports that there is an untracked `.vitest-plugin-loaded`, it is generated by a Vitest plugin inside `vite-plugins-async-test` snap test and can be removed while running tests. However, Vitest VSCode extension can not run the test but automatically loads the config, which creates this file.

This PR adds snap tests directory to Vitest's configure ignore pattern, means Vitest will no longer treat it as a nested config or a workspace project, so this file should not annoy our developing after it.