### PR TITLE
fix(cli): show fail-if-no-match in exec help

### DIFF
--- a/crates/vite_global_cli/src/help.rs
+++ b/crates/vite_global_cli/src/help.rs
@@ -886,6 +886,10 @@ fn delegated_help_doc(command: &str) -> Option<HelpDoc> {
                             "-F, --filter <FILTERS>",
                             "Match packages by name, directory, or glob pattern",
                         ),
+                        row(
+                            "--fail-if-no-match",
+                            "Exit with a non-zero status if a filter matches no packages",
+                        ),
                         row("-c, --shell-mode", "Execute the command within a shell environment"),
                         row("--parallel", "Run concurrently without topological ordering"),
                         row("--reverse", "Reverse execution order"),

--- a/packages/cli/snap-tests-global/command-exec/snap.txt
+++ b/packages/cli/snap-tests-global/command-exec/snap.txt
@@ -27,6 +27,7 @@ Options:
   -t, --transitive             Select the current package and its transitive dependencies
   -w, --workspace-root         Select the workspace root package
   -F, --filter <FILTERS>       Match packages by name, directory, or glob pattern
+  --fail-if-no-match           Exit with a non-zero status if a filter matches no packages
   -c, --shell-mode             Execute the command within a shell environment
   --parallel                   Run concurrently without topological ordering
   --reverse                    Reverse execution order


### PR DESCRIPTION
## Summary

`vp exec --help` now shows the supported `--fail-if-no-match` package filter option.

This keeps the unified global help output aligned with the underlying package query flags already accepted by `vp exec`.

## Validation

- `cargo fmt --check -p vite_global_cli`
- `cargo test -q -p vite_global_cli docs_url_is_mapped_for_grouped_commands`
