### PR TITLE
fix(create/migrate): wrap migrated Vite plugins with lazyPlugins

### DIFF
--- a/crates/vite_migration/src/lib.rs
+++ b/crates/vite_migration/src/lib.rs
@@ -18,4 +18,6 @@ mod vite_config;
 pub use file_walker::{WalkResult, find_ts_files};
 pub use import_rewriter::{BatchRewriteResult, rewrite_imports_in_directory};
 pub use package::{rewrite_eslint, rewrite_prettier, rewrite_scripts};
-pub use vite_config::{MergeResult, has_config_key, merge_json_config, merge_tsdown_config};
+pub use vite_config::{
+    MergeResult, has_config_key, merge_json_config, merge_tsdown_config, wrap_lazy_plugins,
+};

--- a/crates/vite_migration/src/vite_config.rs
+++ b/crates/vite_migration/src/vite_config.rs
@@ -323,7 +323,11 @@ fn is_recognized_config_object_for_lazy_plugins<D: Doc>(object_node: &Node<'_, D
     let Some(parent) = object_node.parent() else { return false };
     match parent.kind().as_ref() {
         "export_statement" => true,
-        "satisfies_expression" => parent.parent().is_some_and(|p| p.kind() == "export_statement"),
+        "satisfies_expression" => parent.parent().is_some_and(|p| {
+            p.kind() == "export_statement"
+                || (p.kind() == "arguments"
+                    && p.parent().is_some_and(|c| is_define_config_call(&c)))
+        }),
         "arguments" => parent.parent().is_some_and(|c| is_define_config_call(&c)),
         "parenthesized_expression" => is_define_config_arrow_body(&parent),
         "return_statement" => is_direct_return_in_define_config_callback(&parent),
@@ -1695,6 +1699,27 @@ export default defineConfig({
 
         assert!(!result.updated);
         assert_eq!(result.content, vite_config);
+    }
+
+    #[test]
+    fn test_wrap_lazy_plugins_handles_satisfies_inside_define_config() {
+        let vite_config = r#"import { defineConfig } from 'vite-plus';
+
+export default defineConfig({
+  plugins: [react()],
+} satisfies UserConfig);"#;
+
+        let result = wrap_lazy_plugins_content(vite_config, None).unwrap();
+
+        assert!(result.updated);
+        assert_eq!(
+            result.content,
+            r#"import { defineConfig, lazyPlugins } from 'vite-plus';
+
+export default defineConfig({
+  plugins: lazyPlugins(() => [react()]),
+} satisfies UserConfig);"#
+        );
     }
 
     #[test]

--- a/crates/vite_migration/src/vite_config.rs
+++ b/crates/vite_migration/src/vite_config.rs
@@ -271,7 +271,10 @@ static RE_REQUIRE_CALL: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#"\brequire\s*\("#).unwrap());
 
 static RE_LOCAL_LAZY_PLUGINS_BINDING: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"(?m)^\s*(?:const|let|var|function|class)\s+lazyPlugins\b"#).unwrap()
+    Regex::new(
+        r#"(?m)^\s*(?:export\s+(?:default\s+)?)?(?:(?:const|let|var|class)\s+lazyPlugins\b|(?:async\s+)?function\s+lazyPlugins\b)"#,
+    )
+    .unwrap()
 });
 
 fn has_conflicting_lazy_plugins_binding(content: &str) -> bool {
@@ -1634,6 +1637,40 @@ export default defineConfig({
         let vite_config = r#"import { defineConfig } from 'vite-plus';
 
 const lazyPlugins = [react()];
+
+export default defineConfig({
+  plugins: [react()],
+});"#;
+
+        let result = wrap_lazy_plugins_content(vite_config, None).unwrap();
+
+        assert!(!result.updated);
+        assert_eq!(result.content, vite_config);
+    }
+
+    #[test]
+    fn test_wrap_lazy_plugins_skips_conflicting_exported_local_binding() {
+        let vite_config = r#"import { defineConfig } from 'vite-plus';
+
+export const lazyPlugins = [react()];
+
+export default defineConfig({
+  plugins: [react()],
+});"#;
+
+        let result = wrap_lazy_plugins_content(vite_config, None).unwrap();
+
+        assert!(!result.updated);
+        assert_eq!(result.content, vite_config);
+    }
+
+    #[test]
+    fn test_wrap_lazy_plugins_skips_conflicting_exported_function_binding() {
+        let vite_config = r#"import { defineConfig } from 'vite-plus';
+
+export async function lazyPlugins() {
+  return [react()];
+}
 
 export default defineConfig({
   plugins: [react()],

--- a/crates/vite_migration/src/vite_config.rs
+++ b/crates/vite_migration/src/vite_config.rs
@@ -277,6 +277,13 @@ static RE_LOCAL_LAZY_PLUGINS_BINDING: LazyLock<Regex> = LazyLock::new(|| {
     .unwrap()
 });
 
+static RE_DESTRUCTURED_LAZY_PLUGINS_BINDING: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"(?ms)^\s*(?:export\s+)?(?:const|let|var)\s+[\{\[][^;]*\blazyPlugins\b[^;]*[\}\]]\s*="#,
+    )
+    .unwrap()
+});
+
 fn has_conflicting_lazy_plugins_binding(content: &str) -> bool {
     let grep = SupportLang::TypeScript.ast_grep(content);
     let root = grep.root();
@@ -295,6 +302,7 @@ fn has_conflicting_lazy_plugins_binding(content: &str) -> bool {
     }
 
     RE_LOCAL_LAZY_PLUGINS_BINDING.is_match(content)
+        || RE_DESTRUCTURED_LAZY_PLUGINS_BINDING.is_match(content)
 }
 
 fn import_binds_lazy_plugins(import_statement: &str) -> bool {
@@ -1641,6 +1649,38 @@ export default defineConfig({
         let vite_config = r#"import { defineConfig } from 'vite-plus';
 
 const lazyPlugins = [react()];
+
+export default defineConfig({
+  plugins: [react()],
+});"#;
+
+        let result = wrap_lazy_plugins_content(vite_config, None).unwrap();
+
+        assert!(!result.updated);
+        assert_eq!(result.content, vite_config);
+    }
+
+    #[test]
+    fn test_wrap_lazy_plugins_skips_conflicting_destructured_binding() {
+        let vite_config = r#"import { defineConfig } from 'vite-plus';
+
+const { lazyPlugins } = helpers;
+
+export default defineConfig({
+  plugins: [react()],
+});"#;
+
+        let result = wrap_lazy_plugins_content(vite_config, None).unwrap();
+
+        assert!(!result.updated);
+        assert_eq!(result.content, vite_config);
+    }
+
+    #[test]
+    fn test_wrap_lazy_plugins_skips_conflicting_destructured_alias_binding() {
+        let vite_config = r#"import { defineConfig } from 'vite-plus';
+
+const { pluginFactory: lazyPlugins } = helpers;
 
 export default defineConfig({
   plugins: [react()],

--- a/crates/vite_migration/src/vite_config.rs
+++ b/crates/vite_migration/src/vite_config.rs
@@ -284,6 +284,10 @@ static RE_DESTRUCTURED_LAZY_PLUGINS_BINDING: LazyLock<Regex> = LazyLock::new(|| 
     .unwrap()
 });
 
+static RE_MULTI_DECLARATOR_LAZY_PLUGINS_BINDING: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?ms)^\s*(?:export\s+)?(?:const|let|var)\s+[^;]*,\s*lazyPlugins\b"#).unwrap()
+});
+
 fn has_conflicting_lazy_plugins_binding(content: &str) -> bool {
     let grep = SupportLang::TypeScript.ast_grep(content);
     let root = grep.root();
@@ -303,6 +307,7 @@ fn has_conflicting_lazy_plugins_binding(content: &str) -> bool {
 
     RE_LOCAL_LAZY_PLUGINS_BINDING.is_match(content)
         || RE_DESTRUCTURED_LAZY_PLUGINS_BINDING.is_match(content)
+        || RE_MULTI_DECLARATOR_LAZY_PLUGINS_BINDING.is_match(content)
 }
 
 fn import_binds_lazy_plugins(import_statement: &str) -> bool {
@@ -1649,6 +1654,39 @@ export default defineConfig({
         let vite_config = r#"import { defineConfig } from 'vite-plus';
 
 const lazyPlugins = [react()];
+
+export default defineConfig({
+  plugins: [react()],
+});"#;
+
+        let result = wrap_lazy_plugins_content(vite_config, None).unwrap();
+
+        assert!(!result.updated);
+        assert_eq!(result.content, vite_config);
+    }
+
+    #[test]
+    fn test_wrap_lazy_plugins_skips_conflicting_multi_declarator_binding() {
+        let vite_config = r#"import { defineConfig } from 'vite-plus';
+
+const other = 0, lazyPlugins = makeHelper();
+
+export default defineConfig({
+  plugins: [react()],
+});"#;
+
+        let result = wrap_lazy_plugins_content(vite_config, None).unwrap();
+
+        assert!(!result.updated);
+        assert_eq!(result.content, vite_config);
+    }
+
+    #[test]
+    fn test_wrap_lazy_plugins_skips_conflicting_multiline_multi_declarator_binding() {
+        let vite_config = r#"import { defineConfig } from 'vite-plus';
+
+const other = 0,
+  lazyPlugins = makeHelper();
 
 export default defineConfig({
   plugins: [react()],

--- a/crates/vite_migration/src/vite_config.rs
+++ b/crates/vite_migration/src/vite_config.rs
@@ -168,11 +168,162 @@ pub fn has_config_key(vite_config_content: &str, config_key: &str) -> Result<boo
     Ok(false)
 }
 
+/// Wrap safe inline Vite plugin arrays with `lazyPlugins(() => [...])`.
+///
+/// This transform is intentionally conservative: it only touches direct
+/// `plugins: [...]` pairs inside recognized Vite config objects and skips
+/// CommonJS configs rather than injecting ESM imports into them.
+pub fn wrap_lazy_plugins(vite_config_path: &Path) -> Result<MergeResult, Error> {
+    let vite_config_content = std::fs::read_to_string(vite_config_path)?;
+    wrap_lazy_plugins_content(&vite_config_content, Some(vite_config_path))
+}
+
+fn wrap_lazy_plugins_content(
+    vite_config_content: &str,
+    vite_config_path: Option<&Path>,
+) -> Result<MergeResult, Error> {
+    let uses_function_callback = check_function_callback(vite_config_content)?;
+
+    if is_commonjs_config(vite_config_content, vite_config_path)
+        || has_conflicting_lazy_plugins_binding(vite_config_content)
+    {
+        return Ok(MergeResult {
+            content: vite_config_content.to_owned(),
+            updated: false,
+            uses_function_callback,
+        });
+    }
+
+    let grep = SupportLang::TypeScript.ast_grep(vite_config_content);
+    let root = grep.root();
+    let mut replacements = Vec::new();
+
+    for node in root.dfs() {
+        if node.kind() != "pair" {
+            continue;
+        }
+        let Some(key_node) = node.field("key") else { continue };
+        if !pair_key_matches(&key_node, "plugins") {
+            continue;
+        }
+        let Some(parent_object) = node.parent() else { continue };
+        if parent_object.kind() != "object" {
+            continue;
+        }
+        if !is_recognized_config_object_for_lazy_plugins(&parent_object) {
+            continue;
+        }
+        let Some(value_node) = node.field("value") else { continue };
+        if value_node.kind() != "array" {
+            continue;
+        }
+
+        let callback = if node_has_descendant_kind(&value_node, "await_expression") {
+            "async () =>"
+        } else {
+            "() =>"
+        };
+        let range = value_node.range();
+        replacements.push((
+            range.start,
+            range.end,
+            format!("lazyPlugins({callback} {})", value_node.text()),
+        ));
+    }
+
+    if replacements.is_empty() {
+        return Ok(MergeResult {
+            content: vite_config_content.to_owned(),
+            updated: false,
+            uses_function_callback,
+        });
+    }
+
+    replacements.sort_by_key(|(start, _, _)| std::cmp::Reverse(*start));
+    let mut content = vite_config_content.to_owned();
+    for (start, end, replacement) in replacements {
+        content.replace_range(start..end, &replacement);
+    }
+    content = ensure_lazy_plugins_import(&content);
+
+    Ok(MergeResult { content, updated: true, uses_function_callback })
+}
+
 fn pair_key_matches<D: Doc>(key_node: &Node<'_, D>, config_key: &str) -> bool {
     let text = key_node.text();
     match key_node.kind().as_ref() {
         "property_identifier" => text == config_key,
         "string" => text.trim_matches(|c| c == '"' || c == '\'' || c == '`') == config_key,
+        _ => false,
+    }
+}
+
+fn is_commonjs_config(content: &str, path: Option<&Path>) -> bool {
+    if path.is_some_and(|p| {
+        p.extension().and_then(|ext| ext.to_str()).is_some_and(|ext| matches!(ext, "cjs" | "cts"))
+    }) {
+        return true;
+    }
+    content.contains("module.exports") || RE_REQUIRE_CALL.is_match(content)
+}
+
+static RE_REQUIRE_CALL: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"\brequire\s*\("#).unwrap());
+
+static RE_LOCAL_LAZY_PLUGINS_BINDING: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?m)^\s*(?:const|let|var|function|class)\s+lazyPlugins\b"#).unwrap()
+});
+
+fn has_conflicting_lazy_plugins_binding(content: &str) -> bool {
+    let grep = SupportLang::TypeScript.ast_grep(content);
+    let root = grep.root();
+
+    for node in root.dfs() {
+        if node.kind() != "import_statement" {
+            continue;
+        }
+        let text = node.text();
+        if imports_from_vite_plus(&text) {
+            continue;
+        }
+        if import_binds_lazy_plugins(&text) {
+            return true;
+        }
+    }
+
+    RE_LOCAL_LAZY_PLUGINS_BINDING.is_match(content)
+}
+
+fn import_binds_lazy_plugins(import_statement: &str) -> bool {
+    let statement = strip_import_comments(import_statement);
+    if RE_DEFAULT_LAZY_PLUGINS_IMPORT.is_match(&statement)
+        || RE_NAMESPACE_LAZY_PLUGINS_IMPORT.is_match(&statement)
+    {
+        return true;
+    }
+
+    let Some(open_brace) = statement.find('{') else { return false };
+    let Some(close_brace) = statement.rfind('}') else { return false };
+    statement[open_brace + 1..close_brace].split(',').any(|specifier| {
+        let specifier = specifier.trim();
+        specifier == "lazyPlugins" || specifier.ends_with(" as lazyPlugins")
+    })
+}
+
+static RE_DEFAULT_LAZY_PLUGINS_IMPORT: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"^\s*import\s+lazyPlugins\b"#).unwrap());
+
+static RE_NAMESPACE_LAZY_PLUGINS_IMPORT: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"^\s*import\s+\*\s+as\s+lazyPlugins\b"#).unwrap());
+
+fn is_recognized_config_object_for_lazy_plugins<D: Doc>(object_node: &Node<'_, D>) -> bool {
+    let Some(parent) = object_node.parent() else { return false };
+    match parent.kind().as_ref() {
+        "export_statement" => true,
+        "satisfies_expression" => parent.parent().is_some_and(|p| p.kind() == "export_statement"),
+        "arguments" => parent.parent().is_some_and(|c| is_define_config_call(&c)),
+        "parenthesized_expression" => is_define_config_arrow_body(&parent),
+        "return_statement" => is_direct_return_in_define_config_callback(&parent),
         _ => false,
     }
 }
@@ -214,6 +365,128 @@ fn is_inside_define_config_callback<D: Doc>(node: &Node<'_, D>) -> bool {
         current = n.parent();
     }
     false
+}
+
+fn is_direct_return_in_define_config_callback<D: Doc>(return_node: &Node<'_, D>) -> bool {
+    let mut current = return_node.parent();
+    while let Some(node) = current {
+        match node.kind().as_ref() {
+            "arrow_function" | "function_expression" => {
+                return node
+                    .parent()
+                    .filter(|parent| parent.kind() == "arguments")
+                    .and_then(|parent| parent.parent())
+                    .is_some_and(|call| is_define_config_call(&call));
+            }
+            "function_declaration" | "method_definition" => return false,
+            _ => current = node.parent(),
+        }
+    }
+    false
+}
+
+fn node_has_descendant_kind<D: Doc>(node: &Node<'_, D>, kind: &str) -> bool {
+    node.dfs().any(|child| child.kind() == kind)
+}
+
+fn ensure_lazy_plugins_import(content: &str) -> String {
+    let grep = SupportLang::TypeScript.ast_grep(content);
+    let root = grep.root();
+    let mut import_insert_at = None;
+    let mut value_import_replacement = None;
+
+    for node in root.dfs() {
+        if node.kind() != "import_statement" {
+            continue;
+        }
+        import_insert_at =
+            Some(import_insert_at.map_or(node.range().end, |end: usize| end.max(node.range().end)));
+
+        let text = node.text();
+        if !imports_from_vite_plus(&text) || text.trim_start().starts_with("import type") {
+            continue;
+        }
+        let Some(open_brace) = text.find('{') else { continue };
+        let Some(close_brace) = text.rfind('}') else { continue };
+        let specifiers = &text[open_brace + 1..close_brace];
+        if has_lazy_plugins_specifier(specifiers) {
+            return content.to_owned();
+        }
+        if value_import_replacement.is_some() || import_specifiers_contain_comments(specifiers) {
+            continue;
+        }
+
+        let replacement = if specifiers.contains('\n') {
+            let specifiers = specifiers.trim_end();
+            let comma = if specifiers.ends_with(',') { "" } else { "," };
+            format!(
+                "{}{specifiers}{comma}\n  lazyPlugins,\n{}",
+                &text[..=open_brace],
+                &text[close_brace..]
+            )
+        } else if specifiers.trim().is_empty() {
+            format!("{} lazyPlugins {}", &text[..=open_brace], &text[close_brace..])
+        } else {
+            let specifiers = specifiers.trim().trim_end_matches(',').trim_end();
+            format!("{} {}, lazyPlugins {}", &text[..=open_brace], specifiers, &text[close_brace..])
+        };
+        let range = node.range();
+        value_import_replacement = Some((range.start, range.end, replacement));
+    }
+
+    if let Some((start, end, replacement)) = value_import_replacement {
+        let mut updated = content.to_owned();
+        updated.replace_range(start..end, &replacement);
+        return updated;
+    }
+
+    let import_stmt = "import { lazyPlugins } from 'vite-plus';";
+    if let Some(insert_at) = import_insert_at {
+        let mut updated = content.to_owned();
+        updated.insert_str(insert_at, &format!("\n{import_stmt}"));
+        updated
+    } else {
+        format!("{import_stmt}\n\n{content}")
+    }
+}
+
+fn imports_from_vite_plus(import_statement: &str) -> bool {
+    import_statement.contains("from 'vite-plus'") || import_statement.contains("from \"vite-plus\"")
+}
+
+fn has_lazy_plugins_specifier(specifiers: &str) -> bool {
+    strip_import_comments(specifiers).split(',').any(|specifier| specifier.trim() == "lazyPlugins")
+}
+
+fn import_specifiers_contain_comments(specifiers: &str) -> bool {
+    specifiers.contains("//") || specifiers.contains("/*")
+}
+
+fn strip_import_comments(input: &str) -> String {
+    let chars: Vec<char> = input.chars().collect();
+    let mut output = String::with_capacity(input.len());
+    let mut i = 0;
+    while i < chars.len() {
+        if chars[i] == '/' && chars.get(i + 1) == Some(&'/') {
+            i += 2;
+            while i < chars.len() && chars[i] != '\n' {
+                i += 1;
+            }
+            if i < chars.len() {
+                output.push('\n');
+            }
+        } else if chars[i] == '/' && chars.get(i + 1) == Some(&'*') {
+            i += 2;
+            while i + 1 < chars.len() && !(chars[i] == '*' && chars[i + 1] == '/') {
+                i += 1;
+            }
+            i = (i + 2).min(chars.len());
+        } else {
+            output.push(chars[i]);
+            i += 1;
+        }
+    }
+    output
 }
 
 /// Check if the vite config uses a function callback pattern
@@ -1310,6 +1583,266 @@ export default defineConfig({
   lint: { options: { typeAware: true, typeCheck: true } },
 });"#
         );
+    }
+
+    #[test]
+    fn test_wrap_lazy_plugins_simple_adds_import() {
+        let vite_config = r#"import { defineConfig } from 'vite-plus';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react(), nitro()],
+});"#;
+
+        let result = wrap_lazy_plugins_content(vite_config, None).unwrap();
+
+        assert!(result.updated);
+        assert_eq!(
+            result.content,
+            r#"import { defineConfig, lazyPlugins } from 'vite-plus';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: lazyPlugins(() => [react(), nitro()]),
+});"#
+        );
+    }
+
+    #[test]
+    fn test_wrap_lazy_plugins_handles_single_line_trailing_import_comma() {
+        let vite_config = r#"import { defineConfig, } from 'vite-plus';
+
+export default defineConfig({
+  plugins: [react()],
+});"#;
+
+        let result = wrap_lazy_plugins_content(vite_config, None).unwrap();
+
+        assert!(result.updated);
+        assert_eq!(
+            result.content,
+            r#"import { defineConfig, lazyPlugins } from 'vite-plus';
+
+export default defineConfig({
+  plugins: lazyPlugins(() => [react()]),
+});"#
+        );
+    }
+
+    #[test]
+    fn test_wrap_lazy_plugins_skips_conflicting_local_binding() {
+        let vite_config = r#"import { defineConfig } from 'vite-plus';
+
+const lazyPlugins = [react()];
+
+export default defineConfig({
+  plugins: [react()],
+});"#;
+
+        let result = wrap_lazy_plugins_content(vite_config, None).unwrap();
+
+        assert!(!result.updated);
+        assert_eq!(result.content, vite_config);
+    }
+
+    #[test]
+    fn test_wrap_lazy_plugins_skips_conflicting_import_binding() {
+        let vite_config = r#"import { lazyPlugins } from './helpers';
+import { defineConfig } from 'vite-plus';
+
+export default defineConfig({
+  plugins: [react()],
+});"#;
+
+        let result = wrap_lazy_plugins_content(vite_config, None).unwrap();
+
+        assert!(!result.updated);
+        assert_eq!(result.content, vite_config);
+    }
+
+    #[test]
+    fn test_wrap_lazy_plugins_adds_separate_value_import_for_type_import() {
+        let vite_config = r#"import type { UserConfig } from 'vite-plus';
+
+export default {
+  plugins: [react()],
+} satisfies UserConfig;"#;
+
+        let result = wrap_lazy_plugins_content(vite_config, None).unwrap();
+
+        assert!(result.updated);
+        assert_eq!(
+            result.content,
+            r#"import type { UserConfig } from 'vite-plus';
+import { lazyPlugins } from 'vite-plus';
+
+export default {
+  plugins: lazyPlugins(() => [react()]),
+} satisfies UserConfig;"#
+        );
+    }
+
+    #[test]
+    fn test_wrap_lazy_plugins_handles_multiline_imports() {
+        let vite_config = r#"import {
+  defineConfig
+} from 'vite-plus';
+
+export default defineConfig({
+  plugins: [react()],
+});"#;
+
+        let result = wrap_lazy_plugins_content(vite_config, None).unwrap();
+
+        assert!(result.updated);
+        assert!(
+            result
+                .content
+                .contains("import {\n  defineConfig,\n  lazyPlugins,\n} from 'vite-plus';")
+        );
+    }
+
+    #[test]
+    fn test_wrap_lazy_plugins_adds_separate_import_for_commented_imports() {
+        let vite_config = r#"import {
+  defineConfig // keep this comment
+} from 'vite-plus';
+
+export default defineConfig({
+  plugins: [react()],
+});"#;
+
+        let result = wrap_lazy_plugins_content(vite_config, None).unwrap();
+
+        assert!(result.updated);
+        assert!(result.content.contains("import {\n  defineConfig // keep this comment\n} from 'vite-plus';\nimport { lazyPlugins } from 'vite-plus';"));
+        assert!(result.content.contains("plugins: lazyPlugins(() => [react()])"));
+    }
+
+    #[test]
+    fn test_wrap_lazy_plugins_detects_commented_existing_lazy_plugins_import() {
+        let vite_config = r#"import {
+  lazyPlugins, // keep this comment
+} from 'vite-plus';
+
+export default defineConfig({
+  plugins: [react()],
+});"#;
+
+        let result = wrap_lazy_plugins_content(vite_config, None).unwrap();
+
+        assert!(result.updated);
+        assert_eq!(result.content.matches("from 'vite-plus'").count(), 1);
+        assert!(result.content.contains("plugins: lazyPlugins(() => [react()])"));
+    }
+
+    #[test]
+    fn test_wrap_lazy_plugins_reuses_later_lazy_plugins_import() {
+        let vite_config = r#"import { defineConfig } from 'vite-plus';
+import { lazyPlugins } from 'vite-plus';
+
+export default defineConfig({
+  plugins: [react()],
+});"#;
+
+        let result = wrap_lazy_plugins_content(vite_config, None).unwrap();
+
+        assert!(result.updated);
+        assert_eq!(result.content.matches("lazyPlugins } from 'vite-plus'").count(), 1);
+        assert_eq!(result.content.matches("lazyPlugins").count(), 2);
+    }
+
+    #[test]
+    fn test_wrap_lazy_plugins_callback_returns() {
+        let vite_config = r#"import { defineConfig, loadEnv } from 'vite-plus';
+
+export default defineConfig(({ mode }) => {
+  function helper() {
+    return { plugins: [helperPlugin()] };
+  }
+  return {
+    plugins: [react()],
+    nested: { plugins: [nestedPlugin()] },
+  };
+});"#;
+
+        let result = wrap_lazy_plugins_content(vite_config, None).unwrap();
+
+        assert!(result.updated);
+        assert_eq!(result.content.matches("lazyPlugins(() =>").count(), 1);
+        assert!(result.content.contains("import { defineConfig, loadEnv, lazyPlugins }"));
+        assert!(result.content.contains("plugins: lazyPlugins(() => [react()])"));
+        assert!(result.content.contains("return { plugins: [helperPlugin()] };"));
+        assert!(result.content.contains("nested: { plugins: [nestedPlugin()] }"));
+    }
+
+    #[test]
+    fn test_wrap_lazy_plugins_uses_async_callback_for_await() {
+        let vite_config = r#"import { defineConfig } from 'vite-plus';
+
+export default defineConfig(async () => ({
+  plugins: [await makePlugin()],
+}));"#;
+
+        let result = wrap_lazy_plugins_content(vite_config, None).unwrap();
+
+        assert!(result.updated);
+        assert!(result.content.contains("plugins: lazyPlugins(async () => [await makePlugin()])"));
+    }
+
+    #[test]
+    fn test_wrap_lazy_plugins_skips_unsupported_and_is_idempotent() {
+        let vite_config = r#"import { defineConfig, lazyPlugins } from 'vite-plus';
+
+const plugins = [react()];
+
+export default defineConfig({
+  plugins,
+  a: { plugins: [nested()] },
+});"#;
+
+        let result = wrap_lazy_plugins_content(vite_config, None).unwrap();
+        assert!(!result.updated);
+        assert_eq!(result.content, vite_config);
+
+        let already_wrapped = r#"import { defineConfig, lazyPlugins } from 'vite-plus';
+
+export default defineConfig({
+  plugins: lazyPlugins(() => [react()]),
+});"#;
+        let result = wrap_lazy_plugins_content(already_wrapped, None).unwrap();
+        assert!(!result.updated);
+        assert_eq!(result.content, already_wrapped);
+    }
+
+    #[test]
+    fn test_wrap_lazy_plugins_skips_commonjs() {
+        let vite_config = r#"const { defineConfig } = require('vite');
+
+module.exports = defineConfig({
+  plugins: [react()],
+});"#;
+
+        let result =
+            wrap_lazy_plugins_content(vite_config, Some(Path::new("vite.config.cjs"))).unwrap();
+
+        assert!(!result.updated);
+        assert_eq!(result.content, vite_config);
+    }
+
+    #[test]
+    fn test_wrap_lazy_plugins_idempotent_after_transform() {
+        let vite_config = r#"import { defineConfig } from 'vite-plus';
+
+export default defineConfig({
+  plugins: [react()],
+});"#;
+
+        let first = wrap_lazy_plugins_content(vite_config, None).unwrap();
+        assert!(first.updated);
+        let second = wrap_lazy_plugins_content(&first.content, None).unwrap();
+        assert!(!second.updated);
+        assert_eq!(second.content, first.content);
     }
 
     #[test]

