### PR TITLE
feat(cli): use version range instead of latest for vite-plus dependencies

### DIFF
--- a/docs/guide/upgrade.md
+++ b/docs/guide/upgrade.md
@@ -36,14 +36,20 @@ Update the project dependency with the package manager commands in Vite+:
 vp update vite-plus
 ```
 
-You can also use `vp add vite-plus@latest` if you want to move the dependency explicitly to the latest version.
+Projects created or migrated by Vite+ declare `vite-plus` with a version range (for example `^0.1.24`), so `vp update vite-plus` picks up new releases within that range. To move beyond the range, update the range explicitly:
+
+```bash
+vp update --latest vite-plus
+# or
+vp add vite-plus@latest
+```
 
 ### Updating Aliased Packages
 
 Vite+ sets up npm aliases for its core packages during installation:
 
-- `vite` is aliased to `npm:@voidzero-dev/vite-plus-core@latest`
-- `vitest` is aliased to `npm:@voidzero-dev/vite-plus-test@latest`
+- `vite` is aliased to `npm:@voidzero-dev/vite-plus-core@^x.y.z`
+- `vitest` is aliased to `npm:@voidzero-dev/vite-plus-test@^x.y.z`
 
 `vp update vite-plus` does not re-resolve these aliases in the lockfile. To fully upgrade, update them separately:
 

--- a/packages/cli/snap-tests-global/migration-add-git-hooks/snap.txt
+++ b/packages/cli/snap-tests-global/migration-add-git-hooks/snap.txt
@@ -26,9 +26,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-auto-create-vite-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-auto-create-vite-config/snap.txt
@@ -56,9 +56,9 @@ export default defineConfig({
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-baseurl-tsconfig/snap.txt
+++ b/packages/cli/snap-tests-global/migration-baseurl-tsconfig/snap.txt
@@ -59,9 +59,9 @@ export default defineConfig({
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-chained-lint-staged-pre-commit/snap.txt
+++ b/packages/cli/snap-tests-global/migration-chained-lint-staged-pre-commit/snap.txt
@@ -26,9 +26,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-composed-husky-custom-dir/snap.txt
+++ b/packages/cli/snap-tests-global/migration-composed-husky-custom-dir/snap.txt
@@ -26,9 +26,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-composed-husky-prepare/snap.txt
+++ b/packages/cli/snap-tests-global/migration-composed-husky-prepare/snap.txt
@@ -26,9 +26,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-env-prefix-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-env-prefix-lint-staged/snap.txt
@@ -26,9 +26,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-eslint-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-lint-staged/snap.txt
@@ -26,9 +26,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-eslint-lintstagedrc/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-lintstagedrc/snap.txt
@@ -26,9 +26,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-eslint-npx-wrapper/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-npx-wrapper/snap.txt
@@ -31,9 +31,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-eslint/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint/snap.txt
@@ -29,9 +29,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-existing-husky-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-husky-lint-staged/snap.txt
@@ -26,9 +26,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-existing-husky-v8-hooks/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-husky-v8-hooks/snap.txt
@@ -29,9 +29,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-existing-husky-v8-multi-hooks/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-husky-v8-multi-hooks/snap.txt
@@ -29,9 +29,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-existing-husky/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-husky/snap.txt
@@ -26,9 +26,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-existing-lint-staged-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-lint-staged-config/snap.txt
@@ -26,9 +26,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-existing-pnpm-exec-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-pnpm-exec-lint-staged/snap.txt
@@ -26,9 +26,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-existing-prepare-script/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-prepare-script/snap.txt
@@ -27,9 +27,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-from-tsdown-json-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-from-tsdown-json-config/snap.txt
@@ -51,9 +51,9 @@ export default defineConfig({
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-from-tsdown/snap.txt
+++ b/packages/cli/snap-tests-global/migration-from-tsdown/snap.txt
@@ -53,9 +53,9 @@ export default defineConfig({
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-from-vitest-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-from-vitest-config/snap.txt
@@ -56,9 +56,9 @@ export default defineConfig({
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-from-vitest-files/snap.txt
+++ b/packages/cli/snap-tests-global/migration-from-vitest-files/snap.txt
@@ -31,9 +31,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-hooks-skip-on-existing-hookspath/snap.txt
+++ b/packages/cli/snap-tests-global/migration-hooks-skip-on-existing-hookspath/snap.txt
@@ -29,9 +29,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-husky-catalog-version/snap.txt
+++ b/packages/cli/snap-tests-global/migration-husky-catalog-version/snap.txt
@@ -34,9 +34,9 @@ packages:
 catalog:
   husky: ^9.1.7
   lint-staged: ^16.2.6
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-husky-latest-dist-tag-v9-installed/snap.txt
+++ b/packages/cli/snap-tests-global/migration-husky-latest-dist-tag-v9-installed/snap.txt
@@ -26,9 +26,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-husky-latest-dist-tag/snap.txt
+++ b/packages/cli/snap-tests-global/migration-husky-latest-dist-tag/snap.txt
@@ -28,9 +28,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-husky-or-prepare/snap.txt
+++ b/packages/cli/snap-tests-global/migration-husky-or-prepare/snap.txt
@@ -26,9 +26,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-husky-semicolon-prepare/snap.txt
+++ b/packages/cli/snap-tests-global/migration-husky-semicolon-prepare/snap.txt
@@ -26,9 +26,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-husky-v8-preserves-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-husky-v8-preserves-lint-staged/snap.txt
@@ -32,9 +32,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-lazy-plugins-await/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lazy-plugins-await/snap.txt
@@ -35,9 +35,9 @@ export default defineConfig({
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-lint-staged-in-scripts/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lint-staged-in-scripts/snap.txt
@@ -27,9 +27,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-lint-staged-merge-fail/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lint-staged-merge-fail/snap.txt
@@ -35,9 +35,9 @@ Please add staged config to vite.config.ts manually, see https://viteplus.dev/gu
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-lint-staged-ts-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lint-staged-ts-config/snap.txt
@@ -30,9 +30,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-json/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-json/snap.txt
@@ -99,9 +99,9 @@ Documentation: https://viteplus.dev/guide/migrate
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-merge-fail/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-merge-fail/snap.txt
@@ -32,9 +32,9 @@ Please add staged config to vite.config.ts manually, see https://viteplus.dev/gu
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-not-support/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-not-support/snap.txt
@@ -43,9 +43,9 @@ export default {
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-staged-exists/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-staged-exists/snap.txt
@@ -27,9 +27,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-merge-vite-config-js/snap.txt
+++ b/packages/cli/snap-tests-global/migration-merge-vite-config-js/snap.txt
@@ -57,9 +57,9 @@ export default {
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-merge-vite-config-ts/snap.txt
+++ b/packages/cli/snap-tests-global/migration-merge-vite-config-ts/snap.txt
@@ -90,9 +90,9 @@ export default defineConfig({
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-monorepo-bun/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-bun/snap.txt
@@ -44,9 +44,9 @@ export default defineConfig({
       "packages/*"
     ],
     "catalog": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest",
-      "vite-plus": "latest"
+      "vite": "npm:@voidzero-dev/vite-plus-core@^<semver>",
+      "vitest": "npm:@voidzero-dev/vite-plus-test@^<semver>",
+      "vite-plus": "^<semver>"
     }
   },
   "scripts": {

--- a/packages/cli/snap-tests-global/migration-monorepo-pnpm-overrides-dependency-selector/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-pnpm-overrides-dependency-selector/snap.txt
@@ -38,9 +38,9 @@ packages:
   - packages/*
 
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 
 overrides:
   '@vitejs/plugin-react>vite': 'npm:vite@<semver>'

--- a/packages/cli/snap-tests-global/migration-monorepo-pnpm/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-pnpm/snap.txt
@@ -82,9 +82,9 @@ packages:
 catalog:
   testnpm2: ^1.0.0
   # test comment here to check if the comment is preserved
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 
 minimumReleaseAge: 1440
 overrides:

--- a/packages/cli/snap-tests-global/migration-monorepo-yarn4/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-yarn4/snap.txt
@@ -65,17 +65,17 @@ export default defineConfig({
   },
   "packageManager": "yarn@<semver>",
   "resolutions": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
+    "vite": "npm:@voidzero-dev/vite-plus-core@^<semver>",
+    "vitest": "npm:@voidzero-dev/vite-plus-test@^<semver>"
   }
 }
 
 > cat .yarnrc.yml # check .yarnrc.yml
 nodeLinker: node-modules
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 
 > cat packages/app/package.json # check app package.json
 {

--- a/packages/cli/snap-tests-global/migration-no-git-repo/snap.txt
+++ b/packages/cli/snap-tests-global/migration-no-git-repo/snap.txt
@@ -24,9 +24,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-no-hooks-with-husky/snap.txt
+++ b/packages/cli/snap-tests-global/migration-no-hooks-with-husky/snap.txt
@@ -31,9 +31,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-no-hooks/snap.txt
+++ b/packages/cli/snap-tests-global/migration-no-hooks/snap.txt
@@ -22,9 +22,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-other-hook-tool/snap.txt
+++ b/packages/cli/snap-tests-global/migration-other-hook-tool/snap.txt
@@ -34,9 +34,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-oxlintrc-json-with-comments/snap.txt
+++ b/packages/cli/snap-tests-global/migration-oxlintrc-json-with-comments/snap.txt
@@ -54,9 +54,9 @@ export default defineConfig({
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-oxlintrc-jsonc/snap.txt
+++ b/packages/cli/snap-tests-global/migration-oxlintrc-jsonc/snap.txt
@@ -56,9 +56,9 @@ export default defineConfig({
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-partially-migrated-pre-commit/snap.txt
+++ b/packages/cli/snap-tests-global/migration-partially-migrated-pre-commit/snap.txt
@@ -29,9 +29,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-prettier-eslint-combo/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier-eslint-combo/snap.txt
@@ -33,9 +33,9 @@ Prettier configuration detected. Auto-migrating to Oxfmt...
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-prettier-ignore-unknown/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier-ignore-unknown/snap.txt
@@ -31,9 +31,9 @@ Prettier configuration detected. Auto-migrating to Oxfmt...
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-prettier-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier-lint-staged/snap.txt
@@ -28,9 +28,9 @@ Prettier configuration detected. Auto-migrating to Oxfmt...
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-prettier-pkg-json/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier-pkg-json/snap.txt
@@ -29,9 +29,9 @@ Prettier configuration detected. Auto-migrating to Oxfmt...
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-prettier/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier/snap.txt
@@ -31,9 +31,9 @@ Prettier configuration detected. Auto-migrating to Oxfmt...
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-rewrite-declare-module/snap.txt
+++ b/packages/cli/snap-tests-global/migration-rewrite-declare-module/snap.txt
@@ -54,9 +54,9 @@ declare module 'vite-plus' {
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-skip-vite-dependency/snap.txt
+++ b/packages/cli/snap-tests-global/migration-skip-vite-dependency/snap.txt
@@ -49,9 +49,9 @@ export default defineConfig({
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-skip-vite-peer-dependency/snap.txt
+++ b/packages/cli/snap-tests-global/migration-skip-vite-peer-dependency/snap.txt
@@ -49,9 +49,9 @@ export default defineConfig({
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-standalone-npm/snap.txt
+++ b/packages/cli/snap-tests-global/migration-standalone-npm/snap.txt
@@ -8,16 +8,16 @@
 {
   "name": "migration-standalone-npm",
   "devDependencies": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vitest": "npm:@voidzero-dev/vite-plus-test@latest",
-    "vite-plus": "latest"
+    "vite": "npm:@voidzero-dev/vite-plus-core@^<semver>",
+    "vitest": "npm:@voidzero-dev/vite-plus-test@^<semver>",
+    "vite-plus": "^<semver>"
   },
   "packageManager": "npm@<semver>",
   "overrides": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
+    "vite": "npm:@voidzero-dev/vite-plus-core@^<semver>",
+    "vitest": "npm:@voidzero-dev/vite-plus-test@^<semver>"
   }
 }
 
-[1]> node -e "const lock = require('./package-lock.json'); const vite = lock.packages['node_modules/vite']; if (vite && vite.resolved && vite.resolved.includes('@voidzero-dev/vite-plus-core')) console.log('lockfile has vite override'); else { console.error('vite override not found in lockfile'); process.exit(1); }" # verify lockfile updated with override
-vite override not found in lockfile
+> node -e "const lock = require('./package-lock.json'); const vite = lock.packages['node_modules/vite']; if (vite && vite.resolved && vite.resolved.includes('@voidzero-dev/vite-plus-core')) console.log('lockfile has vite override'); else { console.error('vite override not found in lockfile'); process.exit(1); }" # verify lockfile updated with override
+lockfile has vite override

--- a/packages/cli/snap-tests-global/migration-standalone-pnpm/snap.txt
+++ b/packages/cli/snap-tests-global/migration-standalone-pnpm/snap.txt
@@ -17,9 +17,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides, peerDependencyRules, and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-subpath/snap.txt
+++ b/packages/cli/snap-tests-global/migration-subpath/snap.txt
@@ -43,9 +43,9 @@ core.hooksPath is not set
 
 > cat foo/pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-tsconfig-esmoduleinterop/snap.txt
+++ b/packages/cli/snap-tests-global/migration-tsconfig-esmoduleinterop/snap.txt
@@ -46,9 +46,9 @@ export default defineConfig({
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-vite-version/snap.txt
+++ b/packages/cli/snap-tests-global/migration-vite-version/snap.txt
@@ -26,9 +26,9 @@
 
 > cat pnpm-workspace.yaml # check pnpm-workspace.yaml has overrides and catalog
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/migration-vitest-peer-dep/snap.txt
+++ b/packages/cli/snap-tests-global/migration-vitest-peer-dep/snap.txt
@@ -29,9 +29,9 @@
 
 > cat pnpm-workspace.yaml
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: 'catalog:'
   vitest: 'catalog:'

--- a/packages/cli/snap-tests-global/new-vite-monorepo-bun/snap.txt
+++ b/packages/cli/snap-tests-global/new-vite-monorepo-bun/snap.txt
@@ -42,9 +42,9 @@ vite.config.ts
     "node": ">=22.12.0"
   },
   "catalog": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vitest": "npm:@voidzero-dev/vite-plus-test@latest",
-    "vite-plus": "latest"
+    "vite": "npm:@voidzero-dev/vite-plus-core@^<semver>",
+    "vitest": "npm:@voidzero-dev/vite-plus-test@^<semver>",
+    "vite-plus": "^<semver>"
   }
 }
 

--- a/packages/cli/snap-tests-global/new-vite-monorepo/snap.txt
+++ b/packages/cli/snap-tests-global/new-vite-monorepo/snap.txt
@@ -64,9 +64,9 @@ catalogMode: prefer
 catalog:
   "@types/node": ^24
   typescript: ^5
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: "catalog:"
   vitest: "catalog:"

--- a/packages/cli/snap-tests/create-org-bundled-monorepo/snap.txt
+++ b/packages/cli/snap-tests/create-org-bundled-monorepo/snap.txt
@@ -25,9 +25,9 @@ packages:
   - apps/*
   - packages/*
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@latest
-  vitest: npm:@voidzero-dev/vite-plus-test@latest
-  vite-plus: latest
+  vite: npm:@voidzero-dev/vite-plus-core@^<semver>
+  vitest: npm:@voidzero-dev/vite-plus-test@^<semver>
+  vite-plus: ^<semver>
 overrides:
   vite: "catalog:"
   vitest: "catalog:"

--- a/packages/cli/src/create/__tests__/monorepo.spec.ts
+++ b/packages/cli/src/create/__tests__/monorepo.spec.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { PackageManager } from '../../types/index.js';
+import { VITE_PLUS_OVERRIDE_PACKAGES, VITE_PLUS_VERSION } from '../../utils/constants.js';
 import { dropAliasedRuntimeDevDeps } from '../templates/monorepo.js';
 
 describe('dropAliasedRuntimeDevDeps', () => {
@@ -60,9 +61,8 @@ describe('dropAliasedRuntimeDevDeps', () => {
   for (const packageManager of [PackageManager.npm, PackageManager.yarn, PackageManager.bun]) {
     it(`drops aliased vite/vitest for ${packageManager}`, () => {
       writeWebsitePackageJson({
-        vite: 'npm:@voidzero-dev/vite-plus-core@latest',
-        vitest: 'npm:@voidzero-dev/vite-plus-test@latest',
-        'vite-plus': 'latest',
+        ...VITE_PLUS_OVERRIDE_PACKAGES,
+        'vite-plus': VITE_PLUS_VERSION,
         typescript: '~6.0.2',
       });
 
@@ -71,7 +71,7 @@ describe('dropAliasedRuntimeDevDeps', () => {
       const devDependencies = readDevDependencies();
       expect(devDependencies.vite).toBeUndefined();
       expect(devDependencies.vitest).toBeUndefined();
-      expect(devDependencies['vite-plus']).toBe('latest');
+      expect(devDependencies['vite-plus']).toBe(VITE_PLUS_VERSION);
     });
   }
 });

--- a/packages/cli/src/migration/__tests__/__snapshots__/migrator.spec.ts.snap
+++ b/packages/cli/src/migration/__tests__/__snapshots__/migrator.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`rewritePackageJson > should rewrite devDependencies and dependencies on
     "foo": "1.0.0",
   },
   "devDependencies": {
-    "vite-plus": "latest",
+    "vite-plus": "^0.1.0",
   },
 }
 `;
@@ -28,7 +28,7 @@ exports[`rewritePackageJson > should rewrite devDependencies and dependencies on
     "foo": "1.0.0",
   },
   "devDependencies": {
-    "vite-plus": "latest",
+    "vite-plus": "^0.1.0",
   },
 }
 `;

--- a/packages/cli/src/migration/__tests__/migrator.spec.ts
+++ b/packages/cli/src/migration/__tests__/migrator.spec.ts
@@ -8,12 +8,20 @@ import { parse as parseYaml } from 'yaml';
 import { PackageManager } from '../../types/index.js';
 import { createMigrationReport } from '../report.js';
 
-// Mock VITE_PLUS_VERSION to a stable value for snapshot tests.
-// When tests run via `vp test`, the env var is injected with the actual version,
-// which would cause snapshot mismatches.
+// Mock the version constants to stable values for snapshot tests. The real
+// values derive from the CLI's own package.json version (e.g. `^0.1.24`),
+// which would cause snapshot mismatches on every release. When tests run via
+// `vp test`, the VP_VERSION env var is also injected with the actual version.
 vi.mock('../../utils/constants.js', async (importOriginal) => {
   const mod = await importOriginal<typeof import('../../utils/constants.js')>();
-  return { ...mod, VITE_PLUS_VERSION: 'latest' };
+  return {
+    ...mod,
+    VITE_PLUS_VERSION: '^0.1.0',
+    VITE_PLUS_OVERRIDE_PACKAGES: {
+      vite: 'npm:@voidzero-dev/vite-plus-core@^0.1.0',
+      vitest: 'npm:@voidzero-dev/vite-plus-test@^0.1.0',
+    },
+  };
 });
 
 const {
@@ -186,6 +194,18 @@ describe('rewritePackageJson', () => {
     expect(pkg.devDependencies['vite-plus']).toBe('^0.1.20');
   });
 
+  it('normalizes the legacy `latest` vite-plus spec to the versioned range on npm monorepo projects', async () => {
+    const pkg = {
+      devDependencies: {
+        'vite-plus': 'latest',
+      },
+    };
+
+    rewritePackageJson(pkg, PackageManager.npm, true);
+
+    expect(pkg.devDependencies['vite-plus']).toBe('^0.1.0');
+  });
+
   it('normalizes a pre-existing pinned vite-plus on yarn/bun monorepo projects', async () => {
     for (const pm of [PackageManager.yarn, PackageManager.bun]) {
       const pkg = { devDependencies: { 'vite-plus': '^0.1.20' } };
@@ -253,8 +273,8 @@ describe('rewritePackageJson', () => {
     rewritePackageJson(pkg, PackageManager.yarn, true);
 
     expect(pkg.devDependencies.vite).toBe('catalog:');
-    expect(pkg.optionalDependencies.vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
-    expect(pkg.optionalDependencies.vitest).toBe('npm:@voidzero-dev/vite-plus-test@latest');
+    expect(pkg.optionalDependencies.vite).toBe('npm:@voidzero-dev/vite-plus-core@^0.1.0');
+    expect(pkg.optionalDependencies.vitest).toBe('npm:@voidzero-dev/vite-plus-test@^0.1.0');
     expect((pkg.devDependencies as Record<string, string>)['vite-plus']).toBe('catalog:');
   });
 
@@ -313,7 +333,7 @@ describe('rewritePackageJson', () => {
     rewritePackageJson(npmPkg, PackageManager.npm);
 
     expect(npmPkg.peerDependencies.vite).toBe('^7.0.0');
-    expect(npmPkg.optionalDependencies.vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
+    expect(npmPkg.optionalDependencies.vite).toBe('npm:@voidzero-dev/vite-plus-core@^0.1.0');
   });
 
   it('adds local vitest when only a peer vitest exists for vitest-adjacent packages', async () => {
@@ -1159,11 +1179,11 @@ describe('rewriteStandaloneProject pnpm workspace yaml', () => {
     };
     expect(yaml.overrides.vite).toBe('catalog:vite7');
     expect(yaml.overrides.vitest).toBe('catalog:');
-    expect(yaml.catalog.vitest).toBe('npm:@voidzero-dev/vite-plus-test@latest');
-    expect(yaml.catalogs.vite7.vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
+    expect(yaml.catalog.vitest).toBe('npm:@voidzero-dev/vite-plus-test@^0.1.0');
+    expect(yaml.catalogs.vite7.vite).toBe('npm:@voidzero-dev/vite-plus-core@^0.1.0');
     expect(yaml.catalogs.vite7.react).toBe('^18.0.0');
-    expect(yaml.catalogs.vite7['vite-plus']).toBe('latest');
-    expect(yaml.catalogs.test.vitest).toBe('npm:@voidzero-dev/vite-plus-test@latest');
+    expect(yaml.catalogs.vite7['vite-plus']).toBe('^0.1.0');
+    expect(yaml.catalogs.test.vitest).toBe('npm:@voidzero-dev/vite-plus-test@^0.1.0');
     expect(yaml.catalogs.test.tsdown).toBeUndefined();
     expect(yaml.catalogs.test['vite-plus']).toBeUndefined();
 
@@ -1207,7 +1227,7 @@ describe('rewriteStandaloneProject pnpm workspace yaml', () => {
     expect(yaml.overrides.vite).toBe('catalog:vite7');
     expect(yaml.overrides.vitest).toBe('catalog:');
     expect(yaml.overrides.react).toBe('^18.0.0');
-    expect(yaml.catalogs.vite7.vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
+    expect(yaml.catalogs.vite7.vite).toBe('npm:@voidzero-dev/vite-plus-core@^0.1.0');
 
     const pkg = readJson(path.join(tmpDir, 'package.json')) as {
       pnpm?: unknown;
@@ -1285,6 +1305,62 @@ describe('rewriteStandaloneProject pnpm workspace yaml', () => {
   });
 });
 
+describe('rewriteStandaloneProject legacy `latest` normalization', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vp-test-latest-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('rewrites a legacy `latest` vite-plus devDependency to the versioned range on npm', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ name: 'test', devDependencies: { 'vite-plus': 'latest' } }),
+    );
+
+    rewriteStandaloneProject(tmpDir, makeWorkspaceInfo(tmpDir, PackageManager.npm), true, true);
+
+    const pkg = readJson(path.join(tmpDir, 'package.json'));
+    expect((pkg.devDependencies as Record<string, string>)['vite-plus']).toBe('^0.1.0');
+  });
+
+  it('keeps a user-pinned vite-plus devDependency on npm', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ name: 'test', devDependencies: { 'vite-plus': '0.1.20' } }),
+    );
+
+    rewriteStandaloneProject(tmpDir, makeWorkspaceInfo(tmpDir, PackageManager.npm), true, true);
+
+    const pkg = readJson(path.join(tmpDir, 'package.json'));
+    expect((pkg.devDependencies as Record<string, string>)['vite-plus']).toBe('0.1.20');
+  });
+
+  it('rewrites a legacy `latest` vite-plus devDependency on a pnpm monorepo root', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ name: 'pnpm-monorepo', devDependencies: { 'vite-plus': 'latest' } }),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'pnpm-workspace.yaml'),
+      ['packages:', '  - packages/*', ''].join('\n'),
+    );
+
+    rewriteMonorepo(makeWorkspaceInfo(tmpDir, PackageManager.pnpm), true);
+
+    const pkg = readJson(path.join(tmpDir, 'package.json'));
+    expect((pkg.devDependencies as Record<string, string>)['vite-plus']).toBe('catalog:');
+    const yaml = readYamlObject(path.join(tmpDir, 'pnpm-workspace.yaml')) as {
+      catalog: Record<string, string>;
+    };
+    expect(yaml.catalog['vite-plus']).toBe('^0.1.0');
+  });
+});
+
 describe('rewriteMonorepo yarn catalog', () => {
   let tmpDir: string;
 
@@ -1328,9 +1404,9 @@ describe('rewriteMonorepo yarn catalog', () => {
       catalogs: Record<string, Record<string, string>>;
     };
     expect(yarnrc.nodeLinker).toBe('node-modules');
-    expect(yarnrc.catalogs.vite7.vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
+    expect(yarnrc.catalogs.vite7.vite).toBe('npm:@voidzero-dev/vite-plus-core@^0.1.0');
     expect(yarnrc.catalogs.vite7.react).toBe('^18.0.0');
-    expect(yarnrc.catalogs.test.vitest).toBe('npm:@voidzero-dev/vite-plus-test@latest');
+    expect(yarnrc.catalogs.test.vitest).toBe('npm:@voidzero-dev/vite-plus-test@^0.1.0');
     expect(yarnrc.catalogs.test.oxlint).toBeUndefined();
 
     const pkg = readJson(path.join(tmpDir, 'package.json')) as {
@@ -1370,7 +1446,7 @@ describe('rewriteMonorepo bun catalog', () => {
     // catalog should be at top level
     const catalog = pkg.catalog as Record<string, string>;
     expect(catalog.vite).toBeDefined();
-    expect(catalog['vite-plus']).toBe('latest');
+    expect(catalog['vite-plus']).toBe('^0.1.0');
     // overrides should reference catalog:
     const overrides = pkg.overrides as Record<string, string>;
     expect(overrides.vite).toBe('catalog:');
@@ -1398,7 +1474,7 @@ describe('rewriteMonorepo bun catalog', () => {
     const workspaces = pkg.workspaces as { packages: string[]; catalog: Record<string, string> };
     expect(workspaces.catalog.react).toBe('^19.0.0');
     expect(workspaces.catalog.vite).toBeDefined();
-    expect(workspaces.catalog['vite-plus']).toBe('latest');
+    expect(workspaces.catalog['vite-plus']).toBe('^0.1.0');
     // workspaces.packages should be preserved
     expect(workspaces.packages).toEqual(['packages/*']);
   });
@@ -1429,10 +1505,10 @@ describe('rewriteMonorepo bun catalog', () => {
       catalog: Record<string, string>;
       workspaces: { catalog: Record<string, string> };
     };
-    expect(pkg.workspaces.catalog.vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
-    expect(pkg.workspaces.catalog['vite-plus']).toBe('latest');
-    expect(pkg.catalog.vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
-    expect(pkg.catalog.vitest).toBe('npm:@voidzero-dev/vite-plus-test@latest');
+    expect(pkg.workspaces.catalog.vite).toBe('npm:@voidzero-dev/vite-plus-core@^0.1.0');
+    expect(pkg.workspaces.catalog['vite-plus']).toBe('^0.1.0');
+    expect(pkg.catalog.vite).toBe('npm:@voidzero-dev/vite-plus-core@^0.1.0');
+    expect(pkg.catalog.vitest).toBe('npm:@voidzero-dev/vite-plus-test@^0.1.0');
     expect(pkg.catalog.tsdown).toBeUndefined();
     expect(pkg.catalog.react).toBe('^19.0.0');
     expect(pkg.catalog['vite-plus']).toBeUndefined();
@@ -1456,7 +1532,7 @@ describe('rewriteMonorepo bun catalog', () => {
     // catalog should be at top level since workspaces.catalog didn't exist
     const catalog = pkg.catalog as Record<string, string>;
     expect(catalog.vite).toBeDefined();
-    expect(catalog['vite-plus']).toBe('latest');
+    expect(catalog['vite-plus']).toBe('^0.1.0');
     // workspaces object should be preserved
     const workspaces = pkg.workspaces as { packages: string[] };
     expect(workspaces.packages).toEqual(['packages/*']);
@@ -1488,11 +1564,11 @@ describe('rewriteMonorepo bun catalog', () => {
       devDependencies: Record<string, string>;
       peerDependencies: Record<string, string>;
     };
-    expect(pkg.catalog.vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
-    expect(pkg.catalogs.build.vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
+    expect(pkg.catalog.vite).toBe('npm:@voidzero-dev/vite-plus-core@^0.1.0');
+    expect(pkg.catalogs.build.vite).toBe('npm:@voidzero-dev/vite-plus-core@^0.1.0');
     expect(pkg.catalogs.build.react).toBe('^19.0.0');
     expect(pkg.catalogs.build.tsdown).toBeUndefined();
-    expect(pkg.catalogs.test.vitest).toBe('npm:@voidzero-dev/vite-plus-test@latest');
+    expect(pkg.catalogs.test.vitest).toBe('npm:@voidzero-dev/vite-plus-test@^0.1.0');
     expect(pkg.overrides.vite).toBe('catalog:build');
     expect(pkg.overrides.vitest).toBe('catalog:');
     expect(pkg.devDependencies.vite).toBe('catalog:build');
@@ -1528,12 +1604,12 @@ describe('rewriteMonorepo bun catalog', () => {
       overrides: Record<string, string>;
     };
     expect(pkg.catalog).toBeUndefined();
-    expect(pkg.workspaces.catalog.vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
-    expect(pkg.workspaces.catalog['vite-plus']).toBe('latest');
-    expect(pkg.workspaces.catalogs.build.vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
+    expect(pkg.workspaces.catalog.vite).toBe('npm:@voidzero-dev/vite-plus-core@^0.1.0');
+    expect(pkg.workspaces.catalog['vite-plus']).toBe('^0.1.0');
+    expect(pkg.workspaces.catalogs.build.vite).toBe('npm:@voidzero-dev/vite-plus-core@^0.1.0');
     expect(pkg.workspaces.catalogs.build.oxlint).toBeUndefined();
-    expect(pkg.workspaces.catalogs.test.vitest).toBe('npm:@voidzero-dev/vite-plus-test@latest');
-    expect(pkg.workspaces.catalogs.test.vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
+    expect(pkg.workspaces.catalogs.test.vitest).toBe('npm:@voidzero-dev/vite-plus-test@^0.1.0');
+    expect(pkg.workspaces.catalogs.test.vite).toBe('npm:@voidzero-dev/vite-plus-core@^0.1.0');
     expect(pkg.overrides.vite).toBe('catalog:');
   });
 
@@ -1564,9 +1640,9 @@ describe('rewriteMonorepo bun catalog', () => {
       };
     };
     expect(pkg.catalog.react).toBe('^19.0.0');
-    expect(pkg.catalog.vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
+    expect(pkg.catalog.vite).toBe('npm:@voidzero-dev/vite-plus-core@^0.1.0');
     expect(pkg.workspaces.catalog).toBeUndefined();
-    expect(pkg.workspaces.catalogs.build.vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
+    expect(pkg.workspaces.catalogs.build.vite).toBe('npm:@voidzero-dev/vite-plus-core@^0.1.0');
   });
 });
 

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -1109,8 +1109,14 @@ export function rewriteStandaloneProject(
       catalogDependencyResolver,
     );
 
-    // ensure vite-plus is in devDependencies
-    if (!pkg.devDependencies?.[VITE_PLUS_NAME] || isForceOverrideMode()) {
+    // ensure vite-plus is in devDependencies; also normalize the legacy
+    // `latest` default written by older vp versions, because package managers
+    // never re-resolve dist-tag specs on `vp update vite-plus`
+    if (
+      !pkg.devDependencies?.[VITE_PLUS_NAME] ||
+      pkg.devDependencies[VITE_PLUS_NAME] === 'latest' ||
+      isForceOverrideMode()
+    ) {
       const version =
         usePnpmWorkspaceYaml && !VITE_PLUS_VERSION.startsWith('file:')
           ? 'catalog:'
@@ -1853,8 +1859,13 @@ function rewriteRootWorkspacePackageJson(
       }
     }
 
-    // ensure vite-plus is in devDependencies
-    if (!pkg.devDependencies?.[VITE_PLUS_NAME]) {
+    // ensure vite-plus is in devDependencies; also normalize the legacy
+    // `latest` default written by older vp versions, because package managers
+    // never re-resolve dist-tag specs on `vp update vite-plus`
+    if (
+      !pkg.devDependencies?.[VITE_PLUS_NAME] ||
+      pkg.devDependencies[VITE_PLUS_NAME] === 'latest'
+    ) {
       pkg.devDependencies = {
         ...pkg.devDependencies,
         [VITE_PLUS_NAME]:
@@ -2000,15 +2011,16 @@ export function rewritePackageJson(
   // force-override (file:) it's the tgz path. Preserve protocol-prefixed
   // specs (catalog:named, workspace:*, link:, file:, npm:, github:, git+/git:,
   // http(s)://) so deliberate user pins survive; only vanilla version ranges
-  // (e.g. `^0.1.20`, `latest`) are rewritten.
+  // (e.g. `^0.1.20`, `latest`) are rewritten. Without catalog support only
+  // the legacy `latest` default is normalized (to the versioned range), so
+  // deliberate user ranges survive.
   const canonicalVitePlusSpec =
     supportCatalog && !VITE_PLUS_VERSION.startsWith('file:') ? 'catalog:' : VITE_PLUS_VERSION;
   const existingVitePlus = pkg.devDependencies?.[VITE_PLUS_NAME];
   const shouldNormalizeExistingVitePlus =
     !!existingVitePlus &&
-    supportCatalog &&
     existingVitePlus !== canonicalVitePlusSpec &&
-    !isProtocolPinnedSpec(existingVitePlus);
+    (supportCatalog ? !isProtocolPinnedSpec(existingVitePlus) : existingVitePlus === 'latest');
   if (needVitePlus || shouldNormalizeExistingVitePlus) {
     pkg.devDependencies = {
       ...pkg.devDependencies,

--- a/packages/cli/src/utils/__tests__/package.spec.ts
+++ b/packages/cli/src/utils/__tests__/package.spec.ts
@@ -1,6 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { checkNpmPackageExists } from '../package.js';
+// Pin the registry so URL assertions don't depend on the developer's npm
+// config (a configured mirror registry would change the requested address).
+vi.mock('../npm-config.js', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../npm-config.js')>();
+  return { ...mod, getNpmRegistry: () => 'https://registry.npmjs.org' };
+});
+
+const { checkNpmPackageExists } = await import('../package.js');
 
 describe('checkNpmPackageExists', () => {
   afterEach(() => {

--- a/packages/cli/src/utils/constants.ts
+++ b/packages/cli/src/utils/constants.ts
@@ -1,13 +1,22 @@
 import { createRequire } from 'node:module';
 
+import cliPkg from '../../package.json' with { type: 'json' };
+
 export const VITE_PLUS_NAME = 'vite-plus';
-export const VITE_PLUS_VERSION = process.env.VP_VERSION || 'latest';
+
+// Range derived from the running CLI's own version (cli/core/test are
+// published in lockstep). A real range instead of the `latest` dist-tag keeps
+// `vp update vite-plus` effective: package managers re-resolve ranges but
+// leave dist-tag specs untouched in the lockfile.
+export const VITE_PLUS_VERSION_RANGE = `^${cliPkg.version}`;
+
+export const VITE_PLUS_VERSION = process.env.VP_VERSION || VITE_PLUS_VERSION_RANGE;
 
 export const VITE_PLUS_OVERRIDE_PACKAGES: Record<string, string> = process.env.VP_OVERRIDE_PACKAGES
   ? JSON.parse(process.env.VP_OVERRIDE_PACKAGES)
   : {
-      vite: 'npm:@voidzero-dev/vite-plus-core@latest',
-      vitest: 'npm:@voidzero-dev/vite-plus-test@latest',
+      vite: `npm:@voidzero-dev/vite-plus-core@${VITE_PLUS_VERSION_RANGE}`,
+      vitest: `npm:@voidzero-dev/vite-plus-test@${VITE_PLUS_VERSION_RANGE}`,
     };
 
 /**

--- a/packages/tools/src/__tests__/utils.spec.ts
+++ b/packages/tools/src/__tests__/utils.spec.ts
@@ -286,6 +286,31 @@ line 3
     expect(replaceUnstableOutput(output.trim())).toMatchSnapshot();
   });
 
+  test('replace vite-plus self-version ranges', () => {
+    const output = [
+      '"vite-plus": "^0.1.24"',
+      'vite-plus: ^0.1.24',
+      '"vite": "npm:@voidzero-dev/vite-plus-core@^0.1.24"',
+      'vitest: npm:@voidzero-dev/vite-plus-test@^0.1.24',
+      'vp add vite-plus@^0.1.25-alpha.7',
+      // the pkg.pr.new hash form keeps its dedicated `<hash>` placeholder
+      '"vite-plus": "^0.0.0-aa9f90fe23216b8ad85b0ba4fc1bccb0614afaf0"',
+      // unrelated caret ranges stay untouched
+      '"typescript": "^5.8.0"',
+    ].join('\n');
+    expect(replaceUnstableOutput(output)).toBe(
+      [
+        '"vite-plus": "^<semver>"',
+        'vite-plus: ^<semver>',
+        '"vite": "npm:@voidzero-dev/vite-plus-core@^<semver>"',
+        'vitest: npm:@voidzero-dev/vite-plus-test@^<semver>',
+        'vp add vite-plus@^<semver>',
+        '"vite-plus": "^0.0.0-<hash>"',
+        '"typescript": "^5.8.0"',
+      ].join('\n'),
+    );
+  });
+
   test.skipIf(process.platform === 'win32')('replace vite-plus home paths', () => {
     const home = homedir();
     const output = [

--- a/packages/tools/src/snap-test.ts
+++ b/packages/tools/src/snap-test.ts
@@ -596,6 +596,11 @@ async function runTestCase(
     GIT_COMMITTER_NAME: 'Test',
     GIT_AUTHOR_EMAIL: 'vite-plus-test@test.com',
     GIT_COMMITTER_EMAIL: 'vite-plus-test@test.com',
+    // Disable commit signing so a contributor's global git config
+    // (commit.gpgsign=true) can't break fixture commits in non-interactive runs
+    GIT_CONFIG_COUNT: '1',
+    GIT_CONFIG_KEY_0: 'commit.gpgsign',
+    GIT_CONFIG_VALUE_0: 'false',
     // Skip `vp install` inside `vp migrate` — snap tests don't need real installs
     VP_SKIP_INSTALL: '1',
     // make sure npm install global packages to the temporary directory

--- a/packages/tools/src/utils.ts
+++ b/packages/tools/src/utils.ts
@@ -64,6 +64,15 @@ export function replaceUnstableOutput(output: string, cwd?: string) {
       // vite-plus hash version
       // e.g.: `vite-plus": "^0.0.0-aa9f90fe23216b8ad85b0ba4fc1bccb0614afaf0"` -> `vite-plus": "^0.0.0-<hash>`
       .replaceAll(/0\.0\.0-\w{40}/g, '0.0.0-<hash>')
