### PR TITLE
fix(cli): fix hanging tests and harden shim against self-exec loop

### DIFF
--- a/crates/vite_global_cli/src/commands/env/pin.rs
+++ b/crates/vite_global_cli/src/commands/env/pin.rs
@@ -290,7 +290,7 @@ async fn pin_node_version_file(
 
     // If a devEngines.runtime range is declared and no longer satisfied, offer to
     // sync it in interactive terminals and warn otherwise (rfcs/dev-engines.md)
-    check_dev_engines_sync(cwd, resolved_version, force).await?;
+    check_dev_engines_sync(cwd, resolved_version, force, std::io::stdin().is_terminal()).await?;
 
     Ok(true)
 }
@@ -336,12 +336,14 @@ async fn read_dev_engines_node_version(cwd: &AbsolutePathBuf) -> Option<String> 
 }
 
 /// After updating `.node-version`, check the declared devEngines.runtime range:
-/// if the new version no longer satisfies it, offer to sync in interactive
-/// terminals and warn otherwise (rfcs/dev-engines.md). Never syncs silently.
+/// if the new version no longer satisfies it, offer to sync when `interactive`
+/// (the caller passes stdin TTY-ness) and warn otherwise (rfcs/dev-engines.md).
+/// Never syncs silently.
 async fn check_dev_engines_sync(
     cwd: &AbsolutePathBuf,
     resolved_version: &str,
     force: bool,
+    interactive: bool,
 ) -> Result<(), Error> {
     let Some(declared) = read_dev_engines_node_version(cwd).await else {
         return Ok(());
@@ -357,7 +359,7 @@ async fn check_dev_engines_sync(
         return Ok(());
     }
 
-    if std::io::stdin().is_terminal() && !force {
+    if interactive && !force {
         print!(
             "devEngines.runtime (\"{declared}\") is no longer satisfied. Update it to \
              {resolved_version}? (y/n): "
@@ -1009,7 +1011,28 @@ mod tests {
 
         // 20.18.0 does not satisfy ^24.0.0: without a TTY this warns and never
         // rewrites the declared range
-        check_dev_engines_sync(&temp_path, "20.18.0", false).await.unwrap();
+        check_dev_engines_sync(&temp_path, "20.18.0", false, false).await.unwrap();
+
+        let content = tokio::fs::read_to_string(temp_path.join("package.json")).await.unwrap();
+        let pkg: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(pkg["devEngines"]["runtime"]["version"].as_str().unwrap(), "^24.0.0");
+    }
+
+    #[tokio::test]
+    async fn test_check_dev_engines_sync_force_skips_prompt() {
+        let temp_dir = TempDir::new().unwrap();
+        let temp_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+
+        tokio::fs::write(
+            temp_path.join("package.json"),
+            r#"{"devEngines":{"runtime":{"name":"node","version":"^24.0.0"}}}"#,
+        )
+        .await
+        .unwrap();
+
+        // --force never prompts, even in an interactive terminal: it warns and
+        // leaves the declared range untouched
+        check_dev_engines_sync(&temp_path, "20.18.0", true, true).await.unwrap();
 
         let content = tokio::fs::read_to_string(temp_path.join("package.json")).await.unwrap();
         let pkg: serde_json::Value = serde_json::from_str(&content).unwrap();
@@ -1024,7 +1047,8 @@ mod tests {
         let original = r#"{"devEngines":{"runtime":{"name":"node","version":"^24.0.0"}}}"#;
         tokio::fs::write(temp_path.join("package.json"), original).await.unwrap();
 
-        check_dev_engines_sync(&temp_path, "24.2.0", false).await.unwrap();
+        // interactive=true must not prompt when the range is already satisfied
+        check_dev_engines_sync(&temp_path, "24.2.0", false, true).await.unwrap();
 
         let content = tokio::fs::read_to_string(temp_path.join("package.json")).await.unwrap();
         assert_eq!(content, original);

--- a/crates/vite_global_cli/src/commands/version.rs
+++ b/crates/vite_global_cli/src/commands/version.rs
@@ -222,6 +222,8 @@ mod tests {
     #[cfg(unix)]
     use std::{fs, path::Path};
 
+    use serial_test::serial;
+
     #[cfg(unix)]
     use super::{ToolSpec, find_local_vite_plus, resolve_tool_version};
     use super::{detect_system_node_version, format_version};
@@ -237,7 +239,11 @@ mod tests {
         assert_eq!(format_version(None), "Not found");
     }
 
+    // Run serially: the spawned `node` inherits this process's environment, and
+    // concurrent #[serial] tests mutate PATH/VP_HOME via std::env::set_var,
+    // which can make a vp shim on PATH resolve incorrectly mid-test.
     #[test]
+    #[serial]
     fn detect_system_node_version_returns_version() {
         let version = detect_system_node_version();
         assert!(version.is_some(), "expected node to be installed");

--- a/crates/vite_global_cli/src/shim/dispatch.rs
+++ b/crates/vite_global_cli/src/shim/dispatch.rs
@@ -1293,21 +1293,17 @@ pub(crate) fn find_system_tool(tool: &str) -> Option<AbsolutePathBuf> {
 
     // Parse VP_BYPASS as a PATH-style list of additional directories to skip.
     // This prevents infinite loops when multiple vite-plus installations exist in PATH.
-    let mut bypass_paths: Vec<std::path::PathBuf> = std::env::var_os(env_vars::VP_BYPASS)
+    let bypass_paths: Vec<std::path::PathBuf> = std::env::var_os(env_vars::VP_BYPASS)
         .map(|v| std::env::split_paths(&v).collect())
         .unwrap_or_default();
-
-    // Also skip the directory containing the running shim executable. The
-    // configured bin dir can point elsewhere (e.g. VP_HOME overridden) while
-    // the invoked shim still lives on PATH; without this the lookup resolves
-    // back to the shim itself, which then exec's itself in an infinite loop.
-    let self_exe = std::env::current_exe().ok();
-    if let Some(self_dir) = self_exe.as_deref().and_then(|exe| exe.parent()) {
-        bypass_paths.push(self_dir.to_path_buf());
-    }
     tracing::debug!("bypass_paths: {:?}", bypass_paths);
 
-    // Filter PATH to exclude our bin directory and any bypass directories
+    let cwd = current_dir().ok()?;
+
+    // Filter PATH to exclude our bin directory and any bypass directories.
+    // Relative entries are resolved against cwd because `which` reports
+    // matches from them as relative paths, which `AbsolutePathBuf` rejects;
+    // `~`-prefixed entries are left to `which`'s own tilde expansion.
     let mut filtered_paths: Vec<_> = std::env::split_paths(&path_var)
         .filter(|p| {
             if let Some(ref bin) = bin_dir {
@@ -1317,15 +1313,17 @@ pub(crate) fn find_system_tool(tool: &str) -> Option<AbsolutePathBuf> {
             }
             !bypass_paths.iter().any(|bp| p == bp)
         })
+        .map(|p| if p.is_absolute() || p.starts_with("~") { p } else { cwd.as_path().join(p) })
         .collect();
 
-    let cwd = current_dir().ok()?;
-
-    // Backstop for symlinked shims that evade the directory filters above
-    // (`current_exe` is fully resolved on Linux): never return the running
-    // executable itself. Skip the self candidate's directory and keep
-    // searching so a real system tool later in PATH is still found.
-    let self_real = self_exe.and_then(|exe| exe.canonicalize().ok());
+    // Never return the running executable itself: with a misconfigured bin
+    // dir (e.g. VP_HOME overridden) the invoked shim can still live on PATH,
+    // and returning it would make the shim exec itself in an infinite loop.
+    // Compare canonical identities (symlinks defeat path comparison, and
+    // `current_exe` is fully resolved on Linux), then skip the self
+    // candidate's directory and keep searching so a real system tool later
+    // in PATH is still found.
+    let self_real = std::env::current_exe().ok().and_then(|exe| exe.canonicalize().ok());
     loop {
         // Use vite_command::resolve_bin with filtered PATH - stops at first match
         let search_path = std::env::join_paths(&filtered_paths).ok()?;
@@ -1333,9 +1331,15 @@ pub(crate) fn find_system_tool(tool: &str) -> Option<AbsolutePathBuf> {
         if self_real.is_none() || resolved.as_path().canonicalize().ok() != self_real {
             return Some(resolved);
         }
-        let self_candidate_dir = resolved.as_path().parent()?.to_path_buf();
+        // Canonicalize both sides of the comparison so symlink-aliased PATH
+        // entries still match the resolved parent.
+        let self_dir = resolved.as_path().parent()?.to_path_buf();
+        let canonical_self_dir = self_dir.canonicalize().ok();
         let len_before = filtered_paths.len();
-        filtered_paths.retain(|p| *p != self_candidate_dir);
+        filtered_paths.retain(|p| {
+            *p != self_dir
+                && (canonical_self_dir.is_none() || p.canonicalize().ok() != canonical_self_dir)
+        });
         if filtered_paths.len() == len_before {
             // Nothing left to drop; give up rather than loop forever.
             return None;
@@ -1475,6 +1479,41 @@ mod tests {
         assert!(
             result.unwrap().as_path().starts_with(&dir_b),
             "Should find the real tool in dir_b, not the self symlink in dir_a"
+        );
+    }
+
+    /// Same as above but with the self-symlink directory listed as a relative
+    /// PATH entry: dropping it requires comparing canonicalized directories,
+    /// otherwise the retry loop gives up instead of reaching dir_b.
+    #[cfg(unix)]
+    #[test]
+    #[serial]
+    fn test_find_system_tool_skips_self_symlink_in_relative_path_entry() {
+        let _guard = EnvGuard::new();
+        let temp = TempDir::new().unwrap();
+        let dir_a = temp.path().join("bin_a");
+        let dir_b = temp.path().join("bin_b");
+        std::fs::create_dir_all(&dir_a).unwrap();
+        std::fs::create_dir_all(&dir_b).unwrap();
+        std::os::unix::fs::symlink(std::env::current_exe().unwrap(), dir_a.join("mytesttool"))
+            .unwrap();
+        create_fake_executable(&dir_b, "mytesttool");
+
+        let original_cwd = current_dir().unwrap();
+        std::env::set_current_dir(temp.path()).unwrap();
+        let path = std::env::join_paths([std::path::Path::new("bin_a"), dir_b.as_path()]).unwrap();
+        // SAFETY: This test runs in isolation with serial_test
+        unsafe {
+            std::env::set_var("PATH", &path);
+            std::env::remove_var(env_vars::VP_BYPASS);
+        }
+
+        let result = find_system_tool("mytesttool");
+        std::env::set_current_dir(original_cwd.as_path()).unwrap();
+        assert!(result.is_some(), "Should skip the relative self-symlink entry and keep searching");
+        assert!(
+            result.unwrap().as_path().starts_with(&dir_b),
+            "Should find the real tool in dir_b, not the self symlink in relative bin_a"
         );
     }
 

--- a/crates/vite_global_cli/src/shim/dispatch.rs
+++ b/crates/vite_global_cli/src/shim/dispatch.rs
@@ -1293,17 +1293,19 @@ pub(crate) fn find_system_tool(tool: &str) -> Option<AbsolutePathBuf> {
 
     // Parse VP_BYPASS as a PATH-style list of additional directories to skip.
     // This prevents infinite loops when multiple vite-plus installations exist in PATH.
-    let bypass_paths: Vec<std::path::PathBuf> = std::env::var_os(env_vars::VP_BYPASS)
+    let mut bypass_paths: Vec<std::path::PathBuf> = std::env::var_os(env_vars::VP_BYPASS)
         .map(|v| std::env::split_paths(&v).collect())
         .unwrap_or_default();
-    tracing::debug!("bypass_paths: {:?}", bypass_paths);
 
     // Also skip the directory containing the running shim executable. The
     // configured bin dir can point elsewhere (e.g. VP_HOME overridden) while
     // the invoked shim still lives on PATH; without this the lookup resolves
     // back to the shim itself, which then exec's itself in an infinite loop.
     let self_exe = std::env::current_exe().ok();
-    let self_dir = self_exe.as_deref().and_then(|exe| exe.parent());
+    if let Some(self_dir) = self_exe.as_deref().and_then(|exe| exe.parent()) {
+        bypass_paths.push(self_dir.to_path_buf());
+    }
+    tracing::debug!("bypass_paths: {:?}", bypass_paths);
 
     // Filter PATH to exclude our bin directory and any bypass directories
     let filtered_paths: Vec<_> = std::env::split_paths(&path_var)
@@ -1312,9 +1314,6 @@ pub(crate) fn find_system_tool(tool: &str) -> Option<AbsolutePathBuf> {
                 if p == bin.as_path() {
                     return false;
                 }
-            }
-            if self_dir == Some(p.as_path()) {
-                return false;
             }
             !bypass_paths.iter().any(|bp| p == bp)
         })

--- a/crates/vite_global_cli/src/shim/dispatch.rs
+++ b/crates/vite_global_cli/src/shim/dispatch.rs
@@ -1287,6 +1287,12 @@ async fn load_shim_mode() -> ShimMode {
 ///
 /// Returns the absolute path to the tool if found, None otherwise.
 pub(crate) fn find_system_tool(tool: &str) -> Option<AbsolutePathBuf> {
+    find_system_tool_in(tool, &current_dir().ok()?)
+}
+
+/// `cwd` only resolves relative PATH entries; it is a parameter so tests can
+/// exercise them without mutating the process-wide working directory.
+fn find_system_tool_in(tool: &str, cwd: &AbsolutePath) -> Option<AbsolutePathBuf> {
     let bin_dir = config::get_bin_dir().ok();
     let path_var = std::env::var_os("PATH")?;
     tracing::debug!("path_var: {:?}", path_var);
@@ -1297,8 +1303,6 @@ pub(crate) fn find_system_tool(tool: &str) -> Option<AbsolutePathBuf> {
         .map(|v| std::env::split_paths(&v).collect())
         .unwrap_or_default();
     tracing::debug!("bypass_paths: {:?}", bypass_paths);
-
-    let cwd = current_dir().ok()?;
 
     // Filter PATH to exclude our bin directory and any bypass directories.
     // Relative entries are resolved against cwd because `which` reports
@@ -1327,7 +1331,7 @@ pub(crate) fn find_system_tool(tool: &str) -> Option<AbsolutePathBuf> {
     loop {
         // Use vite_command::resolve_bin with filtered PATH - stops at first match
         let search_path = std::env::join_paths(&filtered_paths).ok()?;
-        let resolved = vite_command::resolve_bin(tool, Some(&search_path), &cwd).ok()?;
+        let resolved = vite_command::resolve_bin(tool, Some(&search_path), cwd).ok()?;
         if self_real.is_none() || resolved.as_path().canonicalize().ok() != self_real {
             return Some(resolved);
         }
@@ -1449,6 +1453,21 @@ mod tests {
         );
     }
 
+    /// Set up `bin_a` holding a symlink to the running test binary (a
+    /// stand-in for a vp shim) and `bin_b` holding a real fake executable,
+    /// both providing `mytesttool`.
+    #[cfg(unix)]
+    fn setup_self_symlink_dirs(temp: &TempDir) -> (std::path::PathBuf, std::path::PathBuf) {
+        let dir_a = temp.path().join("bin_a");
+        let dir_b = temp.path().join("bin_b");
+        std::fs::create_dir_all(&dir_a).unwrap();
+        std::fs::create_dir_all(&dir_b).unwrap();
+        std::os::unix::fs::symlink(std::env::current_exe().unwrap(), dir_a.join("mytesttool"))
+            .unwrap();
+        create_fake_executable(&dir_b, "mytesttool");
+        (dir_a, dir_b)
+    }
+
     /// A symlink to the running executable evades the directory filters (its
     /// directory differs from `current_exe().parent()`), exercising the
     /// canonicalize backstop: the self candidate must be skipped while the
@@ -1459,13 +1478,7 @@ mod tests {
     fn test_find_system_tool_skips_self_symlink_and_keeps_searching() {
         let _guard = EnvGuard::new();
         let temp = TempDir::new().unwrap();
-        let dir_a = temp.path().join("bin_a");
-        let dir_b = temp.path().join("bin_b");
-        std::fs::create_dir_all(&dir_a).unwrap();
-        std::fs::create_dir_all(&dir_b).unwrap();
-        std::os::unix::fs::symlink(std::env::current_exe().unwrap(), dir_a.join("mytesttool"))
-            .unwrap();
-        create_fake_executable(&dir_b, "mytesttool");
+        let (dir_a, dir_b) = setup_self_symlink_dirs(&temp);
 
         let path = std::env::join_paths([dir_a.as_path(), dir_b.as_path()]).unwrap();
         // SAFETY: This test runs in isolation with serial_test
@@ -1483,24 +1496,17 @@ mod tests {
     }
 
     /// Same as above but with the self-symlink directory listed as a relative
-    /// PATH entry: dropping it requires comparing canonicalized directories,
-    /// otherwise the retry loop gives up instead of reaching dir_b.
+    /// PATH entry (resolved against the injected cwd): dropping it requires
+    /// comparing canonicalized directories, otherwise the retry loop gives up
+    /// instead of reaching dir_b.
     #[cfg(unix)]
     #[test]
     #[serial]
     fn test_find_system_tool_skips_self_symlink_in_relative_path_entry() {
         let _guard = EnvGuard::new();
         let temp = TempDir::new().unwrap();
-        let dir_a = temp.path().join("bin_a");
-        let dir_b = temp.path().join("bin_b");
-        std::fs::create_dir_all(&dir_a).unwrap();
-        std::fs::create_dir_all(&dir_b).unwrap();
-        std::os::unix::fs::symlink(std::env::current_exe().unwrap(), dir_a.join("mytesttool"))
-            .unwrap();
-        create_fake_executable(&dir_b, "mytesttool");
+        let (_dir_a, dir_b) = setup_self_symlink_dirs(&temp);
 
-        let original_cwd = current_dir().unwrap();
-        std::env::set_current_dir(temp.path()).unwrap();
         let path = std::env::join_paths([std::path::Path::new("bin_a"), dir_b.as_path()]).unwrap();
         // SAFETY: This test runs in isolation with serial_test
         unsafe {
@@ -1508,8 +1514,8 @@ mod tests {
             std::env::remove_var(env_vars::VP_BYPASS);
         }
 
-        let result = find_system_tool("mytesttool");
-        std::env::set_current_dir(original_cwd.as_path()).unwrap();
+        let cwd = AbsolutePathBuf::new(temp.path().to_path_buf()).unwrap();
+        let result = find_system_tool_in("mytesttool", &cwd);
         assert!(result.is_some(), "Should skip the relative self-symlink entry and keep searching");
         assert!(
             result.unwrap().as_path().starts_with(&dir_b),

--- a/crates/vite_global_cli/src/shim/dispatch.rs
+++ b/crates/vite_global_cli/src/shim/dispatch.rs
@@ -1298,6 +1298,13 @@ pub(crate) fn find_system_tool(tool: &str) -> Option<AbsolutePathBuf> {
         .unwrap_or_default();
     tracing::debug!("bypass_paths: {:?}", bypass_paths);
 
+    // Also skip the directory containing the running shim executable. The
+    // configured bin dir can point elsewhere (e.g. VP_HOME overridden) while
+    // the invoked shim still lives on PATH; without this the lookup resolves
+    // back to the shim itself, which then exec's itself in an infinite loop.
+    let self_exe = std::env::current_exe().ok();
+    let self_dir = self_exe.as_deref().and_then(|exe| exe.parent());
+
     // Filter PATH to exclude our bin directory and any bypass directories
     let filtered_paths: Vec<_> = std::env::split_paths(&path_var)
         .filter(|p| {
@@ -1305,6 +1312,9 @@ pub(crate) fn find_system_tool(tool: &str) -> Option<AbsolutePathBuf> {
                 if p == bin.as_path() {
                     return false;
                 }
+            }
+            if self_dir == Some(p.as_path()) {
+                return false;
             }
             !bypass_paths.iter().any(|bp| p == bp)
         })
@@ -1314,7 +1324,20 @@ pub(crate) fn find_system_tool(tool: &str) -> Option<AbsolutePathBuf> {
 
     // Use vite_command::resolve_bin with filtered PATH - stops at first match
     let cwd = current_dir().ok()?;
-    vite_command::resolve_bin(tool, Some(&filtered_path), &cwd).ok()
+    let resolved = vite_command::resolve_bin(tool, Some(&filtered_path), &cwd).ok()?;
+
+    // Backstop for symlinked shims that evade the directory filters above
+    // (`current_exe` is fully resolved on Linux): never return the running
+    // executable itself.
+    if let Some(self_exe) = &self_exe
+        && let (Ok(resolved_real), Ok(self_real)) =
+            (resolved.as_path().canonicalize(), self_exe.canonicalize())
+        && resolved_real == self_real
+    {
+        return None;
+    }
+
+    Some(resolved)
 }
 
 #[cfg(test)]

--- a/crates/vite_global_cli/src/shim/dispatch.rs
+++ b/crates/vite_global_cli/src/shim/dispatch.rs
@@ -1308,7 +1308,7 @@ pub(crate) fn find_system_tool(tool: &str) -> Option<AbsolutePathBuf> {
     tracing::debug!("bypass_paths: {:?}", bypass_paths);
 
     // Filter PATH to exclude our bin directory and any bypass directories
-    let filtered_paths: Vec<_> = std::env::split_paths(&path_var)
+    let mut filtered_paths: Vec<_> = std::env::split_paths(&path_var)
         .filter(|p| {
             if let Some(ref bin) = bin_dir {
                 if p == bin.as_path() {
@@ -1319,24 +1319,28 @@ pub(crate) fn find_system_tool(tool: &str) -> Option<AbsolutePathBuf> {
         })
         .collect();
 
-    let filtered_path = std::env::join_paths(filtered_paths).ok()?;
-
-    // Use vite_command::resolve_bin with filtered PATH - stops at first match
     let cwd = current_dir().ok()?;
-    let resolved = vite_command::resolve_bin(tool, Some(&filtered_path), &cwd).ok()?;
 
     // Backstop for symlinked shims that evade the directory filters above
     // (`current_exe` is fully resolved on Linux): never return the running
-    // executable itself.
-    if let Some(self_exe) = &self_exe
-        && let (Ok(resolved_real), Ok(self_real)) =
-            (resolved.as_path().canonicalize(), self_exe.canonicalize())
-        && resolved_real == self_real
-    {
-        return None;
+    // executable itself. Skip the self candidate's directory and keep
+    // searching so a real system tool later in PATH is still found.
+    let self_real = self_exe.and_then(|exe| exe.canonicalize().ok());
+    loop {
+        // Use vite_command::resolve_bin with filtered PATH - stops at first match
+        let search_path = std::env::join_paths(&filtered_paths).ok()?;
+        let resolved = vite_command::resolve_bin(tool, Some(&search_path), &cwd).ok()?;
+        if self_real.is_none() || resolved.as_path().canonicalize().ok() != self_real {
+            return Some(resolved);
+        }
+        let self_candidate_dir = resolved.as_path().parent()?.to_path_buf();
+        let len_before = filtered_paths.len();
+        filtered_paths.retain(|p| *p != self_candidate_dir);
+        if filtered_paths.len() == len_before {
+            // Nothing left to drop; give up rather than loop forever.
+            return None;
+        }
     }
-
-    Some(resolved)
 }
 
 #[cfg(test)]
@@ -1438,6 +1442,39 @@ mod tests {
         assert!(
             result.unwrap().as_path().starts_with(&dir_b),
             "Should find tool in dir_b, not dir_a"
+        );
+    }
+
+    /// A symlink to the running executable evades the directory filters (its
+    /// directory differs from `current_exe().parent()`), exercising the
+    /// canonicalize backstop: the self candidate must be skipped while the
+    /// search continues to the real tool later in PATH.
+    #[cfg(unix)]
+    #[test]
+    #[serial]
+    fn test_find_system_tool_skips_self_symlink_and_keeps_searching() {
+        let _guard = EnvGuard::new();
+        let temp = TempDir::new().unwrap();
+        let dir_a = temp.path().join("bin_a");
+        let dir_b = temp.path().join("bin_b");
+        std::fs::create_dir_all(&dir_a).unwrap();
+        std::fs::create_dir_all(&dir_b).unwrap();
+        std::os::unix::fs::symlink(std::env::current_exe().unwrap(), dir_a.join("mytesttool"))
+            .unwrap();
+        create_fake_executable(&dir_b, "mytesttool");
+
+        let path = std::env::join_paths([dir_a.as_path(), dir_b.as_path()]).unwrap();
+        // SAFETY: This test runs in isolation with serial_test
+        unsafe {
+            std::env::set_var("PATH", &path);
+            std::env::remove_var(env_vars::VP_BYPASS);
+        }
+
+        let result = find_system_tool("mytesttool");
+        assert!(result.is_some(), "Should skip the self symlink and keep searching");
+        assert!(
+            result.unwrap().as_path().starts_with(&dir_b),
+            "Should find the real tool in dir_b, not the self symlink in dir_a"
         );
     }
 

--- a/packages/cli/snap-tests-global/command-install-auto-create-package-json/snap.txt
+++ b/packages/cli/snap-tests-global/command-install-auto-create-package-json/snap.txt
@@ -14,6 +14,7 @@ no package.json
 }
 
 > vp add testnpm2 -D && cat package.json # should add package to auto-created package.json
+✓ Lockfile passes supply-chain policies (verified <variable>ms ago)
 Packages: +<variable>
 +
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done

--- a/packages/cli/snap-tests/command-install-auto-create-package-json/snap.txt
+++ b/packages/cli/snap-tests/command-install-auto-create-package-json/snap.txt
@@ -14,6 +14,7 @@ no package.json
 }
 
 > vp add testnpm2 -D && cat package.json # should add package to auto-created package.json
+✓ Lockfile passes supply-chain policies (verified <variable>ms ago)
 Packages: +<variable>
 +
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done

--- a/packages/cli/src/utils/__tests__/package.spec.ts
+++ b/packages/cli/src/utils/__tests__/package.spec.ts
@@ -2,6 +2,16 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { checkNpmPackageExists } from '../package.js';
 
+// Pin the registry: getNpmRegistry reads the developer's real `.npmrc`, so
+// the URL assertions below would fail for anyone using a mirror registry.
+vi.mock('../npm-config.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../npm-config.js')>();
+  return {
+    ...actual,
+    getNpmRegistry: () => 'https://registry.npmjs.org',
+  };
+});
+
 describe('checkNpmPackageExists', () => {
   afterEach(() => {
     vi.restoreAllMocks();

--- a/packages/tools/src/__tests__/__snapshots__/utils.spec.ts.snap
+++ b/packages/tools/src/__tests__/__snapshots__/utils.spec.ts.snap
@@ -47,10 +47,7 @@ exports[`replaceUnstableOutput() > replace ignore pnpm request warning log 1`] =
 Packages:"
 `;
 
-exports[`replaceUnstableOutput() > replace ignore tarball download average speed warning log 1`] = `
-"WARN  Tarball download average speed 29 KiB/s (size 56 KiB) is below 50 KiB/s: https://registry.<domain>/qs/-/qs-6.14.0.tgz (GET)
- WARN  Tarball download average speed 34 KiB/s (size 347 KiB) is below 50 KiB/s: https://registry.<domain>/undici/-/undici-7.16.0.tgz (GET)"
-`;
+exports[`replaceUnstableOutput() > replace ignore tarball download average speed warning log 1`] = `"Progress: resolved"`;
 
 exports[`replaceUnstableOutput() > replace pnpm progress plus markers with <repeat> 1`] = `
 "Scope: all <variable> workspace projects

--- a/packages/tools/src/__tests__/utils.spec.ts
+++ b/packages/tools/src/__tests__/utils.spec.ts
@@ -243,6 +243,7 @@ https://registry.yarnpkg.com/testnpm2/-/testnpm2-1.0.0.tgz
   test('replace pnpm registry request error warning log', () => {
     const output = `
  WARN  GET https://registry.npmjs.org/test-vite-plus-install error (ECONNRESET). Will retry in 10 seconds. 2 retries left.
+[WARN] GET https://registry.npmjs.org/testnpm2 error (ECONNRESET). Will retry in 10 seconds. 2 retries left.
 Progress: resolved
 `;
     expect(replaceUnstableOutput(output.trim())).toMatchSnapshot();

--- a/packages/tools/src/__tests__/utils.spec.ts
+++ b/packages/tools/src/__tests__/utils.spec.ts
@@ -253,6 +253,7 @@ Progress: resolved
     const output = `
  WARN  Tarball download average speed 29 KiB/s (size 56 KiB) is below 50 KiB/s: https://registry.npmjs.org/qs/-/qs-6.14.0.tgz (GET)
  WARN  Tarball download average speed 34 KiB/s (size 347 KiB) is below 50 KiB/s: https://registry.npmjs.org/undici/-/undici-7.16.0.tgz (GET)
+Progress: resolved
 `;
     expect(replaceUnstableOutput(output.trim())).toMatchSnapshot();
   });

--- a/packages/tools/src/utils.ts
+++ b/packages/tools/src/utils.ts
@@ -91,8 +91,11 @@ export function replaceUnstableOutput(output: string, cwd?: string) {
       .replaceAll(/ ?WARN\s+Request\s+took .+?\n/g, '')
       .replaceAll(/Scope: all \d+ workspace projects/g, 'Scope: all <variable> workspace projects')
       .replaceAll(/\+{2,}\n/g, '+<repeat>\n')
-      // ignore pnpm registry request error warning log
-      .replaceAll(/ ?WARN\s+GET\s+https:\/\/registry\..+?\n/g, '')
+      // ignore pnpm registry request error warning log; the prefix is `WARN`
+      // padded with a thin space (U+2009) by pnpm's TTY reporter, or `[WARN]`
+      // in non-interactive output, e.g.:
+      // `[WARN] GET https://registry.npmjs.org/testnpm2 error (ECONNRESET). Will retry in 10 seconds. 2 retries left.`
+      .replaceAll(/[\u2009 ]?\[?WARN\]?\s+GET\s+https:\/\/registry\..+?\n/g, '')
       // ignore clack spinner frames (e.g. `◒  Preparing local Git repository...`),
       // they appear intermittently depending on timing; the final `◇`/`◆` line stays
       .replaceAll(/^[◐◓◑◒]\s[^\n]*\n?/gm, '')

--- a/packages/tools/src/utils.ts
+++ b/packages/tools/src/utils.ts
@@ -86,14 +86,13 @@ export function replaceUnstableOutput(output: string, cwd?: string) {
       )
       // ignore pnpm progress
       .replaceAll(/Progress: resolved \d+, reused \d+, downloaded \d+, added \d+\n/g, '')
-      // ignore pnpm warn
-      .replaceAll(/ ?WARN\s+Skip\s+adding .+?\n/g, '')
-      .replaceAll(/ ?WARN\s+Request\s+took .+?\n/g, '')
+      // ignore pnpm warn lines; pnpm pads `WARN` with thin spaces (U+2009) in
+      // TTY output and brackets it as `[WARN]` in non-interactive output
+      .replaceAll(/[\u2009 ]?\[?WARN\]?\s+Skip\s+adding .+?\n/g, '')
+      .replaceAll(/[\u2009 ]?\[?WARN\]?\s+Request\s+took .+?\n/g, '')
       .replaceAll(/Scope: all \d+ workspace projects/g, 'Scope: all <variable> workspace projects')
       .replaceAll(/\+{2,}\n/g, '+<repeat>\n')
-      // ignore pnpm registry request error warning log; the prefix is `WARN`
-      // padded with a thin space (U+2009) by pnpm's TTY reporter, or `[WARN]`
-      // in non-interactive output, e.g.:
+      // ignore pnpm registry request error warning log, e.g.:
       // `[WARN] GET https://registry.npmjs.org/testnpm2 error (ECONNRESET). Will retry in 10 seconds. 2 retries left.`
       .replaceAll(/[\u2009 ]?\[?WARN\]?\s+GET\s+https:\/\/registry\..+?\n/g, '')
       // ignore clack spinner frames (e.g. `◒  Preparing local Git repository...`),
@@ -121,7 +120,7 @@ export function replaceUnstableOutput(output: string, cwd?: string) {
       // npm warn Unknown env config "recursive". This will stop working in the next major version of npm
       .replaceAll(/npm warn Unknown env config .+?\n/g, '')
       // WARN  Issue while reading "/path/to/.npmrc". Failed to replace env in config: ${NPM_AUTH_TOKEN}
-      .replaceAll(/WARN\s+Issue\s+while\s+reading .+?\n/g, '')
+      .replaceAll(/[\u2009 ]?\[?WARN\]?\s+Issue\s+while\s+reading .+?\n/g, '')
       // ignore npm audited packages log
       // "removed 1 package, and audited 3 packages in 700ms" => "removed <variable> package in <variable>ms"
       // "up to date, audited 4 packages in 11ms" => "up to date in <variable>ms"
@@ -151,7 +150,7 @@ export function replaceUnstableOutput(output: string, cwd?: string) {
       // ignore npm registry domain
       .replaceAll(/(https?:\/\/registry\.)[^/\s]+(\/?)/g, '$1<domain>$2')
       // ignore pnpm tarball download average speed warning log
-      .replaceAll(/ WARN  Tarball download average speed .+?\n/g, '')
+      .replaceAll(/[\u2009 ]?\[?WARN\]?\s+Tarball download average speed .+?\n/g, '')
       // ignore npm hash values
       .replaceAll(/shasum: .+?\n/g, 'shasum: <hash>\n')
       .replaceAll(/integrity: ([\w-]+)-.+?\n/g, 'integrity: $1-<hash>\n')


### PR DESCRIPTION
## Problem

Two tests in `vite_global_cli` can hang forever:

- `commands::env::pin::tests::test_check_dev_engines_sync_warns_without_tty`: `check_dev_engines_sync` checks `stdin().is_terminal()` internally, so when the suite runs from an interactive terminal the test blocks on `read_line` waiting for keyboard input.
- `commands::version::tests::detect_system_node_version_returns_version` (intermittent): it spawns `node`, which resolves to the vp shim, while concurrent `#[serial]` tests mutate `PATH`/`VP_HOME` process-wide. With `VP_HOME` pointing elsewhere, `find_system_tool` fails to filter the shim's own bin dir, so the shim resolves itself as the system node and exec's itself in an infinite loop at 100% CPU.

## Fix

- Pass interactivity into `check_dev_engines_sync` as a parameter computed at the call site, so tests exercise the non-TTY and `--force` paths deterministically (new force-path test included).
- Mark `detect_system_node_version_returns_version` as `#[serial]` so no other test mutates the process env while it spawns `node`.
- Harden `find_system_tool`: skip the running executable's directory in the PATH scan, and never return a path that canonicalizes to the running executable. This also protects real users from the self-exec spin (e.g. mis-set `VP_HOME` with `~/.vite-plus/bin` on PATH).

Full suite: 1492 tests pass with no hangs, clippy and rustfmt clean.

## Also includes

- Snap normalizer: strip pnpm's bracketed `[WARN] GET <registry url> ... Will retry` retry lines (the existing rule only matched the TTY thin-space `WARN` form, now written as a visible `\u2009` escape).
- `package.spec.ts`: pin `getNpmRegistry` via partial mock so registry URL assertions pass for developers using a mirror registry.
- Refresh install snaps with pnpm's new "Lockfile passes supply-chain policies" line.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Shim PATH filtering changes real bypass/system-first behavior (intended fix for infinite exec); pin UX is unchanged at the call site but the devEngines sync path is user-facing when pinning.
> 
> **Overview**
> Fixes **hanging and flaky `vite_global_cli` tests** and **shim self-exec loops** when PATH resolution picks up the vp shim instead of real `node`.
> 
> **`check_dev_engines_sync`** now takes an explicit `interactive` flag (from stdin TTY at the pin call site) instead of calling `stdin().is_terminal()` inside the helper, so tests can force non-TTY and `--force` behavior without blocking on input. New coverage asserts `--force` skips prompts even when `interactive` is true.
> 
> **`find_system_tool`** excludes the running shim’s directory from PATH scanning and refuses a resolved path that canonicalizes to `current_exe()`, closing loops when `VP_HOME` and the shim on PATH disagree (including symlink edge cases).
> 
> **`detect_system_node_version_returns_version`** runs under `#[serial]` so concurrent tests mutating `PATH`/`VP_HOME` do not break the spawned `node` probe.
> 
> Smaller fixes: snap normalizer strips pnpm **`[WARN] GET …`** retry lines; **`package.spec.ts`** mocks `getNpmRegistry` for mirror setups; install snap fixtures include pnpm’s supply-chain lockfile line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3ccdcbe1cb5dd890d88fcb1e95a4647db872cc4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->