--- a/packages/cli/binding/index.cjs
+++ b/packages/cli/binding/index.cjs
@@ -845,3 +845,4 @@ module.exports.run = nativeBinding.run;
 module.exports.runCommand = nativeBinding.runCommand;
 module.exports.shouldPrintVitePlusHeader = nativeBinding.shouldPrintVitePlusHeader;
 module.exports.vitePlusHeader = nativeBinding.vitePlusHeader;
+module.exports.wrapLazyPlugins = nativeBinding.wrapLazyPlugins;

--- a/packages/cli/binding/index.d.cts
+++ b/packages/cli/binding/index.d.cts
@@ -3609,3 +3609,10 @@ export declare function shouldPrintVitePlusHeader(): boolean;
 
 /** Render the Vite+ header using the Rust implementation. */
 export declare function vitePlusHeader(): string;
+
+/**
+ * Wrap safe inline `plugins: [...]` arrays in recognized Vite config objects
+ * with `lazyPlugins(() => [...])` and add a `lazyPlugins` import from
+ * `vite-plus` when needed.
+ */
+export declare function wrapLazyPlugins(viteConfigPath: string): MergeJsonConfigResult;

--- a/packages/cli/binding/src/migration.rs
+++ b/packages/cli/binding/src/migration.rs
@@ -191,6 +191,21 @@ pub fn merge_tsdown_config(
     })
 }
 
