### PR TITLE
fix(pack): bundle direct tsdown picomatch require

### DIFF
--- a/packages/cli/snap-tests-global/command-pack-picomatch-hoist-false/package.json
+++ b/packages/cli/snap-tests-global/command-pack-picomatch-hoist-false/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "command-pack-picomatch-hoist-false",
+  "version": "1.0.0",
+  "type": "module",
+  "devDependencies": {
+    "typescript": "^6.0.3",
+    "vite-plus": "0.1.23"
+  },
+  "packageManager": "pnpm@11.5.0"
+}

--- a/packages/cli/snap-tests-global/command-pack-picomatch-hoist-false/pnpm-workspace.yaml
+++ b/packages/cli/snap-tests-global/command-pack-picomatch-hoist-false/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+hoist: false

--- a/packages/cli/snap-tests-global/command-pack-picomatch-hoist-false/snap.txt
+++ b/packages/cli/snap-tests-global/command-pack-picomatch-hoist-false/snap.txt
@@ -1,4 +1,4 @@
-> pnpm install --ignore-scripts
+> vp install --ignore-scripts
 > vp pack src/index.ts 2>&1
 ℹ entry: src/index.ts
 ℹ Build start

--- a/packages/cli/snap-tests-global/command-pack-picomatch-hoist-false/snap.txt
+++ b/packages/cli/snap-tests-global/command-pack-picomatch-hoist-false/snap.txt
@@ -1,0 +1,7 @@
+> pnpm install --ignore-scripts
+> vp pack src/index.ts 2>&1
+ℹ entry: src/index.ts
+ℹ Build start
+ℹ dist/index.mjs  <variable> kB │ gzip: <variable> kB
+ℹ 1 files, total: <variable> kB
+✔ Build complete in <variable>ms

--- a/packages/cli/snap-tests-global/command-pack-picomatch-hoist-false/src/index.ts
+++ b/packages/cli/snap-tests-global/command-pack-picomatch-hoist-false/src/index.ts
@@ -1,0 +1,1 @@
+export const value = 1;

