### PR TITLE
fix(cli): remove windows current link without rmdir

### DIFF
--- a/packages/cli/install.ps1
+++ b/packages/cli/install.ps1
@@ -262,6 +262,33 @@ function Cleanup-OldVersions {
     }
 }
 
+function Remove-CurrentLink {
+    param([string]$Path)
+
+    try {
+        $item = Get-Item -LiteralPath $Path -Force -ErrorAction Stop
+    } catch [System.Management.Automation.ItemNotFoundException] {
+        return
+    }
+
+    $isReparsePoint = ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0
+
+    try {
+        if ($isReparsePoint) {
+            if ($item.PSIsContainer) {
+                [System.IO.Directory]::Delete($item.FullName)
+            } else {
+                [System.IO.File]::Delete($item.FullName)
+            }
+            return
+        }
+
+        Remove-Item -LiteralPath $item.FullName -Recurse -Force -ErrorAction Stop
+    } catch {
+        Write-Error-Exit "Failed to remove existing current link at ${Path}: $_"
+    }
+}
+
 # Configure user PATH for ~/.vite-plus/bin
 # Returns: "true" = added, "already" = already configured
 function Configure-UserPath {
@@ -584,11 +611,7 @@ function Main {
     }
 
     # Create/update current junction (symlink)
-    if (Test-Path $CurrentLink) {
-        # Remove existing junction
-        cmd /c rmdir "$CurrentLink" 2>$null
-        Remove-Item -Path $CurrentLink -Force -ErrorAction SilentlyContinue
-    }
+    Remove-CurrentLink $CurrentLink
     # Create new junction pointing to the version directory
     cmd /c mklink /J "$CurrentLink" "$VersionDir" | Out-Null
 


### PR DESCRIPTION
I've hit a powershell issue while installing Vite+ after it hang in the git bash:

```sh
cmd : The directory is not empty.
  At line:589 char:9
  +         cmd /c rmdir "$CurrentLink" 2>$null
  +         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      + CategoryInfo          : NotSpecified: (The directory is not empty.:String) [], RemoteException
      + FullyQualifiedErrorId : NativeCommandError
```

To fix this, the installer now removes the existing `current` via Powershell logic and detects junctions or symlinks, as well as handling stale directories.