+/// Wrap safe inline `plugins: [...]` arrays in recognized Vite config objects
+/// with `lazyPlugins(() => [...])` and add a `lazyPlugins` import from
+/// `vite-plus` when needed.
+#[napi]
+pub fn wrap_lazy_plugins(vite_config_path: String) -> Result<MergeJsonConfigResult> {
+    let result = vite_migration::wrap_lazy_plugins(Path::new(&vite_config_path))
+        .map_err(anyhow::Error::from)?;
+
+    Ok(MergeJsonConfigResult {
+        content: result.content,
+        updated: result.updated,
+        uses_function_callback: result.uses_function_callback,
+    })
+}
+
 /// Rewrite imports in all TypeScript/JavaScript files under a directory
 ///
 /// This function finds all TypeScript and JavaScript files in the specified directory

--- a/packages/cli/snap-tests-global/migration-lazy-plugins-await/package.json
+++ b/packages/cli/snap-tests-global/migration-lazy-plugins-await/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "migration-lazy-plugins-await",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
+    "vite": "^7.0.0"
+  },
+  "packageManager": "pnpm@10.33.2"
+}

--- a/packages/cli/snap-tests-global/migration-lazy-plugins-await/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lazy-plugins-await/snap.txt
@@ -1,0 +1,50 @@
+> vp migrate --no-interactive --no-hooks # migration should wrap awaited inline plugins with async lazyPlugins
+◇ Migrated . to Vite+
+• Node <semver>  pnpm <semver>
+• 1 config update applied, 1 file had imports rewritten
+• Inline Vite plugins wrapped with lazyPlugins for check/lint/fmt
+
+> cat vite.config.ts # check awaited plugins use async lazyPlugins
+import react from '@vitejs/plugin-react';
+import { defineConfig, lazyPlugins } from 'vite-plus';
+
+async function loadPlugin() {
+  return { name: 'loaded-plugin' };
+}
+
+export default defineConfig({
+  fmt: {},
+  lint: {"jsPlugins":[{"name":"vite-plus","specifier":"vite-plus/oxlint-plugin"}],"rules":{"vite-plus/prefer-vite-plus-imports":"error"},"options":{"typeAware":true,"typeCheck":true}},
+  plugins: lazyPlugins(async () => [react(), await loadPlugin()]),
+});
+
+> cat package.json # check package.json
+{
+  "name": "migration-lazy-plugins-await",
+  "scripts": {
+    "dev": "vp dev",
+    "build": "vp build"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
+  },
+  "packageManager": "pnpm@<semver>"
+}
+
+> cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'

