### PR TITLE
fix(cli): add implode help documentation link

### DIFF
--- a/crates/vite_global_cli/src/help.rs
+++ b/crates/vite_global_cli/src/help.rs
@@ -80,6 +80,7 @@ fn documentation_url_for_command_path(command_path: &[&str]) -> Option<&'static 
         ["pack"] => Some("https://viteplus.dev/guide/pack"),
         ["env", ..] => Some("https://viteplus.dev/guide/env"),
         ["upgrade"] => Some("https://viteplus.dev/guide/upgrade"),
+        ["implode"] => Some("https://viteplus.dev/guide/implode"),
         _ => None,
     }
 }
@@ -1166,6 +1167,10 @@ Options:
         assert_eq!(
             documentation_url_for_command_path(&["config"]),
             Some("https://viteplus.dev/guide/commit-hooks")
+        );
+        assert_eq!(
+            documentation_url_for_command_path(&["implode"]),
+            Some("https://viteplus.dev/guide/implode")
         );
     }
 


### PR DESCRIPTION
`vp implode --help` now points users to the existing removal guide, making its help output consistent with the rest of the Vite+ command surface.