### PR TITLE
feat(env): add corepack to the default shims tool list

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -327,8 +327,10 @@ jobs:
             node-version: 22
             command: |
               # scripts/bootstrap.mjs spawns `pnpm build` via tinyexec and needs
-              # pnpm on PATH (not exposed by the vp install itself).
-              vp i -g pnpm
+              # pnpm on PATH (not exposed by the vp install itself). corepack
+              # enable creates a pnpm launcher in the vp bin dir that resolves
+              # the project's pinned packageManager version (pnpm@9.15.9).
+              corepack enable
               node scripts/bootstrap.mjs
               # Report-only: oxlint 1.68.0 surfaces ts1038 ("A 'declare' modifier
               # cannot be used in an already ambient context.") on varlet's

--- a/crates/vite_global_cli/src/cli.rs
+++ b/crates/vite_global_cli/src/cli.rs
@@ -667,6 +667,7 @@ async fn managed_install(
         concurrency.unwrap_or(DEFAULT_GLOBAL_INSTALL_CONCURRENCY),
         false,
         None,
+        false,
     )
     .await
     {
@@ -799,6 +800,7 @@ async fn managed_update(
         concurrency,
         true,
         None,
+        false,
     )
     .await
     {

--- a/crates/vite_global_cli/src/cli.rs
+++ b/crates/vite_global_cli/src/cli.rs
@@ -662,12 +662,14 @@ async fn managed_install(
 ) -> Result<ExitStatus, Error> {
     if let Err((package_name, error)) = global::install::install(
         packages,
-        node,
-        force,
-        concurrency.unwrap_or(DEFAULT_GLOBAL_INSTALL_CONCURRENCY),
-        false,
-        None,
-        false,
+        global::install::InstallOptions {
+            node_version: node,
+            force,
+            concurrency: concurrency.unwrap_or(DEFAULT_GLOBAL_INSTALL_CONCURRENCY),
+            update: false,
+            only_bins: None,
+            progress_to_stderr: false,
+        },
     )
     .await
     {
@@ -795,12 +797,14 @@ async fn managed_update(
     // Call reinstall logic
     if let Err((package_name, error)) = global::install::install(
         &to_update,
-        Some(&current_node_version),
-        false,
-        concurrency,
-        true,
-        None,
-        false,
+        global::install::InstallOptions {
+            node_version: Some(&current_node_version),
+            force: false,
+            concurrency,
+            update: true,
+            only_bins: None,
+            progress_to_stderr: false,
+        },
     )
     .await
     {

--- a/crates/vite_global_cli/src/cli.rs
+++ b/crates/vite_global_cli/src/cli.rs
@@ -256,7 +256,7 @@ impl Commands {
 #[command(after_help = "\
 Examples:
   Setup:
-    vp env setup                  # Create shims for node, npm, npx
+    vp env setup                  # Create shims for node, npm, npx, corepack
     vp env on                     # Use vite-plus managed Node.js
     vp env print                  # Print shell snippet for this session
 
@@ -666,6 +666,7 @@ async fn managed_install(
         force,
         concurrency.unwrap_or(DEFAULT_GLOBAL_INSTALL_CONCURRENCY),
         false,
+        None,
     )
     .await
     {
@@ -791,9 +792,15 @@ async fn managed_update(
     }
 
     // Call reinstall logic
-    if let Err((package_name, error)) =
-        global::install::install(&to_update, Some(&current_node_version), false, concurrency, true)
-            .await
+    if let Err((package_name, error)) = global::install::install(
+        &to_update,
+        Some(&current_node_version),
+        false,
+        concurrency,
+        true,
+        None,
+    )
+    .await
     {
         output::error(&format!(
             "Failed to update {}: {error}",

--- a/crates/vite_global_cli/src/cli.rs
+++ b/crates/vite_global_cli/src/cli.rs
@@ -668,7 +668,6 @@ async fn managed_install(
             concurrency: concurrency.unwrap_or(DEFAULT_GLOBAL_INSTALL_CONCURRENCY),
             update: false,
             only_bins: None,
-            progress_to_stderr: false,
         },
     )
     .await
@@ -803,7 +802,6 @@ async fn managed_update(
             concurrency,
             update: true,
             only_bins: None,
-            progress_to_stderr: false,
         },
     )
     .await

--- a/crates/vite_global_cli/src/commands/env/exec.rs
+++ b/crates/vite_global_cli/src/commands/env/exec.rs
@@ -64,6 +64,8 @@ pub async fn execute(
         // - Recursion prevention via VP_TOOL_RECURSION
         // - Shim mode checking (managed vs system-first)
         let args: Vec<String> = command[1..].to_vec();
+        // stdout belongs to the dispatched tool; route vp's own output to stderr.
+        vite_shared::output::route_user_output_to_stderr();
         let exit_code = shim_dispatch(tool, &args).await;
         return Ok(exit_status(exit_code));
     }

--- a/crates/vite_global_cli/src/commands/env/mod.rs
+++ b/crates/vite_global_cli/src/commands/env/mod.rs
@@ -15,7 +15,7 @@ mod off;
 mod on;
 pub mod package_metadata;
 mod pin;
-mod setup;
+pub(crate) mod setup;
 mod unpin;
 mod r#use;
 mod which;

--- a/crates/vite_global_cli/src/commands/env/package_metadata.rs
+++ b/crates/vite_global_cli/src/commands/env/package_metadata.rs
@@ -24,6 +24,11 @@ pub struct PackageMetadata {
     /// Binary names that are JavaScript files (need Node.js to run).
     #[serde(default)]
     pub js_bins: HashSet<String>,
+    /// Whether `bins` was deliberately restricted to a subset of the bins the
+    /// package declares (e.g., the corepack shim auto-install links only
+    /// `corepack`). Updates keep the restriction; explicit installs reset it.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub bins_restricted: bool,
     /// Package manager used for installation (npm, yarn, pnpm)
     pub manager: String,
     /// Installation timestamp
@@ -57,6 +62,7 @@ impl PackageMetadata {
             platform: Platform { node: node_version, npm: npm_version },
             bins,
             js_bins,
+            bins_restricted: false,
             manager,
             installed_at: Utc::now(),
         }

--- a/crates/vite_global_cli/src/commands/env/setup.rs
+++ b/crates/vite_global_cli/src/commands/env/setup.rs
@@ -1,16 +1,16 @@
 //! Setup command implementation for creating bin directory and shims.
 //!
 //! Creates the following structure:
-//! - ~/.vite-plus/bin/     - Contains vp symlink and node/npm/npx shims
+//! - ~/.vite-plus/bin/     - Contains vp symlink and node/npm/npx/corepack shims
 //! - ~/.vite-plus/current/ - Contains the actual vp CLI binary
 //!
 //! On Unix:
 //! - bin/vp is a symlink to the active vp binary
-//! - bin/node, bin/npm, bin/npx are symlinks to the active vp binary
+//! - bin/node, bin/npm, bin/npx, bin/corepack are symlinks to the active vp binary
 //! - Symlinks preserve argv[0], allowing tool detection via the symlink name
 //!
 //! On Windows:
-//! - bin/vp.exe, bin/node.exe, bin/npm.exe, bin/npx.exe are trampoline executables
+//! - bin/vp.exe, bin/node.exe, bin/npm.exe, bin/npx.exe, bin/corepack.exe are trampoline executables
 //! - Each trampoline detects its tool name from its own filename and spawns
 //!   current\bin\vp.exe with VP_SHIM_TOOL env var set
 //! - This avoids the "Terminate batch job (Y/N)?" prompt from .cmd wrappers
@@ -43,8 +43,8 @@ impl EnvShell {
     }
 }
 
-/// Tools to create shims for (node, npm, npx, vpx, vpr)
-pub(crate) const SHIM_TOOLS: &[&str] = &["node", "npm", "npx", "vpx", "vpr"];
+/// Tools to create shims for (node, npm, npx, corepack, vpx, vpr)
+pub(crate) const SHIM_TOOLS: &[&str] = &["node", "npm", "npx", "corepack", "vpx", "vpr"];
 
 fn accent_command(command: &str) -> String {
     if help::should_style_help() {
@@ -90,7 +90,7 @@ pub async fn execute(refresh: bool, env_only: bool) -> Result<ExitStatus, Error>
     // Create wrapper script in bin/
     setup_vp_wrapper(&current_exe, &bin_dir, refresh).await?;
 
-    // Create shims for node, npm, npx
+    // Create shims for node, npm, npx, corepack
     let mut created = Vec::new();
     let mut skipped = Vec::new();
 
@@ -228,10 +228,10 @@ pub(crate) async fn resolve_unix_vp_shim_target(
     Ok(current_exe.to_path_buf())
 }
 
-/// Create a single shim for node/npm/npx.
+/// Create a single shim for a default shim tool (node/npm/npx/corepack/vpx/vpr).
 ///
 /// Returns `true` if the shim was created, `false` if it already exists.
-async fn create_shim(
+pub(crate) async fn create_shim(
     source: &std::path::Path,
     bin_dir: &vite_path::AbsolutePath,
     tool: &str,
@@ -846,6 +846,13 @@ mod tests {
     use vite_path::AbsolutePathBuf;
 
     use super::*;
+
+    #[test]
+    fn test_shim_tools_contains_default_shims() {
+        // corepack is a default shim (#858, #1309); node/npm/npx resolve the
+        // project Node.js version; vpx/vpr are command shorthands.
+        assert_eq!(SHIM_TOOLS, &["node", "npm", "npx", "corepack", "vpx", "vpr"]);
+    }
 
     /// Helper: create a test_guard with user_home set to the given path.
     fn home_guard(home: impl Into<std::path::PathBuf>) -> vite_shared::TestEnvGuard {

--- a/crates/vite_global_cli/src/commands/env/setup.rs
+++ b/crates/vite_global_cli/src/commands/env/setup.rs
@@ -102,6 +102,12 @@ pub async fn execute(refresh: bool, env_only: bool) -> Result<ExitStatus, Error>
             skipped.push(*tool);
         }
 
+        // Remove corepack-written .cmd/.ps1/extensionless launchers that
+        // would shadow an existing trampoline .exe in PowerShell/Git Bash
+        // (create_shim skips existing shims without cleaning siblings).
+        #[cfg(windows)]
+        cleanup_legacy_windows_shim(&bin_dir, tool).await;
+
         // Drop stale `npm install -g` link configs for default shim names
         // (e.g. a pre-default-shim `npm i -g corepack`): the link itself is
         // replaced by the shim above, and a leftover Npm-sourced BinConfig

--- a/crates/vite_global_cli/src/commands/env/setup.rs
+++ b/crates/vite_global_cli/src/commands/env/setup.rs
@@ -101,6 +101,16 @@ pub async fn execute(refresh: bool, env_only: bool) -> Result<ExitStatus, Error>
         } else {
             skipped.push(*tool);
         }
+
+        // Drop stale `npm install -g` link configs for default shim names
+        // (e.g. a pre-default-shim `npm i -g corepack`): the link itself is
+        // replaced by the shim above, and a leftover Npm-sourced BinConfig
+        // would let a later `npm uninstall -g` delete the default shim.
+        if let Ok(Some(config)) = super::bin_config::BinConfig::load(tool).await
+            && config.source == super::bin_config::BinSource::Npm
+        {
+            let _ = super::bin_config::BinConfig::delete(tool).await;
+        }
     }
 
     #[cfg(windows)]
@@ -484,6 +494,12 @@ pub(crate) async fn cleanup_legacy_windows_shim(bin_dir: &vite_path::AbsolutePat
     let cmd_path = bin_dir.join(format!("{tool}.cmd"));
     let _ = tokio::fs::remove_file(&cmd_path).await;
 
+    // Remove .ps1 launchers (corepack's cmd-shim writes them; PowerShell
+    // resolves `<tool>.ps1` ahead of `<tool>.exe`, so a leftover would shadow
+    // the trampoline). Vite+ never creates per-tool .ps1 files in bin.
+    let ps1_path = bin_dir.join(format!("{tool}.ps1"));
+    let _ = tokio::fs::remove_file(&ps1_path).await;
+
     // Remove old shell script wrapper (extensionless, for Git Bash)
     // Only remove if it starts with #!/bin/sh (not a binary or other file)
     // Read only the first 9 bytes to avoid loading large files into memory
@@ -849,9 +865,11 @@ mod tests {
 
     #[test]
     fn test_shim_tools_contains_default_shims() {
-        // corepack is a default shim (#858, #1309); node/npm/npx resolve the
-        // project Node.js version; vpx/vpr are command shorthands.
-        assert_eq!(SHIM_TOOLS, &["node", "npm", "npx", "corepack", "vpx", "vpr"]);
+        // corepack is a default shim (#858, #1309). It must NOT be a core
+        // shim: `vp install -g corepack` stays allowed (CORE_SHIMS guard) and
+        // dispatch uses a dedicated resolution path instead of the core one.
+        assert!(SHIM_TOOLS.contains(&"corepack"));
+        assert!(!crate::commands::global::CORE_SHIMS.contains(&"corepack"));
     }
 
     /// Helper: create a test_guard with user_home set to the given path.

--- a/crates/vite_global_cli/src/commands/env/which.rs
+++ b/crates/vite_global_cli/src/commands/env/which.rs
@@ -2,8 +2,8 @@
 //!
 //! Shows the path to the tool binary that would be executed.
 //!
-//! For core tools (node, npm, npx), shows the resolved Node.js binary path
-//! along with version and resolution source.
+//! For core tools (node, npm, npx, corepack), shows the resolved Node.js
+//! binary path along with version and resolution source.
 //! For global packages, shows the binary path plus package metadata.
 
 use std::process::ExitStatus;
@@ -23,8 +23,8 @@ use super::{
 };
 use crate::error::Error;
 
-/// Core tools (node, npm, npx)
-const CORE_TOOLS: &[&str] = &["node", "npm", "npx"];
+/// Core tools (node, npm, npx, corepack)
+const CORE_TOOLS: &[&str] = &["node", "npm", "npx", "corepack"];
 
 /// Column width for left-side labels in aligned metadata output
 const LABEL_WIDTH: usize = 10;
@@ -37,6 +37,13 @@ pub async fn execute(cwd: AbsolutePathBuf, tool: &str) -> Result<ExitStatus, Err
 
     // Check if this is a core tool
     if CORE_TOOLS.contains(&tool) {
+        // corepack: a vp-managed global install wins over the Node-bundled
+        // copy (mirrors the shim dispatch order).
+        if tool == "corepack"
+            && let Some(metadata) = PackageMetadata::find_by_binary(tool).await?
+        {
+            return execute_package_binary(tool, &metadata).await;
+        }
         return execute_core_tool(cwd, tool).await;
     }
 
@@ -47,7 +54,7 @@ pub async fn execute(cwd: AbsolutePathBuf, tool: &str) -> Result<ExitStatus, Err
 
     // Unknown tool
     output::error(&format!("tool '{}' not found", tool.bold()));
-    eprintln!("Not a core tool (node, npm, npx) or installed global package.");
+    eprintln!("Not a core tool (node, npm, npx, corepack) or installed global package.");
     eprintln!("Run 'vp list -g' to see installed packages.");
     Ok(exit_status(1))
 }
@@ -94,7 +101,7 @@ async fn execute_package_manager_tool(
     Ok(Some(ExitStatus::default()))
 }
 
-/// Execute which for a core tool (node, npm, npx).
+/// Execute which for a core tool (node, npm, npx, corepack).
 async fn execute_core_tool(cwd: AbsolutePathBuf, tool: &str) -> Result<ExitStatus, Error> {
     // Resolve version for current directory
     let resolution = resolve_version(&cwd).await?;
@@ -115,9 +122,23 @@ async fn execute_core_tool(cwd: AbsolutePathBuf, tool: &str) -> Result<ExitStatu
 
     // Check if the tool exists
     if !tokio::fs::try_exists(&tool_path).await.unwrap_or(false) {
+        #[cfg(windows)]
+        let node_path = home_dir.join("node.exe");
+        #[cfg(not(windows))]
+        let node_path = home_dir.join("bin").join("node");
+        let node_installed = tokio::fs::try_exists(&node_path).await.unwrap_or(false);
+
         output::error(&format!("{} not found", tool.bold()));
-        eprintln!("Node.js {} is not installed.", resolution.version);
-        eprintln!("Run 'vp env install {}' to install it.", resolution.version);
+        if tool == "corepack" && node_installed {
+            // corepack is no longer bundled starting with Node.js 25
+            eprintln!("corepack is not bundled with Node.js {}.", resolution.version);
+            eprintln!(
+                "It is installed automatically on first use, or run 'vp install -g corepack'."
+            );
+        } else {
+            eprintln!("Node.js {} is not installed.", resolution.version);
+            eprintln!("Run 'vp env install {}' to install it.", resolution.version);
+        }
         return Ok(exit_status(1));
     }
 

--- a/crates/vite_global_cli/src/commands/env/which.rs
+++ b/crates/vite_global_cli/src/commands/env/which.rs
@@ -126,12 +126,13 @@ async fn execute_core_tool(cwd: AbsolutePathBuf, tool: &str) -> Result<ExitStatu
     // Check if the tool exists
     if !tokio::fs::try_exists(&tool_path).await.unwrap_or(false) {
         output::error(&format!("{} not found", tool.bold()));
-        // corepack is no longer bundled starting with Node.js 25; only print
-        // that hint when the Node.js installation itself is present.
+        // corepack is no longer bundled starting with Node.js 25 (and a
+        // bundled copy may have been removed); only print that hint when the
+        // Node.js installation itself is present.
         if tool == "corepack"
             && crate::shim::dispatch::locate_tool(&resolution.version, "node").is_ok()
         {
-            eprintln!("corepack is not bundled with Node.js {}.", resolution.version);
+            eprintln!("corepack is not available for Node.js {}.", resolution.version);
             eprintln!(
                 "It is installed automatically on first use, or run 'vp install -g corepack'."
             );

--- a/crates/vite_global_cli/src/commands/env/which.rs
+++ b/crates/vite_global_cli/src/commands/env/which.rs
@@ -38,12 +38,13 @@ pub async fn execute(cwd: AbsolutePathBuf, tool: &str) -> Result<ExitStatus, Err
     // Check if this is a core tool
     if CORE_TOOLS.contains(&tool) {
         // corepack: a vp-managed global install wins over the Node-bundled
-        // copy. Use the same BinConfig-based lookup as the shim dispatch so
-        // the diagnostic cannot disagree with what actually runs.
+        // copy. Mirror the shim dispatch: BinConfig-based lookup, falling
+        // back to the bundled copy when the managed state is unusable
+        // (dispatch warns and falls back the same way), so the diagnostic
+        // matches what actually runs.
         if tool == "corepack"
-            && let Some(metadata) = crate::shim::dispatch::find_package_for_binary(tool)
-                .await
-                .map_err(|e| Error::ConfigError(e.into()))?
+            && let Ok(Some(metadata)) = crate::shim::dispatch::find_package_for_binary(tool).await
+            && locate_package_binary(&metadata.name, tool).is_ok()
         {
             return execute_package_binary(tool, &metadata).await;
         }

--- a/crates/vite_global_cli/src/commands/env/which.rs
+++ b/crates/vite_global_cli/src/commands/env/which.rs
@@ -39,14 +39,17 @@ pub async fn execute(cwd: AbsolutePathBuf, tool: &str) -> Result<ExitStatus, Err
     if CORE_TOOLS.contains(&tool) {
         // corepack: a vp-managed global install wins over the Node-bundled
         // copy. Mirror the shim dispatch: BinConfig-based lookup, falling
-        // back to the bundled copy when the managed state is unusable
-        // (dispatch warns and falls back the same way), so the diagnostic
-        // matches what actually runs.
-        if tool == "corepack"
-            && let Ok(Some(metadata)) = crate::shim::dispatch::find_package_for_binary(tool).await
-            && locate_package_binary(&metadata.name, tool).is_ok()
-        {
-            return execute_package_binary(tool, &metadata).await;
+        // back to the bundled copy (with the same warning) when the managed
+        // state is unusable, so the diagnostic matches what actually runs.
+        if tool == "corepack" {
+            match crate::shim::dispatch::find_package_for_binary(tool).await {
+                Ok(Some(metadata)) => match locate_package_binary(&metadata.name, tool) {
+                    Ok(_) => return execute_package_binary(tool, &metadata).await,
+                    Err(e) => warn_unusable_managed_corepack(&e.to_string()),
+                },
+                Ok(None) => {}
+                Err(e) => warn_unusable_managed_corepack(&e),
+            }
         }
         return execute_core_tool(cwd, tool).await;
     }
@@ -103,6 +106,15 @@ async fn execute_package_manager_tool(
     );
 
     Ok(Some(ExitStatus::default()))
+}
+
+/// Warn that a vp-managed corepack exists but cannot run (mirrors the shim
+/// dispatch warning).
+fn warn_unusable_managed_corepack(reason: &str) {
+    output::warn(&format!(
+        "Ignoring unusable vp-managed corepack ({reason}); falling back to the \
+         Node-bundled corepack. Run `vp remove -g corepack` to clear it."
+    ));
 }
 
 /// Execute which for a core tool (node, npm, npx, corepack).

--- a/crates/vite_global_cli/src/commands/env/which.rs
+++ b/crates/vite_global_cli/src/commands/env/which.rs
@@ -38,9 +38,12 @@ pub async fn execute(cwd: AbsolutePathBuf, tool: &str) -> Result<ExitStatus, Err
     // Check if this is a core tool
     if CORE_TOOLS.contains(&tool) {
         // corepack: a vp-managed global install wins over the Node-bundled
-        // copy (mirrors the shim dispatch order).
+        // copy. Use the same BinConfig-based lookup as the shim dispatch so
+        // the diagnostic cannot disagree with what actually runs.
         if tool == "corepack"
-            && let Some(metadata) = PackageMetadata::find_by_binary(tool).await?
+            && let Some(metadata) = crate::shim::dispatch::find_package_for_binary(tool)
+                .await
+                .map_err(|e| Error::ConfigError(e.into()))?
         {
             return execute_package_binary(tool, &metadata).await;
         }
@@ -122,15 +125,12 @@ async fn execute_core_tool(cwd: AbsolutePathBuf, tool: &str) -> Result<ExitStatu
 
     // Check if the tool exists
     if !tokio::fs::try_exists(&tool_path).await.unwrap_or(false) {
-        #[cfg(windows)]
-        let node_path = home_dir.join("node.exe");
-        #[cfg(not(windows))]
-        let node_path = home_dir.join("bin").join("node");
-        let node_installed = tokio::fs::try_exists(&node_path).await.unwrap_or(false);
-
         output::error(&format!("{} not found", tool.bold()));
-        if tool == "corepack" && node_installed {
-            // corepack is no longer bundled starting with Node.js 25
+        // corepack is no longer bundled starting with Node.js 25; only print
+        // that hint when the Node.js installation itself is present.
+        if tool == "corepack"
+            && crate::shim::dispatch::locate_tool(&resolution.version, "node").is_ok()
+        {
             eprintln!("corepack is not bundled with Node.js {}.", resolution.version);
             eprintln!(
                 "It is installed automatically on first use, or run 'vp install -g corepack'."

--- a/crates/vite_global_cli/src/commands/global/install.rs
+++ b/crates/vite_global_cli/src/commands/global/install.rs
@@ -52,6 +52,17 @@ fn package_error(package_name: &str, error: impl Into<Error>) -> (Option<String>
     (Some(package_name.to_string()), error.into())
 }
 
+/// Symlink target used for package shims on Unix (relative to the bin dir).
+#[cfg(unix)]
+pub(crate) const PACKAGE_SHIM_TARGET: &str = "../current/bin/vp";
+
+/// Check whether a binary name is a shim Vite+ owns unconditionally: core
+/// shims plus the default env shims (node, npm, npx, corepack, vpx, vpr).
+/// Protected shims are never created for or removed on behalf of packages.
+pub(crate) fn is_protected_shim(bin_name: &str) -> bool {
+    CORE_SHIMS.contains(&bin_name) || crate::commands::env::setup::SHIM_TOOLS.contains(&bin_name)
+}
+
 /// Install global packages parallelly.
 ///
 /// If `node_version` is provided, uses that version. Otherwise, resolves from current directory.
@@ -200,14 +211,27 @@ pub async fn install(
         };
         // Restrict exposed binaries when requested (e.g., the corepack shim
         // auto-install only links `corepack`, not the pnpm/yarn launchers
-        // that `corepack enable` creates on demand).
-        let (bin_names, js_bins) = match only_bins {
-            Some(only) => (
-                bin_names.into_iter().filter(|bin| only.contains(&bin.as_str())).collect(),
-                js_bins.into_iter().filter(|bin| only.contains(&bin.as_str())).collect(),
-            ),
-            None => (bin_names, js_bins),
+        // that `corepack enable` creates on demand). Updates carry a recorded
+        // restriction forward so `vp update -g` cannot re-expose the filtered
+        // bins; explicit installs (update=false) re-expose the full bin list.
+        let inherited_restriction: Option<Vec<String>> = if only_bins.is_none() && update {
+            match PackageMetadata::load(&package_name).await {
+                Ok(Some(previous)) if previous.bins_restricted => Some(previous.bins),
+                _ => None,
+            }
+        } else {
+            None
         };
+        let bins_restricted = only_bins.is_some() || inherited_restriction.is_some();
+        let mut bin_names = bin_names;
+        let mut js_bins = js_bins;
+        if let Some(only) = only_bins {
+            bin_names.retain(|bin| only.contains(&bin.as_str()));
+            js_bins.retain(|bin| only.contains(&bin.as_str()));
+        } else if let Some(only) = &inherited_restriction {
+            bin_names.retain(|bin| only.contains(bin));
+            js_bins.retain(|bin| only.contains(bin));
+        }
         let mut backup = backup;
         let stale_bin_names = match stale_bin_names_for_package(&package_name, &bin_names).await {
             Ok(bin_names) => bin_names,
@@ -304,7 +328,7 @@ pub async fn install(
             }
         };
 
-        let metadata = PackageMetadata::new(
+        let mut metadata = PackageMetadata::new(
             package_name.clone(),
             installed_version.clone(),
             node_version.clone(),
@@ -313,6 +337,7 @@ pub async fn install(
             js_bins,
             "npm".to_string(),
         );
+        metadata.bins_restricted = bins_restricted;
         if let Err(error) =
             metadata.save().await.map_err(|error| package_error(&package_name, error))
         {
@@ -657,7 +682,15 @@ pub async fn uninstall(package_name: &str, dry_run: bool) -> Result<(), Error> {
 
         output::raw(&format!("Would uninstall {}:", package_name));
         for bin_name in &bins {
-            output::raw(&format!("  - shim: {}", bin_dir.join(bin_name).as_path().display()));
+            // Protected shims survive the real uninstall; keep dry-run honest.
+            if is_protected_shim(bin_name) {
+                output::raw(&format!(
+                    "  - shim: {} (kept: default shim)",
+                    bin_dir.join(bin_name).as_path().display()
+                ));
+            } else {
+                output::raw(&format!("  - shim: {}", bin_dir.join(bin_name).as_path().display()));
+            }
         }
         output::raw(&format!("  - package dir: {}", package_dir.as_path().display()));
         output::raw(&format!("  - metadata: {}", metadata_path.as_path().display()));
@@ -788,7 +821,7 @@ pub(crate) async fn create_package_shim(
 
         // Check if already a managed shim (symlink to ../current/bin/vp)
         if let Ok(target) = tokio::fs::read_link(&shim_path).await {
-            if target == std::path::Path::new("../current/bin/vp") {
+            if target == std::path::Path::new(PACKAGE_SHIM_TARGET) {
                 return Ok(());
             }
             // Exists but points elsewhere (e.g., npm-installed direct symlink) — replace it
@@ -796,7 +829,7 @@ pub(crate) async fn create_package_shim(
         }
 
         // Create symlink to ../current/bin/vp
-        tokio::fs::symlink("../current/bin/vp", &shim_path).await?;
+        tokio::fs::symlink(PACKAGE_SHIM_TARGET, &shim_path).await?;
         tracing::debug!("Created package shim symlink {:?} -> ../current/bin/vp", shim_path);
     }
 
@@ -833,11 +866,10 @@ async fn remove_package_shim(
     bin_dir: &vite_path::AbsolutePath,
     bin_name: &str,
 ) -> Result<(), Error> {
-    // Don't remove core shims or default env shims (e.g., `vp remove -g corepack`
-    // must keep the default corepack shim so it falls back to the Node-bundled
-    // or auto-installed corepack).
-    if CORE_SHIMS.contains(&bin_name) || crate::commands::env::setup::SHIM_TOOLS.contains(&bin_name)
-    {
+    // Don't remove protected shims (e.g., `vp remove -g corepack` must keep
+    // the default corepack shim so it falls back to the Node-bundled or
+    // auto-installed corepack).
+    if is_protected_shim(bin_name) {
         return Ok(());
     }
 

--- a/crates/vite_global_cli/src/commands/global/install.rs
+++ b/crates/vite_global_cli/src/commands/global/install.rs
@@ -57,12 +57,16 @@ fn package_error(package_name: &str, error: impl Into<Error>) -> (Option<String>
 /// If `node_version` is provided, uses that version. Otherwise, resolves from current directory.
 /// If `force` is true, auto-uninstalls conflicting packages.
 /// Use `concurrency` to control the number of packages to install in parallel.
+/// If `only_bins` is provided, only those binaries are exposed as shims; other
+/// bins the package declares are ignored (used by the corepack shim
+/// auto-install, which must not link corepack's pnpm/yarn launchers).
 pub async fn install(
     package_specs: &[String],
     node_version: Option<&str>,
     force: bool,
     concurrency: usize,
     update: bool,
+    only_bins: Option<&[&str]>,
 ) -> Result<(), (Option<String>, Error)> {
     if package_specs.is_empty() {
         return Ok(());
@@ -193,6 +197,16 @@ pub async fn install(
         let Some(InstalledPackage { installed_version, bin_names, js_bins, backup }) = install
         else {
             continue;
+        };
+        // Restrict exposed binaries when requested (e.g., the corepack shim
+        // auto-install only links `corepack`, not the pnpm/yarn launchers
+        // that `corepack enable` creates on demand).
+        let (bin_names, js_bins) = match only_bins {
+            Some(only) => (
+                bin_names.into_iter().filter(|bin| only.contains(&bin.as_str())).collect(),
+                js_bins.into_iter().filter(|bin| only.contains(&bin.as_str())).collect(),
+            ),
+            None => (bin_names, js_bins),
         };
         let mut backup = backup;
         let stale_bin_names = match stale_bin_names_for_package(&package_name, &bin_names).await {
@@ -751,7 +765,7 @@ fn is_javascript_binary(path: &AbsolutePath) -> bool {
 ///
 /// On Unix: Creates a symlink to ../current/bin/vp
 /// On Windows: Creates a trampoline .exe that forwards to vp.exe
-async fn create_package_shim(
+pub(crate) async fn create_package_shim(
     bin_dir: &vite_path::AbsolutePath,
     bin_name: &str,
     package_name: &str,
@@ -819,8 +833,11 @@ async fn remove_package_shim(
     bin_dir: &vite_path::AbsolutePath,
     bin_name: &str,
 ) -> Result<(), Error> {
-    // Don't remove core shims
-    if CORE_SHIMS.contains(&bin_name) {
+    // Don't remove core shims or default env shims (e.g., `vp remove -g corepack`
+    // must keep the default corepack shim so it falls back to the Node-bundled
+    // or auto-installed corepack).
+    if CORE_SHIMS.contains(&bin_name) || crate::commands::env::setup::SHIM_TOOLS.contains(&bin_name)
+    {
         return Ok(());
     }
 

--- a/crates/vite_global_cli/src/commands/global/install.rs
+++ b/crates/vite_global_cli/src/commands/global/install.rs
@@ -56,29 +56,17 @@ fn package_error(package_name: &str, error: impl Into<Error>) -> (Option<String>
 /// corepack shim auto-install, which must keep the wrapped tool's stdout
 /// parseable).
 fn emit_info(to_stderr: bool, msg: &str) {
-    if to_stderr {
-        eprintln!("{} {msg}", "info:".bright_blue().bold());
-    } else {
-        output::info(msg);
-    }
+    if to_stderr { output::info_stderr(msg) } else { output::info(msg) }
 }
 
 /// See [`emit_info`].
 fn emit_success(to_stderr: bool, msg: &str) {
-    if to_stderr {
-        eprintln!("{} {msg}", output::CHECK.green());
-    } else {
-        output::success(msg);
-    }
+    if to_stderr { output::success_stderr(msg) } else { output::success(msg) }
 }
 
 /// See [`emit_info`].
 fn emit_raw(to_stderr: bool, msg: &str) {
-    if to_stderr {
-        eprintln!("{msg}");
-    } else {
-        output::raw(msg);
-    }
+    if to_stderr { output::raw_stderr(msg) } else { output::raw(msg) }
 }
 
 /// Symlink target used for package shims on Unix (relative to the bin dir).
@@ -95,25 +83,33 @@ pub(crate) fn is_protected_shim(bin_name: &str) -> bool {
     CORE_SHIMS.contains(&bin_name) || crate::commands::env::setup::SHIM_TOOLS.contains(&bin_name)
 }
 
+/// Options for [`install`].
+pub struct InstallOptions<'a> {
+    /// Node.js version to install with; resolved from the current directory
+    /// when `None`.
+    pub node_version: Option<&'a str>,
+    /// Auto-uninstall packages whose binaries conflict.
+    pub force: bool,
+    /// Number of packages to install in parallel.
+    pub concurrency: usize,
+    /// `vp update -g` semantics: carries a recorded bin restriction forward.
+    pub update: bool,
+    /// Only expose these binaries as shims; other bins the package declares
+    /// are ignored (used by the corepack shim auto-install, which must not
+    /// link corepack's pnpm/yarn launchers).
+    pub only_bins: Option<&'a [&'a str]>,
+    /// Route progress lines to stderr so a wrapping shim's stdout stays
+    /// parseable.
+    pub progress_to_stderr: bool,
+}
+
 /// Install global packages parallelly.
-///
-/// If `node_version` is provided, uses that version. Otherwise, resolves from current directory.
-/// If `force` is true, auto-uninstalls conflicting packages.
-/// Use `concurrency` to control the number of packages to install in parallel.
-/// If `only_bins` is provided, only those binaries are exposed as shims; other
-/// bins the package declares are ignored (used by the corepack shim
-/// auto-install, which must not link corepack's pnpm/yarn launchers).
-/// `progress_to_stderr` routes the progress lines to stderr so a wrapping
-/// shim's stdout stays parseable.
 pub async fn install(
     package_specs: &[String],
-    node_version: Option<&str>,
-    force: bool,
-    concurrency: usize,
-    update: bool,
-    only_bins: Option<&[&str]>,
-    progress_to_stderr: bool,
+    options: InstallOptions<'_>,
 ) -> Result<(), (Option<String>, Error)> {
+    let InstallOptions { node_version, force, concurrency, update, only_bins, progress_to_stderr } =
+        options;
     if package_specs.is_empty() {
         return Ok(());
     }
@@ -215,7 +211,14 @@ pub async fn install(
             installs.push(async {
                 (
                     package_name.clone(),
-                    install_one(package_name, package.spec, &npm_path, &node_bin_dir).await,
+                    install_one(
+                        package_name,
+                        package.spec,
+                        &npm_path,
+                        &node_bin_dir,
+                        progress_to_stderr,
+                    )
+                    .await,
                 )
             });
         }
@@ -500,6 +503,7 @@ async fn install_one(
     package_spec: &str,
     npm_path: &AbsolutePathBuf,
     node_bin_dir: &AbsolutePathBuf,
+    progress_to_stderr: bool,
 ) -> Result<InstalledPackage, Error> {
     // 1. Backup a installed package, create directories
     let packages_dir = get_packages_dir()?;
@@ -520,8 +524,13 @@ async fn install_one(
         .await?;
 
     if !output.status.success() {
-        // Show captured output to help debug the failure
-        let _ = std::io::stdout().write_all(&output.stdout);
+        // Show captured output to help debug the failure. npm's stdout joins
+        // stderr when the caller needs its own stdout to stay parseable.
+        if progress_to_stderr {
+            let _ = std::io::stderr().write_all(&output.stdout);
+        } else {
+            let _ = std::io::stdout().write_all(&output.stdout);
+        }
         let _ = std::io::stderr().write_all(&output.stderr);
         cleanup_failed_install(package_name, backup).await?;
         return Err(Error::ConfigError(
@@ -593,9 +602,14 @@ impl PackageBackup {
             tokio::fs::create_dir_all(parent).await?;
         }
 
-        tokio::fs::rename(package_dir, &backup_dir).await?;
-
-        Ok(Some(Self { package_dir: package_dir.clone(), backup_dir }))
+        match tokio::fs::rename(package_dir, &backup_dir).await {
+            Ok(()) => Ok(Some(Self { package_dir: package_dir.clone(), backup_dir })),
+            // The package dir vanished between the existence check and the
+            // rename (a concurrent install/uninstall of the same package):
+            // treat it as no previous install.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e.into()),
+        }
     }
 
     async fn restore(self) -> Result<(), Error> {

--- a/crates/vite_global_cli/src/commands/global/install.rs
+++ b/crates/vite_global_cli/src/commands/global/install.rs
@@ -52,6 +52,35 @@ fn package_error(package_name: &str, error: impl Into<Error>) -> (Option<String>
     (Some(package_name.to_string()), error.into())
 }
 
+/// Route an install progress line to stdout (default) or stderr (used by the
+/// corepack shim auto-install, which must keep the wrapped tool's stdout
+/// parseable).
+fn emit_info(to_stderr: bool, msg: &str) {
+    if to_stderr {
+        eprintln!("{} {msg}", "info:".bright_blue().bold());
+    } else {
+        output::info(msg);
+    }
+}
+
+/// See [`emit_info`].
+fn emit_success(to_stderr: bool, msg: &str) {
+    if to_stderr {
+        eprintln!("{} {msg}", output::CHECK.green());
+    } else {
+        output::success(msg);
+    }
+}
+
+/// See [`emit_info`].
+fn emit_raw(to_stderr: bool, msg: &str) {
+    if to_stderr {
+        eprintln!("{msg}");
+    } else {
+        output::raw(msg);
+    }
+}
+
 /// Symlink target used for package shims on Unix (relative to the bin dir).
 #[cfg(unix)]
 pub(crate) const PACKAGE_SHIM_TARGET: &str = "../current/bin/vp";
@@ -74,6 +103,8 @@ pub(crate) fn is_protected_shim(bin_name: &str) -> bool {
 /// If `only_bins` is provided, only those binaries are exposed as shims; other
 /// bins the package declares are ignored (used by the corepack shim
 /// auto-install, which must not link corepack's pnpm/yarn launchers).
+/// `progress_to_stderr` routes the progress lines to stderr so a wrapping
+/// shim's stdout stays parseable.
 pub async fn install(
     package_specs: &[String],
     node_version: Option<&str>,
@@ -81,6 +112,7 @@ pub async fn install(
     concurrency: usize,
     update: bool,
     only_bins: Option<&[&str]>,
+    progress_to_stderr: bool,
 ) -> Result<(), (Option<String>, Error)> {
     if package_specs.is_empty() {
         return Ok(());
@@ -145,13 +177,16 @@ pub async fn install(
     let packages_count = packages.len();
 
     let concurrency = concurrency.max(1);
-    output::info(&format!(
-        "{} {} global {} with Node.js {}",
-        operation_progress,
-        packages_count,
-        if packages_count == 1 { "package" } else { "packages" },
-        node_version
-    ));
+    emit_info(
+        progress_to_stderr,
+        &format!(
+            "{} {} global {} with Node.js {}",
+            operation_progress,
+            packages_count,
+            if packages_count == 1 { "package" } else { "packages" },
+            node_version
+        ),
+    );
 
     let progress = ProgressBar::new(packages_count as u64);
     if std::io::stderr().is_terminal() && std::env::var_os("CI").is_none() {
@@ -303,10 +338,10 @@ pub async fn install(
                     conflicts.iter().map(|(_, pkg)| pkg.clone()).collect();
                 let mut uninstall_failed = false;
                 for pkg in packages_to_remove {
-                    output::raw(&format!(
-                        "Uninstalling {} (conflicts with {})...",
-                        pkg, package_name
-                    ));
+                    emit_raw(
+                        progress_to_stderr,
+                        &format!("Uninstalling {} (conflicts with {})...", pkg, package_name),
+                    );
                     if let Err(error) = Box::pin(uninstall(&pkg, false)).await {
                         let _ = cleanup_failed_install(&package_name, backup.take()).await;
                         if first_error.is_none() {
@@ -433,23 +468,26 @@ pub async fn install(
         }
 
         // 4.7 Print success message
-        output::success(&format!(
-            "{} {} {}{}",
-            operation_past,
-            package_name.bold(),
-            if update { "to " } else { "" },
-            installed_version.bold()
-        ));
+        emit_success(
+            progress_to_stderr,
+            &format!(
+                "{} {} {}{}",
+                operation_past,
+                package_name.bold(),
+                if update { "to " } else { "" },
+                installed_version.bold()
+            ),
+        );
         if !bin_names.is_empty() {
             let bins = bin_names
                 .iter()
                 .map(|bin_name| bin_name.bold().to_string())
                 .collect::<Vec<_>>()
                 .join(", ");
-            output::raw(&format!("  Bins: {}", bins));
+            emit_raw(progress_to_stderr, &format!("  Bins: {}", bins));
         }
         if index + 1 < packages_count {
-            output::raw("");
+            emit_raw(progress_to_stderr, "");
         }
     }
 

--- a/crates/vite_global_cli/src/commands/global/install.rs
+++ b/crates/vite_global_cli/src/commands/global/install.rs
@@ -52,26 +52,22 @@ fn package_error(package_name: &str, error: impl Into<Error>) -> (Option<String>
     (Some(package_name.to_string()), error.into())
 }
 
-/// Route an install progress line to stdout (default) or stderr (used by the
-/// corepack shim auto-install, which must keep the wrapped tool's stdout
-/// parseable).
-fn emit_info(to_stderr: bool, msg: &str) {
-    if to_stderr { output::info_stderr(msg) } else { output::info(msg) }
-}
-
-/// See [`emit_info`].
-fn emit_success(to_stderr: bool, msg: &str) {
-    if to_stderr { output::success_stderr(msg) } else { output::success(msg) }
-}
-
-/// See [`emit_info`].
-fn emit_raw(to_stderr: bool, msg: &str) {
-    if to_stderr { output::raw_stderr(msg) } else { output::raw(msg) }
-}
-
 /// Symlink target used for package shims on Unix (relative to the bin dir).
 #[cfg(unix)]
 pub(crate) const PACKAGE_SHIM_TARGET: &str = "../current/bin/vp";
+
+/// Check whether a bin symlink target points at the vp binary: the standard
+/// relative package-shim target, or a resolvable link to a binary named `vp`
+/// (absolute paths in external/dev layouts created by `vp env setup`).
+#[cfg(unix)]
+pub(crate) fn is_vp_shim_target(
+    target: &std::path::Path,
+    shim_path: &vite_path::AbsolutePath,
+) -> bool {
+    target == std::path::Path::new(PACKAGE_SHIM_TARGET)
+        || (target.file_name().is_some_and(|file_name| file_name == "vp")
+            && std::fs::exists(shim_path.as_path()).unwrap_or(false))
+}
 
 /// Check whether a binary name is a shim Vite+ owns unconditionally: core
 /// shims plus the default env shims (node, npm, npx, corepack, vpx, vpr).
@@ -98,9 +94,6 @@ pub struct InstallOptions<'a> {
     /// are ignored (used by the corepack shim auto-install, which must not
     /// link corepack's pnpm/yarn launchers).
     pub only_bins: Option<&'a [&'a str]>,
-    /// Route progress lines to stderr so a wrapping shim's stdout stays
-    /// parseable.
-    pub progress_to_stderr: bool,
 }
 
 /// Install global packages parallelly.
@@ -108,8 +101,7 @@ pub async fn install(
     package_specs: &[String],
     options: InstallOptions<'_>,
 ) -> Result<(), (Option<String>, Error)> {
-    let InstallOptions { node_version, force, concurrency, update, only_bins, progress_to_stderr } =
-        options;
+    let InstallOptions { node_version, force, concurrency, update, only_bins } = options;
     if package_specs.is_empty() {
         return Ok(());
     }
@@ -173,16 +165,13 @@ pub async fn install(
     let packages_count = packages.len();
 
     let concurrency = concurrency.max(1);
-    emit_info(
-        progress_to_stderr,
-        &format!(
-            "{} {} global {} with Node.js {}",
-            operation_progress,
-            packages_count,
-            if packages_count == 1 { "package" } else { "packages" },
-            node_version
-        ),
-    );
+    output::info(&format!(
+        "{} {} global {} with Node.js {}",
+        operation_progress,
+        packages_count,
+        if packages_count == 1 { "package" } else { "packages" },
+        node_version
+    ));
 
     let progress = ProgressBar::new(packages_count as u64);
     if std::io::stderr().is_terminal() && std::env::var_os("CI").is_none() {
@@ -211,14 +200,7 @@ pub async fn install(
             installs.push(async {
                 (
                     package_name.clone(),
-                    install_one(
-                        package_name,
-                        package.spec,
-                        &npm_path,
-                        &node_bin_dir,
-                        progress_to_stderr,
-                    )
-                    .await,
+                    install_one(package_name, package.spec, &npm_path, &node_bin_dir).await,
                 )
             });
         }
@@ -341,10 +323,10 @@ pub async fn install(
                     conflicts.iter().map(|(_, pkg)| pkg.clone()).collect();
                 let mut uninstall_failed = false;
                 for pkg in packages_to_remove {
-                    emit_raw(
-                        progress_to_stderr,
-                        &format!("Uninstalling {} (conflicts with {})...", pkg, package_name),
-                    );
+                    output::raw(&format!(
+                        "Uninstalling {} (conflicts with {})...",
+                        pkg, package_name
+                    ));
                     if let Err(error) = Box::pin(uninstall(&pkg, false)).await {
                         let _ = cleanup_failed_install(&package_name, backup.take()).await;
                         if first_error.is_none() {
@@ -471,26 +453,23 @@ pub async fn install(
         }
 
         // 4.7 Print success message
-        emit_success(
-            progress_to_stderr,
-            &format!(
-                "{} {} {}{}",
-                operation_past,
-                package_name.bold(),
-                if update { "to " } else { "" },
-                installed_version.bold()
-            ),
-        );
+        output::success(&format!(
+            "{} {} {}{}",
+            operation_past,
+            package_name.bold(),
+            if update { "to " } else { "" },
+            installed_version.bold()
+        ));
         if !bin_names.is_empty() {
             let bins = bin_names
                 .iter()
                 .map(|bin_name| bin_name.bold().to_string())
                 .collect::<Vec<_>>()
                 .join(", ");
-            emit_raw(progress_to_stderr, &format!("  Bins: {}", bins));
+            output::raw(&format!("  Bins: {}", bins));
         }
         if index + 1 < packages_count {
-            emit_raw(progress_to_stderr, "");
+            output::raw("");
         }
     }
 
@@ -503,7 +482,6 @@ async fn install_one(
     package_spec: &str,
     npm_path: &AbsolutePathBuf,
     node_bin_dir: &AbsolutePathBuf,
-    progress_to_stderr: bool,
 ) -> Result<InstalledPackage, Error> {
     // 1. Backup a installed package, create directories
     let packages_dir = get_packages_dir()?;
@@ -525,8 +503,8 @@ async fn install_one(
 
     if !output.status.success() {
         // Show captured output to help debug the failure. npm's stdout joins
-        // stderr when the caller needs its own stdout to stay parseable.
-        if progress_to_stderr {
+        // stderr when vp's stdout must stay parseable (shim dispatch).
+        if output::user_output_to_stderr() {
             let _ = std::io::stderr().write_all(&output.stdout);
         } else {
             let _ = std::io::stdout().write_all(&output.stdout);
@@ -895,15 +873,10 @@ pub(crate) async fn create_package_shim(
     {
         let shim_path = bin_dir.join(bin_name);
 
-        // Check if already a Vite+ shim: either the standard relative target
-        // or a resolvable absolute path to the vp binary (external/dev
-        // layouts created by `vp env setup`, where replacing it with the
-        // relative target would dangle because VP_HOME/current is absent).
+        // Keep an existing Vite+ shim: replacing an external/dev-layout link
+        // with the relative target would dangle when VP_HOME/current is absent.
         if let Ok(target) = tokio::fs::read_link(&shim_path).await {
-            let is_vp_target = target == std::path::Path::new(PACKAGE_SHIM_TARGET)
-                || (target.file_name().is_some_and(|file_name| file_name == "vp")
-                    && std::fs::exists(shim_path.as_path()).unwrap_or(false));
-            if is_vp_target {
+            if is_vp_shim_target(&target, &shim_path) {
                 return Ok(());
             }
             // Exists but points elsewhere (e.g., npm-installed direct symlink) — replace it

--- a/crates/vite_global_cli/src/commands/global/install.rs
+++ b/crates/vite_global_cli/src/commands/global/install.rs
@@ -79,6 +79,15 @@ pub(crate) fn is_protected_shim(bin_name: &str) -> bool {
     CORE_SHIMS.contains(&bin_name) || crate::commands::env::setup::SHIM_TOOLS.contains(&bin_name)
 }
 
+/// Whether a package may own a bin name. Protected shim names never belong
+/// to packages, with one exception: the `corepack` package owning its own
+/// `corepack` bin, so an explicit `vp install -g corepack` wins the shim's
+/// resolution order. The exemption is scoped to the package name; any other
+/// package declaring a `corepack` bin must not take BinConfig ownership.
+pub(crate) fn package_may_own_bin(package_name: &str, bin_name: &str) -> bool {
+    !is_protected_shim(bin_name) || (bin_name == "corepack" && package_name == "corepack")
+}
+
 /// Options for [`install`].
 pub struct InstallOptions<'a> {
     /// Node.js version to install with; resolved from the current directory
@@ -265,6 +274,21 @@ pub async fn install(
             bin_names.retain(|bin| only.contains(bin));
             js_bins.retain(|bin| only.contains(bin));
         }
+
+        // Drop bin names the package must not own before conflict detection,
+        // shim creation, BinConfig ownership, and metadata recording.
+        bin_names.retain(|bin| {
+            let allowed = package_may_own_bin(&package_name, bin);
+            if !allowed {
+                output::warn(&format!(
+                    "Package '{}' provides '{}' binary, but it conflicts with a built-in shim. \
+                     Skipping.",
+                    package_name, bin
+                ));
+            }
+            allowed
+        });
+        js_bins.retain(|bin| package_may_own_bin(&package_name, bin));
 
         let stale_bin_names = match stale_bin_names_for_package(
             previous_metadata.as_ref(),
@@ -853,12 +877,10 @@ pub(crate) async fn create_package_shim(
     bin_name: &str,
     package_name: &str,
 ) -> Result<(), Error> {
-    // Check for conflicts with protected shims. corepack is the exception:
-    // an explicit `vp install -g corepack` must own a BinConfig so the
-    // managed copy wins in the shim's resolution order, and its default shim
-    // dispatches through vp either way. vpx/vpr never dispatch to packages,
-    // so a package binary with those names would be unreachable.
-    if is_protected_shim(bin_name) && bin_name != "corepack" {
+    // Defense in depth: the finalize loop already filters bin names the
+    // package must not own (see package_may_own_bin); keep the guard here so
+    // no other caller can hand a protected shim to a package.
+    if !package_may_own_bin(package_name, bin_name) {
         output::warn(&format!(
             "Package '{}' provides '{}' binary, but it conflicts with a built-in shim. Skipping.",
             package_name, bin_name
@@ -1040,6 +1062,41 @@ mod tests {
         let shim_path = bin_dir.join("node");
         #[cfg(windows)]
         let shim_path = bin_dir.join("node.exe");
+        assert!(!shim_path.as_path().exists());
+    }
+
+    #[test]
+    fn test_package_may_own_bin_scopes_corepack_to_its_package() {
+        // Only the corepack package may own the corepack bin; any other
+        // package declaring a `corepack` bin must not take BinConfig
+        // ownership (it would win the corepack shim's resolution order).
+        assert!(package_may_own_bin("corepack", "corepack"));
+        assert!(!package_may_own_bin("some-package", "corepack"));
+        assert!(!package_may_own_bin("@scope/corepack", "corepack"));
+
+        // Other protected shims never belong to packages
+        assert!(!package_may_own_bin("corepack", "npm"));
+        assert!(!package_may_own_bin("some-package", "vpx"));
+        assert!(!package_may_own_bin("some-package", "vpr"));
+
+        // Regular bins are unrestricted
+        assert!(package_may_own_bin("typescript", "tsc"));
+    }
+
+    #[tokio::test]
+    async fn test_create_package_shim_skips_corepack_bin_for_other_packages() {
+        use tempfile::TempDir;
+        use vite_path::AbsolutePathBuf;
+
+        let temp_dir = TempDir::new().unwrap();
+        let bin_dir = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+
+        create_package_shim(&bin_dir, "corepack", "some-package").await.unwrap();
+
+        #[cfg(unix)]
+        let shim_path = bin_dir.join("corepack");
+        #[cfg(windows)]
+        let shim_path = bin_dir.join("corepack.exe");
         assert!(!shim_path.as_path().exists());
     }
 

--- a/crates/vite_global_cli/src/commands/global/install.rs
+++ b/crates/vite_global_cli/src/commands/global/install.rs
@@ -58,7 +58,10 @@ pub(crate) const PACKAGE_SHIM_TARGET: &str = "../current/bin/vp";
 
 /// Check whether a binary name is a shim Vite+ owns unconditionally: core
 /// shims plus the default env shims (node, npm, npx, corepack, vpx, vpr).
-/// Protected shims are never created for or removed on behalf of packages.
+/// Protected shims are never removed on behalf of packages, and are never
+/// created for packages either, with one exception: `vp install -g corepack`
+/// may take BinConfig ownership of the corepack shim (see
+/// `create_package_shim`).
 pub(crate) fn is_protected_shim(bin_name: &str) -> bool {
     CORE_SHIMS.contains(&bin_name) || crate::commands::env::setup::SHIM_TOOLS.contains(&bin_name)
 }
@@ -205,35 +208,51 @@ pub async fn install(
     // 4. Finalize installed packages.
     let mut bin_owners = HashMap::<String, String>::new();
     for (index, (package_name, Package { spec: _, install })) in packages.into_iter().enumerate() {
-        let Some(InstalledPackage { installed_version, bin_names, js_bins, backup }) = install
+        let Some(InstalledPackage { installed_version, mut bin_names, mut js_bins, mut backup }) =
+            install
         else {
             continue;
         };
+
+        // Previous metadata drives both the inherited bin restriction and
+        // stale-bin detection below; load it once.
+        let previous_metadata = match PackageMetadata::load(&package_name).await {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                let _ = cleanup_failed_install(&package_name, backup.take()).await;
+                if first_error.is_none() {
+                    first_error = Some(package_error(&package_name, error));
+                }
+                continue;
+            }
+        };
+
         // Restrict exposed binaries when requested (e.g., the corepack shim
         // auto-install only links `corepack`, not the pnpm/yarn launchers
         // that `corepack enable` creates on demand). Updates carry a recorded
         // restriction forward so `vp update -g` cannot re-expose the filtered
         // bins; explicit installs (update=false) re-expose the full bin list.
-        let inherited_restriction: Option<Vec<String>> = if only_bins.is_none() && update {
-            match PackageMetadata::load(&package_name).await {
-                Ok(Some(previous)) if previous.bins_restricted => Some(previous.bins),
-                _ => None,
-            }
-        } else {
-            None
+        let restriction: Option<Vec<String>> = match only_bins {
+            Some(only) => Some(only.iter().map(ToString::to_string).collect()),
+            None if update => previous_metadata
+                .as_ref()
+                .filter(|previous| previous.bins_restricted)
+                .map(|previous| previous.bins.clone()),
+            None => None,
         };
-        let bins_restricted = only_bins.is_some() || inherited_restriction.is_some();
-        let mut bin_names = bin_names;
-        let mut js_bins = js_bins;
-        if let Some(only) = only_bins {
-            bin_names.retain(|bin| only.contains(&bin.as_str()));
-            js_bins.retain(|bin| only.contains(&bin.as_str()));
-        } else if let Some(only) = &inherited_restriction {
+        let bins_restricted = restriction.is_some();
+        if let Some(only) = &restriction {
             bin_names.retain(|bin| only.contains(bin));
             js_bins.retain(|bin| only.contains(bin));
         }
-        let mut backup = backup;
-        let stale_bin_names = match stale_bin_names_for_package(&package_name, &bin_names).await {
+
+        let stale_bin_names = match stale_bin_names_for_package(
+            previous_metadata.as_ref(),
+            &package_name,
+            &bin_names,
+        )
+        .await
+        {
             Ok(bin_names) => bin_names,
             Err(error) => {
                 let _ = cleanup_failed_install(&package_name, backup.take()).await;
@@ -625,14 +644,15 @@ async fn cleanup_installed_package(package_name: &str) -> Result<(), Error> {
 }
 
 async fn stale_bin_names_for_package(
+    previous_metadata: Option<&PackageMetadata>,
     package_name: &str,
     current_bin_names: &[String],
 ) -> Result<Vec<String>, Error> {
     let current_bin_names: HashSet<_> = current_bin_names.iter().cloned().collect();
     let mut previous_bin_names = HashSet::new();
 
-    if let Some(metadata) = PackageMetadata::load(package_name).await? {
-        previous_bin_names.extend(metadata.bins);
+    if let Some(metadata) = previous_metadata {
+        previous_bin_names.extend(metadata.bins.iter().cloned());
     }
 
     previous_bin_names.extend(BinConfig::find_by_package(package_name).await?);
@@ -803,10 +823,14 @@ pub(crate) async fn create_package_shim(
     bin_name: &str,
     package_name: &str,
 ) -> Result<(), Error> {
-    // Check for conflicts with core shims
-    if CORE_SHIMS.contains(&bin_name) {
+    // Check for conflicts with protected shims. corepack is the exception:
+    // an explicit `vp install -g corepack` must own a BinConfig so the
+    // managed copy wins in the shim's resolution order, and its default shim
+    // dispatches through vp either way. vpx/vpr never dispatch to packages,
+    // so a package binary with those names would be unreachable.
+    if is_protected_shim(bin_name) && bin_name != "corepack" {
         output::warn(&format!(
-            "Package '{}' provides '{}' binary, but it conflicts with a core shim. Skipping.",
+            "Package '{}' provides '{}' binary, but it conflicts with a built-in shim. Skipping.",
             package_name, bin_name
         ));
         return Ok(());
@@ -819,9 +843,15 @@ pub(crate) async fn create_package_shim(
     {
         let shim_path = bin_dir.join(bin_name);
 
-        // Check if already a managed shim (symlink to ../current/bin/vp)
+        // Check if already a Vite+ shim: either the standard relative target
+        // or a resolvable absolute path to the vp binary (external/dev
+        // layouts created by `vp env setup`, where replacing it with the
+        // relative target would dangle because VP_HOME/current is absent).
         if let Ok(target) = tokio::fs::read_link(&shim_path).await {
-            if target == std::path::Path::new(PACKAGE_SHIM_TARGET) {
+            let is_vp_target = target == std::path::Path::new(PACKAGE_SHIM_TARGET)
+                || (target.file_name().is_some_and(|file_name| file_name == "vp")
+                    && std::fs::exists(shim_path.as_path()).unwrap_or(false));
+            if is_vp_target {
                 return Ok(());
             }
             // Exists but points elsewhere (e.g., npm-installed direct symlink) — replace it

--- a/crates/vite_global_cli/src/commands/vpx.rs
+++ b/crates/vite_global_cli/src/commands/vpx.rs
@@ -154,17 +154,11 @@ async fn find_global_binary(cmd: &str) -> Option<GlobalBinary> {
 /// Ensures the required Node.js version is installed, prepends its bin dir
 /// and local node_modules/.bin dirs to PATH, then executes.
 async fn execute_global_binary(bin: GlobalBinary, args: &[String], cwd: &AbsolutePath) -> i32 {
-    // Ensure Node.js is installed
-    if let Err(e) = dispatch::ensure_installed(&bin.node_version).await {
-        output::error(&format!("vpx: Failed to install Node {}: {e}", bin.node_version));
-        return 1;
-    }
-
-    // Locate node binary for this version
-    let node_path = match dispatch::locate_tool(&bin.node_version, "node") {
+    // Ensure Node.js is installed and locate its binary
+    let node_path = match dispatch::ensure_installed(&bin.node_version).await {
         Ok(p) => p,
         Err(e) => {
-            output::error(&format!("vpx: Node not found: {e}"));
+            output::error(&format!("vpx: Failed to install Node {}: {e}", bin.node_version));
             return 1;
         }
     };

--- a/crates/vite_global_cli/src/help.rs
+++ b/crates/vite_global_cli/src/help.rs
@@ -543,7 +543,7 @@ fn env_help_doc() -> HelpDoc {
                 "Examples",
                 vec![
                     "  Setup:",
-                    "    vp env setup                  # Create shims for node, npm, npx",
+                    "    vp env setup                  # Create shims for node, npm, npx, corepack",
                     "    vp env on                     # Use vite-plus managed Node.js",
                     "    vp env print                  # Print shell snippet for this session",
                     "",

--- a/crates/vite_global_cli/src/help.rs
+++ b/crates/vite_global_cli/src/help.rs
@@ -936,11 +936,11 @@ fn delegated_help_doc(command: &str) -> Option<HelpDoc> {
     }
 }
 
-fn is_help_flag(arg: &str) -> bool {
+pub(crate) fn is_help_flag(arg: &str) -> bool {
     matches!(arg, "-h" | "--help")
 }
 
-fn has_help_flag_before_terminator(args: &[String]) -> bool {
+pub(crate) fn has_help_flag_before_terminator(args: &[String]) -> bool {
     args.iter().take_while(|arg| arg.as_str() != "--").any(|arg| is_help_flag(arg))
 }
 

--- a/crates/vite_global_cli/src/main.rs
+++ b/crates/vite_global_cli/src/main.rs
@@ -315,7 +315,9 @@ async fn main() -> ExitCode {
     tracing::debug!("argv0: {argv0}");
 
     if let Some(tool) = shim::detect_shim_tool(argv0) {
-        // Shim mode - dispatch to the appropriate tool
+        // Shim mode - dispatch to the appropriate tool. stdout belongs to the
+        // wrapped tool; route vp's own output to stderr.
+        output::route_user_output_to_stderr();
         let exit_code = shim::dispatch(&tool, &args[1..]).await;
         return ExitCode::from(exit_code as u8);
     }

--- a/crates/vite_global_cli/src/shim/corepack.rs
+++ b/crates/vite_global_cli/src/shim/corepack.rs
@@ -133,14 +133,16 @@ async fn resolve_corepack_invocation() -> Result<CorepackInvocation, i32> {
         return Ok(CorepackInvocation { program: corepack_path, pre_args: Vec::new() });
     }
 
-    // 3. Node.js 25+ no longer bundles corepack: install it as a vp-managed
-    //    global package, then run that copy. Only the `corepack` bin is
-    //    linked; the pnpm/yarn launchers the package also declares stay
-    //    unexposed (that is `corepack enable`'s job) and must not conflict
-    //    with vp-managed package managers. The notice goes to stderr so the
-    //    wrapped corepack's stdout stays parseable.
+    // 3. No usable corepack in the resolved Node.js (Node.js 25+ no longer
+    //    bundles it; a bundled copy may also have been removed, e.g. by
+    //    `npm uninstall -g corepack`): install it as a vp-managed global
+    //    package, then run that copy. Only the `corepack` bin is linked; the
+    //    pnpm/yarn launchers the package also declares stay unexposed (that
+    //    is `corepack enable`'s job) and must not conflict with vp-managed
+    //    package managers. The notice goes to stderr so the wrapped
+    //    corepack's stdout stays parseable.
     eprintln!(
-        "vp: corepack is not bundled with Node.js {}; installing it as a managed global package",
+        "vp: corepack is not available for Node.js {}; installing it as a managed global package",
         resolution.version
     );
     if let Err((_, error)) = crate::commands::global::install::install(

--- a/crates/vite_global_cli/src/shim/corepack.rs
+++ b/crates/vite_global_cli/src/shim/corepack.rs
@@ -148,12 +148,11 @@ async fn resolve_corepack_invocation() -> Result<CorepackInvocation, i32> {
     // Preserve the shape of a previous explicit (unrestricted) install: the
     // reinstall must not silently drop launcher bins the user had exposed
     // (the stale-bin cleanup would delete their pnpm/yarn shims).
-    let restrict =
-        match crate::commands::env::package_metadata::PackageMetadata::load("corepack").await {
-            Ok(Some(previous)) if !previous.bins_restricted => false,
-            _ => true,
-        };
-    let only_bins: Option<&[&str]> = if restrict { Some(&["corepack"]) } else { None };
+    let unrestricted = matches!(
+        crate::commands::env::package_metadata::PackageMetadata::load("corepack").await,
+        Ok(Some(previous)) if !previous.bins_restricted
+    );
+    let only_bins: Option<&[&str]> = if unrestricted { None } else { Some(&["corepack"]) };
     if let Err((_, error)) = crate::commands::global::install::install(
         &["corepack".to_string()],
         None,

--- a/crates/vite_global_cli/src/shim/corepack.rs
+++ b/crates/vite_global_cli/src/shim/corepack.rs
@@ -155,13 +155,15 @@ async fn resolve_corepack_invocation() -> Result<CorepackInvocation, i32> {
     let only_bins: Option<&[&str]> = if unrestricted { None } else { Some(&["corepack"]) };
     if let Err((_, error)) = crate::commands::global::install::install(
         &["corepack".to_string()],
-        None,
-        false,
-        1,
-        false,
-        only_bins,
-        // Keep the wrapped corepack's stdout parseable
-        true,
+        crate::commands::global::install::InstallOptions {
+            node_version: None,
+            force: false,
+            concurrency: 1,
+            update: false,
+            only_bins,
+            // Keep the wrapped corepack's stdout parseable
+            progress_to_stderr: true,
+        },
     )
     .await
     {

--- a/crates/vite_global_cli/src/shim/corepack.rs
+++ b/crates/vite_global_cli/src/shim/corepack.rs
@@ -77,6 +77,11 @@ pub(crate) async fn dispatch_corepack(args: &[String]) -> i32 {
         }
     }
 
+    // The bundled corepack and native binaries have no leading args; exec
+    // with the caller's slice instead of cloning every argument.
+    if full_args.is_empty() {
+        return exec::exec_tool(&program, args);
+    }
     full_args.extend(args.iter().cloned());
     exec::exec_tool(&program, &full_args)
 }
@@ -115,11 +120,19 @@ async fn resolve_corepack_invocation() -> Result<CorepackInvocation, i32> {
             return Err(1);
         }
     };
-    if let Err(e) = ensure_installed(&resolution.version).await {
-        eprintln!("vp: Failed to install Node {}: {e}", resolution.version);
-        return Err(1);
-    }
-    if let Ok(corepack_path) = locate_tool(&resolution.version, "corepack") {
+    let corepack_path = match locate_tool(&resolution.version, "corepack") {
+        Ok(path) => Some(path),
+        Err(_) => {
+            // The runtime may not be installed yet; download it before
+            // concluding that corepack is not bundled.
+            if let Err(e) = ensure_installed(&resolution.version).await {
+                eprintln!("vp: Failed to install Node {}: {e}", resolution.version);
+                return Err(1);
+            }
+            locate_tool(&resolution.version, "corepack").ok()
+        }
+    };
+    if let Some(corepack_path) = corepack_path {
         // The bundled corepack sits in the same bin directory as node;
         // prepend it so corepack's child processes see the same runtime.
         if let Some(node_bin_dir) = corepack_path.parent() {
@@ -161,8 +174,6 @@ async fn resolve_corepack_invocation() -> Result<CorepackInvocation, i32> {
             concurrency: 1,
             update: false,
             only_bins,
-            // Keep the wrapped corepack's stdout parseable
-            progress_to_stderr: true,
         },
     )
     .await
@@ -203,20 +214,12 @@ async fn managed_corepack_invocation() -> Result<Option<CorepackInvocation>, Str
 /// Everything after a `--` separator is positional (package-manager names),
 /// so the subcommand and help flags are only looked for before it.
 fn is_corepack_link_command(args: &[String]) -> bool {
-    let mut subcommand = None;
-    for arg in args {
-        if arg == "--" {
-            break;
-        }
-        // Help output doesn't touch link files; run it as-is.
-        if arg == "-h" || arg == "--help" {
-            return false;
-        }
-        if subcommand.is_none() && !arg.starts_with('-') {
-            subcommand = Some(arg.as_str());
-        }
+    // Help output doesn't touch link files; run it as-is.
+    if crate::help::has_help_flag_before_terminator(args) {
+        return false;
     }
-    matches!(subcommand, Some("enable" | "disable"))
+    let subcommand = args.iter().take_while(|arg| *arg != "--").find(|arg| !arg.starts_with('-'));
+    matches!(subcommand.map(String::as_str), Some("enable" | "disable"))
 }
 
 /// Return the user args for an intercepted `corepack enable`/`disable` run,
@@ -466,10 +469,9 @@ async fn npm_link_source(_bin_dir: &AbsolutePath, _name: &str) -> Option<Absolut
 /// Check whether the bin entry is an intact Vite+ package shim.
 #[cfg(unix)]
 async fn is_vp_shim(bin_dir: &AbsolutePath, name: &str) -> bool {
-    match tokio::fs::read_link(bin_dir.join(name)).await {
-        Ok(target) => {
-            target == std::path::Path::new(crate::commands::global::install::PACKAGE_SHIM_TARGET)
-        }
+    let shim_path = bin_dir.join(name);
+    match tokio::fs::read_link(&shim_path).await {
+        Ok(target) => crate::commands::global::install::is_vp_shim_target(&target, &shim_path),
         Err(_) => false,
     }
 }

--- a/crates/vite_global_cli/src/shim/corepack.rs
+++ b/crates/vite_global_cli/src/shim/corepack.rs
@@ -160,6 +160,8 @@ async fn resolve_corepack_invocation() -> Result<CorepackInvocation, i32> {
         1,
         false,
         only_bins,
+        // Keep the wrapped corepack's stdout parseable
+        true,
     )
     .await
     {

--- a/crates/vite_global_cli/src/shim/corepack.rs
+++ b/crates/vite_global_cli/src/shim/corepack.rs
@@ -1,0 +1,386 @@
+//! Corepack shim dispatch.
+//!
+//! `corepack` is a default shim (created by `vp env setup`), but unlike the
+//! core tools (node/npm/npx) it is not always available in the resolved
+//! Node.js installation: Node.js 25 removed the bundled corepack.
+//!
+//! Resolution order:
+//! 1. vp-managed global package (`vp install -g corepack`) — an explicit
+//!    install wins and provides a consistent corepack across Node.js versions
+//! 2. corepack bundled with the project-resolved Node.js (Node.js <= 24)
+//! 3. auto-install corepack as a vp-managed global package
+//!
+//! `corepack enable`/`corepack disable` create or remove package-manager
+//! launchers next to the corepack binary found in PATH, which under the shim
+//! would be the per-version Node.js bin directory (not on PATH). To keep the
+//! launchers reachable, these commands get `--install-directory ~/.vite-plus/bin`
+//! injected when not explicitly set, and Vite+-owned shims are restored
+//! afterwards if corepack removed or replaced them.
+
+use vite_path::{AbsolutePath, AbsolutePathBuf, current_dir};
+use vite_shared::{PrependOptions, env_vars, output, prepend_to_path_env};
+
+use super::{
+    dispatch::{
+        ensure_installed, find_package_for_binary, locate_package_binary, locate_tool,
+        resolve_with_cache,
+    },
+    exec,
+};
+use crate::commands::env::{
+    bin_config::{BinConfig, BinSource},
+    config, setup,
+};
+
+/// Binary names corepack `enable`/`disable` may create or remove in the
+/// install directory (npm/npx only when explicitly requested).
+const COREPACK_MANAGED_BIN_NAMES: &[&str] = &["npm", "npx", "pnpm", "pnpx", "yarn", "yarnpkg"];
+
+/// How to invoke the resolved corepack binary.
+struct CorepackInvocation {
+    /// Program to execute (the corepack binary itself, or node for a JS entry)
+    program: AbsolutePathBuf,
+    /// Arguments to pass before the user-supplied args (e.g., the JS entry path)
+    pre_args: Vec<String>,
+}
+
+/// Dispatch a `corepack` shim invocation.
+pub(crate) async fn dispatch_corepack(args: &[String]) -> i32 {
+    let invocation = match resolve_corepack_invocation().await {
+        Ok(invocation) => invocation,
+        Err(exit_code) => return exit_code,
+    };
+
+    // enable/disable: run with spawn+wait so Vite+-owned shims can be
+    // restored after corepack touched the install directory.
+    if let Ok(bin_dir) = config::get_bin_dir()
+        && let Some(link_args) = corepack_link_command_args(args, &bin_dir)
+    {
+        let mut full_args = invocation.pre_args.clone();
+        full_args.extend(link_args);
+        let exit_code = exec::spawn_tool(&invocation.program, &full_args);
+        restore_vp_owned_shims(&bin_dir).await;
+        return exit_code;
+    }
+
+    let mut full_args = invocation.pre_args.clone();
+    full_args.extend(args.iter().cloned());
+    exec::exec_tool(&invocation.program, &full_args)
+}
+
+/// Resolve which corepack binary to execute.
+///
+/// Returns an exit code on failure (errors are already printed).
+async fn resolve_corepack_invocation() -> Result<CorepackInvocation, i32> {
+    // 1. An explicit `vp install -g corepack` wins.
+    match managed_corepack_invocation().await {
+        Ok(Some(invocation)) => return Ok(invocation),
+        Ok(None) => {}
+        Err(e) => {
+            eprintln!("vp: Failed to resolve installed corepack: {e}");
+            return Err(1);
+        }
+    }
+
+    // 2. corepack bundled with the project-resolved Node.js (Node.js <= 24).
+    let cwd = match current_dir() {
+        Ok(path) => path,
+        Err(e) => {
+            eprintln!("vp: Failed to get current directory: {e}");
+            return Err(1);
+        }
+    };
+    let resolution = match resolve_with_cache(&cwd).await {
+        Ok(resolution) => resolution,
+        Err(e) => {
+            eprintln!("vp: Failed to resolve Node version: {e}");
+            eprintln!("vp: Run 'vp env doctor' for diagnostics");
+            return Err(1);
+        }
+    };
+    if let Err(e) = ensure_installed(&resolution.version).await {
+        eprintln!("vp: Failed to install Node {}: {e}", resolution.version);
+        return Err(1);
+    }
+    if let Ok(corepack_path) = locate_tool(&resolution.version, "corepack") {
+        prepend_node_bin_dir(&resolution.version);
+        // Match the core-tool dispatch: nested core-tool shims pass through.
+        // SAFETY: Setting env vars at this point before exec/spawn is safe
+        unsafe {
+            std::env::set_var(env_vars::VP_TOOL_RECURSION, "1");
+        }
+        return Ok(CorepackInvocation { program: corepack_path, pre_args: Vec::new() });
+    }
+
+    // 3. Node.js 25+ no longer bundles corepack: install it as a vp-managed
+    //    global package, then run that copy. Only the `corepack` bin is
+    //    linked; the pnpm/yarn launchers the package also declares stay
+    //    unexposed (that is `corepack enable`'s job) and must not conflict
+    //    with vp-managed package managers.
+    output::info(&format!(
+        "corepack is not bundled with Node.js {}; installing it as a managed global package",
+        resolution.version
+    ));
+    if let Err((_, error)) = crate::commands::global::install::install(
+        &["corepack".to_string()],
+        None,
+        false,
+        1,
+        false,
+        Some(&["corepack"]),
+    )
+    .await
+    {
+        eprintln!("vp: Failed to install corepack: {error}");
+        eprintln!("vp: Run 'vp install -g corepack' manually, then retry");
+        return Err(1);
+    }
+    match managed_corepack_invocation().await {
+        Ok(Some(invocation)) => Ok(invocation),
+        _ => {
+            eprintln!("vp: corepack was installed but its binary could not be located");
+            Err(1)
+        }
+    }
+}
+
+/// Resolve a corepack installed via `vp install -g corepack`, if any.
+///
+/// Mirrors `dispatch_package_binary`: uses the install-time Node.js version
+/// and prepends its bin directory to PATH for child processes.
+async fn managed_corepack_invocation() -> Result<Option<CorepackInvocation>, String> {
+    let Some(metadata) = find_package_for_binary("corepack").await? else {
+        return Ok(None);
+    };
+
+    let node_version = metadata.platform.node.clone();
+    ensure_installed(&node_version).await?;
+    let binary_path = locate_package_binary(&metadata.name, "corepack")?;
+    let node_path = locate_tool(&node_version, "node")?;
+    let node_bin_dir =
+        node_path.parent().ok_or_else(|| "Node has no parent directory".to_string())?;
+    let _ = prepend_to_path_env(node_bin_dir, PrependOptions::default());
+
+    if metadata.is_js_binary("corepack") {
+        Ok(Some(CorepackInvocation {
+            program: node_path,
+            pre_args: vec![binary_path.as_path().display().to_string()],
+        }))
+    } else {
+        Ok(Some(CorepackInvocation { program: binary_path, pre_args: Vec::new() }))
+    }
+}
+
+/// Prepend the resolved Node.js bin directory to PATH for child processes.
+fn prepend_node_bin_dir(version: &str) {
+    if let Ok(node_path) = locate_tool(version, "node")
+        && let Some(node_bin_dir) = node_path.parent()
+    {
+        let _ = prepend_to_path_env(node_bin_dir, PrependOptions::default());
+    }
+}
+
+/// Detect a `corepack enable`/`corepack disable` invocation and return the
+/// user args to run it with, injecting `--install-directory <bin_dir>` when
+/// not explicitly set so launchers land on PATH.
+///
+/// Returns None for all other corepack commands (plain exec, no restore).
+fn corepack_link_command_args(args: &[String], bin_dir: &AbsolutePath) -> Option<Vec<String>> {
+    let subcommand = args.iter().find(|arg| !arg.starts_with('-'))?;
+    if subcommand != "enable" && subcommand != "disable" {
+        return None;
+    }
+    // Help output doesn't touch link files; run it as-is.
+    if args.iter().any(|arg| arg == "-h" || arg == "--help") {
+        return None;
+    }
+
+    let mut rewritten = args.to_vec();
+    let has_install_directory = args
+        .iter()
+        .any(|arg| arg == "--install-directory" || arg.starts_with("--install-directory="));
+    if !has_install_directory {
+        rewritten.push("--install-directory".to_string());
+        rewritten.push(bin_dir.as_path().display().to_string());
+    }
+    Some(rewritten)
+}
+
+/// Restore Vite+-owned shims that corepack `enable`/`disable` may have
+/// removed or replaced in the bin directory.
+///
+/// - Default shims (npm/npx) always belong to Vite+; they already resolve the
+///   project package-manager version, so corepack must not manage them.
+/// - Binaries installed via `vp install -g` (BinConfig source `vp`) are
+///   restored with a warning pointing at `vp remove -g`.
+async fn restore_vp_owned_shims(bin_dir: &AbsolutePath) {
+    let Ok(current_exe) = std::env::current_exe() else {
+        return;
+    };
+    // Resolve through the shim symlink chain so recreated shims point at the
+    // real vp binary, not at this process's `corepack` shim path.
+    let current_exe = tokio::fs::canonicalize(&current_exe).await.unwrap_or(current_exe);
+
+    for name in COREPACK_MANAGED_BIN_NAMES {
+        if setup::SHIM_TOOLS.contains(name) {
+            if core_shim_intact(bin_dir, name).await {
+                continue;
+            }
+            let _ = tokio::fs::remove_file(bin_dir.join(name)).await;
+            match setup::create_shim(&current_exe, bin_dir, name, false).await {
+                Ok(_) => output::warn(&format!(
+                    "'{name}' is managed by Vite+ and was restored. Vite+ already resolves \
+                     '{name}' per project, so corepack does not need to manage it."
+                )),
+                Err(e) => tracing::warn!("Failed to restore '{}' shim: {}", name, e),
+            }
+            // Remove corepack's extensionless/cmd launchers that would shadow
+            // the trampoline .exe in Git Bash.
+            #[cfg(windows)]
+            setup::cleanup_legacy_windows_shim(bin_dir, name).await;
+            continue;
+        }
+
+        // Binaries installed via `vp install -g`.
+        let Ok(Some(bin_config)) = BinConfig::load(name).await else {
+            continue;
+        };
+        if bin_config.source != BinSource::Vp || is_vp_shim(bin_dir, name).await {
+            continue;
+        }
+        output::warn(&format!(
+            "'{name}' is managed by `vp install -g {pkg}` and was restored. \
+             Run `vp remove -g {pkg}` first to let corepack manage '{name}'.",
+            pkg = bin_config.package
+        ));
+        if let Err(e) = crate::commands::global::install::create_package_shim(
+            bin_dir,
+            name,
+            &bin_config.package,
+        )
+        .await
+        {
+            tracing::warn!("Failed to restore '{}' shim: {}", name, e);
+        }
+    }
+}
+
+/// Check whether a default shim (npm/npx) is still an intact Vite+ shim.
+///
+/// Vite+ shims always link to the vp binary (relative `../current/bin/vp` or
+/// an absolute path in dev layouts); corepack launchers link to corepack's
+/// `dist/*.js` files. Broken symlinks count as not intact.
+#[cfg(unix)]
+async fn core_shim_intact(bin_dir: &AbsolutePath, name: &str) -> bool {
+    let shim_path = bin_dir.join(name);
+    match tokio::fs::read_link(&shim_path).await {
+        Ok(target) => {
+            target.file_name().is_some_and(|file_name| file_name == "vp")
+                && std::fs::exists(shim_path.as_path()).unwrap_or(false)
+        }
+        Err(_) => false,
+    }
+}
+
+/// Check whether a default shim (npm/npx) is still an intact Vite+ shim.
+#[cfg(windows)]
+async fn core_shim_intact(bin_dir: &AbsolutePath, name: &str) -> bool {
+    is_vp_shim(bin_dir, name).await
+}
+
+/// Check whether the bin entry is an intact Vite+ shim.
+#[cfg(unix)]
+async fn is_vp_shim(bin_dir: &AbsolutePath, name: &str) -> bool {
+    match tokio::fs::read_link(bin_dir.join(name)).await {
+        Ok(target) => target == std::path::Path::new("../current/bin/vp"),
+        Err(_) => false,
+    }
+}
+
+/// Check whether the bin entry is an intact Vite+ shim.
+///
+/// Trampoline shims are `.exe` files; corepack's cmd-shim launchers are
+/// `.cmd`/`.ps1`/extensionless files that would shadow the trampoline in
+/// Git Bash, so their presence means the shim needs restoring.
+#[cfg(windows)]
+async fn is_vp_shim(bin_dir: &AbsolutePath, name: &str) -> bool {
+    let exe_exists =
+        tokio::fs::try_exists(&bin_dir.join(format!("{name}.exe"))).await.unwrap_or(false);
+    let cmd_exists =
+        tokio::fs::try_exists(&bin_dir.join(format!("{name}.cmd"))).await.unwrap_or(false);
+    let sh_exists = tokio::fs::try_exists(&bin_dir.join(name)).await.unwrap_or(false);
+    exe_exists && !cmd_exists && !sh_exists
+}
+
+#[cfg(test)]
+mod tests {
+    use vite_path::AbsolutePathBuf;
+
+    use super::*;
+
+    fn bin_dir() -> AbsolutePathBuf {
+        #[cfg(windows)]
+        {
+            AbsolutePathBuf::new(std::path::PathBuf::from("C:\\Users\\test\\.vite-plus\\bin"))
+                .unwrap()
+        }
+        #[cfg(not(windows))]
+        {
+            AbsolutePathBuf::new(std::path::PathBuf::from("/home/test/.vite-plus/bin")).unwrap()
+        }
+    }
+
+    fn s(strs: &[&str]) -> Vec<String> {
+        strs.iter().map(ToString::to_string).collect()
+    }
+
+    #[test]
+    fn test_link_command_args_injects_install_directory() {
+        let bin_dir = bin_dir();
+        let rewritten = corepack_link_command_args(&s(&["enable"]), &bin_dir).unwrap();
+        assert_eq!(
+            rewritten,
+            s(&["enable", "--install-directory", &bin_dir.as_path().display().to_string()])
+        );
+
+        let rewritten = corepack_link_command_args(&s(&["disable", "yarn"]), &bin_dir).unwrap();
+        assert_eq!(
+            rewritten,
+            s(&[
+                "disable",
+                "yarn",
+                "--install-directory",
+                &bin_dir.as_path().display().to_string()
+            ])
+        );
+    }
+
+    #[test]
+    fn test_link_command_args_keeps_explicit_install_directory() {
+        let bin_dir = bin_dir();
+        let args = s(&["enable", "--install-directory", "/custom/dir"]);
+        let rewritten = corepack_link_command_args(&args, &bin_dir).unwrap();
+        assert_eq!(rewritten, args);
+
+        let args = s(&["enable", "--install-directory=/custom/dir"]);
+        let rewritten = corepack_link_command_args(&args, &bin_dir).unwrap();
+        assert_eq!(rewritten, args);
+    }
+
+    #[test]
+    fn test_link_command_args_ignores_other_commands() {
+        let bin_dir = bin_dir();
+        assert!(corepack_link_command_args(&s(&[]), &bin_dir).is_none());
+        assert!(corepack_link_command_args(&s(&["--version"]), &bin_dir).is_none());
+        assert!(corepack_link_command_args(&s(&["use", "pnpm@9"]), &bin_dir).is_none());
+        assert!(corepack_link_command_args(&s(&["pnpm", "install"]), &bin_dir).is_none());
+        assert!(corepack_link_command_args(&s(&["up"]), &bin_dir).is_none());
+    }
+
+    #[test]
+    fn test_link_command_args_skips_help() {
+        let bin_dir = bin_dir();
+        assert!(corepack_link_command_args(&s(&["enable", "--help"]), &bin_dir).is_none());
+        assert!(corepack_link_command_args(&s(&["enable", "-h"]), &bin_dir).is_none());
+    }
+}

--- a/crates/vite_global_cli/src/shim/corepack.rs
+++ b/crates/vite_global_cli/src/shim/corepack.rs
@@ -94,7 +94,7 @@ async fn resolve_corepack_invocation() -> Result<CorepackInvocation, i32> {
         Err(e) => {
             output::warn(&format!(
                 "Ignoring unusable vp-managed corepack ({e}); falling back to the \
-                 Node-bundled corepack. Run `vp install -g corepack` to repair it."
+                 Node-bundled corepack. Run `vp remove -g corepack` to clear it."
             ));
         }
     }
@@ -145,13 +145,22 @@ async fn resolve_corepack_invocation() -> Result<CorepackInvocation, i32> {
         "vp: corepack is not available for Node.js {}; installing it as a managed global package",
         resolution.version
     );
+    // Preserve the shape of a previous explicit (unrestricted) install: the
+    // reinstall must not silently drop launcher bins the user had exposed
+    // (the stale-bin cleanup would delete their pnpm/yarn shims).
+    let restrict =
+        match crate::commands::env::package_metadata::PackageMetadata::load("corepack").await {
+            Ok(Some(previous)) if !previous.bins_restricted => false,
+            _ => true,
+        };
+    let only_bins: Option<&[&str]> = if restrict { Some(&["corepack"]) } else { None };
     if let Err((_, error)) = crate::commands::global::install::install(
         &["corepack".to_string()],
         None,
         false,
         1,
         false,
-        Some(&["corepack"]),
+        only_bins,
     )
     .await
     {
@@ -161,8 +170,12 @@ async fn resolve_corepack_invocation() -> Result<CorepackInvocation, i32> {
     }
     match managed_corepack_invocation().await {
         Ok(Some(invocation)) => Ok(invocation),
-        _ => {
+        Ok(None) => {
             eprintln!("vp: corepack was installed but its binary could not be located");
+            Err(1)
+        }
+        Err(e) => {
+            eprintln!("vp: corepack was installed but cannot be resolved: {e}");
             Err(1)
         }
     }
@@ -183,28 +196,40 @@ async fn managed_corepack_invocation() -> Result<Option<CorepackInvocation>, Str
 
 /// Check whether the args invoke `corepack enable`/`corepack disable`
 /// (the commands that create or remove launchers in the install directory).
+///
+/// Everything after a `--` separator is positional (package-manager names),
+/// so the subcommand and help flags are only looked for before it.
 fn is_corepack_link_command(args: &[String]) -> bool {
-    let Some(subcommand) = args.iter().find(|arg| !arg.starts_with('-')) else {
-        return false;
-    };
-    if subcommand != "enable" && subcommand != "disable" {
-        return false;
+    let mut subcommand = None;
+    for arg in args {
+        if arg == "--" {
+            break;
+        }
+        // Help output doesn't touch link files; run it as-is.
+        if arg == "-h" || arg == "--help" {
+            return false;
+        }
+        if subcommand.is_none() && !arg.starts_with('-') {
+            subcommand = Some(arg.as_str());
+        }
     }
-    // Help output doesn't touch link files; run it as-is.
-    !args.iter().any(|arg| arg == "-h" || arg == "--help")
+    matches!(subcommand, Some("enable" | "disable"))
 }
 
 /// Return the user args for an intercepted `corepack enable`/`disable` run,
 /// injecting `--install-directory <bin_dir>` when not explicitly set so the
-/// created launchers land on PATH.
+/// created launchers land on PATH. The flag is inserted before any `--`
+/// separator; tokens after it are package-manager names.
 fn inject_install_directory(args: &[String], bin_dir: &AbsolutePath) -> Vec<String> {
     let mut rewritten = args.to_vec();
     let has_install_directory = args
         .iter()
+        .take_while(|arg| *arg != "--")
         .any(|arg| arg == "--install-directory" || arg.starts_with("--install-directory="));
     if !has_install_directory {
-        rewritten.push("--install-directory".to_string());
-        rewritten.push(bin_dir.as_path().display().to_string());
+        let insert_at = args.iter().position(|arg| arg == "--").unwrap_or(args.len());
+        rewritten.insert(insert_at, bin_dir.as_path().display().to_string());
+        rewritten.insert(insert_at, "--install-directory".to_string());
     }
     rewritten
 }
@@ -214,37 +239,50 @@ enum OwnedShim {
     /// Default shim (npm/npx) — always belongs to Vite+.
     Core { name: &'static str },
     /// Binary installed via `vp install -g` (BinConfig source `vp`).
-    Package { name: &'static str, bin_config: BinConfig },
+    Package { bin_config: BinConfig },
     /// Direct link created by the `npm install -g` interception
-    /// (BinConfig source `npm`).
-    NpmLink { name: &'static str, bin_config: BinConfig },
+    /// (BinConfig source `npm`). `source` is the link target captured at
+    /// snapshot time (Unix); when unavailable the restore falls back to the
+    /// managed Node.js layout via `locate_tool`.
+    NpmLink { bin_config: BinConfig, source: Option<AbsolutePathBuf> },
 }
 
 /// Snapshot which Vite+-owned shims among the corepack-managed launcher
 /// names are intact before corepack runs. Only entries in this snapshot are
 /// candidates for restoration, so shims the user removed on purpose are not
 /// resurrected and untouched entries produce no spurious warnings.
+///
+/// Default shims already replaced by a corepack launcher (e.g. a previous
+/// interrupted run) are included too, so the restore self-heals them.
 async fn snapshot_vp_owned_shims(bin_dir: &AbsolutePath) -> Vec<OwnedShim> {
     let mut owned = Vec::new();
     for name in COREPACK_MANAGED_BIN_NAMES {
         if setup::SHIM_TOOLS.contains(name) {
-            if core_shim_intact(bin_dir, name).await {
+            if core_shim_intact(bin_dir, name).await
+                || corepack_launcher_present(bin_dir, name).await
+            {
                 owned.push(OwnedShim::Core { name });
             }
             continue;
         }
-        let Ok(Some(bin_config)) = BinConfig::load(name).await else {
-            continue;
+        let bin_config = match BinConfig::load(name).await {
+            Ok(Some(config)) => config,
+            Ok(None) => continue,
+            Err(e) => {
+                tracing::warn!("Skipping shim snapshot for '{}': {}", name, e);
+                continue;
+            }
         };
         match bin_config.source {
             BinSource::Vp => {
                 if is_vp_shim(bin_dir, name).await {
-                    owned.push(OwnedShim::Package { name, bin_config });
+                    owned.push(OwnedShim::Package { bin_config });
                 }
             }
             BinSource::Npm => {
                 if npm_link_intact(bin_dir, name).await {
-                    owned.push(OwnedShim::NpmLink { name, bin_config });
+                    let source = npm_link_source(bin_dir, name).await;
+                    owned.push(OwnedShim::NpmLink { bin_config, source });
                 }
             }
         }
@@ -255,10 +293,21 @@ async fn snapshot_vp_owned_shims(bin_dir: &AbsolutePath) -> Vec<OwnedShim> {
 /// Restore Vite+-owned shims that corepack `enable`/`disable` removed or
 /// replaced, based on the pre-invocation snapshot.
 async fn restore_vp_owned_shims(bin_dir: &AbsolutePath, owned_shims: &[OwnedShim]) {
-    // Resolved lazily (only when a core shim actually needs restoring), and
-    // resolved through the shim symlink chain so recreated shims point at the
-    // real vp binary, not at this process's `corepack` shim path.
-    let mut resolved_exe: Option<std::path::PathBuf> = None;
+    // Resolved through the shim symlink chain so recreated shims point at the
+    // real vp binary, not at this process's `corepack` shim path. A failure
+    // only disables core-shim restores; package and npm-link restores below
+    // don't need the executable path.
+    let resolved_exe = if owned_shims.iter().any(|shim| matches!(shim, OwnedShim::Core { .. })) {
+        match std::env::current_exe() {
+            Ok(exe) => Some(tokio::fs::canonicalize(&exe).await.unwrap_or(exe)),
+            Err(e) => {
+                tracing::warn!("Cannot resolve the current executable for shim restore: {}", e);
+                None
+            }
+        }
+    } else {
+        None
+    };
 
     for shim in owned_shims {
         match shim {
@@ -266,17 +315,9 @@ async fn restore_vp_owned_shims(bin_dir: &AbsolutePath, owned_shims: &[OwnedShim
                 if core_shim_intact(bin_dir, name).await {
                     continue;
                 }
-                let exe = match &resolved_exe {
-                    Some(exe) => exe.clone(),
-                    None => {
-                        let Ok(exe) = std::env::current_exe() else { return };
-                        let exe = tokio::fs::canonicalize(&exe).await.unwrap_or(exe);
-                        resolved_exe = Some(exe.clone());
-                        exe
-                    }
-                };
+                let Some(exe) = &resolved_exe else { continue };
                 let _ = tokio::fs::remove_file(bin_dir.join(name)).await;
-                match setup::create_shim(&exe, bin_dir, name, false).await {
+                match setup::create_shim(exe, bin_dir, name, false).await {
                     Ok(_) => output::warn(&format!(
                         "'{name}' is managed by Vite+ and was restored. Vite+ already resolves \
                          '{name}' per project, so corepack does not need to manage it."
@@ -288,40 +329,52 @@ async fn restore_vp_owned_shims(bin_dir: &AbsolutePath, owned_shims: &[OwnedShim
                 #[cfg(windows)]
                 setup::cleanup_legacy_windows_shim(bin_dir, name).await;
             }
-            OwnedShim::Package { name, bin_config } => {
+            OwnedShim::Package { bin_config } => {
+                let name = bin_config.name.as_str();
                 if is_vp_shim(bin_dir, name).await {
                     continue;
                 }
-                output::warn(&format!(
-                    "'{name}' is managed by `vp install -g {pkg}` and was restored. \
-                     Run `vp remove -g {pkg}` first to let corepack manage '{name}'.",
-                    pkg = bin_config.package
-                ));
-                if let Err(e) = crate::commands::global::install::create_package_shim(
+                match crate::commands::global::install::create_package_shim(
                     bin_dir,
                     name,
                     &bin_config.package,
                 )
                 .await
                 {
-                    tracing::warn!("Failed to restore '{}' shim: {}", name, e);
+                    Ok(()) => output::warn(&format!(
+                        "'{name}' is managed by `vp install -g {pkg}` and was restored. \
+                         Run `vp remove -g {pkg}` first to let corepack manage '{name}'.",
+                        pkg = bin_config.package
+                    )),
+                    Err(e) => tracing::warn!("Failed to restore '{}' shim: {}", name, e),
                 }
             }
-            OwnedShim::NpmLink { name, bin_config } => {
+            OwnedShim::NpmLink { bin_config, source } => {
+                let name = bin_config.name.as_str();
                 if npm_link_intact(bin_dir, name).await {
                     continue;
                 }
+                // Prefer the captured original target; fall back to the
+                // managed Node.js layout (validated per-OS by locate_tool).
+                let source_path = match source {
+                    Some(path) => path.clone(),
+                    None => match locate_tool(&bin_config.node_version, name) {
+                        Ok(path) => path,
+                        Err(e) => {
+                            output::warn(&format!(
+                                "'{name}' was linked by `npm install -g {pkg}` and removed by \
+                                 corepack, but its source could not be located ({e}). \
+                                 Run `npm install -g {pkg}` to recreate it.",
+                                pkg = bin_config.package
+                            ));
+                            continue;
+                        }
+                    },
+                };
                 output::warn(&format!(
-                    "'{name}' was linked by `npm install -g {pkg}` and was restored.",
+                    "'{name}' was linked by `npm install -g {pkg}`; restoring the link.",
                     pkg = bin_config.package
                 ));
-                let Ok(home_dir) = vite_shared::get_vp_home() else { continue };
-                let source_path = home_dir
-                    .join("js_runtime")
-                    .join("node")
-                    .join(&bin_config.node_version)
-                    .join("bin")
-                    .join(name);
                 let _ = tokio::fs::remove_file(bin_dir.join(name)).await;
                 create_bin_link(
                     bin_dir,
@@ -356,6 +409,55 @@ async fn core_shim_intact(bin_dir: &AbsolutePath, name: &str) -> bool {
 #[cfg(windows)]
 async fn core_shim_intact(bin_dir: &AbsolutePath, name: &str) -> bool {
     is_vp_shim(bin_dir, name).await
+}
+
+/// Check whether the bin entry currently holds a corepack launcher (the shape
+/// corepack `enable` writes). Used to self-heal default shims clobbered by a
+/// previous run that never reached its restore step: present launchers are
+/// snapshotted as Vite+-owned, while an absent entry (deliberately removed by
+/// the user) is not.
+#[cfg(unix)]
+async fn corepack_launcher_present(bin_dir: &AbsolutePath, name: &str) -> bool {
+    match tokio::fs::read_link(bin_dir.join(name)).await {
+        // corepack launchers are symlinks to corepack's dist/<name>.js
+        Ok(target) => {
+            target.extension().is_some_and(|extension| extension == "js" || extension == "cjs")
+        }
+        Err(_) => false,
+    }
+}
+
+/// Check whether the bin entry currently holds a corepack launcher.
+///
+/// corepack's cmd-shim writes `.cmd`/`.ps1`/extensionless wrappers; Vite+
+/// never creates those for default shim names.
+#[cfg(windows)]
+async fn corepack_launcher_present(bin_dir: &AbsolutePath, name: &str) -> bool {
+    let cmd_exists =
+        tokio::fs::try_exists(&bin_dir.join(format!("{name}.cmd"))).await.unwrap_or(false);
+    let ps1_exists =
+        tokio::fs::try_exists(&bin_dir.join(format!("{name}.ps1"))).await.unwrap_or(false);
+    let sh_exists = tokio::fs::try_exists(&bin_dir.join(name)).await.unwrap_or(false);
+    cmd_exists || ps1_exists || sh_exists
+}
+
+/// Capture the current target of an npm-interception link so the restore can
+/// recreate it exactly (it may point at a custom npm prefix, not the managed
+/// Node.js directory).
+#[cfg(unix)]
+async fn npm_link_source(bin_dir: &AbsolutePath, name: &str) -> Option<AbsolutePathBuf> {
+    let target = tokio::fs::read_link(bin_dir.join(name)).await.ok()?;
+    AbsolutePathBuf::new(target)
+}
+
+/// Capture the current target of an npm-interception link.
+///
+/// On Windows the link is a `.cmd` wrapper whose target is embedded in its
+/// body; reconstructing it is not worth the parsing, so the restore falls
+/// back to the managed Node.js layout via `locate_tool`.
+#[cfg(windows)]
+async fn npm_link_source(_bin_dir: &AbsolutePath, _name: &str) -> Option<AbsolutePathBuf> {
+    None
 }
 
 /// Check whether the bin entry is an intact Vite+ package shim.
@@ -443,12 +545,16 @@ mod tests {
         assert!(is_corepack_link_command(&s(&["enable"])));
         assert!(is_corepack_link_command(&s(&["disable", "yarn"])));
         assert!(is_corepack_link_command(&s(&["enable", "--install-directory", "/custom"])));
+        assert!(is_corepack_link_command(&s(&["enable", "--", "pnpm"])));
 
         assert!(!is_corepack_link_command(&s(&[])));
         assert!(!is_corepack_link_command(&s(&["--version"])));
         assert!(!is_corepack_link_command(&s(&["use", "pnpm@9"])));
         assert!(!is_corepack_link_command(&s(&["pnpm", "install"])));
         assert!(!is_corepack_link_command(&s(&["up"])));
+
+        // Everything after `--` is positional, not a subcommand
+        assert!(!is_corepack_link_command(&s(&["--", "enable"])));
 
         // Help output doesn't touch link files
         assert!(!is_corepack_link_command(&s(&["enable", "--help"])));
@@ -484,5 +590,24 @@ mod tests {
 
         let args = s(&["enable", "--install-directory=/custom/dir"]);
         assert_eq!(inject_install_directory(&args, &bin_dir), args);
+    }
+
+    #[test]
+    fn test_inject_install_directory_inserts_before_separator() {
+        let bin_dir = bin_dir();
+        let dir = bin_dir.as_path().display().to_string();
+
+        // The injected flag must precede `--`; tokens after it are
+        // package-manager names.
+        let rewritten = inject_install_directory(&s(&["enable", "--", "pnpm"]), &bin_dir);
+        assert_eq!(rewritten, s(&["enable", "--install-directory", &dir, "--", "pnpm"]));
+
+        // An --install-directory after `--` is a positional, not the flag
+        let rewritten =
+            inject_install_directory(&s(&["enable", "--", "--install-directory"]), &bin_dir);
+        assert_eq!(
+            rewritten,
+            s(&["enable", "--install-directory", &dir, "--", "--install-directory"])
+        );
     }
 }

--- a/crates/vite_global_cli/src/shim/corepack.rs
+++ b/crates/vite_global_cli/src/shim/corepack.rs
@@ -22,8 +22,8 @@ use vite_shared::{PrependOptions, env_vars, output, prepend_to_path_env};
 
 use super::{
     dispatch::{
-        ensure_installed, find_package_for_binary, locate_package_binary, locate_tool,
-        resolve_with_cache,
+        create_bin_link, ensure_installed, find_package_for_binary, locate_tool,
+        package_binary_invocation, resolve_with_cache,
     },
     exec,
 };
@@ -50,35 +50,52 @@ pub(crate) async fn dispatch_corepack(args: &[String]) -> i32 {
         Ok(invocation) => invocation,
         Err(exit_code) => return exit_code,
     };
+    let CorepackInvocation { program, pre_args } = invocation;
+    let mut full_args = pre_args;
 
-    // enable/disable: run with spawn+wait so Vite+-owned shims can be
-    // restored after corepack touched the install directory.
-    if let Ok(bin_dir) = config::get_bin_dir()
-        && let Some(link_args) = corepack_link_command_args(args, &bin_dir)
-    {
-        let mut full_args = invocation.pre_args.clone();
-        full_args.extend(link_args);
-        let exit_code = exec::spawn_tool(&invocation.program, &full_args);
-        restore_vp_owned_shims(&bin_dir).await;
-        return exit_code;
+    // enable/disable create or remove launchers in the install directory.
+    // Inject the vp bin dir (so they land on PATH), run with spawn+wait, and
+    // restore any Vite+-owned shims corepack removed or replaced. The arg
+    // check runs first so the common path skips bin-dir resolution entirely.
+    if is_corepack_link_command(args) {
+        match config::get_bin_dir() {
+            Ok(bin_dir) => {
+                full_args.extend(inject_install_directory(args, &bin_dir));
+                let owned_shims = snapshot_vp_owned_shims(&bin_dir).await;
+                let exit_code = exec::spawn_tool(&program, &full_args);
+                restore_vp_owned_shims(&bin_dir, &owned_shims).await;
+                return exit_code;
+            }
+            Err(e) => {
+                // Without a bin dir there is nothing to inject or restore;
+                // run corepack as-is, but say so instead of failing silently.
+                output::warn(&format!(
+                    "Cannot resolve the Vite+ bin directory ({e}); running corepack without \
+                     an --install-directory default, created launchers may not be on PATH"
+                ));
+            }
+        }
     }
 
-    let mut full_args = invocation.pre_args.clone();
     full_args.extend(args.iter().cloned());
-    exec::exec_tool(&invocation.program, &full_args)
+    exec::exec_tool(&program, &full_args)
 }
 
 /// Resolve which corepack binary to execute.
 ///
 /// Returns an exit code on failure (errors are already printed).
 async fn resolve_corepack_invocation() -> Result<CorepackInvocation, i32> {
-    // 1. An explicit `vp install -g corepack` wins.
+    // 1. An explicit `vp install -g corepack` wins. Resolution errors (stale
+    //    metadata, missing package files) fall through to the bundled copy
+    //    instead of failing: broken managed state must not brick the shim.
     match managed_corepack_invocation().await {
         Ok(Some(invocation)) => return Ok(invocation),
         Ok(None) => {}
         Err(e) => {
-            eprintln!("vp: Failed to resolve installed corepack: {e}");
-            return Err(1);
+            output::warn(&format!(
+                "Ignoring unusable vp-managed corepack ({e}); falling back to the \
+                 Node-bundled corepack. Run `vp install -g corepack` to repair it."
+            ));
         }
     }
 
@@ -103,7 +120,11 @@ async fn resolve_corepack_invocation() -> Result<CorepackInvocation, i32> {
         return Err(1);
     }
     if let Ok(corepack_path) = locate_tool(&resolution.version, "corepack") {
-        prepend_node_bin_dir(&resolution.version);
+        // The bundled corepack sits in the same bin directory as node;
+        // prepend it so corepack's child processes see the same runtime.
+        if let Some(node_bin_dir) = corepack_path.parent() {
+            let _ = prepend_to_path_env(node_bin_dir, PrependOptions::default());
+        }
         // Match the core-tool dispatch: nested core-tool shims pass through.
         // SAFETY: Setting env vars at this point before exec/spawn is safe
         unsafe {
@@ -116,11 +137,12 @@ async fn resolve_corepack_invocation() -> Result<CorepackInvocation, i32> {
     //    global package, then run that copy. Only the `corepack` bin is
     //    linked; the pnpm/yarn launchers the package also declares stay
     //    unexposed (that is `corepack enable`'s job) and must not conflict
-    //    with vp-managed package managers.
-    output::info(&format!(
-        "corepack is not bundled with Node.js {}; installing it as a managed global package",
+    //    with vp-managed package managers. The notice goes to stderr so the
+    //    wrapped corepack's stdout stays parseable.
+    eprintln!(
+        "vp: corepack is not bundled with Node.js {}; installing it as a managed global package",
         resolution.version
-    ));
+    );
     if let Err((_, error)) = crate::commands::global::install::install(
         &["corepack".to_string()],
         None,
@@ -146,55 +168,34 @@ async fn resolve_corepack_invocation() -> Result<CorepackInvocation, i32> {
 
 /// Resolve a corepack installed via `vp install -g corepack`, if any.
 ///
-/// Mirrors `dispatch_package_binary`: uses the install-time Node.js version
-/// and prepends its bin directory to PATH for child processes.
+/// Uses the install-time Node.js version, like every other vp-managed
+/// package binary.
 async fn managed_corepack_invocation() -> Result<Option<CorepackInvocation>, String> {
     let Some(metadata) = find_package_for_binary("corepack").await? else {
         return Ok(None);
     };
-
-    let node_version = metadata.platform.node.clone();
-    ensure_installed(&node_version).await?;
-    let binary_path = locate_package_binary(&metadata.name, "corepack")?;
-    let node_path = locate_tool(&node_version, "node")?;
-    let node_bin_dir =
-        node_path.parent().ok_or_else(|| "Node has no parent directory".to_string())?;
-    let _ = prepend_to_path_env(node_bin_dir, PrependOptions::default());
-
-    if metadata.is_js_binary("corepack") {
-        Ok(Some(CorepackInvocation {
-            program: node_path,
-            pre_args: vec![binary_path.as_path().display().to_string()],
-        }))
-    } else {
-        Ok(Some(CorepackInvocation { program: binary_path, pre_args: Vec::new() }))
-    }
+    let (program, pre_args) =
+        package_binary_invocation(&metadata, "corepack", &metadata.platform.node).await?;
+    Ok(Some(CorepackInvocation { program, pre_args }))
 }
 
-/// Prepend the resolved Node.js bin directory to PATH for child processes.
-fn prepend_node_bin_dir(version: &str) {
-    if let Ok(node_path) = locate_tool(version, "node")
-        && let Some(node_bin_dir) = node_path.parent()
-    {
-        let _ = prepend_to_path_env(node_bin_dir, PrependOptions::default());
-    }
-}
-
-/// Detect a `corepack enable`/`corepack disable` invocation and return the
-/// user args to run it with, injecting `--install-directory <bin_dir>` when
-/// not explicitly set so launchers land on PATH.
-///
-/// Returns None for all other corepack commands (plain exec, no restore).
-fn corepack_link_command_args(args: &[String], bin_dir: &AbsolutePath) -> Option<Vec<String>> {
-    let subcommand = args.iter().find(|arg| !arg.starts_with('-'))?;
+/// Check whether the args invoke `corepack enable`/`corepack disable`
+/// (the commands that create or remove launchers in the install directory).
+fn is_corepack_link_command(args: &[String]) -> bool {
+    let Some(subcommand) = args.iter().find(|arg| !arg.starts_with('-')) else {
+        return false;
+    };
     if subcommand != "enable" && subcommand != "disable" {
-        return None;
+        return false;
     }
     // Help output doesn't touch link files; run it as-is.
-    if args.iter().any(|arg| arg == "-h" || arg == "--help") {
-        return None;
-    }
+    !args.iter().any(|arg| arg == "-h" || arg == "--help")
+}
 
+/// Return the user args for an intercepted `corepack enable`/`disable` run,
+/// injecting `--install-directory <bin_dir>` when not explicitly set so the
+/// created launchers land on PATH.
+fn inject_install_directory(args: &[String], bin_dir: &AbsolutePath) -> Vec<String> {
     let mut rewritten = args.to_vec();
     let has_install_directory = args
         .iter()
@@ -203,64 +204,131 @@ fn corepack_link_command_args(args: &[String], bin_dir: &AbsolutePath) -> Option
         rewritten.push("--install-directory".to_string());
         rewritten.push(bin_dir.as_path().display().to_string());
     }
-    Some(rewritten)
+    rewritten
 }
 
-/// Restore Vite+-owned shims that corepack `enable`/`disable` may have
-/// removed or replaced in the bin directory.
-///
-/// - Default shims (npm/npx) always belong to Vite+; they already resolve the
-///   project package-manager version, so corepack must not manage them.
-/// - Binaries installed via `vp install -g` (BinConfig source `vp`) are
-///   restored with a warning pointing at `vp remove -g`.
-async fn restore_vp_owned_shims(bin_dir: &AbsolutePath) {
-    let Ok(current_exe) = std::env::current_exe() else {
-        return;
-    };
-    // Resolve through the shim symlink chain so recreated shims point at the
-    // real vp binary, not at this process's `corepack` shim path.
-    let current_exe = tokio::fs::canonicalize(&current_exe).await.unwrap_or(current_exe);
+/// A Vite+-owned bin entry that was intact before corepack ran.
+enum OwnedShim {
+    /// Default shim (npm/npx) — always belongs to Vite+.
+    Core { name: &'static str },
+    /// Binary installed via `vp install -g` (BinConfig source `vp`).
+    Package { name: &'static str, bin_config: BinConfig },
+    /// Direct link created by the `npm install -g` interception
+    /// (BinConfig source `npm`).
+    NpmLink { name: &'static str, bin_config: BinConfig },
+}
 
+/// Snapshot which Vite+-owned shims among the corepack-managed launcher
+/// names are intact before corepack runs. Only entries in this snapshot are
+/// candidates for restoration, so shims the user removed on purpose are not
+/// resurrected and untouched entries produce no spurious warnings.
+async fn snapshot_vp_owned_shims(bin_dir: &AbsolutePath) -> Vec<OwnedShim> {
+    let mut owned = Vec::new();
     for name in COREPACK_MANAGED_BIN_NAMES {
         if setup::SHIM_TOOLS.contains(name) {
             if core_shim_intact(bin_dir, name).await {
-                continue;
+                owned.push(OwnedShim::Core { name });
             }
-            let _ = tokio::fs::remove_file(bin_dir.join(name)).await;
-            match setup::create_shim(&current_exe, bin_dir, name, false).await {
-                Ok(_) => output::warn(&format!(
-                    "'{name}' is managed by Vite+ and was restored. Vite+ already resolves \
-                     '{name}' per project, so corepack does not need to manage it."
-                )),
-                Err(e) => tracing::warn!("Failed to restore '{}' shim: {}", name, e),
-            }
-            // Remove corepack's extensionless/cmd launchers that would shadow
-            // the trampoline .exe in Git Bash.
-            #[cfg(windows)]
-            setup::cleanup_legacy_windows_shim(bin_dir, name).await;
             continue;
         }
-
-        // Binaries installed via `vp install -g`.
         let Ok(Some(bin_config)) = BinConfig::load(name).await else {
             continue;
         };
-        if bin_config.source != BinSource::Vp || is_vp_shim(bin_dir, name).await {
-            continue;
+        match bin_config.source {
+            BinSource::Vp => {
+                if is_vp_shim(bin_dir, name).await {
+                    owned.push(OwnedShim::Package { name, bin_config });
+                }
+            }
+            BinSource::Npm => {
+                if npm_link_intact(bin_dir, name).await {
+                    owned.push(OwnedShim::NpmLink { name, bin_config });
+                }
+            }
         }
-        output::warn(&format!(
-            "'{name}' is managed by `vp install -g {pkg}` and was restored. \
-             Run `vp remove -g {pkg}` first to let corepack manage '{name}'.",
-            pkg = bin_config.package
-        ));
-        if let Err(e) = crate::commands::global::install::create_package_shim(
-            bin_dir,
-            name,
-            &bin_config.package,
-        )
-        .await
-        {
-            tracing::warn!("Failed to restore '{}' shim: {}", name, e);
+    }
+    owned
+}
+
+/// Restore Vite+-owned shims that corepack `enable`/`disable` removed or
+/// replaced, based on the pre-invocation snapshot.
+async fn restore_vp_owned_shims(bin_dir: &AbsolutePath, owned_shims: &[OwnedShim]) {
+    // Resolved lazily (only when a core shim actually needs restoring), and
+    // resolved through the shim symlink chain so recreated shims point at the
+    // real vp binary, not at this process's `corepack` shim path.
+    let mut resolved_exe: Option<std::path::PathBuf> = None;
+
+    for shim in owned_shims {
+        match shim {
+            OwnedShim::Core { name } => {
+                if core_shim_intact(bin_dir, name).await {
+                    continue;
+                }
+                let exe = match &resolved_exe {
+                    Some(exe) => exe.clone(),
+                    None => {
+                        let Ok(exe) = std::env::current_exe() else { return };
+                        let exe = tokio::fs::canonicalize(&exe).await.unwrap_or(exe);
+                        resolved_exe = Some(exe.clone());
+                        exe
+                    }
+                };
+                let _ = tokio::fs::remove_file(bin_dir.join(name)).await;
+                match setup::create_shim(&exe, bin_dir, name, false).await {
+                    Ok(_) => output::warn(&format!(
+                        "'{name}' is managed by Vite+ and was restored. Vite+ already resolves \
+                         '{name}' per project, so corepack does not need to manage it."
+                    )),
+                    Err(e) => tracing::warn!("Failed to restore '{}' shim: {}", name, e),
+                }
+                // Remove corepack's extensionless/cmd/ps1 launchers that would
+                // shadow the trampoline .exe in Git Bash or PowerShell.
+                #[cfg(windows)]
+                setup::cleanup_legacy_windows_shim(bin_dir, name).await;
+            }
+            OwnedShim::Package { name, bin_config } => {
+                if is_vp_shim(bin_dir, name).await {
+                    continue;
+                }
+                output::warn(&format!(
+                    "'{name}' is managed by `vp install -g {pkg}` and was restored. \
+                     Run `vp remove -g {pkg}` first to let corepack manage '{name}'.",
+                    pkg = bin_config.package
+                ));
+                if let Err(e) = crate::commands::global::install::create_package_shim(
+                    bin_dir,
+                    name,
+                    &bin_config.package,
+                )
+                .await
+                {
+                    tracing::warn!("Failed to restore '{}' shim: {}", name, e);
+                }
+            }
+            OwnedShim::NpmLink { name, bin_config } => {
+                if npm_link_intact(bin_dir, name).await {
+                    continue;
+                }
+                output::warn(&format!(
+                    "'{name}' was linked by `npm install -g {pkg}` and was restored.",
+                    pkg = bin_config.package
+                ));
+                let Ok(home_dir) = vite_shared::get_vp_home() else { continue };
+                let source_path = home_dir
+                    .join("js_runtime")
+                    .join("node")
+                    .join(&bin_config.node_version)
+                    .join("bin")
+                    .join(name);
+                let _ = tokio::fs::remove_file(bin_dir.join(name)).await;
+                create_bin_link(
+                    bin_dir,
+                    name,
+                    &source_path,
+                    &bin_config.package,
+                    &bin_config.node_version,
+                );
+            }
         }
     }
 }
@@ -288,28 +356,62 @@ async fn core_shim_intact(bin_dir: &AbsolutePath, name: &str) -> bool {
     is_vp_shim(bin_dir, name).await
 }
 
-/// Check whether the bin entry is an intact Vite+ shim.
+/// Check whether the bin entry is an intact Vite+ package shim.
 #[cfg(unix)]
 async fn is_vp_shim(bin_dir: &AbsolutePath, name: &str) -> bool {
     match tokio::fs::read_link(bin_dir.join(name)).await {
-        Ok(target) => target == std::path::Path::new("../current/bin/vp"),
+        Ok(target) => {
+            target == std::path::Path::new(crate::commands::global::install::PACKAGE_SHIM_TARGET)
+        }
         Err(_) => false,
     }
 }
 
-/// Check whether the bin entry is an intact Vite+ shim.
+/// Check whether the bin entry is an intact Vite+ package shim.
 ///
 /// Trampoline shims are `.exe` files; corepack's cmd-shim launchers are
-/// `.cmd`/`.ps1`/extensionless files that would shadow the trampoline in
-/// Git Bash, so their presence means the shim needs restoring.
+/// `.cmd`/`.ps1`/extensionless files that shadow the trampoline in Git Bash
+/// (extensionless) and PowerShell (`.ps1`), so any of them present means the
+/// shim needs restoring.
 #[cfg(windows)]
 async fn is_vp_shim(bin_dir: &AbsolutePath, name: &str) -> bool {
     let exe_exists =
         tokio::fs::try_exists(&bin_dir.join(format!("{name}.exe"))).await.unwrap_or(false);
     let cmd_exists =
         tokio::fs::try_exists(&bin_dir.join(format!("{name}.cmd"))).await.unwrap_or(false);
+    let ps1_exists =
+        tokio::fs::try_exists(&bin_dir.join(format!("{name}.ps1"))).await.unwrap_or(false);
     let sh_exists = tokio::fs::try_exists(&bin_dir.join(name)).await.unwrap_or(false);
-    exe_exists && !cmd_exists && !sh_exists
+    exe_exists && !cmd_exists && !ps1_exists && !sh_exists
+}
+
+/// Check whether a link created by the `npm install -g` interception is
+/// still intact.
+///
+/// On Unix these are symlinks pointing at the binary of the same name in a
+/// managed Node.js bin directory; corepack launchers point at `dist/*.js`
+/// files instead.
+#[cfg(unix)]
+async fn npm_link_intact(bin_dir: &AbsolutePath, name: &str) -> bool {
+    let link_path = bin_dir.join(name);
+    match tokio::fs::read_link(&link_path).await {
+        Ok(target) => {
+            target.file_name().is_some_and(|file_name| file_name == name)
+                && std::fs::exists(link_path.as_path()).unwrap_or(false)
+        }
+        Err(_) => false,
+    }
+}
+
+/// Check whether a link created by the `npm install -g` interception is
+/// still intact.
+///
+/// On Windows npm links are `.cmd` wrappers. corepack also writes `.cmd`
+/// launchers, so an overwritten (rather than deleted) link is not detected;
+/// the deletion case (`corepack disable`) is the one that matters.
+#[cfg(windows)]
+async fn npm_link_intact(bin_dir: &AbsolutePath, name: &str) -> bool {
+    tokio::fs::try_exists(&bin_dir.join(format!("{name}.cmd"))).await.unwrap_or(false)
 }
 
 #[cfg(test)]
@@ -335,15 +437,32 @@ mod tests {
     }
 
     #[test]
-    fn test_link_command_args_injects_install_directory() {
+    fn test_is_corepack_link_command() {
+        assert!(is_corepack_link_command(&s(&["enable"])));
+        assert!(is_corepack_link_command(&s(&["disable", "yarn"])));
+        assert!(is_corepack_link_command(&s(&["enable", "--install-directory", "/custom"])));
+
+        assert!(!is_corepack_link_command(&s(&[])));
+        assert!(!is_corepack_link_command(&s(&["--version"])));
+        assert!(!is_corepack_link_command(&s(&["use", "pnpm@9"])));
+        assert!(!is_corepack_link_command(&s(&["pnpm", "install"])));
+        assert!(!is_corepack_link_command(&s(&["up"])));
+
+        // Help output doesn't touch link files
+        assert!(!is_corepack_link_command(&s(&["enable", "--help"])));
+        assert!(!is_corepack_link_command(&s(&["enable", "-h"])));
+    }
+
+    #[test]
+    fn test_inject_install_directory_appends_when_missing() {
         let bin_dir = bin_dir();
-        let rewritten = corepack_link_command_args(&s(&["enable"]), &bin_dir).unwrap();
+        let rewritten = inject_install_directory(&s(&["enable"]), &bin_dir);
         assert_eq!(
             rewritten,
             s(&["enable", "--install-directory", &bin_dir.as_path().display().to_string()])
         );
 
-        let rewritten = corepack_link_command_args(&s(&["disable", "yarn"]), &bin_dir).unwrap();
+        let rewritten = inject_install_directory(&s(&["disable", "yarn"]), &bin_dir);
         assert_eq!(
             rewritten,
             s(&[
@@ -356,31 +475,12 @@ mod tests {
     }
 
     #[test]
-    fn test_link_command_args_keeps_explicit_install_directory() {
+    fn test_inject_install_directory_keeps_explicit_value() {
         let bin_dir = bin_dir();
         let args = s(&["enable", "--install-directory", "/custom/dir"]);
-        let rewritten = corepack_link_command_args(&args, &bin_dir).unwrap();
-        assert_eq!(rewritten, args);
+        assert_eq!(inject_install_directory(&args, &bin_dir), args);
 
         let args = s(&["enable", "--install-directory=/custom/dir"]);
-        let rewritten = corepack_link_command_args(&args, &bin_dir).unwrap();
-        assert_eq!(rewritten, args);
-    }
-
-    #[test]
-    fn test_link_command_args_ignores_other_commands() {
-        let bin_dir = bin_dir();
-        assert!(corepack_link_command_args(&s(&[]), &bin_dir).is_none());
-        assert!(corepack_link_command_args(&s(&["--version"]), &bin_dir).is_none());
-        assert!(corepack_link_command_args(&s(&["use", "pnpm@9"]), &bin_dir).is_none());
-        assert!(corepack_link_command_args(&s(&["pnpm", "install"]), &bin_dir).is_none());
-        assert!(corepack_link_command_args(&s(&["up"]), &bin_dir).is_none());
-    }
-
-    #[test]
-    fn test_link_command_args_skips_help() {
-        let bin_dir = bin_dir();
-        assert!(corepack_link_command_args(&s(&["enable", "--help"]), &bin_dir).is_none());
-        assert!(corepack_link_command_args(&s(&["enable", "-h"]), &bin_dir).is_none());
+        assert_eq!(inject_install_directory(&args, &bin_dir), args);
     }
 }

--- a/crates/vite_global_cli/src/shim/corepack.rs
+++ b/crates/vite_global_cli/src/shim/corepack.rs
@@ -382,6 +382,10 @@ async fn restore_vp_owned_shims(bin_dir: &AbsolutePath, owned_shims: &[OwnedShim
                     pkg = bin_config.package
                 ));
                 let _ = tokio::fs::remove_file(bin_dir.join(name)).await;
+                // Remove corepack's launcher files (.cmd/.ps1/extensionless)
+                // so they cannot shadow the rewritten link.
+                #[cfg(windows)]
+                setup::cleanup_legacy_windows_shim(bin_dir, name).await;
                 create_bin_link(
                     bin_dir,
                     name,
@@ -515,12 +519,28 @@ async fn npm_link_intact(bin_dir: &AbsolutePath, name: &str) -> bool {
 /// Check whether a link created by the `npm install -g` interception is
 /// still intact.
 ///
-/// On Windows npm links are `.cmd` wrappers. corepack also writes `.cmd`
-/// launchers, so an overwritten (rather than deleted) link is not detected;
-/// the deletion case (`corepack disable`) is the one that matters.
+/// On Windows npm links are `.cmd` wrappers with a fixed three-line shape
+/// (see `create_bin_link`). corepack also writes `.cmd` launchers, so the
+/// content is checked to detect an overwritten (not just deleted) link.
 #[cfg(windows)]
 async fn npm_link_intact(bin_dir: &AbsolutePath, name: &str) -> bool {
-    tokio::fs::try_exists(&bin_dir.join(format!("{name}.cmd"))).await.unwrap_or(false)
+    match tokio::fs::read_to_string(&bin_dir.join(format!("{name}.cmd"))).await {
+        Ok(content) => is_npm_link_wrapper(&content),
+        Err(_) => false,
+    }
+}
+
+/// Whether `.cmd` content matches vp's npm-link wrapper shape written by
+/// `create_bin_link`: `@echo off`, a quoted source invocation forwarding all
+/// args, and the exit-code forward. corepack's cmd-shim launchers have a
+/// different, multi-branch shape.
+#[cfg(any(windows, test))]
+fn is_npm_link_wrapper(content: &str) -> bool {
+    let mut lines = content.lines();
+    lines.next() == Some("@echo off")
+        && lines.next().is_some_and(|line| line.starts_with('"') && line.ends_with("\" %*"))
+        && lines.next() == Some("exit /b %ERRORLEVEL%")
+        && lines.next().is_none()
 }
 
 #[cfg(test)]
@@ -595,6 +615,19 @@ mod tests {
 
         let args = s(&["enable", "--install-directory=/custom/dir"]);
         assert_eq!(inject_install_directory(&args, &bin_dir), args);
+    }
+
+    #[test]
+    fn test_is_npm_link_wrapper_shape() {
+        // vp's wrapper as written by create_bin_link
+        let wrapper = "@echo off\r\n\"C:\\vp\\node\\pnpm.cmd\" %*\r\nexit /b %ERRORLEVEL%\r\n";
+        assert!(is_npm_link_wrapper(wrapper));
+
+        // corepack cmd-shim output is multi-branch and must not match
+        let corepack = "@SETLOCAL\r\n@IF EXIST \"%~dp0\\node.exe\" (\r\n  ...\r\n)\r\n";
+        assert!(!is_npm_link_wrapper(corepack));
+        assert!(!is_npm_link_wrapper(""));
+        assert!(!is_npm_link_wrapper("@echo off\r\nsomething else\r\n"));
     }
 
     #[test]

--- a/crates/vite_global_cli/src/shim/dispatch.rs
+++ b/crates/vite_global_cli/src/shim/dispatch.rs
@@ -23,7 +23,7 @@ use crate::{
             config::{self, ShimMode},
             package_metadata::PackageMetadata,
         },
-        global::CORE_SHIMS,
+        global::install::is_protected_shim,
     },
     error::Error,
 };
@@ -265,8 +265,8 @@ fn check_npm_global_install_result(
         let bin_names = extract_bin_names(&package_json);
 
         for bin_name in bin_names {
-            // Skip core shims
-            if CORE_SHIMS.contains(&bin_name.as_str()) {
+            // Skip protected shims (core shims and default env shims)
+            if is_protected_shim(&bin_name) {
                 continue;
             }
 
@@ -419,7 +419,7 @@ fn extract_bin_path(package_json: &serde_json::Value, bin_name: &str) -> Option<
 }
 
 /// Create a bin link for a binary and record it via BinConfig.
-fn create_bin_link(
+pub(crate) fn create_bin_link(
     bin_dir: &AbsolutePath,
     bin_name: &str,
     source_path: &AbsolutePath,
@@ -514,8 +514,10 @@ fn remove_npm_global_uninstall_links(bin_entries: &[(String, String)], npm_prefi
     let Ok(bin_dir) = config::get_bin_dir() else { return };
 
     for (bin_name, package_name) in bin_entries {
-        // Skip core shims
-        if CORE_SHIMS.contains(&bin_name.as_str()) {
+        // Skip protected shims: a stale Npm BinConfig (e.g. a pre-default-shim
+        // `npm install -g corepack`) must not let `npm uninstall -g` delete a
+        // default shim that `vp env setup` now owns.
+        if is_protected_shim(bin_name) {
             continue;
         }
 
@@ -1015,44 +1017,50 @@ async fn dispatch_package_binary(tool: &str, args: &[String]) -> i32 {
         package_metadata.platform.node.clone()
     };
 
-    // Ensure Node.js is installed
-    if let Err(e) = ensure_installed(&node_version).await {
-        eprintln!("vp: Failed to install Node {}: {e}", node_version);
-        return 1;
-    }
+    let (program, mut full_args) =
+        match package_binary_invocation(&package_metadata, tool, &node_version).await {
+            Ok(invocation) => invocation,
+            Err(e) => {
+                eprintln!("vp: {e}");
+                return 1;
+            }
+        };
+    full_args.extend(args.iter().cloned());
+    exec::exec_tool(&program, &full_args)
+}
+
+/// Resolve how to invoke a package binary installed via `vp install -g` with
+/// the given Node.js version: ensures the runtime is present, prepends its bin
+/// directory to PATH for child processes, and returns the program plus leading
+/// arguments (JS binaries run through node).
+pub(crate) async fn package_binary_invocation(
+    metadata: &PackageMetadata,
+    tool: &str,
+    node_version: &str,
+) -> Result<(AbsolutePathBuf, Vec<String>), String> {
+    ensure_installed(node_version)
+        .await
+        .map_err(|e| format!("Failed to install Node {node_version}: {e}"))?;
 
     // Locate the actual binary in the package directory
-    let binary_path = match locate_package_binary(&package_metadata.name, tool) {
-        Ok(p) => p,
-        Err(e) => {
-            eprintln!("vp: Binary '{tool}' not found: {e}");
-            return 1;
-        }
-    };
+    let binary_path = locate_package_binary(&metadata.name, tool)
+        .map_err(|e| format!("Binary '{tool}' not found: {e}"))?;
 
-    // Locate node binary for this version
-    let node_path = match locate_tool(&node_version, "node") {
-        Ok(p) => p,
-        Err(e) => {
-            eprintln!("vp: Node not found: {e}");
-            return 1;
-        }
-    };
+    let node_path =
+        locate_tool(node_version, "node").map_err(|e| format!("Node not found: {e}"))?;
 
     // Prepare environment for recursive invocations
-    let node_bin_dir = node_path.parent().expect("Node has no parent directory");
+    let node_bin_dir =
+        node_path.parent().ok_or_else(|| "Node has no parent directory".to_string())?;
     let _ = prepend_to_path_env(node_bin_dir, PrependOptions::default());
 
-    // Check if the binary is a JavaScript file that needs Node.js
-    // This info was determined at install time and stored in metadata
-    if package_metadata.is_js_binary(tool) {
-        // Execute: node <binary_path> <args>
-        let mut full_args = vec![binary_path.as_path().display().to_string()];
-        full_args.extend(args.iter().cloned());
-        exec::exec_tool(&node_path, &full_args)
+    // JS binaries (determined at install time and stored in metadata) run
+    // through node; native executables run directly.
+    if metadata.is_js_binary(tool) {
+        let pre_args = vec![binary_path.as_path().display().to_string()];
+        Ok((node_path, pre_args))
     } else {
-        // Execute the binary directly (native executable or non-Node script)
-        exec::exec_tool(&binary_path, args)
+        Ok((binary_path, Vec::new()))
     }
 }
 

--- a/crates/vite_global_cli/src/shim/dispatch.rs
+++ b/crates/vite_global_cli/src/shim/dispatch.rs
@@ -265,8 +265,21 @@ fn check_npm_global_install_result(
         let bin_names = extract_bin_names(&package_json);
 
         for bin_name in bin_names {
-            // Skip protected shims (core shims and default env shims)
+            // Skip protected shims (core shims and default env shims). Tell
+            // the user for the non-core names (e.g. `npm i -g corepack`):
+            // npm installed the package, but the binary stays unlinked.
             if is_protected_shim(&bin_name) {
+                if !crate::commands::global::CORE_SHIMS.contains(&bin_name.as_str()) {
+                    let hint = if bin_name == "corepack" {
+                        " Use `vp install -g corepack` to manage its version."
+                    } else {
+                        ""
+                    };
+                    output::note(&vite_str::format!(
+                        "'{bin_name}' is a Vite+ default shim; the npm-installed copy is not \
+                         linked.{hint}"
+                    ));
+                }
                 continue;
             }
 
@@ -1038,16 +1051,21 @@ pub(crate) async fn package_binary_invocation(
     tool: &str,
     node_version: &str,
 ) -> Result<(AbsolutePathBuf, Vec<String>), String> {
-    ensure_installed(node_version)
-        .await
-        .map_err(|e| format!("Failed to install Node {node_version}: {e}"))?;
+    // Fast path: an existing node binary means the install is complete;
+    // only fall into the download path when it is missing.
+    let node_path = match locate_tool(node_version, "node") {
+        Ok(path) => path,
+        Err(_) => {
+            ensure_installed(node_version)
+                .await
+                .map_err(|e| format!("Failed to install Node {node_version}: {e}"))?;
+            locate_tool(node_version, "node").map_err(|e| format!("Node not found: {e}"))?
+        }
+    };
 
     // Locate the actual binary in the package directory
     let binary_path = locate_package_binary(&metadata.name, tool)
         .map_err(|e| format!("Binary '{tool}' not found: {e}"))?;
-
-    let node_path =
-        locate_tool(node_version, "node").map_err(|e| format!("Node not found: {e}"))?;
 
     // Prepare environment for recursive invocations
     let node_bin_dir =

--- a/crates/vite_global_cli/src/shim/dispatch.rs
+++ b/crates/vite_global_cli/src/shim/dispatch.rs
@@ -820,19 +820,13 @@ pub async fn dispatch(tool: &str, args: &[String]) -> i32 {
         }
     };
 
-    // Ensure Node.js is installed
-    if let Err(e) = ensure_installed(&resolution.version).await {
-        eprintln!("vp: Failed to install Node {}: {e}", resolution.version);
-        return 1;
-    }
-
-    // Locate the Node binary for PATH preparation. Package-manager shims can use
-    // their own declared version, but JS-based package managers still need the
-    // project-resolved Node.js runtime to execute.
-    let node_path = match locate_tool(&resolution.version, "node") {
+    // Ensure Node.js is installed and locate its binary for PATH preparation.
+    // Package-manager shims can use their own declared version, but JS-based
+    // package managers still need the project-resolved Node.js runtime.
+    let node_path = match ensure_installed(&resolution.version).await {
         Ok(p) => p,
         Err(e) => {
-            eprintln!("vp: Node not found: {e}");
+            eprintln!("vp: Failed to install Node {}: {e}", resolution.version);
             return 1;
         }
     };
@@ -963,14 +957,19 @@ async fn dispatch_package_binary(tool: &str, args: &[String]) -> i32 {
                     };
 
                     if !node_version.is_empty() {
-                        if let Err(e) = ensure_installed(&node_version).await {
-                            eprintln!("vp: Failed to install Node {}: {e}", node_version);
-                            return 1;
-                        }
-                        if let Ok(node_path) = locate_tool(&node_version, "node")
-                            && let Some(node_bin_dir) = node_path.parent()
-                        {
-                            let _ = prepend_to_path_env(node_bin_dir, PrependOptions::default());
+                        match ensure_installed(&node_version).await {
+                            Ok(node_path) => {
+                                if let Some(node_bin_dir) = node_path.parent() {
+                                    let _ = prepend_to_path_env(
+                                        node_bin_dir,
+                                        PrependOptions::default(),
+                                    );
+                                }
+                            }
+                            Err(e) => {
+                                eprintln!("vp: Failed to install Node {}: {e}", node_version);
+                                return 1;
+                            }
                         }
                     }
                 }
@@ -1038,6 +1037,11 @@ async fn dispatch_package_binary(tool: &str, args: &[String]) -> i32 {
                 return 1;
             }
         };
+    // Native binaries have no leading args; exec with the caller's slice
+    // instead of cloning every argument.
+    if full_args.is_empty() {
+        return exec::exec_tool(&program, args);
+    }
     full_args.extend(args.iter().cloned());
     exec::exec_tool(&program, &full_args)
 }
@@ -1051,17 +1055,9 @@ pub(crate) async fn package_binary_invocation(
     tool: &str,
     node_version: &str,
 ) -> Result<(AbsolutePathBuf, Vec<String>), String> {
-    // Fast path: an existing node binary means the install is complete;
-    // only fall into the download path when it is missing.
-    let node_path = match locate_tool(node_version, "node") {
-        Ok(path) => path,
-        Err(_) => {
-            ensure_installed(node_version)
-                .await
-                .map_err(|e| format!("Failed to install Node {node_version}: {e}"))?;
-            locate_tool(node_version, "node").map_err(|e| format!("Node not found: {e}"))?
-        }
-    };
+    let node_path = ensure_installed(node_version)
+        .await
+        .map_err(|e| format!("Failed to install Node {node_version}: {e}"))?;
 
     // Locate the actual binary in the package directory
     let binary_path = locate_package_binary(&metadata.name, tool)
@@ -1260,7 +1256,7 @@ pub(crate) async fn resolve_with_cache(cwd: &AbsolutePathBuf) -> Result<ResolveC
 }
 
 /// Ensure Node.js is installed.
-pub(crate) async fn ensure_installed(version: &str) -> Result<(), String> {
+pub(crate) async fn ensure_installed(version: &str) -> Result<AbsolutePathBuf, String> {
     let home_dir = vite_shared::get_vp_home()
         .map_err(|e| format!("Failed to get vite-plus home dir: {e}"))?
         .join("js_runtime")
@@ -1274,14 +1270,18 @@ pub(crate) async fn ensure_installed(version: &str) -> Result<(), String> {
 
     // Check if already installed
     if binary_path.as_path().exists() {
-        return Ok(());
+        return Ok(binary_path);
     }
 
     // Download the runtime
     vite_js_runtime::download_runtime(vite_js_runtime::JsRuntimeType::Node, version)
         .await
         .map_err(|e| format!("{e}"))?;
-    Ok(())
+
+    if !binary_path.as_path().exists() {
+        return Err(format!("Node not found at {}", binary_path.as_path().display()));
+    }
+    Ok(binary_path)
 }
 
 /// Locate a tool binary within the Node.js installation.

--- a/crates/vite_global_cli/src/shim/dispatch.rs
+++ b/crates/vite_global_cli/src/shim/dispatch.rs
@@ -701,8 +701,8 @@ async fn resolve_matching_package_manager_tool(
 
 /// Main shim dispatch entry point.
 ///
-/// Called when the binary is invoked as node, npm, npx, or a package binary.
-/// Returns an exit code to be used with std::process::exit.
+/// Called when the binary is invoked as node, npm, npx, corepack, or a
+/// package binary. Returns an exit code to be used with std::process::exit.
 pub async fn dispatch(tool: &str, args: &[String]) -> i32 {
     tracing::debug!("dispatch: tool: {tool}, args: {:?}", args);
 
@@ -770,6 +770,15 @@ pub async fn dispatch(tool: &str, args: &[String]) -> i32 {
             return exec::exec_tool(&system_path, args);
         }
         // Fall through to managed if system not found
+    }
+
+    // corepack: dedicated resolution chain (vp-managed package → Node-bundled
+    // → auto-install), see shim::corepack. Intentionally placed after the
+    // bypass/system-first checks and outside the recursion passthrough so it
+    // always re-resolves (corepack may not exist on the prepended PATH at all
+    // with Node.js 25+).
+    if tool == "corepack" {
+        return super::corepack::dispatch_corepack(args).await;
     }
 
     // Check if this is a package binary (not node/npm/npx)
@@ -1147,7 +1156,7 @@ fn passthrough_to_system(tool: &str, args: &[String]) -> i32 {
 }
 
 /// Resolve version with caching.
-async fn resolve_with_cache(cwd: &AbsolutePathBuf) -> Result<ResolveCacheEntry, String> {
+pub(crate) async fn resolve_with_cache(cwd: &AbsolutePathBuf) -> Result<ResolveCacheEntry, String> {
     // Fast-path: VP_NODE_VERSION env var set by `vp env use`
     // Skip all disk I/O for cache when session override is active
     if let Ok(env_version) = std::env::var(config::VERSION_ENV_VAR) {

--- a/crates/vite_global_cli/src/shim/mod.rs
+++ b/crates/vite_global_cli/src/shim/mod.rs
@@ -1,7 +1,8 @@
-//! Shim module for intercepting node, npm, npx, and package binary commands.
+//! Shim module for intercepting node, npm, npx, corepack, and package binary commands.
 //!
 //! This module provides the functionality for the vp binary to act as a shim
-//! when invoked as `node`, `npm`, `npx`, or any globally installed package binary.
+//! when invoked as `node`, `npm`, `npx`, `corepack`, or any globally installed
+//! package binary.
 //!
 //! Detection methods:
 //! - Unix: Symlinks to vp binary preserve argv[0], allowing tool detection
@@ -9,6 +10,7 @@
 //! - Legacy: `.cmd` wrappers call `vp env exec <tool>` directly (deprecated)
 
 mod cache;
+pub(crate) mod corepack;
 pub(crate) mod dispatch;
 pub(crate) mod exec;
 
@@ -17,7 +19,12 @@ pub use dispatch::dispatch;
 pub(crate) use dispatch::find_system_tool;
 use vite_shared::env_vars;
 
-/// Core shim tools (node, npm, npx)
+/// Core shim tools (node, npm, npx).
+///
+/// `corepack` is also a default shim (see `commands::env::setup::SHIM_TOOLS`)
+/// but is intentionally not a core tool: it is not always bundled with the
+/// resolved Node.js version (removed in Node.js 25+), so it has a dedicated
+/// dispatch path with a managed fallback and never uses recursion passthrough.
 pub const CORE_SHIM_TOOLS: &[&str] = &["node", "npm", "npx"];
 
 /// Extract the tool name from argv[0].
@@ -193,6 +200,9 @@ mod tests {
         assert!(!is_core_shim_tool("vp"));
         assert!(!is_core_shim_tool("cargo"));
         assert!(!is_core_shim_tool("tsc")); // Package binary, not core
+        // corepack is a default shim but intentionally not a core tool:
+        // it has a dedicated dispatch path and never uses recursion passthrough
+        assert!(!is_core_shim_tool("corepack"));
 
         // is_shim_tool includes core tools
         assert!(is_shim_tool("node"));

--- a/crates/vite_js_runtime/src/runtime.rs
+++ b/crates/vite_js_runtime/src/runtime.rs
@@ -531,7 +531,9 @@ fn check_constraint(
         Ok(range) => {
             if !range.satisfies(version) {
                 let source_str = source.map_or("none".to_string(), |s| s.to_string());
-                println!(
+                // Warnings go to stderr: shims must keep the wrapped
+                // tool's stdout parseable.
+                eprintln!(
                     "warning: Node.js version {resolved_version} (from {source_str}) does not \
                      satisfy {constraint_source} constraint '{constraint}'"
                 );
@@ -580,7 +582,7 @@ pub fn normalize_version(version: &Str, source: &str) -> Option<Str> {
 
     // Invalid version — print warning (only if non-empty, empty is just "not specified")
     if !trimmed.is_empty() {
-        println!("warning: invalid version '{version}' in {source}, ignoring");
+        eprintln!("warning: invalid version '{version}' in {source}, ignoring");
     }
     None
 }

--- a/crates/vite_shared/src/output.rs
+++ b/crates/vite_shared/src/output.rs
@@ -3,7 +3,27 @@
 //! All commands should use these functions instead of ad-hoc formatting to ensure
 //! consistent output across the entire CLI.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use owo_colors::OwoColorize;
+
+/// When set, user-facing stdout output (info/pass/note/success/raw) is routed
+/// to stderr instead. Shim dispatch enables this once at entry: a shim's
+/// stdout belongs to the wrapped tool and must stay parseable.
+static USER_OUTPUT_TO_STDERR: AtomicBool = AtomicBool::new(false);
+
+/// Route subsequent user-facing stdout output to stderr.
+///
+/// Called once at shim-dispatch entry, before any output is produced.
+pub fn route_user_output_to_stderr() {
+    USER_OUTPUT_TO_STDERR.store(true, Ordering::Relaxed);
+}
+
+/// Whether user-facing output is currently routed to stderr.
+#[must_use]
+pub fn user_output_to_stderr() -> bool {
+    USER_OUTPUT_TO_STDERR.load(Ordering::Relaxed)
+}
 
 // Standard status symbols
 /// Success checkmark: ✓
@@ -16,15 +36,23 @@ pub const WARN_SIGN: &str = "\u{26A0}";
 pub const ARROW: &str = "\u{2192}";
 
 /// Print an info message to stdout.
-#[expect(clippy::print_stdout, clippy::disallowed_macros)]
+#[expect(clippy::print_stdout, clippy::print_stderr, clippy::disallowed_macros)]
 pub fn info(msg: &str) {
-    println!("{} {msg}", "info:".bright_blue().bold());
+    if user_output_to_stderr() {
+        eprintln!("{} {msg}", "info:".bright_blue().bold());
+    } else {
+        println!("{} {msg}", "info:".bright_blue().bold());
+    }
 }
 
 /// Print a pass message to stdout using the same accent styling as info.
-#[expect(clippy::print_stdout, clippy::disallowed_macros)]
+#[expect(clippy::print_stdout, clippy::print_stderr, clippy::disallowed_macros)]
 pub fn pass(msg: &str) {
-    println!("{} {msg}", "pass:".bright_blue().bold());
+    if user_output_to_stderr() {
+        eprintln!("{} {msg}", "pass:".bright_blue().bold());
+    } else {
+        println!("{} {msg}", "pass:".bright_blue().bold());
+    }
 }
 
 /// Print a warning message to stderr.
@@ -40,44 +68,47 @@ pub fn error(msg: &str) {
 }
 
 /// Print a note message to stdout (supplementary info).
-#[expect(clippy::print_stdout, clippy::disallowed_macros)]
+#[expect(clippy::print_stdout, clippy::print_stderr, clippy::disallowed_macros)]
 pub fn note(msg: &str) {
-    println!("{} {msg}", "note:".dimmed().bold());
+    if user_output_to_stderr() {
+        eprintln!("{} {msg}", "note:".dimmed().bold());
+    } else {
+        println!("{} {msg}", "note:".dimmed().bold());
+    }
 }
 
 /// Print a success line with checkmark to stdout.
-#[expect(clippy::print_stdout, clippy::disallowed_macros)]
+#[expect(clippy::print_stdout, clippy::print_stderr, clippy::disallowed_macros)]
 pub fn success(msg: &str) {
-    println!("{} {msg}", CHECK.green());
+    if user_output_to_stderr() {
+        eprintln!("{} {msg}", CHECK.green());
+    } else {
+        println!("{} {msg}", CHECK.green());
+    }
 }
 
 /// Print a raw message to stdout with no prefix or formatting.
-#[expect(clippy::print_stdout, clippy::disallowed_macros)]
+#[expect(clippy::print_stdout, clippy::print_stderr, clippy::disallowed_macros)]
 pub fn raw(msg: &str) {
-    println!("{msg}");
+    if user_output_to_stderr() {
+        eprintln!("{msg}");
+    } else {
+        println!("{msg}");
+    }
 }
 
 /// Print a raw message to stdout without a trailing newline.
-#[expect(clippy::print_stdout, clippy::disallowed_macros)]
+#[expect(clippy::print_stdout, clippy::print_stderr, clippy::disallowed_macros)]
 pub fn raw_inline(msg: &str) {
-    print!("{msg}");
+    if user_output_to_stderr() {
+        eprint!("{msg}");
+    } else {
+        print!("{msg}");
+    }
 }
 
 /// Print a raw message to stderr with no prefix or formatting.
 #[expect(clippy::print_stderr, clippy::disallowed_macros)]
 pub fn raw_stderr(msg: &str) {
     eprintln!("{msg}");
-}
-
-/// Print an info message to stderr (for flows whose stdout must stay
-/// parseable, e.g. shim-wrapped tool invocations).
-#[expect(clippy::print_stderr, clippy::disallowed_macros)]
-pub fn info_stderr(msg: &str) {
-    eprintln!("{} {msg}", "info:".bright_blue().bold());
-}
-
-/// Print a success line with checkmark to stderr.
-#[expect(clippy::print_stderr, clippy::disallowed_macros)]
-pub fn success_stderr(msg: &str) {
-    eprintln!("{} {msg}", CHECK.green());
 }

--- a/crates/vite_shared/src/output.rs
+++ b/crates/vite_shared/src/output.rs
@@ -68,3 +68,16 @@ pub fn raw_inline(msg: &str) {
 pub fn raw_stderr(msg: &str) {
     eprintln!("{msg}");
 }
+
+/// Print an info message to stderr (for flows whose stdout must stay
+/// parseable, e.g. shim-wrapped tool invocations).
+#[expect(clippy::print_stderr, clippy::disallowed_macros)]
+pub fn info_stderr(msg: &str) {
+    eprintln!("{} {msg}", "info:".bright_blue().bold());
+}
+
+/// Print a success line with checkmark to stderr.
+#[expect(clippy::print_stderr, clippy::disallowed_macros)]
+pub fn success_stderr(msg: &str) {
+    eprintln!("{} {msg}", CHECK.green());
+}

--- a/docs/guide/env.md
+++ b/docs/guide/env.md
@@ -125,7 +125,7 @@ vp node -e "console.log(1+1)" # Shorthand: forward any node flag or argument
 Vite+ creates a `corepack` shim by default, so corepack works without a system Node.js installation:
 
 - On Node.js 24 and earlier, the shim runs the corepack bundled with the resolved Node.js version.
-- On Node.js 25 and later, where corepack is no longer bundled, Vite+ installs corepack as a managed global package on first use (the same as running `vp install -g corepack`).
+- On Node.js 25 and later, where corepack is no longer bundled, Vite+ installs corepack as a managed global package on first use. Only the `corepack` binary is linked; run `vp install -g corepack` yourself if you also want the package's pnpm/yarn launchers exposed directly.
 - If you install corepack explicitly with `vp install -g corepack`, that installation is always preferred.
 
 `corepack enable` normally creates `pnpm`/`yarn` launchers next to the corepack binary, which under Vite+ would not be on `PATH`. The shim fixes this by defaulting `--install-directory` to `VP_HOME/bin`, so after `corepack enable` the launchers are available everywhere and still resolve the project's Node.js and package-manager versions:
@@ -134,6 +134,8 @@ Vite+ creates a `corepack` shim by default, so corepack works without a system N
 corepack enable               # pnpm and yarn now resolve via corepack
 corepack disable              # Remove the pnpm/yarn launchers again
 ```
+
+The launchers reference the corepack copy that created them. If that copy is later removed (for example by uninstalling the Node.js version it shipped with), rerun `corepack enable` to recreate them.
 
 Shims owned by Vite+ (`npm`, `npx`, and binaries installed with `vp install -g`) are protected: if corepack removes or replaces them, Vite+ restores them and prints a warning.
 

--- a/docs/guide/env.md
+++ b/docs/guide/env.md
@@ -95,7 +95,7 @@ In CI, `vp env use` can still run without shell initialization. It writes a temp
 
 ```bash
 # Setup
-vp env setup                  # Create shims for node, npm, npx
+vp env setup                  # Create shims for node, npm, npx, corepack
 vp env on                     # Use Vite+ managed Node.js
 vp env print                  # Print shell snippet for this session
 
@@ -119,6 +119,23 @@ vp env exec node -v           # Use shim mode with automatic version resolution
 vp node script.js             # Shorthand: run a Node.js script with the resolved version
 vp node -e "console.log(1+1)" # Shorthand: forward any node flag or argument
 ```
+
+## Corepack
+
+Vite+ creates a `corepack` shim by default, so corepack works without a system Node.js installation:
+
+- On Node.js 24 and earlier, the shim runs the corepack bundled with the resolved Node.js version.
+- On Node.js 25 and later, where corepack is no longer bundled, Vite+ installs corepack as a managed global package on first use (the same as running `vp install -g corepack`).
+- If you install corepack explicitly with `vp install -g corepack`, that installation is always preferred.
+
+`corepack enable` normally creates `pnpm`/`yarn` launchers next to the corepack binary, which under Vite+ would not be on `PATH`. The shim fixes this by defaulting `--install-directory` to `VP_HOME/bin`, so after `corepack enable` the launchers are available everywhere and still resolve the project's Node.js and package-manager versions:
+
+```bash
+corepack enable               # pnpm and yarn now resolve via corepack
+corepack disable              # Remove the pnpm/yarn launchers again
+```
+
+Shims owned by Vite+ (`npm`, `npx`, and binaries installed with `vp install -g`) are protected: if corepack removes or replaces them, Vite+ restores them and prints a warning.
 
 ## Custom Node.js Mirror
 

--- a/packages/cli/install.ps1
+++ b/packages/cli/install.ps1
@@ -631,7 +631,7 @@ function Main {
         # Pre-trampoline versions: fall back to legacy .cmd and shell script wrappers.
         # Remove any stale trampoline .exe shims left by a newer install — .exe wins
         # over .cmd on Windows PATH, so leftover trampolines would bypass the wrappers.
-        foreach ($stale in @("vp.exe", "node.exe", "npm.exe", "npx.exe", "vpx.exe")) {
+        foreach ($stale in @("vp.exe", "node.exe", "npm.exe", "npx.exe", "corepack.exe", "vpx.exe", "vpr.exe")) {
             $stalePath = Join-Path "$InstallDir\bin" $stale
             if (Test-Path $stalePath) {
                 Remove-Item -Path $stalePath -Force -ErrorAction SilentlyContinue

--- a/packages/cli/install.ps1
+++ b/packages/cli/install.ps1
@@ -387,7 +387,7 @@ function Refresh-Shims {
     }
 }
 
-# Setup Node.js version manager (node/npm/npx shims)
+# Setup Node.js version manager (node/npm/npx/corepack shims)
 # Returns: "true" = enabled, "false" = not enabled, "already" = already configured
 function Setup-NodeManager {
     param([string]$BinDir)
@@ -433,7 +433,7 @@ function Setup-NodeManager {
     if ($isInteractive) {
         Write-Host ""
         Write-Host "Would you like Vite+ to manage your Node.js versions?"
-        Write-Host "It adds ``node``, ``npm``, and ``npx`` shims to ~/.vite-plus/bin/ and automatically uses the right version."
+        Write-Host "It adds ``node``, ``npm``, ``npx``, and ``corepack`` shims to ~/.vite-plus/bin/ and automatically uses the right version."
         Write-Host "Opt out anytime with ``vp env off``."
         $response = Read-Host "Press Enter to accept (Y/n)"
 

--- a/packages/cli/install.sh
+++ b/packages/cli/install.sh
@@ -728,7 +728,7 @@ refresh_shims() {
   fi
 }
 
-# Setup Node.js version manager (node/npm/npx shims)
+# Setup Node.js version manager (node/npm/npx/corepack shims)
 # Sets NODE_MANAGER_ENABLED global
 # Arguments: bin_dir - path to the version's bin directory containing vp
 setup_node_manager() {
@@ -787,7 +787,7 @@ setup_node_manager() {
   if [ -e /dev/tty ] && [ -t 1 ]; then
     echo ""
     echo "Would you like Vite+ to manage your Node.js versions?"
-    echo "It adds \`node\`, \`npm\`, and \`npx\` shims to ~/.vite-plus/bin/ and automatically uses the right version."
+    echo "It adds \`node\`, \`npm\`, \`npx\`, and \`corepack\` shims to ~/.vite-plus/bin/ and automatically uses the right version."
     echo "Opt out anytime with \`vp env off\`."
     echo -n "Press Enter to accept (Y/n): "
     read -r response < /dev/tty

--- a/packages/cli/snap-tests-global/cli-helper-message/snap.txt
+++ b/packages/cli/snap-tests-global/cli-helper-message/snap.txt
@@ -372,7 +372,7 @@ Inspect:
 
 Examples:
   Setup:
-    vp env setup                  # Create shims for node, npm, npx
+    vp env setup                  # Create shims for node, npm, npx, corepack
     vp env on                     # Use vite-plus managed Node.js
     vp env print                  # Print shell snippet for this session
 

--- a/packages/cli/snap-tests-global/command-env-global-install-multiple-fail/snap.txt
+++ b/packages/cli/snap-tests-global/command-env-global-install-multiple-fail/snap.txt
@@ -1,9 +1,9 @@
-[1]> vp install -g . voidzero-nonexistent-pkg-xyz-12345
+[1]> vp install -g . voidzero-nonexistent-pkg-xyz-23456
 info: Installing 2 global packages with Node.js <semver>
 npm error code E404
-npm error 404 Not Found - GET https://registry.<domain>/voidzero-nonexistent-pkg-xyz-12345 - Not found
+npm error 404 Not Found - GET https://registry.<domain>/voidzero-nonexistent-pkg-xyz-23456 - Not found
 npm error 404
-npm error 404  The requested resource 'voidzero-nonexistent-pkg-xyz-12345@*' could not be found or you do not have permission to access it.
+npm error 404  The requested resource 'voidzero-nonexistent-pkg-xyz-23456@*' could not be found or you do not have permission to access it.
 npm error 404
 npm error 404 Note that you can also install from a
 npm error 404 tarball, folder, http url, or git url.
@@ -11,7 +11,7 @@ npm error A complete log of this run can be found in: <homedir>/.npm/_logs/<time
 ✓ Installed install-fail-local-package <semver>
   Bins: install-fail-local-package
 
-error: Failed to install voidzero-nonexistent-pkg-xyz-12345: Configuration error: npm install failed with exit code: Some(1)
+error: Failed to install voidzero-nonexistent-pkg-xyz-23456: Configuration error: npm install failed with exit code: Some(1)
 
 > install-fail-local-package
 The package is installed successfully

--- a/packages/cli/snap-tests-global/command-env-global-install-multiple-fail/steps.json
+++ b/packages/cli/snap-tests-global/command-env-global-install-multiple-fail/steps.json
@@ -1,6 +1,6 @@
 {
   "env": {},
   "ignoredPlatforms": ["win32"],
-  "commands": ["vp install -g . voidzero-nonexistent-pkg-xyz-12345", "install-fail-local-package"],
+  "commands": ["vp install -g . voidzero-nonexistent-pkg-xyz-23456", "install-fail-local-package"],
   "after": ["vp remove -g install-fail-local-package"]
 }

--- a/packages/cli/snap-tests-global/command-env-install-conflict/snap.txt
+++ b/packages/cli/snap-tests-global/command-env-install-conflict/snap.txt
@@ -1,6 +1,6 @@
 > vp install -g ./conflict-pkg # Install package with conflicting binary name (uses cwd version)
 info: Installing 1 global package with Node.js <semver>
-warn: Package 'conflict-pkg' provides 'node' binary, but it conflicts with a core shim. Skipping.
+warn: Package 'conflict-pkg' provides 'node' binary, but it conflicts with a built-in shim. Skipping.
 ✓ Installed conflict-pkg <semver>
   Bins: conflict-cli, node
 
@@ -9,7 +9,7 @@ Uninstalled conflict-pkg
 
 > vp install -g --node 20 ./conflict-pkg # Install with specific Node.js version
 info: Installing 1 global package with Node.js <semver>
-warn: Package 'conflict-pkg' provides 'node' binary, but it conflicts with a core shim. Skipping.
+warn: Package 'conflict-pkg' provides 'node' binary, but it conflicts with a built-in shim. Skipping.
 ✓ Installed conflict-pkg <semver>
   Bins: conflict-cli, node
 

--- a/packages/cli/snap-tests-global/command-env-install-conflict/snap.txt
+++ b/packages/cli/snap-tests-global/command-env-install-conflict/snap.txt
@@ -2,7 +2,7 @@
 info: Installing 1 global package with Node.js <semver>
 warn: Package 'conflict-pkg' provides 'node' binary, but it conflicts with a built-in shim. Skipping.
 ✓ Installed conflict-pkg <semver>
-  Bins: conflict-cli, node
+  Bins: conflict-cli
 
 > vp remove -g conflict-pkg # Cleanup
 Uninstalled conflict-pkg
@@ -11,7 +11,7 @@ Uninstalled conflict-pkg
 info: Installing 1 global package with Node.js <semver>
 warn: Package 'conflict-pkg' provides 'node' binary, but it conflicts with a built-in shim. Skipping.
 ✓ Installed conflict-pkg <semver>
-  Bins: conflict-cli, node
+  Bins: conflict-cli
 
 > vp remove -g conflict-pkg # Cleanup
 Uninstalled conflict-pkg

--- a/packages/cli/snap-tests-global/command-env-setup-external-vp/assert-shims.mjs
+++ b/packages/cli/snap-tests-global/command-env-setup-external-vp/assert-shims.mjs
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 const expected = path.resolve('external/vp');
 
-for (const shim of ['vp', 'node', 'npm', 'npx', 'vpx', 'vpr']) {
+for (const shim of ['vp', 'node', 'npm', 'npx', 'corepack', 'vpx', 'vpr']) {
   const shimPath = path.join('home', 'bin', shim);
   const target = fs.readlinkSync(shimPath);
   if (target !== expected) {

--- a/packages/cli/snap-tests-global/command-env-which/snap.txt
+++ b/packages/cli/snap-tests-global/command-env-which/snap.txt
@@ -1,3 +1,4 @@
+> vp remove -g corepack >/dev/null 2>&1 || true # Isolate from a leftover managed corepack, which would win over the bundled one
 > vp env exec node --version # Ensure Node.js is installed first
 v20.18.0
 

--- a/packages/cli/snap-tests-global/command-env-which/snap.txt
+++ b/packages/cli/snap-tests-global/command-env-which/snap.txt
@@ -16,6 +16,11 @@ v20.18.0
   Version:    <semver>
   Source:     <cwd>/.node-version
 
+> vp env which corepack # Core tool - corepack bundled with the resolved Node.js
+<vite-plus-home>/js_runtime/node/<semver>/bin/corepack
+  Version:    <semver>
+  Source:     <cwd>/.node-version
+
 > vp install -g cowsay@1.6.0 # Install a global package via vp
 info: Installing 1 global package with Node.js <semver>
 ✓ Installed cowsay <semver>
@@ -33,5 +38,5 @@ Uninstalled cowsay
 
 [1]> vp env which unknown-tool # Unknown tool - error message
 error: tool 'unknown-tool' not found
-Not a core tool (node, npm, npx) or installed global package.
+Not a core tool (node, npm, npx, corepack) or installed global package.
 Run 'vp list -g' to see installed packages.

--- a/packages/cli/snap-tests-global/command-env-which/steps.json
+++ b/packages/cli/snap-tests-global/command-env-which/steps.json
@@ -6,6 +6,7 @@
     "vp env which node # Core tool - shows resolved Node.js binary path",
     "vp env which npm # Core tool - shows resolved npm binary path",
     "vp env which npx # Core tool - shows resolved npx binary path",
+    "vp env which corepack # Core tool - corepack bundled with the resolved Node.js",
     "vp install -g cowsay@1.6.0 # Install a global package via vp",
     "vp env which cowsay # Global package - shows binary path with metadata",
     "vp remove -g cowsay # Cleanup",

--- a/packages/cli/snap-tests-global/command-env-which/steps.json
+++ b/packages/cli/snap-tests-global/command-env-which/steps.json
@@ -2,6 +2,10 @@
   "env": {},
   "ignoredPlatforms": ["win32"],
   "commands": [
+    {
+      "command": "vp remove -g corepack >/dev/null 2>&1 || true # Isolate from a leftover managed corepack, which would win over the bundled one",
+      "ignoreOutput": true
+    },
     "vp env exec node --version # Ensure Node.js is installed first",
     "vp env which node # Core tool - shows resolved Node.js binary path",
     "vp env which npm # Core tool - shows resolved npm binary path",

--- a/packages/cli/snap-tests-global/shim-corepack-bundled/snap.txt
+++ b/packages/cli/snap-tests-global/shim-corepack-bundled/snap.txt
@@ -1,0 +1,6 @@
+> printf '20.18.0\n' > .node-version # Pin the project Node.js version
+> vp env exec node --version # Ensure Node.js is installed first
+v20.18.0
+
+> corepack --version # corepack shim runs the Node-bundled corepack
+0.29.3

--- a/packages/cli/snap-tests-global/shim-corepack-bundled/snap.txt
+++ b/packages/cli/snap-tests-global/shim-corepack-bundled/snap.txt
@@ -1,3 +1,4 @@
+> vp remove -g corepack >/dev/null 2>&1 || true # Isolate from a leftover managed corepack, which would win over the bundled one
 > printf '20.18.0\n' > .node-version # Pin the project Node.js version
 > vp env exec node --version # Ensure Node.js is installed first
 v20.18.0

--- a/packages/cli/snap-tests-global/shim-corepack-bundled/steps.json
+++ b/packages/cli/snap-tests-global/shim-corepack-bundled/steps.json
@@ -1,6 +1,10 @@
 {
   "ignoredPlatforms": ["win32"],
   "commands": [
+    {
+      "command": "vp remove -g corepack >/dev/null 2>&1 || true # Isolate from a leftover managed corepack, which would win over the bundled one",
+      "ignoreOutput": true
+    },
     "printf '20.18.0\\n' > .node-version # Pin the project Node.js version",
     "vp env exec node --version # Ensure Node.js is installed first",
     "corepack --version # corepack shim runs the Node-bundled corepack"

--- a/packages/cli/snap-tests-global/shim-corepack-bundled/steps.json
+++ b/packages/cli/snap-tests-global/shim-corepack-bundled/steps.json
@@ -1,0 +1,8 @@
+{
+  "ignoredPlatforms": ["win32"],
+  "commands": [
+    "printf '20.18.0\\n' > .node-version # Pin the project Node.js version",
+    "vp env exec node --version # Ensure Node.js is installed first",
+    "corepack --version # corepack shim runs the Node-bundled corepack"
+  ]
+}

--- a/packages/cli/snap-tests-global/shim-corepack-enable-install-directory/fake-corepack.sh
+++ b/packages/cli/snap-tests-global/shim-corepack-enable-install-directory/fake-corepack.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Fake bundled corepack: echoes its invocation with the test root normalized
+# for stable snapshots, and simulates corepack clobbering the npm shim on
+# `enable` so the test can assert that Vite+ restores it.
+if [ "$1" = "enable" ]; then
+  rm -f "$VP_HOME/bin/npm"
+fi
+out="corepack"
+for arg in "$@"; do
+  out="$out $(printf '%s' "$arg" | sed "s#$PWD#<root>#g")"
+done
+printf '%s\n' "$out"

--- a/packages/cli/snap-tests-global/shim-corepack-enable-install-directory/snap.txt
+++ b/packages/cli/snap-tests-global/shim-corepack-enable-install-directory/snap.txt
@@ -1,0 +1,19 @@
+> mkdir -p home # Isolated VP_HOME
+> printf '22.18.0\n' > .node-version # Project Node.js version
+> mkdir -p home/js_runtime/node/22.18.0/bin # Fake managed Node runtime layout
+> printf '#!/bin/sh\necho fake-node\n' > home/js_runtime/node/22.18.0/bin/node && chmod +x home/js_runtime/node/22.18.0/bin/node # Fake node binary
+> cp fake-corepack.sh home/js_runtime/node/22.18.0/bin/corepack && chmod +x home/js_runtime/node/22.18.0/bin/corepack # Fake bundled corepack that echoes its args
+> VP_HOME="$(pwd)/home" vp env setup # Create shims in the isolated home
+> VP_HOME="$(pwd)/home" PATH="$(pwd)/home/bin:$PATH" corepack use pnpm@10 # Non-link commands run unchanged
+corepack use pnpm@10
+
+> VP_HOME="$(pwd)/home" PATH="$(pwd)/home/bin:$PATH" corepack enable --install-directory /tmp/custom-dir # Explicit --install-directory is respected, clobbered npm shim is restored
+corepack enable --install-directory /tmp/custom-dir
+warn: 'npm' is managed by Vite+ and was restored. Vite+ already resolves 'npm' per project, so corepack does not need to manage it.
+
+> VP_HOME="$(pwd)/home" PATH="$(pwd)/home/bin:$PATH" corepack enable # --install-directory defaults to VP_HOME/bin
+corepack enable --install-directory <root>/home/bin
+warn: 'npm' is managed by Vite+ and was restored. Vite+ already resolves 'npm' per project, so corepack does not need to manage it.
+
+> test -L home/bin/npm && echo 'npm shim restored' # Vite+ owns the npm shim
+npm shim restored

--- a/packages/cli/snap-tests-global/shim-corepack-enable-install-directory/steps.json
+++ b/packages/cli/snap-tests-global/shim-corepack-enable-install-directory/steps.json
@@ -1,0 +1,18 @@
+{
+  "ignoredPlatforms": ["win32"],
+  "commands": [
+    "mkdir -p home # Isolated VP_HOME",
+    "printf '22.18.0\\n' > .node-version # Project Node.js version",
+    "mkdir -p home/js_runtime/node/22.18.0/bin # Fake managed Node runtime layout",
+    "printf '#!/bin/sh\\necho fake-node\\n' > home/js_runtime/node/22.18.0/bin/node && chmod +x home/js_runtime/node/22.18.0/bin/node # Fake node binary",
+    "cp fake-corepack.sh home/js_runtime/node/22.18.0/bin/corepack && chmod +x home/js_runtime/node/22.18.0/bin/corepack # Fake bundled corepack that echoes its args",
+    {
+      "command": "VP_HOME=\"$(pwd)/home\" vp env setup # Create shims in the isolated home",
+      "ignoreOutput": true
+    },
+    "VP_HOME=\"$(pwd)/home\" PATH=\"$(pwd)/home/bin:$PATH\" corepack use pnpm@10 # Non-link commands run unchanged",
+    "VP_HOME=\"$(pwd)/home\" PATH=\"$(pwd)/home/bin:$PATH\" corepack enable --install-directory /tmp/custom-dir # Explicit --install-directory is respected, clobbered npm shim is restored",
+    "VP_HOME=\"$(pwd)/home\" PATH=\"$(pwd)/home/bin:$PATH\" corepack enable # --install-directory defaults to VP_HOME/bin",
+    "test -L home/bin/npm && echo 'npm shim restored' # Vite+ owns the npm shim"
+  ]
+}

--- a/rfcs/env-command.md
+++ b/rfcs/env-command.md
@@ -1907,7 +1907,7 @@ When the `corepack` shim is invoked:
 
 1. **vp-managed global package**: if corepack was installed via `vp install -g corepack`, that installation wins. Explicit user intent takes precedence, and the managed copy provides a consistent corepack version across Node.js versions (same philosophy as `packageManager` winning over the Node-bundled npm).
 2. **Node-bundled corepack**: resolve the project Node.js version (same resolution chain as `node`/`npm`/`npx`) and use the `corepack` bundled with that installation (present in Node.js ≤ 24).
-3. **Auto-install fallback**: on Node.js 25+ where corepack is not bundled, automatically install corepack as a vp-managed global package and execute it. Unlike an explicit `vp install -g corepack` (which exposes every binary the package declares, including its pnpm/yarn launchers), the auto-install links **only the `corepack` binary**: creating package-manager launchers stays `corepack enable`'s job, and the auto-install can never conflict with vp-managed package managers like an existing `vp install -g pnpm`. The restriction is recorded in the package metadata (`bins_restricted`) so `vp update -g` preserves it; an explicit `vp install -g corepack` resets it. A one-line notice is printed to stderr when the install happens.
+3. **Auto-install fallback**: on Node.js 25+ where corepack is not bundled, automatically install corepack as a vp-managed global package and execute it. Unlike an explicit `vp install -g corepack` (which exposes every binary the package declares, including its pnpm/yarn launchers), the auto-install links **only the `corepack` binary**: creating package-manager launchers stays `corepack enable`'s job, and the auto-install can never conflict with vp-managed package managers like an existing `vp install -g pnpm`. The restriction is recorded in the package metadata (`bins_restricted`) so `vp update -g` preserves it; an explicit `vp install -g corepack` resets it, and a shim-triggered reinstall over a previous unrestricted install keeps it unrestricted (it must not silently delete the user's exposed launcher bins). A one-line notice is printed to stderr when the install happens.
 
 ### `corepack enable` / `corepack disable`
 
@@ -1922,7 +1922,7 @@ To fix this, the shim intercepts `corepack enable` and `corepack disable` invoca
 
 - `corepack` is **not** added to `CORE_SHIMS` (the `vp install -g` conflict guard), so `vp install -g corepack` remains allowed — it is the explicit way to control the corepack version and the documented fallback for older Vite+ versions.
 - `vp remove -g corepack` removes the package and its `BinConfig`, but keeps the default `corepack` shim in place (resolution falls back to the Node-bundled / auto-install path).
-- `npm install -g corepack` is unaffected: the existing post-install check sees `corepack` already present in `~/.vite-plus/bin` and skips link creation.
+- `npm install -g corepack` installs the package but does not link the binary: the post-install check skips protected shim names (default shims are guarded by `is_protected_shim`) and prints a note pointing at `vp install -g corepack` instead.
 
 ### Out of Scope
 

--- a/rfcs/env-command.md
+++ b/rfcs/env-command.md
@@ -1907,7 +1907,7 @@ When the `corepack` shim is invoked:
 
 1. **vp-managed global package**: if corepack was installed via `vp install -g corepack`, that installation wins. Explicit user intent takes precedence, and the managed copy provides a consistent corepack version across Node.js versions (same philosophy as `packageManager` winning over the Node-bundled npm).
 2. **Node-bundled corepack**: resolve the project Node.js version (same resolution chain as `node`/`npm`/`npx`) and use the `corepack` bundled with that installation (present in Node.js ≤ 24).
-3. **Auto-install fallback**: on Node.js 25+ where corepack is not bundled, automatically install corepack as a vp-managed global package and execute it. Unlike an explicit `vp install -g corepack` (which exposes every binary the package declares, including its pnpm/yarn launchers), the auto-install links **only the `corepack` binary**: creating package-manager launchers stays `corepack enable`'s job, and the auto-install can never conflict with vp-managed package managers like an existing `vp install -g pnpm`. A one-line notice is printed when the install happens.
+3. **Auto-install fallback**: on Node.js 25+ where corepack is not bundled, automatically install corepack as a vp-managed global package and execute it. Unlike an explicit `vp install -g corepack` (which exposes every binary the package declares, including its pnpm/yarn launchers), the auto-install links **only the `corepack` binary**: creating package-manager launchers stays `corepack enable`'s job, and the auto-install can never conflict with vp-managed package managers like an existing `vp install -g pnpm`. The restriction is recorded in the package metadata (`bins_restricted`) so `vp update -g` preserves it; an explicit `vp install -g corepack` resets it. A one-line notice is printed to stderr when the install happens.
 
 ### `corepack enable` / `corepack disable`
 
@@ -1916,7 +1916,7 @@ Corepack's `enable` command creates package-manager launchers (`pnpm`, `yarn`, .
 To fix this, the shim intercepts `corepack enable` and `corepack disable` invocations that do not pass an explicit `--install-directory` and injects `--install-directory ~/.vite-plus/bin` (the same spawn+wait pattern used for `npm install -g` interception):
 
 - `corepack enable` places `pnpm`/`yarn` launchers into `~/.vite-plus/bin`, which is on `PATH`. The launchers run via the shimmed `node`, so they still respect per-project Node.js version resolution, while corepack itself respects `package.json#packageManager`.
-- `corepack disable` removes them from the same location. Vite+-owned shims are protected: core shims (`vp`, `node`, `npm`, `npx`, `corepack`, `vpx`, `vpr`) and `vp install -g` binaries tracked by a `BinConfig` are restored after corepack exits if corepack removed them.
+- `corepack disable` removes them from the same location. Vite+-owned entries among the corepack-managed launcher names (`npm`, `npx`, `pnpm`, `pnpx`, `yarn`, `yarnpkg`) are protected: default shims, `vp install -g` binaries, and `npm install -g` links tracked by a `BinConfig` are snapshotted before corepack runs and restored afterwards if corepack removed or replaced them. Entries that were already absent or not Vite+-owned before the run are left alone.
 
 ### Interplay with `vp install -g corepack`
 

--- a/rfcs/env-command.md
+++ b/rfcs/env-command.md
@@ -2,9 +2,9 @@
 
 ## Summary
 
-This RFC proposes adding a `vp env` command that provides system-wide, IDE-safe Node.js version management through a shim-based architecture. The shims intercept `node`, `npm`, and `npx` commands, automatically resolving and executing the correct Node.js version based on project configuration.
+This RFC proposes adding a `vp env` command that provides system-wide, IDE-safe Node.js version management through a shim-based architecture. The shims intercept `node`, `npm`, `npx`, and `corepack` commands, automatically resolving and executing the correct Node.js version based on project configuration.
 
-> **Note**: Corepack shim is not included as vite-plus has integrated package manager functionality.
+> **Note**: The `corepack` shim was originally excluded because Vite+ has integrated package manager functionality. This was revisited in [#858](https://github.com/voidzero-dev/vite-plus/issues/858) and [#1309](https://github.com/voidzero-dev/vite-plus/issues/1309): users and scripts invoke `corepack`/`pnpm`/`yarn` directly, and without a system Node.js installation there is no reachable `corepack` at all. See [Corepack Shim](#corepack-shim).
 
 ## Motivation
 
@@ -23,7 +23,7 @@ This RFC proposes adding a `vp env` command that provides system-wide, IDE-safe 
 A shim-based approach where:
 
 - `VITE_PLUS_HOME/bin/` directory is added to PATH (system-level for IDE reliability)
-- Shims (`node`, `npm`, `npx`) are symlinks to the `vp` binary (Unix) or trampoline `.exe` files (Windows)
+- Shims (`node`, `npm`, `npx`, `corepack`) are symlinks to the `vp` binary (Unix) or trampoline `.exe` files (Windows)
 - The `vp` CLI itself is also in `VITE_PLUS_HOME/bin/`, so users only need one PATH entry
 - The binary detects invocation via `argv[0]` and dispatches accordingly
 - Version resolution and installation leverage existing `vite_js_runtime` infrastructure
@@ -221,6 +221,7 @@ vp update -g typescript   # Update specific package
 node -v           # Uses project-specific version
 npm install       # Uses packageManager npm@<version> when explicitly configured, otherwise Node-bundled npm
 npx vitest        # Uses packageManager npm@<version> when explicitly configured, otherwise Node-bundled npx
+corepack enable   # Uses Node-bundled or vp-managed corepack (see Corepack Shim)
 ```
 
 Package-manager shims use `packageManager` only when the invoked command matches the configured manager or one of its generated aliases. For example, `packageManager: "npm@11.14.0"` makes the `npm` and `npx` shims run npm 11.14.0, while `packageManager: "pnpm@10.19.0"` does not turn `npm install` into `pnpm install`; `npm` falls back to the npm available through the resolved Node.js runtime. Alias pairs follow the package-manager download layout: `npm`/`npx`, `pnpm`/`pnpx`, `yarn`/`yarnpkg`, and `bun`/`bunx`.
@@ -236,6 +237,7 @@ argv[0] = "vp"        → Normal CLI mode (vp env, vp build, etc.)
 argv[0] = "node"      → Shim mode: resolve version, exec node
 argv[0] = "npm"       → Shim mode: resolve version, exec npm
 argv[0] = "npx"       → Shim mode: resolve version, exec npx
+argv[0] = "corepack"  → Shim mode: resolve version, exec corepack (managed fallback on Node 25+)
 ```
 
 ### Architecture Diagram
@@ -315,7 +317,8 @@ argv[0] = "npx"       → Shim mode: resolve version, exec npx
 │  │   ├── vp   ──────────────────────  Symlink to ../current/bin/vp          │
 │  │   ├── node ──────────────────────┐                                       │
 │  │   ├── npm  ──────────────────────┼──▶ Symlinks to ../current/bin/vp      │
-│  │   └── npx  ──────────────────────┘                                       │
+│  │   ├── npx  ──────────────────────┤                                       │
+│  │   └── corepack ──────────────────┘                                       │
 │  ├── current/bin/vp                   The actual vp CLI binary              │
 │  ├── js_runtime/node/                 Node.js installations                 │
 │  │   ├── 20.18.0/bin/node             Installed Node.js versions            │
@@ -362,11 +365,13 @@ VITE_PLUS_HOME/                              # Default: ~/.vite-plus
 │   ├── node -> ../current/bin/vp     # Symlink to vp binary (Unix)
 │   ├── npm -> ../current/bin/vp      # Symlink to vp binary (Unix)
 │   ├── npx -> ../current/bin/vp      # Symlink to vp binary (Unix)
+│   ├── corepack -> ../current/bin/vp # Symlink to vp binary (Unix)
 │   ├── tsc -> ../current/bin/vp      # Symlink for global package (Unix)
 │   ├── vp.exe                        # Trampoline forwarding to current\bin\vp.exe (Windows)
 │   ├── node.exe                      # Trampoline shim for node (Windows)
 │   ├── npm.exe                       # Trampoline shim for npm (Windows)
 │   ├── npx.exe                       # Trampoline shim for npx (Windows)
+│   ├── corepack.exe                  # Trampoline shim for corepack (Windows)
 │   └── tsc.exe                       # Trampoline shim for global package (Windows)
 ├── current/
 │   └── bin/
@@ -406,16 +411,16 @@ VITE_PLUS_HOME/                              # Default: ~/.vite-plus
 
 **Key Directories:**
 
-| Directory          | Purpose                                                            |
-| ------------------ | ------------------------------------------------------------------ |
-| `bin/`             | vp symlink and all shims (node, npm, npx, global package binaries) |
-| `current/bin/`     | The actual vp CLI binary (bin/ shims point here)                   |
-| `js_runtime/node/` | Installed Node.js versions                                         |
-| `packages/`        | Installed global packages with metadata                            |
-| `bins/`            | Per-binary config files (tracks which package owns each binary)    |
-| `shared/`          | NODE_PATH symlinks for package require() resolution                |
-| `tmp/`             | Staging area for atomic installations                              |
-| `cache/`           | Resolution cache                                                   |
+| Directory          | Purpose                                                                      |
+| ------------------ | ---------------------------------------------------------------------------- |
+| `bin/`             | vp symlink and all shims (node, npm, npx, corepack, global package binaries) |
+| `current/bin/`     | The actual vp CLI binary (bin/ shims point here)                             |
+| `js_runtime/node/` | Installed Node.js versions                                                   |
+| `packages/`        | Installed global packages with metadata                                      |
+| `bins/`            | Per-binary config files (tracks which package owns each binary)              |
+| `shared/`          | NODE_PATH symlinks for package require() resolution                          |
+| `tmp/`             | Staging area for atomic installations                                        |
+| `cache/`           | Resolution cache                                                             |
 
 ### config.json Format
 
@@ -840,7 +845,7 @@ $ vp env doctor
 Installation
   ✓ VITE_PLUS_HOME    ~/.vite-plus
   ✓ Bin directory     exists
-  ✓ Shims             node, npm, npx
+  ✓ Shims             node, npm, npx, corepack
 
 Configuration
   ✓ Node.js mode      managed
@@ -918,6 +923,7 @@ Created shims:
   /Users/user/.vite-plus/bin/node
   /Users/user/.vite-plus/bin/npm
   /Users/user/.vite-plus/bin/npx
+  /Users/user/.vite-plus/bin/corepack
 
 Add to your shell profile (~/.zshrc, ~/.bashrc, etc.):
 
@@ -938,7 +944,7 @@ $ vp env doctor
 Installation
   ✓ VITE_PLUS_HOME    ~/.vite-plus
   ✓ Bin directory     exists
-  ✓ Shims             node, npm, npx
+  ✓ Shims             node, npm, npx, corepack
 
 Configuration
   ✓ Node.js mode      managed
@@ -949,6 +955,7 @@ PATH
   ✓ node              ~/.vite-plus/bin/node (vp shim)
   ✓ npm               ~/.vite-plus/bin/npm (vp shim)
   ✓ npx               ~/.vite-plus/bin/npx (vp shim)
+  ✓ corepack          ~/.vite-plus/bin/corepack (vp shim)
 
 Version Resolution
     Directory         /Users/user/projects/my-app
@@ -1019,7 +1026,7 @@ $ vp env doctor
 Installation
   ✓ VITE_PLUS_HOME    ~/.vite-plus
   ✗ Bin directory     does not exist
-  ✗ Missing shims     node, npm, npx
+  ✗ Missing shims     node, npm, npx, corepack
                       Run 'vp env setup' to create bin directory and shims.
 
 Configuration
@@ -1042,6 +1049,7 @@ PATH
   node                not found
   npm                 not found
   npx                 not found
+  corepack            not found
 
 Version Resolution
     Directory         /Users/user/projects/my-app
@@ -1378,7 +1386,7 @@ $ vp env which eslint
 # Unknown tool (not core tool, not in any global package)
 $ vp env which unknown-tool
 error: tool 'unknown-tool' not found
-Not a core tool (node, npm, npx) or installed global package.
+Not a core tool (node, npm, npx, corepack) or installed global package.
 Run 'vp list -g' to see installed packages.
 
 # Node.js version not installed
@@ -1881,6 +1889,46 @@ When `npm uninstall -g` is detected, the shim uses `spawn_tool()` (like install)
 
 On Unix, `exec_tool()` uses `exec()` which replaces the current process — no code runs after. For `npm install -g` and `npm uninstall -g` specifically, we use `spawn_tool()` (spawn + wait) to retain control after npm finishes, enabling the post-install hint and post-uninstall link cleanup. All other npm commands continue to use `exec_tool()` for zero overhead.
 
+## Corepack Shim
+
+> Added in response to [#858](https://github.com/voidzero-dev/vite-plus/issues/858) and [#1309](https://github.com/voidzero-dev/vite-plus/issues/1309).
+
+`corepack` is part of the default shim tool list, so `vp env setup` (and the install scripts and `vp upgrade` shim refresh) create a `corepack` shim alongside `node`, `npm`, and `npx`.
+
+### Motivation
+
+- Without a system Node.js installation, corepack is unreachable even though Node.js ≤ 24 bundles it: `npm list -g` shows `corepack`, but no shim exists in `~/.vite-plus/bin`, so `corepack enable` fails with "command not found" (#1309).
+- Many projects, scripts, and AI agents invoke `pnpm`/`yarn` directly instead of `vp` commands (#858). Corepack provides version-correct package manager executables based on `package.json#packageManager`, covering workflows `vp pm` does not (e.g., `yarn plugin ...`, see [#1539](https://github.com/voidzero-dev/vite-plus/issues/1539)).
+- Node.js 25+ no longer bundles corepack, so the shim needs a managed fallback rather than relying on the bundled binary forever.
+
+### Resolution Order
+
+When the `corepack` shim is invoked:
+
+1. **vp-managed global package**: if corepack was installed via `vp install -g corepack`, that installation wins. Explicit user intent takes precedence, and the managed copy provides a consistent corepack version across Node.js versions (same philosophy as `packageManager` winning over the Node-bundled npm).
+2. **Node-bundled corepack**: resolve the project Node.js version (same resolution chain as `node`/`npm`/`npx`) and use the `corepack` bundled with that installation (present in Node.js ≤ 24).
+3. **Auto-install fallback**: on Node.js 25+ where corepack is not bundled, automatically install corepack as a vp-managed global package and execute it. Unlike an explicit `vp install -g corepack` (which exposes every binary the package declares, including its pnpm/yarn launchers), the auto-install links **only the `corepack` binary**: creating package-manager launchers stays `corepack enable`'s job, and the auto-install can never conflict with vp-managed package managers like an existing `vp install -g pnpm`. A one-line notice is printed when the install happens.
+
+### `corepack enable` / `corepack disable`
+
+Corepack's `enable` command creates package-manager launchers (`pnpm`, `yarn`, ...) **next to the corepack binary found in `PATH`**. Under the Vite+ shim that would be the per-version Node.js bin directory (`~/.vite-plus/js_runtime/node/<version>/bin/`), which is not on `PATH` — `corepack enable` would silently produce unreachable launchers.
+
+To fix this, the shim intercepts `corepack enable` and `corepack disable` invocations that do not pass an explicit `--install-directory` and injects `--install-directory ~/.vite-plus/bin` (the same spawn+wait pattern used for `npm install -g` interception):
+
+- `corepack enable` places `pnpm`/`yarn` launchers into `~/.vite-plus/bin`, which is on `PATH`. The launchers run via the shimmed `node`, so they still respect per-project Node.js version resolution, while corepack itself respects `package.json#packageManager`.
+- `corepack disable` removes them from the same location. Vite+-owned shims are protected: core shims (`vp`, `node`, `npm`, `npx`, `corepack`, `vpx`, `vpr`) and `vp install -g` binaries tracked by a `BinConfig` are restored after corepack exits if corepack removed them.
+
+### Interplay with `vp install -g corepack`
+
+- `corepack` is **not** added to `CORE_SHIMS` (the `vp install -g` conflict guard), so `vp install -g corepack` remains allowed — it is the explicit way to control the corepack version and the documented fallback for older Vite+ versions.
+- `vp remove -g corepack` removes the package and its `BinConfig`, but keeps the default `corepack` shim in place (resolution falls back to the Node-bundled / auto-install path).
+- `npm install -g corepack` is unaffected: the existing post-install check sees `corepack` already present in `~/.vite-plus/bin` and skips link creation.
+
+### Out of Scope
+
+- Default `pnpm`/`yarn` shims that route to `vp pm` equivalents — `vp pm` does not cover all package-manager subcommands yet ([#1539](https://github.com/voidzero-dev/vite-plus/issues/1539)).
+- Replacing corepack with built-in Vite+ functionality. The shim is the compatibility bridge "until there is a proper alternative that everyone is happy to use".
+
 ## Exec Command
 
 The `vp env exec` command executes a command with a specific Node.js version. It operates in two modes:
@@ -2132,6 +2180,7 @@ VITE_PLUS_HOME/
 │   ├── node -> ../current/bin/vp    # Symlink to same binary
 │   ├── npm -> ../current/bin/vp     # Symlink to same binary
 │   ├── npx -> ../current/bin/vp     # Symlink to same binary
+│   ├── corepack -> ../current/bin/vp # Symlink to same binary
 │   └── tsc -> ../current/bin/vp     # Symlink for global package
 └── current/
     └── bin/
@@ -2160,6 +2209,7 @@ All shims use relative symlinks:
 ln -sf ../current/bin/vp ~/.vite-plus/bin/node
 ln -sf ../current/bin/vp ~/.vite-plus/bin/npm
 ln -sf ../current/bin/vp ~/.vite-plus/bin/npx
+ln -sf ../current/bin/vp ~/.vite-plus/bin/corepack
 
 # Global package binaries
 ln -sf ../current/bin/vp ~/.vite-plus/bin/tsc
@@ -2176,6 +2226,7 @@ VITE_PLUS_HOME\
 │   ├── node.exe     # Trampoline shim (sets VITE_PLUS_SHIM_TOOL=node)
 │   ├── npm.exe      # Trampoline shim (sets VITE_PLUS_SHIM_TOOL=npm)
 │   ├── npx.exe      # Trampoline shim (sets VITE_PLUS_SHIM_TOOL=npx)
+│   ├── corepack.exe # Trampoline shim (sets VITE_PLUS_SHIM_TOOL=corepack)
 │   └── tsc.exe      # Trampoline shim for global package
 └── current\
     └── bin\
@@ -2217,7 +2268,7 @@ The Windows installer (`install.ps1`) follows this flow:
 
 1. Download and install `vp.exe` and `vp-shim.exe` to `~/.vite-plus/current/bin/`
 2. Create `~/.vite-plus/bin/vp.exe` trampoline (copy of `vp-shim.exe`)
-3. Create shim trampolines: `node.exe`, `npm.exe`, `npx.exe` (via `vp env setup`)
+3. Create shim trampolines: `node.exe`, `npm.exe`, `npx.exe`, `corepack.exe` (via `vp env setup`)
 4. Configure User PATH to include `~/.vite-plus/bin`
 
 ## Testing Strategy
@@ -2312,6 +2363,14 @@ env-doctor/
 
 1. NODE_PATH setup for shared package resolution
 
+### Phase 5: Corepack Shim (P1)
+
+1. Add `corepack` to the default shim tool list created by `vp env setup` (Unix symlink, Windows trampoline)
+2. Dispatch: vp-managed global corepack first, then Node-bundled corepack, then auto-install fallback (Node.js 25+)
+3. Intercept `corepack enable`/`corepack disable` to default `--install-directory` to `~/.vite-plus/bin`, restoring Vite+-owned shims afterwards
+4. Keep `vp install -g corepack` allowed; `vp remove -g corepack` keeps the default shim
+5. Update `vp env doctor`, `vp env which`, install scripts, and docs; add snap tests
+
 ## Backward Compatibility
 
 This is a new feature with no impact on existing functionality. The `vp` binary continues to work normally when invoked directly.
@@ -2330,7 +2389,7 @@ The following decisions have been made:
 
 2. **Windows Shim Strategy**: Trampoline `.exe` files that set `VITE_PLUS_SHIM_TOOL` and spawn `vp.exe` - Avoids "Terminate batch job?" prompt, works in all shells. See [RFC: Trampoline EXE for Shims](./trampoline-exe-for-shims.md).
 
-3. **Corepack Handling**: Not included - vite-plus has integrated package manager functionality, making corepack shims unnecessary.
+3. **Corepack Handling**: Included as a default shim (revisited in [#1309](https://github.com/voidzero-dev/vite-plus/issues/1309), originally excluded). The shim prefers a vp-managed global corepack, falls back to the Node-bundled binary (Node.js ≤ 24), and auto-installs a managed copy on Node.js 25+ where corepack is no longer bundled. See [Corepack Shim](#corepack-shim).
 
 4. **Cache Persistence**: Persist across upgrades - Better performance, with cache format versioning for compatibility.
 

--- a/rfcs/trampoline-exe-for-shims.md
+++ b/rfcs/trampoline-exe-for-shims.md
@@ -6,7 +6,7 @@ Implemented
 
 ## Summary
 
-Replace Windows `.cmd` wrapper scripts with lightweight trampoline `.exe` binaries for all shim tools (`vp`, `node`, `npm`, `npx`, `vpx`, `vpr`, and globally installed package binaries). This eliminates the `Terminate batch job (Y/N)?` prompt that appears when users press Ctrl+C, providing the same clean signal behavior as direct `.exe` invocation.
+Replace Windows `.cmd` wrapper scripts with lightweight trampoline `.exe` binaries for all shim tools (`vp`, `node`, `npm`, `npx`, `corepack`, `vpx`, `vpr`, and globally installed package binaries). This eliminates the `Terminate batch job (Y/N)?` prompt that appears when users press Ctrl+C, providing the same clean signal behavior as direct `.exe` invocation.
 
 ## Motivation
 
@@ -61,12 +61,13 @@ On Unix, shims are symlinks to the `vp` binary. The binary detects the tool name
 
 ```
 ~/.vite-plus/bin/
-├── vp   → ../current/bin/vp     (symlink)
-├── node → ../current/bin/vp     (symlink)
-├── npm  → ../current/bin/vp     (symlink)
-├── npx  → ../current/bin/vp     (symlink)
-├── vpx  → ../current/bin/vp     (symlink)
-└── vpr  → ../current/bin/vp     (symlink)
+├── vp       → ../current/bin/vp     (symlink)
+├── node     → ../current/bin/vp     (symlink)
+├── npm      → ../current/bin/vp     (symlink)
+├── npx      → ../current/bin/vp     (symlink)
+├── corepack → ../current/bin/vp     (symlink)
+├── vpx      → ../current/bin/vp     (symlink)
+└── vpr      → ../current/bin/vp     (symlink)
 ```
 
 ### Windows (Trampoline `.exe` Files)
@@ -77,6 +78,7 @@ On Unix, shims are symlinks to the `vp` binary. The binary detects the tool name
 ├── node.exe     # Trampoline → sets VITE_PLUS_SHIM_TOOL=node, spawns vp.exe
 ├── npm.exe      # Trampoline → sets VITE_PLUS_SHIM_TOOL=npm, spawns vp.exe
 ├── npx.exe      # Trampoline → sets VITE_PLUS_SHIM_TOOL=npx, spawns vp.exe
+├── corepack.exe # Trampoline → sets VITE_PLUS_SHIM_TOOL=corepack, spawns vp.exe
 ├── vpx.exe      # Trampoline → sets VITE_PLUS_SHIM_TOOL=vpx, spawns vp.exe
 ├── vpr.exe      # Trampoline → sets VITE_PLUS_SHIM_TOOL=vpr, spawns vp.exe
 └── tsc.exe      # Trampoline → sets VITE_PLUS_SHIM_TOOL=tsc, spawns vp.exe (package shim)
@@ -211,8 +213,8 @@ When `vp env setup --refresh` is invoked through the trampoline (`~/.vite-plus/b
 
 During `vp upgrade`, after the `current` link is swapped to the new version, `vp env setup --refresh` is invoked to regenerate all trampoline `.exe` files. This ensures that when the trampoline binary (`vp-shim.exe`) changes between versions, all shims pick up the new version:
 
-1. **Core shims** (`vp.exe`, `node.exe`, `npm.exe`, `npx.exe`, `vpx.exe`, `vpr.exe`) are refreshed by the standard `--refresh` logic.
-2. **Package shims** (e.g., `corepack.exe`, `tsc.exe`, installed via `vp install -g`) are discovered by scanning `~/.vite-plus/bins/` for `BinConfig` entries with `source: Vp`, and each `.exe` is replaced with the new trampoline.
+1. **Core shims** (`vp.exe`, `node.exe`, `npm.exe`, `npx.exe`, `corepack.exe`, `vpx.exe`, `vpr.exe`) are refreshed by the standard `--refresh` logic.
+2. **Package shims** (e.g., `tsc.exe`, `eslint.exe`, installed via `vp install -g`) are discovered by scanning `~/.vite-plus/bins/` for `BinConfig` entries with `source: Vp`, and each `.exe` is replaced with the new trampoline.
 
 Package shims installed via npm interception (`source: Npm`) use `.cmd` wrappers, not trampoline `.exe` files, and are not affected by this refresh.
 

--- a/rfcs/upgrade-command.md
+++ b/rfcs/upgrade-command.md
@@ -302,7 +302,7 @@ Key differences on Windows:
 
 After the symlink swap (the **point of no return**), post-update operations are treated as non-fatal. Errors are printed to stderr as warnings but do not trigger the outer error handler (which would delete the now-active version directory).
 
-1. **Refresh shims**: Run the equivalent of `vp env setup --refresh` to ensure node/npm/npx shims point to the new version. This also refreshes trampoline `.exe` files for globally installed package shims (e.g., `corepack.exe`, `tsc.exe`) by scanning `BinConfig` entries. If this fails, the user can run it manually.
+1. **Refresh shims**: Run the equivalent of `vp env setup --refresh` to ensure node/npm/npx/corepack shims point to the new version. This also refreshes trampoline `.exe` files for globally installed package shims (e.g., `tsc.exe`) by scanning `BinConfig` entries. If this fails, the user can run it manually.
 2. **Cleanup old versions**: Remove old version directories, keeping the 3 most recent by **creation time** (matching `install.sh` behavior). The new version and the previous version are always protected from cleanup, even if they fall outside the top 3 (e.g., after a downgrade via `--rollback`).
 
 #### Step 7: Running Binary Consideration


### PR DESCRIPTION
Closes #1309
Closes #858

Without a system Node.js, corepack is unreachable under Vite+ even though Node.js <= 24 bundles it, and Node.js 25+ removed it entirely. This adds `corepack` to the default shims created by `vp env setup`.

## How it works

- Resolution order: vp-managed global install (`vp install -g corepack`) > Node-bundled corepack (Node.js <= 24) > auto-install as a managed global package (Node.js 25+). The auto-install links only the `corepack` bin, so it never conflicts with an existing `vp install -g pnpm` (the corepack package also declares pnpm/yarn launcher bins).
- `corepack enable`/`disable` without an explicit `--install-directory` get `--install-directory ~/.vite-plus/bin` injected, so the created pnpm/yarn launchers land on PATH and still resolve the project Node.js version. Vite+-owned shims (npm/npx, `vp install -g` binaries) are restored with a warning if corepack removes or replaces them.
- `vp remove -g corepack` keeps the default shim; `vp env doctor` and `vp env which corepack` cover the new shim.

RFC updates in `rfcs/env-command.md` (new Corepack Shim section), `rfcs/trampoline-exe-for-shims.md`, and `rfcs/upgrade-command.md` describe the design.

## Testing

- New snap tests: `shim-corepack-bundled` (real bundled corepack via Node 20.18.0) and `shim-corepack-enable-install-directory` (hermetic test for the install-directory injection and npm shim restore).
- Verified manually: bundled dispatch, auto-install on Node 25 (corepack 0.34.7, only `corepack` bin linked), managed-first precedence, `vp remove -g corepack` fallback, and a real `corepack enable`/`disable` cycle (`yarn --version` works through the launcher, vp-managed pnpm restored).

Note: `just lint` currently fails on main due to a pre-existing `clippy::unused_async_trait_impl` warning in `js_executor.rs` from the nightly-2026-06-10 bump, unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core shim dispatch, global bin ownership, and auto-install side effects on first `corepack` use; mistakes could break npm/corepack on PATH or corrupt bin layout on Windows.
> 
> **Overview**
> **Adds `corepack` as a default env shim** (setup, install scripts, docs, E2E varlet matrix uses `corepack enable` instead of `vp i -g pnpm`).
> 
> **New dedicated corepack dispatch** resolves in order: `vp install -g corepack` → Node-bundled corepack → auto-install as a managed global (Node 25+), with optional **`only_bins`** so auto-install links only `corepack` (not pnpm/yarn launchers). **`bins_restricted`** metadata preserves that restriction across `vp update -g`.
> 
> **`corepack enable`/`disable`** default `--install-directory` to `VP_HOME/bin`, then **restore** Vite+-owned shims (default npm/npx, `vp install -g`, npm links) if corepack clobbers them; Windows setup also strips conflicting `.ps1`/legacy launchers.
> 
> **Global install/refactor**: `InstallOptions` replaces positional args; **`is_protected_shim` / `package_may_own_bin`** guard default shims (corepack only ownable by the `corepack` package); protected shims survive uninstall/dry-run; **`ensure_installed`** returns the node path.
> 
> **Shim UX**: **`route_user_output_to_stderr`** during shim/`vp env exec` dispatch so wrapped tools keep parseable stdout; version warnings and npm install log routing follow the same rule.
> 
> **Tests/docs**: snap tests for bundled corepack and enable install-directory; RFCs updated for corepack design.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75c5f98d4d7757831248e0bc13fba6f83f5c1dfc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->