### PR TITLE
fix(deps): resolve docs dependabot advisories

### DIFF
--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  lodash-es: ^4.18.0
+  lodash-es: ^4.18.1
 
 importers:
 

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -5,10 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  vite: ^7.3.5
-  defu: ^6.1.5
   lodash-es: ^4.18.0
-  picomatch: ^4.0.4
 
 importers:
 
@@ -730,7 +727,7 @@ packages:
   '@tailwindcss/vite@4.2.1':
     resolution: {integrity: sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w==}
     peerDependencies:
-      vite: ^7.3.5
+      vite: ^5.2.0 || ^6 || ^7
 
   '@tanstack/virtual-core@3.13.22':
     resolution: {integrity: sha512-isuUGKsc5TAPDoHSbWTbl1SCil54zOS2MiWz/9GCWHPUQOvNTQx8qJEWC7UWR0lShhbK0Lmkcf0SZYxvch7G3g==}
@@ -886,7 +883,7 @@ packages:
     resolution: {integrity: sha512-bL3AxKuQySfk1iGcBsQnoRVexTPJq0Z/ixFVM8OhVJAP6ZXXXLtM7NFKWhLl30Kg7uTBqIaPXbh+nuQCuBDedg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: ^7.3.5
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
 
   '@voidzero-dev/vitepress-theme@4.8.3':
@@ -1325,7 +1322,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^4.0.4
+      picomatch: ^3 || ^4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -1948,7 +1945,7 @@ packages:
   vitepress-plugin-group-icons@1.7.5:
     resolution: {integrity: sha512-QzcroUuIiVKyXpmEiiHVbfRTQIy9Zbwxpk5JC/zavO8mavitwumz2RZWlwTchMCCHducYyPptkYvXvdnNUWkog==}
     peerDependencies:
-      vite: ^7.3.5
+      vite: '>=3'
     peerDependenciesMeta:
       vite:
         optional: true

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  vite: ^7.3.2
+  defu: ^6.1.5
+  lodash-es: ^4.18.0
+  picomatch: ^4.0.4
+
 importers:
 
   .:
@@ -22,7 +28,7 @@ importers:
         version: 2.22.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       vitepress-plugin-group-icons:
         specifier: ^1.7.5
-        version: 1.7.5(vite@7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1))
+        version: 1.7.5(vite@7.3.5(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1))
       vitepress-plugin-llms:
         specifier: ^1.12.2
         version: 1.12.2
@@ -38,7 +44,7 @@ importers:
     devDependencies:
       '@voidzero-dev/vitepress-theme':
         specifier: 4.8.3
-        version: 4.8.3(focus-trap@7.8.0)(vite@7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1))(vitepress@2.0.0-alpha.15(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1)(oxc-minify@0.120.0)(postcss@8.5.8)(typescript@6.0.3))(vue@3.5.30(typescript@6.0.3))
+        version: 4.8.3(focus-trap@7.8.0)(vite@7.3.5(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1))(vitepress@2.0.0-alpha.15(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1)(oxc-minify@0.120.0)(postcss@8.5.8)(typescript@6.0.3))(vue@3.5.30(typescript@6.0.3))
       oxc-minify:
         specifier: ^0.120.0
         version: 0.120.0
@@ -724,7 +730,7 @@ packages:
   '@tailwindcss/vite@4.2.1':
     resolution: {integrity: sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w==}
     peerDependencies:
-      vite: ^5.2.0 || ^6 || ^7
+      vite: ^7.3.2
 
   '@tanstack/virtual-core@3.13.22':
     resolution: {integrity: sha512-isuUGKsc5TAPDoHSbWTbl1SCil54zOS2MiWz/9GCWHPUQOvNTQx8qJEWC7UWR0lShhbK0Lmkcf0SZYxvch7G3g==}