--- a/packages/cli/snap-tests-global/migration-lazy-plugins-await/steps.json
+++ b/packages/cli/snap-tests-global/migration-lazy-plugins-await/steps.json
@@ -1,0 +1,8 @@
+{
+  "commands": [
+    "vp migrate --no-interactive --no-hooks # migration should wrap awaited inline plugins with async lazyPlugins",
+    "cat vite.config.ts # check awaited plugins use async lazyPlugins",
+    "cat package.json # check package.json",
+    "cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog"
+  ]
+}

--- a/packages/cli/snap-tests-global/migration-lazy-plugins-await/vite.config.ts
+++ b/packages/cli/snap-tests-global/migration-lazy-plugins-await/vite.config.ts
@@ -1,0 +1,10 @@
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+
+async function loadPlugin() {
+  return { name: 'loaded-plugin' };
+}
+
+export default defineConfig({
+  plugins: [react(), await loadPlugin()],
+});

--- a/packages/cli/snap-tests-global/migration-merge-vite-config-js/snap.txt
+++ b/packages/cli/snap-tests-global/migration-merge-vite-config-js/snap.txt
@@ -1,10 +1,12 @@
 > vp migrate --no-interactive # migration should merge vite.config.js and remove oxlintrc
 ◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
-• 2 config updates applied
+• 3 config updates applied
+• Inline Vite plugins wrapped with lazyPlugins for check/lint/fmt
 
 > cat vite.config.js # check vite.config.js
 import react from '@vitejs/plugin-react';
