### PR TITLE
fix(cli): show supported run help options

### DIFF
--- a/crates/vite_global_cli/src/help.rs
+++ b/crates/vite_global_cli/src/help.rs
@@ -826,10 +826,25 @@ fn delegated_help_doc(command: &str) -> Option<HelpDoc> {
                             "Match packages by name, directory, or glob pattern",
                         ),
                         row(
+                            "--fail-if-no-match",
+                            "Exit with a non-zero status if a filter matches no packages",
+                        ),
+                        row(
                             "--ignore-depends-on",
                             "Do not run dependencies specified in `dependsOn` fields",
                         ),
                         row("-v, --verbose", "Show full detailed summary after execution"),
+                        row("--cache", "Force caching on for all tasks and scripts"),
+                        row("--no-cache", "Force caching off for all tasks and scripts"),
+                        row("--log <MODE>", "Set output mode: interleaved, labeled, or grouped"),
+                        row(
+                            "--concurrency-limit <N>",
+                            "Maximum number of tasks to run concurrently (default: 4)",
+                        ),
+                        row(
+                            "--parallel",
+                            "Run tasks without dependency ordering (unlimited concurrency by default)",
+                        ),
                         row("--last-details", "Display the detailed summary of the last run"),
                         row("-h, --help", "Print help (see more with '--help')"),
                     ],