@@ -880,7 +886,7 @@ packages:
     resolution: {integrity: sha512-bL3AxKuQySfk1iGcBsQnoRVexTPJq0Z/ixFVM8OhVJAP6ZXXXLtM7NFKWhLl30Kg7uTBqIaPXbh+nuQCuBDedg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: ^7.3.2
       vue: ^3.2.25
 
   '@voidzero-dev/vitepress-theme@4.8.3':
@@ -1249,8 +1255,8 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
-  defu@6.1.4:
-    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
   delaunator@5.0.1:
     resolution: {integrity: sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==}
@@ -1319,7 +1325,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: ^4.0.4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -1494,8 +1500,8 @@ packages:
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
 
-  lodash-es@4.17.23:
-    resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -1676,8 +1682,8 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   pkg-types@1.3.1:
@@ -1899,8 +1905,8 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+  vite@7.3.5:
+    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -1942,7 +1948,7 @@ packages:
   vitepress-plugin-group-icons@1.7.5:
     resolution: {integrity: sha512-QzcroUuIiVKyXpmEiiHVbfRTQIy9Zbwxpk5JC/zavO8mavitwumz2RZWlwTchMCCHducYyPptkYvXvdnNUWkog==}
     peerDependencies:
-      vite: '>=3'
+      vite: ^7.3.2
     peerDependenciesMeta:
       vite:
         optional: true
@@ -2064,12 +2070,12 @@ snapshots:
     dependencies:
       '@chevrotain/gast': 11.1.2
       '@chevrotain/types': 11.1.2
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
 
   '@chevrotain/gast@11.1.2':
     dependencies:
       '@chevrotain/types': 11.1.2
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
 
   '@chevrotain/regexp-to-ast@11.1.2': {}
 
@@ -2520,12 +2526,12 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.2.1
 
-  '@tailwindcss/vite@4.2.1(vite@7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1))':
+  '@tailwindcss/vite@4.2.1(vite@7.3.5(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1))':
     dependencies:
       '@tailwindcss/node': 4.2.1
       '@tailwindcss/oxide': 4.2.1
       tailwindcss: 4.2.1
-      vite: 7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1)
+      vite: 7.3.5(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1)
 
   '@tanstack/virtual-core@3.13.22': {}
 
@@ -2702,13 +2708,13 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vitejs/plugin-vue@6.0.5(vite@7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1))(vue@3.5.30(typescript@6.0.3))':
+  '@vitejs/plugin-vue@6.0.5(vite@7.3.5(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1))(vue@3.5.30(typescript@6.0.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.2
-      vite: 7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1)
+      vite: 7.3.5(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1)
       vue: 3.5.30(typescript@6.0.3)
 
-  '@voidzero-dev/vitepress-theme@4.8.3(focus-trap@7.8.0)(vite@7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1))(vitepress@2.0.0-alpha.15(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1)(oxc-minify@0.120.0)(postcss@8.5.8)(typescript@6.0.3))(vue@3.5.30(typescript@6.0.3))':
+  '@voidzero-dev/vitepress-theme@4.8.3(focus-trap@7.8.0)(vite@7.3.5(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1))(vitepress@2.0.0-alpha.15(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1)(oxc-minify@0.120.0)(postcss@8.5.8)(typescript@6.0.3))(vue@3.5.30(typescript@6.0.3))':
     dependencies:
       '@docsearch/css': 4.6.0
       '@docsearch/js': 4.6.0
@@ -2716,7 +2722,7 @@ snapshots:
       '@iconify/vue': 5.0.0(vue@3.5.30(typescript@6.0.3))
       '@rive-app/canvas-lite': 2.35.2
       '@tailwindcss/typography': 0.5.19(tailwindcss@4.2.1)
-      '@tailwindcss/vite': 4.2.1(vite@7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1))
+      '@tailwindcss/vite': 4.2.1(vite@7.3.5(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1))
       '@vue/shared': 3.5.30
       '@vueuse/core': 14.2.1(vue@3.5.30(typescript@6.0.3))
       '@vueuse/integrations': 14.2.1(focus-trap@7.8.0)(vue@3.5.30(typescript@6.0.3))
@@ -2870,7 +2876,7 @@ snapshots:
   chevrotain-allstar@0.3.1(chevrotain@11.1.2):
     dependencies:
       chevrotain: 11.1.2
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
 
   chevrotain@11.1.2:
     dependencies:
@@ -2879,7 +2885,7 @@ snapshots:
       '@chevrotain/regexp-to-ast': 11.1.2
       '@chevrotain/types': 11.1.2
       '@chevrotain/utils': 11.1.2
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
 
   cliui@8.0.1:
     dependencies:
@@ -3095,7 +3101,7 @@ snapshots:
   dagre-d3-es@7.0.14:
     dependencies:
       d3: 7.9.0
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
 
   dayjs@1.11.20: {}
 
@@ -3107,7 +3113,7 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
-  defu@6.1.4: {}
+  defu@6.1.7: {}
 
   delaunator@5.0.1:
     dependencies:
