### PR TITLE
fix(vite_setup): support custom registry during setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7800,6 +7800,7 @@ dependencies = [
  "tracing",
  "vite_install",
  "vite_path",
+ "vite_shared",
  "vite_str",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8557,6 +8557,7 @@ dependencies = [
  "vite_install",
  "vite_js_runtime",
  "vite_path",
+ "vite_shared",
  "vite_str",
 ]
 

--- a/crates/vite_setup/Cargo.toml
+++ b/crates/vite_setup/Cargo.toml
@@ -20,6 +20,7 @@ tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
 vite_install = { workspace = true }
 vite_path = { workspace = true }
+vite_shared = { workspace = true }
 vite_str = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/vite_setup/Cargo.toml
+++ b/crates/vite_setup/Cargo.toml
@@ -21,6 +21,7 @@ tracing = { workspace = true }
 vite_install = { workspace = true }
 vite_js_runtime = { workspace = true }
 vite_path = { workspace = true }
+vite_shared = { workspace = true }
 vite_str = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/vite_setup/src/install.rs
+++ b/crates/vite_setup/src/install.rs
@@ -269,7 +269,7 @@ pub async fn install_production_deps(
         args.push(registry_url);
     }
 
-    let output = run_vp_install(version_dir, &vp_binary, &args).await?;
+    let output = run_vp_install(version_dir, &vp_binary, &args, registry).await?;
 
     if !output.status.success() {
         let log_path = write_upgrade_log(version_dir, &output.stdout, &output.stderr).await;
@@ -301,7 +301,7 @@ pub async fn install_production_deps(
         // Only create the local override after explicit consent. This preserves
         // minimumReleaseAge protection for the default and non-interactive paths.
         write_release_age_overrides(version_dir).await?;
-        let retry_output = run_vp_install(version_dir, &vp_binary, &args).await?;
+        let retry_output = run_vp_install(version_dir, &vp_binary, &args, registry).await?;
         if !retry_output.status.success() {
             let retry_log_path =
                 write_upgrade_log(version_dir, &retry_output.stdout, &retry_output.stderr).await;
@@ -323,14 +323,16 @@ async fn run_vp_install(
     version_dir: &AbsolutePath,
     vp_binary: &AbsolutePath,
     args: &[&str],
+    registry: Option<&str>,
 ) -> Result<Output, Error> {
-    let output = tokio::process::Command::new(vp_binary.as_path())
-        .args(args)
-        .current_dir(version_dir)
-        .env("CI", "true")
-        .output()
-        .await?;
+    let mut cmd = tokio::process::Command::new(vp_binary.as_path());
+    cmd.args(args).current_dir(version_dir).env("CI", "true");
 
+    if let Some(registry_url) = registry {
+        cmd.env("npm_config_registry", registry_url);
+    }
+
+    let output = cmd.output().await?;
     Ok(output)
 }
 

--- a/crates/vite_setup/src/install.rs
+++ b/crates/vite_setup/src/install.rs
@@ -329,7 +329,7 @@ async fn run_vp_install(
     cmd.args(args).current_dir(version_dir).env("CI", "true");
 
     if let Some(registry_url) = registry {
-        cmd.env("npm_config_registry", registry_url);
+        cmd.env(vite_shared::env_vars::NPM_CONFIG_REGISTRY, registry_url);
     }
 
     let output = cmd.output().await?;

--- a/crates/vite_setup/src/install.rs
+++ b/crates/vite_setup/src/install.rs
@@ -359,7 +359,7 @@ async fn run_pnpm_install(
         .env("PATH", path);
 
     if let Some(registry_url) = registry {
-        cmd.env("npm_config_registry", registry_url);
+        cmd.env(vite_shared::env_vars::NPM_CONFIG_REGISTRY, registry_url);
     }
 
     let output = cmd.output().await?;

--- a/crates/vite_setup/src/install.rs
+++ b/crates/vite_setup/src/install.rs
@@ -856,13 +856,15 @@ mod tests {
         );
     }
 
+    /// Build a fake managed Node.js runtime that records how `run_pnpm_install`
+    /// invokes it: arguments to `invocation.txt`, `$PATH` to `path.txt`, and
+    /// `$npm_config_registry` to `registry.txt` (all relative to `version_dir`).
     #[cfg(unix)]
-    #[tokio::test]
-    async fn run_pnpm_install_uses_managed_node_directly() {
+    async fn fake_pnpm_runtime(
+        version_dir: &AbsolutePath,
+    ) -> (AbsolutePathBuf, AbsolutePathBuf, vite_js_runtime::JsRuntime, AbsolutePathBuf) {
         use std::os::unix::fs::PermissionsExt;
 
-        let temp = tempfile::tempdir().unwrap();
-        let version_dir = AbsolutePathBuf::new(temp.path().to_path_buf()).unwrap();
         let node_bin = version_dir.join("node").join("bin");
         let pnpm_bin = version_dir.join("pnpm").join("bin");
         tokio::fs::create_dir_all(&node_bin).await.unwrap();
@@ -882,6 +884,16 @@ mod tests {
         tokio::fs::write(&pnpm_entry, "").await.unwrap();
         let node_runtime =
             vite_js_runtime::JsRuntime::from_system(JsRuntimeType::Node, node_binary);
+
+        (node_bin, pnpm_bin, node_runtime, pnpm_entry)
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn run_pnpm_install_uses_managed_node_directly() {
+        let temp = tempfile::tempdir().unwrap();
+        let version_dir = AbsolutePathBuf::new(temp.path().to_path_buf()).unwrap();
+        let (node_bin, pnpm_bin, node_runtime, pnpm_entry) = fake_pnpm_runtime(&version_dir).await;
 
         let output = run_pnpm_install(&version_dir, &node_runtime, &pnpm_entry, &["install"], None)
             .await
@@ -906,29 +918,9 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn run_pnpm_install_passes_custom_registry_env() {
-        use std::os::unix::fs::PermissionsExt;
-
         let temp = tempfile::tempdir().unwrap();
         let version_dir = AbsolutePathBuf::new(temp.path().to_path_buf()).unwrap();
-        let node_bin = version_dir.join("node").join("bin");
-        let pnpm_bin = version_dir.join("pnpm").join("bin");
-        tokio::fs::create_dir_all(&node_bin).await.unwrap();
-        tokio::fs::create_dir_all(&pnpm_bin).await.unwrap();
-
-        let node_binary = node_bin.join("node");
-        tokio::fs::write(
-            &node_binary,
-            "#!/bin/sh\nprintf '%s' \"$npm_config_registry\" > registry.txt\n",
-        )
-        .await
-        .unwrap();
-        tokio::fs::set_permissions(&node_binary, std::fs::Permissions::from_mode(0o755))
-            .await
-            .unwrap();
-        let pnpm_entry = pnpm_bin.join("pnpm.cjs");
-        tokio::fs::write(&pnpm_entry, "").await.unwrap();
-        let node_runtime =
-            vite_js_runtime::JsRuntime::from_system(JsRuntimeType::Node, node_binary);
+        let (_, _, node_runtime, pnpm_entry) = fake_pnpm_runtime(&version_dir).await;
 
         let registry_url = "https://registry.example.com/";
         let output = run_pnpm_install(

--- a/crates/vite_setup/src/install.rs
+++ b/crates/vite_setup/src/install.rs
@@ -316,7 +316,8 @@ pub async fn install_production_deps(
         // Only create the local override after explicit consent. This preserves
         // minimumReleaseAge protection for the default and non-interactive paths.
         write_release_age_overrides(version_dir).await?;
-        let retry_output = run_pnpm_install(version_dir, &node_runtime, &pnpm_entry, &args, registry).await?;
+        let retry_output =
+            run_pnpm_install(version_dir, &node_runtime, &pnpm_entry, &args, registry).await?;
         if !retry_output.status.success() {
             let retry_log_path =
                 write_upgrade_log(version_dir, &retry_output.stdout, &retry_output.stderr).await;
@@ -870,7 +871,7 @@ mod tests {
         let node_binary = node_bin.join("node");
         tokio::fs::write(
             &node_binary,
-            "#!/bin/sh\nprintf '%s\\n' \"$@\" > invocation.txt\nprintf '%s' \"$PATH\" > path.txt\n",
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > invocation.txt\nprintf '%s' \"$PATH\" > path.txt\nprintf '%s' \"$npm_config_registry\" > registry.txt\n",
         )
         .await
         .unwrap();
@@ -882,8 +883,9 @@ mod tests {
         let node_runtime =
             vite_js_runtime::JsRuntime::from_system(JsRuntimeType::Node, node_binary);
 
-        let output =
-            run_pnpm_install(&version_dir, &node_runtime, &pnpm_entry, &["install"]).await.unwrap();
+        let output = run_pnpm_install(&version_dir, &node_runtime, &pnpm_entry, &["install"], None)
+            .await
+            .unwrap();
         assert!(output.status.success());
 
         let invocation =
@@ -894,6 +896,54 @@ mod tests {
         let path_entries = env::split_paths(&path).collect::<Vec<_>>();
         assert_eq!(path_entries[0], node_bin.as_path());
         assert_eq!(path_entries[1], pnpm_bin.as_path());
+
+        // Without a custom registry, npm_config_registry must not be set so pnpm
+        // falls back to its default registry.
+        let registry = tokio::fs::read_to_string(version_dir.join("registry.txt")).await.unwrap();
+        assert_eq!(registry, "");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn run_pnpm_install_passes_custom_registry_env() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let version_dir = AbsolutePathBuf::new(temp.path().to_path_buf()).unwrap();
+        let node_bin = version_dir.join("node").join("bin");
+        let pnpm_bin = version_dir.join("pnpm").join("bin");
+        tokio::fs::create_dir_all(&node_bin).await.unwrap();
+        tokio::fs::create_dir_all(&pnpm_bin).await.unwrap();
+
+        let node_binary = node_bin.join("node");
+        tokio::fs::write(
+            &node_binary,
+            "#!/bin/sh\nprintf '%s' \"$npm_config_registry\" > registry.txt\n",
+        )
+        .await
+        .unwrap();
+        tokio::fs::set_permissions(&node_binary, std::fs::Permissions::from_mode(0o755))
+            .await
+            .unwrap();
+        let pnpm_entry = pnpm_bin.join("pnpm.cjs");
+        tokio::fs::write(&pnpm_entry, "").await.unwrap();
+        let node_runtime =
+            vite_js_runtime::JsRuntime::from_system(JsRuntimeType::Node, node_binary);
+
+        let registry_url = "https://registry.example.com/";
+        let output = run_pnpm_install(
+            &version_dir,
+            &node_runtime,
+            &pnpm_entry,
+            &["install"],
+            Some(registry_url),
+        )
+        .await
+        .unwrap();
+        assert!(output.status.success());
+
+        let registry = tokio::fs::read_to_string(version_dir.join("registry.txt")).await.unwrap();
+        assert_eq!(registry, registry_url);
     }
 
     #[test]

--- a/crates/vite_setup/src/install.rs
+++ b/crates/vite_setup/src/install.rs
@@ -284,7 +284,7 @@ pub async fn install_production_deps(
             format!("pnpm entry not found at {}", pnpm_entry.as_path().display()).into(),
         ));
     }
-    let output = run_pnpm_install(version_dir, &node_runtime, &pnpm_entry, &args).await?;
+    let output = run_pnpm_install(version_dir, &node_runtime, &pnpm_entry, &args, registry).await?;
 
     if !output.status.success() {
         let log_path = write_upgrade_log(version_dir, &output.stdout, &output.stderr).await;
@@ -316,7 +316,7 @@ pub async fn install_production_deps(
         // Only create the local override after explicit consent. This preserves
         // minimumReleaseAge protection for the default and non-interactive paths.
         write_release_age_overrides(version_dir).await?;
-        let retry_output = run_pnpm_install(version_dir, &node_runtime, &pnpm_entry, &args).await?;
+        let retry_output = run_pnpm_install(version_dir, &node_runtime, &pnpm_entry, &args, registry).await?;
         if !retry_output.status.success() {
             let retry_log_path =
                 write_upgrade_log(version_dir, &retry_output.stdout, &retry_output.stderr).await;
@@ -339,6 +339,7 @@ async fn run_pnpm_install(
     node_runtime: &vite_js_runtime::JsRuntime,
     pnpm_entry: &AbsolutePath,
     args: &[&str],
+    registry: Option<&str>,
 ) -> Result<Output, Error> {
     let node_bin = node_runtime.get_bin_prefix();
     let pnpm_bin = pnpm_entry.parent().ok_or_else(|| {
@@ -350,15 +351,18 @@ async fn run_pnpm_install(
     let path = env::join_paths(path_entries)
         .map_err(|error| Error::Setup(format!("Failed to build PATH for pnpm: {error}").into()))?;
 
-    let output = tokio::process::Command::new(node_runtime.get_binary_path().as_path())
-        .arg(pnpm_entry.as_path())
+    let mut cmd = tokio::process::Command::new(node_runtime.get_binary_path().as_path());
+    cmd.arg(pnpm_entry.as_path())
         .args(args)
         .current_dir(version_dir)
         .env("CI", "true")
-        .env("PATH", path)
-        .output()
-        .await?;
+        .env("PATH", path);
 
+    if let Some(registry_url) = registry {
+        cmd.env("npm_config_registry", registry_url);
+    }
+
+    let output = cmd.output().await?;
     Ok(output)
 }
 


### PR DESCRIPTION
Pass the configured npm registry to the inner pnpm install via `npm_config_registry` so vp-setup downloads pnpm from the custom registry instead of the default npmjs.org.

Closes #1794