--- a/packages/cli/snap-tests-global/command-run-help/snap.txt
+++ b/packages/cli/snap-tests-global/command-run-help/snap.txt
@@ -1,0 +1,73 @@
+> vp run --help
+Usage: vp run [OPTIONS] [TASK_SPECIFIER] [ADDITIONAL_ARGS]...
+
+Run tasks.
+
+Arguments:
+  [TASK_SPECIFIER]      `packageName#taskName` or `taskName`. If omitted, lists all available tasks
+  [ADDITIONAL_ARGS]...  Additional arguments to pass to the tasks
+
+Options:
+  -r, --recursive          Select all packages in the workspace
+  -t, --transitive         Select the current package and its transitive dependencies
+  -w, --workspace-root     Select the workspace root package
+  -F, --filter <FILTERS>   Match packages by name, directory, or glob pattern
+  --fail-if-no-match       Exit with a non-zero status if a filter matches no packages
+  --ignore-depends-on      Do not run dependencies specified in `dependsOn` fields
+  -v, --verbose            Show full detailed summary after execution
+  --cache                  Force caching on for all tasks and scripts
+  --no-cache               Force caching off for all tasks and scripts
+  --log <MODE>             Set output mode: interleaved, labeled, or grouped
+  --concurrency-limit <N>  Maximum number of tasks to run concurrently (default: 4)
+  --parallel               Run tasks without dependency ordering (unlimited concurrency by default)
+  --last-details           Display the detailed summary of the last run
+  -h, --help               Print help (see more with '--help')
+
+Filter Patterns:
+  --filter <pattern>        Select by package name (e.g. foo, @scope/*)
+  --filter ./<dir>          Select packages under a directory
+  --filter {<dir>}          Same as ./<dir>, but allows traversal suffixes
+  --filter <pattern>...     Select package and its dependencies
+  --filter ...<pattern>     Select package and its dependents
+  --filter <pattern>^...    Select only the dependencies (exclude the package itself)
+  --filter !<pattern>       Exclude packages matching the pattern
+
+Documentation: https://viteplus.dev/guide/run
+
+
+> vp help run
+Usage: vp run [OPTIONS] [TASK_SPECIFIER] [ADDITIONAL_ARGS]...
+
+Run tasks.
+
+Arguments:
+  [TASK_SPECIFIER]      `packageName#taskName` or `taskName`. If omitted, lists all available tasks
+  [ADDITIONAL_ARGS]...  Additional arguments to pass to the tasks
+
+Options:
+  -r, --recursive          Select all packages in the workspace
+  -t, --transitive         Select the current package and its transitive dependencies
+  -w, --workspace-root     Select the workspace root package
+  -F, --filter <FILTERS>   Match packages by name, directory, or glob pattern
+  --fail-if-no-match       Exit with a non-zero status if a filter matches no packages
+  --ignore-depends-on      Do not run dependencies specified in `dependsOn` fields
+  -v, --verbose            Show full detailed summary after execution
+  --cache                  Force caching on for all tasks and scripts
+  --no-cache               Force caching off for all tasks and scripts
+  --log <MODE>             Set output mode: interleaved, labeled, or grouped
+  --concurrency-limit <N>  Maximum number of tasks to run concurrently (default: 4)
+  --parallel               Run tasks without dependency ordering (unlimited concurrency by default)
+  --last-details           Display the detailed summary of the last run
+  -h, --help               Print help (see more with '--help')
+
+Filter Patterns:
+  --filter <pattern>        Select by package name (e.g. foo, @scope/*)
+  --filter ./<dir>          Select packages under a directory
+  --filter {<dir>}          Same as ./<dir>, but allows traversal suffixes
+  --filter <pattern>...     Select package and its dependencies
+  --filter ...<pattern>     Select package and its dependents
+  --filter <pattern>^...    Select only the dependencies (exclude the package itself)
+  --filter !<pattern>       Exclude packages matching the pattern
+
+Documentation: https://viteplus.dev/guide/run
+

--- a/packages/cli/snap-tests-global/command-run-help/steps.json
+++ b/packages/cli/snap-tests-global/command-run-help/steps.json
@@ -1,0 +1,3 @@
+{
+  "commands": ["vp run --help", "vp help run"]
+}

--- a/packages/cli/snap-tests-global/command-vpr/snap.txt
+++ b/packages/cli/snap-tests-global/command-vpr/snap.txt
@@ -8,14 +8,20 @@ Arguments:
   [ADDITIONAL_ARGS]...  Additional arguments to pass to the tasks
 
 Options:
-  -r, --recursive         Select all packages in the workspace
-  -t, --transitive        Select the current package and its transitive dependencies
-  -w, --workspace-root    Select the workspace root package
-  -F, --filter <FILTERS>  Match packages by name, directory, or glob pattern
-  --ignore-depends-on     Do not run dependencies specified in `dependsOn` fields
-  -v, --verbose           Show full detailed summary after execution
-  --last-details          Display the detailed summary of the last run
-  -h, --help              Print help (see more with '--help')
+  -r, --recursive          Select all packages in the workspace
+  -t, --transitive         Select the current package and its transitive dependencies
+  -w, --workspace-root     Select the workspace root package
+  -F, --filter <FILTERS>   Match packages by name, directory, or glob pattern
+  --fail-if-no-match       Exit with a non-zero status if a filter matches no packages
+  --ignore-depends-on      Do not run dependencies specified in `dependsOn` fields
+  -v, --verbose            Show full detailed summary after execution
+  --cache                  Force caching on for all tasks and scripts
+  --no-cache               Force caching off for all tasks and scripts
+  --log <MODE>             Set output mode: interleaved, labeled, or grouped
+  --concurrency-limit <N>  Maximum number of tasks to run concurrently (default: 4)
+  --parallel               Run tasks without dependency ordering (unlimited concurrency by default)
+  --last-details           Display the detailed summary of the last run
+  -h, --help               Print help (see more with '--help')
 
 Filter Patterns:
   --filter <pattern>        Select by package name (e.g. foo, @scope/*)


### PR DESCRIPTION
## Summary

`vp run --help` now shows supported task-runner options that were already implemented but missing from the normal help output.

This adds help coverage for cache controls, log mode, concurrency controls, parallel execution, and strict filter matching. `vpr --help` is updated to stay aligned, and a focused global snapshot now covers `vp run --help` / `vp help run`.

## Validation

- `cargo fmt --check -p vite_global_cli`
- `cargo test -q -p vite_global_cli docs_url_is_mapped_for_grouped_commands`