+import { lazyPlugins } from 'vite-plus';
 
 export default {
   staged: {
@@ -27,7 +29,7 @@ export default {
       }
     ]
   },
-  plugins: [react()],
+  plugins: lazyPlugins(() => [react()]),
 }
 
 > test ! -f .oxlintrc.json # check .oxlintrc.json is removed

--- a/packages/cli/snap-tests-global/migration-merge-vite-config-ts/snap.txt
+++ b/packages/cli/snap-tests-global/migration-merge-vite-config-ts/snap.txt
@@ -1,14 +1,15 @@
 > vp migrate --no-interactive # migration should merge vite.config.ts and remove oxlintrc and oxfmtrc
 ◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
-• 3 config updates applied, 1 file had imports rewritten
+• 4 config updates applied, 1 file had imports rewritten
+• Inline Vite plugins wrapped with lazyPlugins for check/lint/fmt
 
 > cat vite.config.ts # check vite.config.ts
 import { join } from 'node:path';
 
 import react from '@vitejs/plugin-react';
 import { playwright } from 'vite-plus/test/browser-playwright';
-import { defineConfig } from 'vite-plus';
+import { defineConfig, lazyPlugins } from 'vite-plus';
 
 export default defineConfig({
   staged: {
@@ -37,7 +38,7 @@ export default defineConfig({
       }
     ]
   },
-  plugins: [react()],
+  plugins: lazyPlugins(() => [react()]),
   test: {
     dir: join(import.meta.dirname, 'test'),
     browser: {

--- a/packages/cli/snap-tests-global/migration-monorepo-bun/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-bun/snap.txt
@@ -3,11 +3,12 @@
 ✔ Merged .oxlintrc.json into vite.config.ts
 ◇ Migrated . to Vite+
 • Node <semver>  bun <semver>
-• 1 config update applied, 1 file had imports rewritten
+• 2 config updates applied, 1 file had imports rewritten
+• Inline Vite plugins wrapped with lazyPlugins for check/lint/fmt
 
 > cat vite.config.ts # check vite.config.ts
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite-plus';
+import { defineConfig, lazyPlugins } from 'vite-plus';
 
 export default defineConfig({
   staged: {
@@ -30,7 +31,7 @@ export default defineConfig({
       }
     ]
   },
-  plugins: [react()],
+  plugins: lazyPlugins(() => [react()]),
 });
 
 > test ! -f .oxlintrc.json # check .oxlintrc.json is removed

--- a/packages/cli/snap-tests-global/migration-monorepo-pnpm-overrides-dependency-selector/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-pnpm-overrides-dependency-selector/snap.txt
@@ -1,11 +1,12 @@
 > vp migrate --no-interactive # migration should merge pnpm overrides with dependency selector
 ◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
-• 1 config update applied, 1 file had imports rewritten
+• 2 config updates applied, 1 file had imports rewritten
+• Inline Vite plugins wrapped with lazyPlugins for check/lint/fmt
 
 > cat vite.config.ts # check vite.config.ts
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite-plus';
+import { defineConfig, lazyPlugins } from 'vite-plus';
 
 export default defineConfig({
   staged: {
@@ -13,7 +14,7 @@ export default defineConfig({
   },
   fmt: {},
   lint: {"jsPlugins":[{"name":"vite-plus","specifier":"vite-plus/oxlint-plugin"}],"rules":{"vite-plus/prefer-vite-plus-imports":"error"},"options":{"typeAware":true,"typeCheck":true}},
-  plugins: [react()],
+  plugins: lazyPlugins(() => [react()]),
 });
 
 > cat package.json # check package.json

--- a/packages/cli/snap-tests-global/migration-monorepo-pnpm/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-pnpm/snap.txt
@@ -5,11 +5,12 @@
 ✔ Merged .oxfmtrc.json into vite.config.ts
 ◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
-• 3 config updates applied, 1 file had imports rewritten
+• 4 config updates applied, 1 file had imports rewritten
+• Inline Vite plugins wrapped with lazyPlugins for check/lint/fmt
 
 > cat vite.config.ts # check vite.config.ts
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite-plus';
+import { defineConfig, lazyPlugins } from 'vite-plus';
 
 export default defineConfig({
   staged: {
@@ -38,7 +39,7 @@ export default defineConfig({
       }
     ]
   },
-  plugins: [react()],
+  plugins: lazyPlugins(() => [react()]),
 });
 
 > test ! -f .oxlintrc.json # check .oxlintrc.json is removed

--- a/packages/cli/snap-tests-global/migration-monorepo-yarn4/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-yarn4/snap.txt
@@ -3,11 +3,12 @@
 ✔ Merged .oxlintrc.json into vite.config.ts
 ◇ Migrated . to Vite+
 • Node <semver>  yarn <semver>
-• 1 config update applied, 1 file had imports rewritten
+• 2 config updates applied, 1 file had imports rewritten
+• Inline Vite plugins wrapped with lazyPlugins for check/lint/fmt
 
 > cat vite.config.ts # check vite.config.ts
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite-plus';
+import { defineConfig, lazyPlugins } from 'vite-plus';
 
 export default defineConfig({
   staged: {
@@ -30,7 +31,7 @@ export default defineConfig({
       }
     ]
   },
-  plugins: [react()],
+  plugins: lazyPlugins(() => [react()]),
 });
 
 > test ! -f .oxlintrc.json # check .oxlintrc.json is removed

--- a/packages/cli/snap-tests-global/new-create-vite-migrates-eslint-prettier/snap.txt
+++ b/packages/cli/snap-tests-global/new-create-vite-migrates-eslint-prettier/snap.txt
@@ -6,7 +6,7 @@ eslint.config.js removed
 .oxlintrc.json merged into vite.config.ts
 
 > cat my-react-ts/vite.config.ts # merged vite config should contain lint and fmt sections
-import { defineConfig } from "vite-plus";
+import { defineConfig, lazyPlugins } from "vite-plus";
 import react from "@vitejs/plugin-react";
 
 // https://vite.dev/config/
@@ -135,7 +135,7 @@ export default defineConfig({
       "vite-plus/prefer-vite-plus-imports": "error",
     },
   },
-  plugins: [react()],
+  plugins: lazyPlugins(() => [react()]),
 });
 
 > node -e "const p=require('./my-react-ts/package.json');console.log('lint:', p.scripts && p.scripts.lint);console.log('eslint dep:', !!(p.devDependencies && p.devDependencies.eslint));console.log('vite-plus dep:', !!(p.devDependencies && p.devDependencies['vite-plus']));" # scripts rewritten, eslint dep removed, vite-plus added

--- a/packages/cli/src/__tests__/index.spec.ts
+++ b/packages/cli/src/__tests__/index.spec.ts
@@ -53,7 +53,7 @@ test.each(['dev', 'build', 'test', 'preview'])(
   },
 );
 
-test.each(['lint', 'fmt', 'check', 'pack', 'install', 'run'])(
+test.each(['lint', 'fmt', 'check', 'staged', 'pack', 'install', 'run'])(
   'lazyPlugins returns undefined when VP_COMMAND is %s',
   (cmd) => {
     process.env.VP_COMMAND = cmd;

--- a/packages/cli/src/migration/__tests__/migrator.spec.ts
+++ b/packages/cli/src/migration/__tests__/migrator.spec.ts
@@ -20,6 +20,7 @@ const {
   rewritePackageJson,
   rewriteStandaloneProject,
   rewriteMonorepo,
+  rewriteMonorepoProject,
   parseNvmrcVersion,
   detectNodeVersionManagerFile,
   migrateNodeVersionManagerFile,
@@ -1725,6 +1726,135 @@ describe('framework shim', () => {
       expect(content).toContain("'@other'");
       expect(content).not.toContain('@your-org');
     });
+  });
+});
+
+describe('rewriteStandaloneProject — lazy plugin wrapping', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vp-test-lazy-plugins-'));
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ name: 'test', devDependencies: { vite: '^7.0.0' } }),
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('wraps standalone inline plugin arrays after import rewriting', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'vite.config.ts'),
+      `import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react(), nitro({ rollupConfig: { external: [/^@sentry\\//] } })],
+});
+`,
+    );
+    const report = createMigrationReport();
+
+    rewriteStandaloneProject(
+      tmpDir,
+      makeWorkspaceInfo(tmpDir, PackageManager.pnpm),
+      true,
+      true,
+      report,
+    );
+
+    const viteConfig = fs.readFileSync(path.join(tmpDir, 'vite.config.ts'), 'utf8');
+    expect(viteConfig).toContain("import { defineConfig, lazyPlugins } from 'vite-plus'");
+    expect(viteConfig).toContain(
+      'plugins: lazyPlugins(() => [react(), nitro({ rollupConfig: { external: [/^@sentry\\//] } })])',
+    );
+    expect(viteConfig).not.toContain('plugins: [react(), nitro(');
+    expect(report.wrappedPluginConfigCount).toBe(1);
+  });
+
+  it('leaves unsupported plugin expressions unchanged', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'vite.config.ts'),
+      `import { defineConfig } from 'vite-plus';
+
+const plugins = [react()];
+
+export default defineConfig({
+  plugins,
+});
+`,
+    );
+    const report = createMigrationReport();
+
+    rewriteStandaloneProject(
+      tmpDir,
+      makeWorkspaceInfo(tmpDir, PackageManager.pnpm),
+      true,
+      true,
+      report,
+    );
+
+    const viteConfig = fs.readFileSync(path.join(tmpDir, 'vite.config.ts'), 'utf8');
+    expect(viteConfig).toContain('plugins,');
+    expect(viteConfig).not.toContain('lazyPlugins');
+    expect(report.wrappedPluginConfigCount).toBe(0);
+  });
+
+  it('wraps direct monorepo project rewrites used by create-monorepo flows', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'vite.config.ts'),
+      `import { defineConfig } from 'vite-plus';
+
+export default defineConfig({
+  plugins: [react()],
+});
+`,
+    );
+    const report = createMigrationReport();
+
+    rewriteMonorepoProject(tmpDir, PackageManager.pnpm, true, true, report);
+
+    const viteConfig = fs.readFileSync(path.join(tmpDir, 'vite.config.ts'), 'utf8');
+    expect(viteConfig).toContain("import { defineConfig, lazyPlugins } from 'vite-plus'");
+    expect(viteConfig).toContain('plugins: lazyPlugins(() => [react()])');
+    expect(report.wrappedPluginConfigCount).toBe(1);
+  });
+
+  it('wraps package-level inline plugin arrays in monorepos', () => {
+    const appDir = path.join(tmpDir, 'apps', 'web');
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ name: 'root', workspaces: ['apps/*'], devDependencies: { vite: '^7.0.0' } }),
+    );
+    fs.writeFileSync(
+      path.join(appDir, 'package.json'),
+      JSON.stringify({ name: 'web', devDependencies: { vite: '^7.0.0' } }),
+    );
+    fs.writeFileSync(
+      path.join(appDir, 'vite.config.ts'),
+      `import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [react()],
+});
+`,
+    );
+    const workspaceInfo = makeWorkspaceInfo(tmpDir, PackageManager.pnpm);
+    workspaceInfo.isMonorepo = true;
+    workspaceInfo.workspacePatterns = ['apps/*'];
+    workspaceInfo.parentDirs = ['apps'];
+    workspaceInfo.packages = [{ name: 'web', path: 'apps/web', isTemplatePackage: false }];
+    const report = createMigrationReport();
+
+    rewriteMonorepo(workspaceInfo, true, true, report);
+
+    const viteConfig = fs.readFileSync(path.join(appDir, 'vite.config.ts'), 'utf8');
+    expect(viteConfig).toContain("import { defineConfig, lazyPlugins } from 'vite-plus'");
+    expect(viteConfig).toContain('plugins: lazyPlugins(() => [react()])');
+    expect(report.wrappedPluginConfigCount).toBe(1);
   });
 });
 

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -571,7 +571,8 @@ function showMigrationSummary(options: {
     report.mergedStagedConfigCount +
     report.inlinedLintStagedConfigCount +
     report.removedConfigCount +
-    report.tsdownImportCount;
+    report.tsdownImportCount +
+    report.wrappedPluginConfigCount;
 
   log(
     `${styleText('magenta', '◇')} ${updatedExistingVitePlus ? 'Updated' : 'Migrated'} ${accent(projectLabel)}${
@@ -610,6 +611,11 @@ function showMigrationSummary(options: {
   }
   if (report.nodeVersionFileMigrated) {
     log(`${styleText('gray', '•')} Node version manager file migrated to .node-version`);
+  }
+  if (report.wrappedPluginConfigCount > 0) {
+    log(
+      `${styleText('gray', '•')} Inline Vite plugins wrapped with lazyPlugins for check/lint/fmt`,
+    );
   }
   if (report.gitHooksConfigured) {
     log(`${styleText('gray', '•')} Git hooks configured`);

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -16,6 +16,7 @@ import {
   rewritePrettier,
   rewriteScripts,
   rewriteImportsInDirectory,
+  wrapLazyPlugins,
   type DownloadPackageManagerResult,
 } from '../../binding/index.js';
 import {
@@ -1157,8 +1158,9 @@ export function rewriteStandaloneProject(
   injectLintTypeCheckDefaults(projectPath, silent, report);
   injectFmtDefaults(projectPath, silent, report);
   mergeTsdownConfigFile(projectPath, silent, report);
-  // rewrite imports in all TypeScript/JavaScript files
+  // rewrite imports in all TypeScript/JavaScript files before lazy plugin import merging
   rewriteAllImports(projectPath, silent, report);
+  wrapLazyPluginsInViteConfig(projectPath, silent, report);
   // set package manager
   setPackageManager(projectPath, workspaceInfo.downloadPackageManager);
 }
@@ -1211,6 +1213,7 @@ export function rewriteMonorepo(
       report,
       catalogDependencyResolver,
       workspaceContext,
+      true,
     );
   }
 
@@ -1223,8 +1226,12 @@ export function rewriteMonorepo(
   injectLintTypeCheckDefaults(workspaceInfo.rootDir, silent, report);
   injectFmtDefaults(workspaceInfo.rootDir, silent, report);
   mergeTsdownConfigFile(workspaceInfo.rootDir, silent, report);
-  // rewrite imports in all TypeScript/JavaScript files
+  // rewrite imports in all TypeScript/JavaScript files before lazy plugin import merging
   rewriteAllImports(workspaceInfo.rootDir, silent, report);
+  wrapLazyPluginsInViteConfig(workspaceInfo.rootDir, silent, report);
+  for (const pkg of workspaceInfo.packages) {
+    wrapLazyPluginsInViteConfig(path.join(workspaceInfo.rootDir, pkg.path), silent, report);
+  }
   // set package manager
   setPackageManager(workspaceInfo.rootDir, workspaceInfo.downloadPackageManager);
 }
@@ -1246,6 +1253,7 @@ export function rewriteMonorepoProject(
   report?: MigrationReport,
   catalogDependencyResolver?: CatalogDependencyResolver,
   workspaceContext?: { rootDir: string; packages: WorkspacePackage[] },
+  deferLazyPluginWrapping = false,
 ): void {
   cleanupDeprecatedTsconfigOptions(projectPath, silent, report);
   rewriteTsconfigTypes(projectPath, silent, report);
@@ -1287,6 +1295,10 @@ export function rewriteMonorepoProject(
     if (mergeStagedConfigToViteConfig(projectPath, extractedStagedConfig, silent, report)) {
       removeLintStagedFromPackageJson(packageJsonPath);
     }
+  }
+
+  if (!deferLazyPluginWrapping) {
+    wrapLazyPluginsInViteConfig(projectPath, silent, report);
   }
 }
 
@@ -1870,6 +1882,7 @@ function rewriteRootWorkspacePackageJson(
     undefined,
     catalogDependencyResolver,
     packages ? { rootDir: projectPath, packages } : undefined,
+    true,
   );
 }
 
@@ -2747,6 +2760,37 @@ export function hasStagedConfigInViteConfig(projectPath: string): boolean {
   const viteConfigPath = path.join(projectPath, configs.viteConfig);
   const content = fs.readFileSync(viteConfigPath, 'utf8');
   return /\bstaged\s*:/.test(content);
+}
+
+/**
+ * Wrap safe inline Vite plugin arrays with lazyPlugins so check/lint/fmt do not
+ * eagerly execute plugin factories while loading vite.config.ts.
+ */
+function wrapLazyPluginsInViteConfig(
+  projectPath: string,
+  silent = false,
+  report?: MigrationReport,
+): void {
+  const configs = detectConfigs(projectPath);
+  if (!configs.viteConfig) {
+    return;
+  }
+
+  const viteConfigPath = path.join(projectPath, configs.viteConfig);
+  const result = wrapLazyPlugins(viteConfigPath);
+  if (!result.updated) {
+    return;
+  }
+
+  fs.writeFileSync(viteConfigPath, result.content);
+  if (report) {
+    report.wrappedPluginConfigCount++;
+  }
+  if (!silent) {
+    prompts.log.success(
+      `✔ Wrapped inline Vite plugins with lazyPlugins in ${displayRelative(viteConfigPath)}`,
+    );
+  }
 }
 
 /**

--- a/packages/cli/src/migration/report.ts
+++ b/packages/cli/src/migration/report.ts
@@ -5,6 +5,7 @@ export interface MigrationReport {
   inlinedLintStagedConfigCount: number;
   removedConfigCount: number;
   tsdownImportCount: number;
+  wrappedPluginConfigCount: number;
   rewrittenImportFileCount: number;
   rewrittenImportErrors: Array<{ path: string; message: string }>;
   eslintMigrated: boolean;
@@ -24,6 +25,7 @@ export function createMigrationReport(): MigrationReport {
     inlinedLintStagedConfigCount: 0,
     removedConfigCount: 0,
     tsdownImportCount: 0,
+    wrappedPluginConfigCount: 0,
     rewrittenImportFileCount: 0,
     rewrittenImportErrors: [],
     eslintMigrated: false,


### PR DESCRIPTION
## Summary

Fixes #1739 by preventing Vite plugin factories from being eagerly executed during lint/format/check workflows.

This teaches create/migrate to wrap safe inline Vite plugin arrays with `lazyPlugins`, so commands like `vp check --fix` and `vp staged` do not hang when a plugin leaves open handles during config loading.

## Changes

- Add a conservative Rust transform for Vite configs:
  - wraps direct inline `plugins: [...]` arrays as `lazyPlugins(() => [...])`
  - uses `lazyPlugins(async () => [...])` when the array contains `await`
  - skips CommonJS configs, dynamic plugin references, nested unsupported shapes, and existing conflicting `lazyPlugins` bindings
  - reuses or adds `lazyPlugins` imports from `vite-plus` without duplicating imports
- Expose the transform through the CLI NAPI binding.
- Apply the rewrite in standalone and monorepo create/migrate paths.
- Surface the rewrite in migration reporting.
- Add regression coverage for standalone, monorepo, unsupported expressions, `staged`, and import edge cases.

## Why

Issue #1739 showed this path:

```txt
vp staged
→ vp check --fix
→ vp lint
→ loads vite.config.ts
→ plugin factories execute eagerly
→ plugins like nitro can leave open handles
→ command hangs
```

Wrapping generated/migrated inline plugins with `lazyPlugins` keeps plugin factories from running for `lint`, `fmt`, `check`, and `staged`, while preserving normal plugin execution for `dev`, `build`, `test`, and `preview`.

## Validation

- `cargo fmt --check`
- `cargo test -p vite_migration`
- `vp test packages/cli/src/migration/__tests__/migrator.spec.ts packages/cli/src/__tests__/index.spec.ts`