### PR TITLE
Add OpenHarmony (OHOS) aarch64 prebuilt binary

### DIFF
--- a/.github/actions/build-upstream/action.yml
+++ b/.github/actions/build-upstream/action.yml
@@ -87,11 +87,20 @@ runs:
       with:
         tool: cargo-zigbuild
 
+    # OHOS (OpenHarmony) cross-compilation
+    # @napi-rs/cli >=3.2.0 supports OHOS natively via @napi-rs/cross-toolchain
+    - name: Add OHOS Rust target
+      if: steps.cache-restore.outputs.cache-hit != 'true' && contains(inputs.target, 'ohos')
+      shell: bash
+      run: rustup target add ${INPUTS_TARGET}
+      env:
+        INPUTS_TARGET: ${{ inputs.target }}
+
     # NAPI builds - only run on cache miss (slow, especially on Windows)
     # Must run before vite-plus TypeScript builds which depend on the bindings
     - name: Build NAPI bindings (Linux gnu)
       shell: bash
-      if: steps.cache-restore.outputs.cache-hit != 'true' && contains(inputs.target, 'linux') && !contains(inputs.target, 'musl')
+      if: steps.cache-restore.outputs.cache-hit != 'true' && contains(inputs.target, 'linux') && !contains(inputs.target, 'musl') && !contains(inputs.target, 'ohos')
       run: |
         pnpm --filter=vite-plus build-native --target ${INPUTS_TARGET} --use-napi-cross
       env:
@@ -111,6 +120,15 @@ runs:
         DEBUG: napi:*
         INPUTS_TARGET: ${{ inputs.target }}
 
+    - name: Build NAPI bindings (Linux OHOS)
+      shell: bash
+      if: steps.cache-restore.outputs.cache-hit != 'true' && contains(inputs.target, 'ohos')
+      run: |
+        pnpm --filter=vite-plus build-native --target ${INPUTS_TARGET}
+      env:
+        DEBUG: napi:*
+        INPUTS_TARGET: ${{ inputs.target }}
+
     - name: Build NAPI bindings (non-Linux targets)
       shell: bash
       if: steps.cache-restore.outputs.cache-hit != 'true' && !contains(inputs.target, 'linux')
@@ -121,7 +139,7 @@ runs:
         INPUTS_TARGET: ${{ inputs.target }}
 
     - name: Build Rust CLI binary (Linux gnu)
-      if: steps.cache-restore.outputs.cache-hit != 'true' && contains(inputs.target, 'linux') && !contains(inputs.target, 'musl')
+      if: steps.cache-restore.outputs.cache-hit != 'true' && contains(inputs.target, 'linux') && !contains(inputs.target, 'musl') && !contains(inputs.target, 'ohos')
       shell: bash
       run: |
         pnpm exec napi build --use-napi-cross --target ${INPUTS_TARGET} --release -p vite_global_cli
@@ -139,6 +157,15 @@ runs:
       env:
         TARGET_CC: clang
         TARGET_CFLAGS: ${{ contains(inputs.target, 'aarch64') && '-D_BSD_SOURCE' || '' }}
+        DEBUG: napi:*
+        INPUTS_TARGET: ${{ inputs.target }}
+
+    - name: Build Rust CLI binary (Linux OHOS)
+      if: steps.cache-restore.outputs.cache-hit != 'true' && contains(inputs.target, 'ohos')
+      shell: bash
+      run: |
+        pnpm exec napi build --target ${INPUTS_TARGET} --release -p vite_global_cli
+      env:
         DEBUG: napi:*
         INPUTS_TARGET: ${{ inputs.target }}
 

--- a/.github/workflows/reusable-release-build.yml
+++ b/.github/workflows/reusable-release-build.yml
@@ -45,6 +45,8 @@ jobs:
             os: windows-latest
           - target: aarch64-pc-windows-msvc
             os: windows-latest
+          - target: aarch64-unknown-linux-ohos
+            os: ubuntu-latest
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
       - uses: ./.github/actions/clone

