### PR TITLE
docs(cli): document create opt-out options

### DIFF
--- a/docs/guide/create.md
+++ b/docs/guide/create.md
@@ -44,11 +44,14 @@ Run `vp create --list` to see the built-in templates and the common shorthand te
 
 - `--directory <dir>` writes the generated project into a specific target directory
 - `--agent <name>` creates agent instructions files during scaffolding
+- `--no-agent` skips agent instruction setup
 - `--editor <name>` writes editor config files
+- `--no-editor` skips editor config setup
 - `--git` initialize a git repository
 - `--no-git` skips git repository initialization
 - `--hooks` enables pre-commit hook setup
 - `--no-hooks` skips hook setup
+- `--package-manager <name>` uses a specified package manager (`pnpm`, `npm`, `yarn`, or `bun`)
 - `--no-interactive` runs without prompts
 - `--verbose` shows detailed scaffolding output
 - `--list` prints the available built-in and popular templates

--- a/packages/cli/snap-tests-global/command-create-help/snap.txt
+++ b/packages/cli/snap-tests-global/command-create-help/snap.txt
@@ -16,7 +16,9 @@ Arguments:
 Options:
   --directory DIR         Target directory for the generated project.
   --agent NAME            Write coding agent instructions to AGENTS.md, CLAUDE.md, etc.
+  --no-agent              Skip writing coding agent instructions
   --editor NAME           Write editor config files for the specified editor.
+  --no-editor             Skip writing editor config files
   --git                   Initialize a git repository with an initial commit
   --no-git                Skip git repository initialization
   --hooks                 Set up pre-commit hooks (default in non-interactive mode)
@@ -79,7 +81,9 @@ Arguments:
 Options:
   --directory DIR         Target directory for the generated project.
   --agent NAME            Write coding agent instructions to AGENTS.md, CLAUDE.md, etc.
+  --no-agent              Skip writing coding agent instructions
   --editor NAME           Write editor config files for the specified editor.
+  --no-editor             Skip writing editor config files
   --git                   Initialize a git repository with an initial commit
   --no-git                Skip git repository initialization
   --hooks                 Set up pre-commit hooks (default in non-interactive mode)
@@ -142,7 +146,9 @@ Arguments:
 Options:
   --directory DIR         Target directory for the generated project.
   --agent NAME            Write coding agent instructions to AGENTS.md, CLAUDE.md, etc.
+  --no-agent              Skip writing coding agent instructions
   --editor NAME           Write editor config files for the specified editor.
+  --no-editor             Skip writing editor config files
   --git                   Initialize a git repository with an initial commit
   --no-git                Skip git repository initialization
   --hooks                 Set up pre-commit hooks (default in non-interactive mode)

--- a/packages/cli/snap-tests-global/new-check/snap.txt
+++ b/packages/cli/snap-tests-global/new-check/snap.txt
@@ -16,7 +16,9 @@ Arguments:
 Options:
   --directory DIR         Target directory for the generated project.
   --agent NAME            Write coding agent instructions to AGENTS.md, CLAUDE.md, etc.
+  --no-agent              Skip writing coding agent instructions
   --editor NAME           Write editor config files for the specified editor.
+  --no-editor             Skip writing editor config files
   --git                   Initialize a git repository with an initial commit
   --no-git                Skip git repository initialization
   --hooks                 Set up pre-commit hooks (default in non-interactive mode)

--- a/packages/cli/src/create/bin.ts
+++ b/packages/cli/src/create/bin.ts
@@ -113,10 +113,12 @@ const helpMessage = renderCliDoc({
           label: '--agent NAME',
           description: 'Write coding agent instructions to AGENTS.md, CLAUDE.md, etc.',
         },
+        { label: '--no-agent', description: 'Skip writing coding agent instructions' },
         {
           label: '--editor NAME',
           description: 'Write editor config files for the specified editor.',
         },
+        { label: '--no-editor', description: 'Skip writing editor config files' },
         { label: '--git', description: 'Initialize a git repository with an initial commit' },
         { label: '--no-git', description: 'Skip git repository initialization' },
         {


### PR DESCRIPTION
## Summary

`vp create` help and docs now show the supported agent/editor opt-out flags, so users can discover `--no-agent` and `--no-editor` without relying on examples or implementation details.

The create guide also documents `--package-manager`, matching the option already exposed in CLI help.