+      // vite-plus self-version ranges written by create/migrate
+      // e.g.: `"vite-plus": "^0.1.24"` -> `"vite-plus": "^<semver>"`
+      // e.g.: `vite-plus: ^0.1.24` (pnpm-workspace.yaml catalog) -> `vite-plus: ^<semver>`
+      // e.g.: `npm:@voidzero-dev/vite-plus-core@^0.1.24` -> `npm:@voidzero-dev/vite-plus-core@^<semver>`
+      // (the trailing lookahead keeps `^0.0.0-<hash>` from the rule above intact)
+      .replaceAll(
+        /((?:vite-plus["']?:\s*["']?|vite-plus@|@voidzero-dev\/vite-plus-\w+@)\^)\d+\.\d+\.\d+(?:-[\w.]+)?(?![-\w])/g,
+        '$1<semver>',
+      )
       // date (YYYY-MM-DD HH:MM:SS)
       .replaceAll(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/g, '<date>')
       // date only (YYYY-MM-DD)


### PR DESCRIPTION
## Problem

`vp create` and `vp migrate` wrote the `latest` dist-tag for `vite-plus` and the `vite`/`vitest` aliases. Dist-tag specs are not re-resolved consistently by package managers, so `vp update vite-plus` was often a no-op, and npm did not record the alias overrides in the lockfile.

## Changes

- Derive a caret range (e.g. `^0.1.24`) from the CLI's own version for the `vite-plus`, `@voidzero-dev/vite-plus-core`, and `@voidzero-dev/vite-plus-test` specs; cli/core/test are published in lockstep. `VP_VERSION` and `VP_OVERRIDE_PACKAGES` overrides keep working.
- `vp migrate` normalizes a legacy `"vite-plus": "latest"` devDependency to the versioned range; deliberate user pins are untouched.
- Snap runner normalizes the new specs to `^<semver>` so snapshots stay stable across releases; regenerated 67 snapshots.
- Updated the upgrade guide: `vp update vite-plus` updates within the range, `vp update --latest vite-plus` or `vp add vite-plus@latest` moves beyond it.
- Test stability: disable commit signing in snap fixture commits and mock `getNpmRegistry` in `package.spec.ts`.

With real ranges npm now records the `vite`/`vitest` alias overrides in the lockfile: the previously failing verification step in the `migration-standalone-npm` snap test now passes.