@@ -3183,9 +3189,9 @@ snapshots:
     dependencies:
       format: 0.2.2
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   focus-trap@7.8.0:
     dependencies:
@@ -3327,7 +3333,7 @@ snapshots:
     dependencies:
       uc.micro: 2.1.0
 
-  lodash-es@4.17.23: {}
+  lodash-es@4.18.1: {}
 
   longest-streak@3.1.0: {}
 
@@ -3434,7 +3440,7 @@ snapshots:
       dompurify: 3.3.3
       katex: 0.16.38
       khroma: 2.1.0
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
       marked: 16.4.2
       roughjs: 4.6.6
       stylis: 4.3.6
@@ -3654,7 +3660,7 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
   pkg-types@1.3.1:
     dependencies:
@@ -3725,7 +3731,7 @@ snapshots:
       '@vueuse/core': 14.2.1(vue@3.5.30(typescript@6.0.3))
       '@vueuse/shared': 14.2.1(vue@3.5.30(typescript@6.0.3))
       aria-hidden: 1.2.6
-      defu: 6.1.4
+      defu: 6.1.7
       ohash: 2.0.11
       vue: 3.5.30(typescript@6.0.3)
     transitivePeerDependencies:
@@ -3863,8 +3869,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tokenx@1.3.0: {}
 
@@ -3946,11 +3952,11 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1):
+  vite@7.3.5(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1):
     dependencies:
       esbuild: 0.27.4
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.8
       rollup: 4.59.0
       tinyglobby: 0.2.15
@@ -3960,13 +3966,13 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.31.1
 
-  vitepress-plugin-group-icons@1.7.5(vite@7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1)):
+  vitepress-plugin-group-icons@1.7.5(vite@7.3.5(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1)):
     dependencies:
       '@iconify-json/logos': 1.2.11
       '@iconify-json/vscode-icons': 1.2.46
       '@iconify/utils': 3.1.0
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1)
+      vite: 7.3.5(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1)
 
   vitepress-plugin-llms@1.12.2:
     dependencies:
@@ -4003,7 +4009,7 @@ snapshots:
       '@shikijs/transformers': 3.23.0
       '@shikijs/types': 3.23.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 6.0.5(vite@7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1))(vue@3.5.30(typescript@6.0.3))
+      '@vitejs/plugin-vue': 6.0.5(vite@7.3.5(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1))(vue@3.5.30(typescript@6.0.3))
       '@vue/devtools-api': 8.1.0
       '@vue/shared': 3.5.30
       '@vueuse/core': 14.2.1(vue@3.5.30(typescript@6.0.3))
@@ -4012,7 +4018,7 @@ snapshots:
       mark.js: 8.11.1
       minisearch: 7.2.0
       shiki: 3.23.0
-      vite: 7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1)
+      vite: 7.3.5(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1)
       vue: 3.5.30(typescript@6.0.3)
     optionalDependencies:
       oxc-minify: 0.120.0

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  vite: ^7.3.2
+  vite: ^7.3.5
   defu: ^6.1.5
   lodash-es: ^4.18.0
   picomatch: ^4.0.4
@@ -730,7 +730,7 @@ packages:
   '@tailwindcss/vite@4.2.1':
     resolution: {integrity: sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w==}
     peerDependencies:
-      vite: ^7.3.2
+      vite: ^7.3.5
 
   '@tanstack/virtual-core@3.13.22':
     resolution: {integrity: sha512-isuUGKsc5TAPDoHSbWTbl1SCil54zOS2MiWz/9GCWHPUQOvNTQx8qJEWC7UWR0lShhbK0Lmkcf0SZYxvch7G3g==}
