### PR TITLE
fix(deps): resolve rust dependabot advisories (openssl, libyml)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3104,16 +3104,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
-]
-
-[[package]]
 name = "link-section"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6422,21 +6412,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yml"
-version = "0.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
-dependencies = [
- "indexmap",
- "itoa",
- "libyml",
- "memchr",
- "ryu",
- "serde",
- "version_check",
-]
-
-[[package]]
 name = "serial_test"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7612,7 +7587,6 @@ dependencies = [
  "rusqlite",
  "semver 1.0.27",
  "serde_json",
- "serde_yml",
  "thiserror 2.0.18",
  "tokio",
  "vite_path",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3702,15 +3702,14 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -3743,9 +3742,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -263,7 +263,6 @@ semver = "1.0.26"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 serde_yaml = "0.9.34"
-serde_yml = "0.0.12"
 serial_test = "3.2.0"
 sha1 = "0.10.6"
 sha2 = "0.10.9"

--- a/crates/vite_error/Cargo.toml
+++ b/crates/vite_error/Cargo.toml
@@ -17,7 +17,6 @@ nix = { workspace = true }
 rusqlite = { workspace = true }
 semver = { workspace = true }
 serde_json = { workspace = true }
-serde_yml = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 vite_path = { workspace = true }

--- a/crates/vite_error/src/lib.rs
+++ b/crates/vite_error/src/lib.rs
@@ -60,9 +60,6 @@ pub enum Error {
     IgnoreError(#[from] ignore::Error),
 
     #[error(transparent)]
-    SerdeYml(#[from] serde_yml::Error),
-
-    #[error(transparent)]
     WorkspaceError(#[from] vite_workspace::Error),
 
     #[error("Lint failed, reason: {reason}")]


### PR DESCRIPTION
Resolves the open Rust Dependabot advisories in `Cargo.lock`, as two independent commits.

## openssl 0.10.80

Bumps the transitive `rust-openssl` crate (pulled via `native-tls`/`reqwest`), resolving:

- GHSA-xp3w-r5p5-63rr
- GHSA-pqf5-4pqq-29f5
- GHSA-8c75-8mhr-p7r9
- GHSA-ghm9-cr32-g9qj
- GHSA-hppc-g8h3-xhp3

Lockfile-only change: `openssl` 0.10.76 to 0.10.80, `openssl-sys` 0.9.112 to 0.9.116.

## Drop serde_yml to remove unmaintained libyml

`libyml` (GHSA-gfxp-f68g-8x78) has no patched version; it is unmaintained and flagged as unsound. It reached the tree only through `serde_yml`, which here was dead code: a single unused error variant `SerdeYml(#[from] serde_yml::Error)` in `vite_error`, with no YAML parsing anywhere in the workspace. Removing the variant and the `serde_yml` dependency drops both `serde_yml` and `libyml` from the tree.

## Validation

- `cargo check --workspace --locked` compiles.
- `serde_yml` and `libyml` no longer appear in `Cargo.lock`; `openssl` is 0.10.80.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only changes with no runtime logic changes; removing an unused error variant is unlikely to affect behavior.
> 
> **Overview**
> Addresses Dependabot Rust advisories with **lockfile OpenSSL upgrades** and **removal of unused YAML crates**.
> 
> **OpenSSL:** `Cargo.lock` bumps transitive `openssl` (0.10.76 → 0.10.80) and `openssl-sys` (0.9.112 → 0.9.116), including dropping the `once_cell` dependency on the `openssl` crate entry—typical of the patched release pulled in via `reqwest` / native TLS.
> 
> **libyml / serde_yml:** Removes workspace `serde_yml` and the `vite_error` dependency, plus the unused `SerdeYml` `thiserror` variant. That prunes `serde_yml` and unmaintained `libyml` from the dependency tree; YAML elsewhere still uses `serde_yaml` in the workspace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1ddea61c75c3d513db384413ae55baa82b0534f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->