--- a/packages/cli/snap-tests-global/command-pack-picomatch-hoist-false/steps.json
+++ b/packages/cli/snap-tests-global/command-pack-picomatch-hoist-false/steps.json
@@ -2,7 +2,7 @@
   "linkCheckoutPackages": true,
   "commands": [
     {
-      "command": "pnpm install --ignore-scripts",
+      "command": "vp install --ignore-scripts",
       "ignoreOutput": true,
       "timeout": 120000
     },

--- a/packages/cli/snap-tests-global/command-pack-picomatch-hoist-false/steps.json
+++ b/packages/cli/snap-tests-global/command-pack-picomatch-hoist-false/steps.json
@@ -1,0 +1,11 @@
+{
+  "linkCheckoutPackages": true,
+  "commands": [
+    {
+      "command": "pnpm install --ignore-scripts",
+      "ignoreOutput": true,
+      "timeout": 120000
+    },
+    "vp pack src/index.ts 2>&1"
+  ]
+}

--- a/packages/core/build-support/find-create-require.ts
+++ b/packages/core/build-support/find-create-require.ts
@@ -54,14 +54,11 @@ export async function replaceThirdPartyCjsRequires(
   const thirdPartyModules = new Set<string>();
 
   // Find all createRequire patterns and their require calls
-  const results = [
-    findCreateRequireInStaticImports(ast),
-    findCreateRequireInGlobalModule(ast),
-  ].filter((result): result is { requireVarName: string; calls: RequireCall[] } => Boolean(result));
+  const results = [findCreateRequireInStaticImports(ast), findCreateRequireInGlobalModule(ast)];
 
   // Collect all third-party require calls
   const replacements: RequireCall[] = [];
-  for (const { calls } of results) {
+  for (const calls of results) {
     for (const call of calls) {
       if (isThirdPartyModule(call.module)) {
         const parts = call.module.split('/');
@@ -129,20 +126,60 @@ function findRequireCalls(ast: ParseResult, requireVarName: string): RequireCall
   return calls;
 }
 
+function getLiteralRequireArgument(node: CallExpression): RequireCall | undefined {
+  if (node.arguments.length === 0) {
+    return undefined;
+  }
+  const arg = node.arguments[0];
+  if (arg.type !== 'Literal') {
+    return undefined;
+  }
+  const value = (arg as { value: unknown; start: number; end: number }).value;
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  return {
+    module: value,
+    start: arg.start,
+    end: arg.end,
+  };
+}
+
+function findDirectCreateRequireCalls(
+  ast: ParseResult,
+  isCreateRequireCall: (node: CallExpression) => boolean,
+): RequireCall[] {
+  const calls: RequireCall[] = [];
+
+  const visitor = new Visitor({
+    CallExpression(node: CallExpression) {
+      if (node.callee.type !== 'CallExpression' || !isCreateRequireCall(node.callee)) {
+        return;
+      }
+
+      const call = getLiteralRequireArgument(node);
+      if (call) {
+        calls.push(call);
+      }
+    },
+  });
+
+  visitor.visit(ast.program);
+  return calls;
+}
+
 /**
  * Find createRequire from static imports and return the require variable name + all require calls
  * Handles: `import { createRequire } from "node:module"` then `const require = createRequire(...)`
  */
-function findCreateRequireInStaticImports(
-  ast: ParseResult,
-): { requireVarName: string; calls: RequireCall[] } | undefined {
+function findCreateRequireInStaticImports(ast: ParseResult): RequireCall[] {
   // Find import from 'module' or 'node:module'
   const importFromModule = ast.module.staticImports.find((imt) => {
     const { value } = imt.moduleRequest;
     return value === 'node:module' || value === 'module';
   });
   if (!importFromModule) {
-    return undefined;
+    return [];
   }
 
   // Find the createRequire import entry
@@ -150,7 +187,7 @@ function findCreateRequireInStaticImports(
     return entry.importName.name === 'createRequire';
   });
   if (!createRequireEntry) {
-    return undefined;
+    return [];
   }
 
   const createRequireLocalName = createRequireEntry.localName.value;
@@ -174,14 +211,14 @@ function findCreateRequireInStaticImports(
   });
   varVisitor.visit(ast.program);
 
-  if (!requireVarName) {
-    return undefined;
-  }
+  const calls = requireVarName ? findRequireCalls(ast, requireVarName) : [];
+  calls.push(
+    ...findDirectCreateRequireCalls(ast, (node) => {
+      return node.callee.type === 'Identifier' && node.callee.name === createRequireLocalName;
+    }),
+  );
 
-  // Find all calls to the require variable
-  const calls = findRequireCalls(ast, requireVarName);
-
-  return { requireVarName, calls };
+  return calls;
 }
 
 // Helper to check if an expression is `process` or `globalThis.process`
@@ -240,9 +277,7 @@ function isGetBuiltinModuleCall(expr: Expression): boolean {
  * Handles: `const require = globalThis.process.getBuiltinModule("module").createRequire(import.meta.url)`
  * Or: `const require = process.getBuiltinModule("module").createRequire(import.meta.url)`
  */
-function findCreateRequireInGlobalModule(
-  ast: ParseResult,
-): { requireVarName: string; calls: RequireCall[] } | undefined {
+function findCreateRequireInGlobalModule(ast: ParseResult): RequireCall[] {
   let requireVarName: string | undefined;
 
   const visitor = new Visitor({
@@ -276,12 +311,16 @@ function findCreateRequireInGlobalModule(
 
   visitor.visit(ast.program);
 
-  if (!requireVarName) {
-    return undefined;
-  }
+  const calls = requireVarName ? findRequireCalls(ast, requireVarName) : [];
+  calls.push(
+    ...findDirectCreateRequireCalls(ast, (node) => {
+      if (node.callee.type !== 'MemberExpression' || node.callee.computed) {
+        return false;
+      }
+      const callee = node.callee as StaticMemberExpression;
+      return callee.property.name === 'createRequire' && isGetBuiltinModuleCall(callee.object);
+    }),
+  );
 
-  // Find all calls to the require variable
-  const calls = findRequireCalls(ast, requireVarName);
-
-  return { requireVarName, calls };
+  return calls;
 }

--- a/packages/core/build-support/find-create-require.ts
+++ b/packages/core/build-support/find-create-require.ts
@@ -103,21 +103,9 @@ function findRequireCalls(ast: ParseResult, requireVarName: string): RequireCall
         return;
       }
 
-      // Extract the first argument (module specifier)
-      if (node.arguments.length === 0) {
-        return;
-      }
-      const arg = node.arguments[0];
-      if (arg.type !== 'Literal') {
-        return;
-      }
-      const value = (arg as { value: unknown; start: number; end: number }).value;
-      if (typeof value === 'string') {
-        calls.push({
-          module: value,
-          start: arg.start,
-          end: arg.end,
-        });
+      const call = getLiteralRequireArgument(node);
+      if (call) {
+        calls.push(call);
       }
     },
   });


### PR DESCRIPTION
## Summary

Fixes the bundled `tsdown` build so direct `createRequire(...)("picomatch")` calls are rewritten to the bundled local CJS entry, matching the existing handling for assigned `require` calls.

This prevents `vp pack` from depending on an undeclared runtime `picomatch` resolution when installed with pnpm `hoist: false`.

## Root Cause

The core package build step already scans bundled tsdown output for third-party CJS requires and creates local bundled entry files. It handled patterns like:

```js
const require = createRequire(import.meta.url);
require("pkg");
```

but missed direct-call patterns like:

```js
createRequire(import.meta.url)("picomatch");
```

As a result, `picomatch` remained a runtime package lookup from `@voidzero-dev/vite-plus-core/dist/tsdown/main-*.js`.

## Validation

- `pnpm -F @voidzero-dev/vite-plus-core build`
- `pnpm -F vite-plus snap-test-global command-pack-picomatch-hoist-false`
- `git diff --check -- packages/core/build-support/find-create-require.ts packages/cli/snap-tests-global/command-pack-picomatch-hoist-false`

Fixes #1731

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core build-time AST rewriting for bundled tsdown CJS requires; incorrect detection could break pack/runtime resolution, but scope is limited to the existing replaceThirdPartyCjsRequires path.
> 
> **Overview**
> Extends the tsdown re-bundle step’s **createRequire** scanner so inline `createRequire(...)("picomatch")` (and similar) calls get rewritten to local bundled CJS entry paths, not only `const require = createRequire(...); require("pkg")`.
> 
> The AST helpers now return flat **RequireCall** lists, share literal-argument extraction, and add **findDirectCreateRequireCalls** for both static-import and **getBuiltinModule** **createRequire** patterns.
> 
> Adds a global snap fixture **command-pack-picomatch-hoist-false** (pnpm **hoist: false**) to assert **vp pack** completes without relying on hoisted **picomatch**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03f5f913e0c9802f5ec2ca786c5e7d7843703cc4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->