### PR TITLE
fix(cli): set VP_COMMAND in oxlint/oxfmt LSP wrappers

### DIFF
--- a/packages/cli/bin/oxfmt
+++ b/packages/cli/bin/oxfmt
@@ -21,7 +21,10 @@ const require = createRequire(import.meta.url);
 const oxfmtMainPath = require.resolve('oxfmt');
 const oxfmtBin = join(dirname(dirname(oxfmtMainPath)), 'bin', 'oxfmt');
 
-// This allows oxfmt to load vite.config.ts
-// For `vp check` and `vp fmt`, it is injected by `merge_resolved_envs_with_version()` in `cli.rs`
+// This allows oxfmt to load vite.config.ts.
+// For `vp check` and `vp fmt`, VP_VERSION is injected by
+// `merge_resolved_envs_with_version()` in `cli.rs`, and VP_COMMAND is injected
+// by `SubcommandResolver::resolve()`.
 process.env.VP_VERSION = pkg.version;
+process.env.VP_COMMAND ??= 'fmt';
 await import(pathToFileURL(oxfmtBin).href);

--- a/packages/cli/bin/oxlint
+++ b/packages/cli/bin/oxlint
@@ -19,7 +19,10 @@ const require = createRequire(import.meta.url);
 const oxlintMainPath = require.resolve('oxlint');
 const oxlintBin = join(dirname(dirname(oxlintMainPath)), 'bin', 'oxlint');
 
-// This allows oxlint to load vite.config.ts
-// For `vp check` and `vp lint`, it is injected by `merge_resolved_envs_with_version()` in `cli.rs`
+// This allows oxlint to load vite.config.ts.
+// For `vp check` and `vp lint`, VP_VERSION is injected by
+// `merge_resolved_envs_with_version()` in `cli.rs`, and VP_COMMAND is injected
+// by `SubcommandResolver::resolve()`.
 process.env.VP_VERSION = pkg.version;
+process.env.VP_COMMAND ??= 'lint';
 await import(pathToFileURL(oxlintBin).href);


### PR DESCRIPTION
## Summary

Fixes #1756 by setting `VP_COMMAND` in the IDE-only oxlint/oxfmt wrapper scripts.

The wrappers already set `VP_VERSION`, which makes OXC load `vite.config.ts` through the Vite+ config path. However, `lazyPlugins()` relies on `VP_COMMAND` to decide whether framework plugins should be skipped during lint/fmt config loading.
                                
Without `VP_COMMAND`, the IDE/LSP path can execute framework plugins such as SvelteKit while OXC is only trying to read the `lint`/`fmt` fields from `vite.config.ts`, which can create a stray `.svelte-kit` directory at the monorepo root.

This PR aligns the IDE wrapper path with the normal `vp lint` / `vp fmt` resolver path:
  -  `bin/oxlint` now sets `VP_COMMAND ??= 'lint'`
  - `bin/oxfmt` now sets `VP_COMMAND ??= 'fmt'`

## Testing

 - `pnpm -F vite-plus build`
 - `pnpm -F vite-plus snap-test-local bin-oxlint-wrapper`
 - `pnpm -F vite-plus snap-test-local bin-oxfmt-wrapper`

For manual verification, I built this branch locally, packed it, and installed it into the reproduction project from #1756. I then re-ran the original VS Code/OXC extension reproduction by opening the reproduction repo root and reloading the VS Code window.