@@ -886,7 +886,7 @@ packages:
     resolution: {integrity: sha512-bL3AxKuQySfk1iGcBsQnoRVexTPJq0Z/ixFVM8OhVJAP6ZXXXLtM7NFKWhLl30Kg7uTBqIaPXbh+nuQCuBDedg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: ^7.3.2
+      vite: ^7.3.5
       vue: ^3.2.25
 
   '@voidzero-dev/vitepress-theme@4.8.3':
@@ -1948,7 +1948,7 @@ packages:
   vitepress-plugin-group-icons@1.7.5:
     resolution: {integrity: sha512-QzcroUuIiVKyXpmEiiHVbfRTQIy9Zbwxpk5JC/zavO8mavitwumz2RZWlwTchMCCHducYyPptkYvXvdnNUWkog==}
     peerDependencies:
-      vite: ^7.3.2
+      vite: ^7.3.5
     peerDependenciesMeta:
       vite:
         optional: true

--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -3,7 +3,7 @@ packages:
 
 overrides:
   # Security overrides for vulnerable transitive dependencies (dependabot)
-  vite: ^7.3.2 # GHSA-v2wj-q39q-566r, GHSA-p9ff-h696-f583
+  vite: ^7.3.5 # GHSA-v2wj-q39q-566r, GHSA-p9ff-h696-f583
   defu: ^6.1.5 # GHSA-737v-mqg7-c878
   lodash-es: ^4.18.0 # GHSA-r5fr-rjxr-66jc
   picomatch: ^4.0.4 # GHSA-c2c7-rcm5-vvqj

--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -6,7 +6,7 @@ overrides:
   # so the patched 4.18.x cannot be reached without forcing it. The other docs
   # advisory fixes (vite, defu, picomatch) are patched directly in the lockfile
   # since they fall within the ranges their parents already declare.
-  lodash-es: ^4.18.0 # GHSA-r5fr-rjxr-66jc
+  lodash-es: ^4.18.1 # GHSA-r5fr-rjxr-66jc
 
 peerDependencyRules:
   allowAny:

--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -2,11 +2,11 @@ packages:
   - .
 
 overrides:
-  # Security overrides for vulnerable transitive dependencies (dependabot)
-  vite: ^7.3.5 # GHSA-v2wj-q39q-566r, GHSA-p9ff-h696-f583
-  defu: ^6.1.5 # GHSA-737v-mqg7-c878
+  # Security override: chevrotain (via mermaid) pins lodash-es to exactly 4.17.23,
+  # so the patched 4.18.x cannot be reached without forcing it. The other docs
+  # advisory fixes (vite, defu, picomatch) are patched directly in the lockfile
+  # since they fall within the ranges their parents already declare.
   lodash-es: ^4.18.0 # GHSA-r5fr-rjxr-66jc
-  picomatch: ^4.0.4 # GHSA-c2c7-rcm5-vvqj
 
 peerDependencyRules:
   allowAny:

--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -2,10 +2,8 @@ packages:
   - .
 
 overrides:
-  # Security override: chevrotain (via mermaid) pins lodash-es to exactly 4.17.23,
-  # so the patched 4.18.x cannot be reached without forcing it. The other docs
-  # advisory fixes (vite, defu, picomatch) are patched directly in the lockfile
-  # since they fall within the ranges their parents already declare.
+  # chevrotain (via mermaid) pins lodash-es to exactly 4.17.23, so the patched
+  # 4.18.x can only be reached by forcing it.
   lodash-es: ^4.18.1 # GHSA-r5fr-rjxr-66jc
 
 peerDependencyRules:

--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -1,6 +1,13 @@
 packages:
   - .
 
+overrides:
+  # Security overrides for vulnerable transitive dependencies (dependabot)
+  vite: ^7.3.2 # GHSA-v2wj-q39q-566r, GHSA-p9ff-h696-f583
+  defu: ^6.1.5 # GHSA-737v-mqg7-c878
+  lodash-es: ^4.18.0 # GHSA-r5fr-rjxr-66jc
+  picomatch: ^4.0.4 # GHSA-c2c7-rcm5-vvqj
+
 peerDependencyRules:
   allowAny:
     - vitepress


### PR DESCRIPTION
Resolves the open Dependabot advisories in the documentation site (`docs/` is a separate pnpm workspace, `docs/pnpm-lock.yaml`).

Most fixes land through a normal lockfile refresh, since the patched versions already fall within the ranges their parents declare. Only `lodash-es` needs an override: `chevrotain` (via `mermaid`) pins it to exactly `4.17.23`, so the patched `4.18.x` can't be reached any other way.

| Package | Resolved | How | Advisories |
| --- | --- | --- | --- |
| `vite` | 7.3.5 | lockfile | GHSA-v2wj-q39q-566r, GHSA-p9ff-h696-f583 |
| `defu` | 6.1.7 | lockfile | GHSA-737v-mqg7-c878 |
| `picomatch` | 4.0.4 | lockfile | GHSA-c2c7-rcm5-vvqj |
| `lodash-es` | 4.18.1 | override | GHSA-r5fr-rjxr-66jc |

## Validation

- `pnpm install` in `docs/` succeeds and the lockfile is consistent.
- No vulnerable versions remain (`lodash-es` 4.17.23 is fully replaced by the override).