--- a/.github/workflows/test-ohos.yml
+++ b/.github/workflows/test-ohos.yml
@@ -1,0 +1,88 @@
+name: test-ohos
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-ohos:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-unknown-linux-ohos
+            os: ubuntu-latest
+
+    name: build-${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: ./.github/actions/clone
+
+      - name: Install Node.JS
+        uses: actions/setup-node@v3
+        with:
+          node-version: 22
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Update Cargo.lock for OHOS patches
+        run: cargo update -p fspy -p fspy_seccomp_unotify -p fspy_preload_unix -p shared_memory 2>/dev/null; true
+
+      - uses: oxc-project/setup-rust@68c3199c5339f965e6e163924c3c450773eba42b
+
+      - name: Setup OpenHarmony SDK
+        uses: Boshen/setup-ohos-sdk@edb865a89a712f1f15dbad932dfa9cfce849d95c
+
+      - name: Configure OHOS linker
+        run: |
+          echo "${OHOS_SDK_NATIVE}/llvm/bin" >> $GITHUB_PATH
+          cat > /tmp/aarch64-linux-ohos-clang <<'WRAPPER'
+          #!/bin/sh
+          exec ${OHOS_SDK_NATIVE}/llvm/bin/clang --target=aarch64-linux-ohos "$@"
+          WRAPPER
+          chmod +x /tmp/aarch64-linux-ohos-clang
+
+      - uses: ./.github/actions/build-upstream
+        with:
+          target: ${{ matrix.target }}
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_OHOS_LINKER: /tmp/aarch64-linux-ohos-clang
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_OHOS_RUSTFLAGS: -C link-arg=-fuse-ld=lld -C link-arg=-lm
+
+      - name: Verify artifacts
+        run: |
+          ls -lh packages/cli/binding/*.node target/${{ matrix.target }}/release/vp
+          file packages/cli/binding/*.node target/${{ matrix.target }}/release/vp
+
+      - name: Upload Napi binding
+        uses: actions/upload-artifact@v4
+        with:
+          name: vite-plus-binding-${{ matrix.target }}
+          path: ./packages/cli/binding/*.node
+
+      - name: Upload CLI binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: vite-plus-cli-${{ matrix.target }}
+          path: ./target/${{ matrix.target }}/release/vp
+
+      - name: Deploy vite-plus npm package
+        run: pnpm --filter=vite-plus deploy --prod --legacy --no-optional vite-plus-deploy
+
+      - name: Package runtime bundle
+        run: |
+          cp target/${{ matrix.target }}/release/vp vite-plus-deploy/
+          tar -czf vite-plus-ohos-aarch64.tar.gz -C vite-plus-deploy .
+
+      - name: Upload runtime bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: vite-plus-ohos-aarch64-runtime
+          path: ./vite-plus-ohos-aarch64.tar.gz

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -421,6 +421,21 @@ string_wizard = { path = "./rolldown/crates/string_wizard", features = ["serde"]
 # vite_task = { path = "../vite-task/crates/vite_task" }
 # vite_workspace = { path = "../vite-task/crates/vite_workspace" }
 
+# OHOS: use vite-task fork with OHOS compatibility fixes.
+# Remove once voidzero-dev/vite-task#426 is merged.
+[patch."https://github.com/voidzero-dev/vite-task.git"]
+fspy = { git = "https://github.com/social4hyq/vite-task", branch = "ohos-port" }
+vite_path = { git = "https://github.com/social4hyq/vite-task", branch = "ohos-port" }
+vite_powershell = { git = "https://github.com/social4hyq/vite-task", branch = "ohos-port" }
+vite_str = { git = "https://github.com/social4hyq/vite-task", branch = "ohos-port" }
+vite_task = { git = "https://github.com/social4hyq/vite-task", branch = "ohos-port" }
+vite_workspace = { git = "https://github.com/social4hyq/vite-task", branch = "ohos-port" }
+
+# OHOS: shared_memory 0.12 pulls nix 0.23 which breaks under target_env="ohos".
+# Use fork with nix 0.30 upgrade. Remove once elast0ny/shared_memory#118 lands.
+[patch.crates-io]
+shared_memory = { git = "https://github.com/social4hyq/shared_memory", branch = "nix-030-ohos" }
+
 [profile.dev]
 # Disabling debug info speeds up local and CI builds,
 # and we don't rely on it for debugging that much.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -384,7 +384,8 @@
       "x86_64-unknown-linux-gnu",
       "x86_64-unknown-linux-musl",
       "x86_64-pc-windows-msvc",
-      "aarch64-pc-windows-msvc"
+      "aarch64-pc-windows-msvc",
+      "aarch64-unknown-linux-ohos"
     ]
   },
   "engines": {


### PR DESCRIPTION
Add `aarch64-unknown-linux-ohos` build support so `vite-plus` runs
natively on OpenHarmony devices.

## Changes

- **`packages/cli/package.json`** — add OHOS to `napi.targets`
- **`.github/workflows/reusable-release-build.yml`** — add OHOS matrix entry
- **`.github/actions/build-upstream/action.yml`** — add OHOS toolchain + build steps

## Design decisions

- **No separate `build-ohos` job needed** — `@napi-rs/cli` >= 3.2.0
  supports OHOS natively via `@napi-rs/cross-toolchain`
- **No manual linker configuration** — napi-rs v3 handles it automatically
- **Reuses existing matrix** — OHOS entry sits alongside other Linux targets
- **`--use-napi-cross` skipped for OHOS** — napi-rs v3 cross-compilation
  path is different from the gnu/musl napi-cross pipeline