### PR TITLE
fix(migrate): complete vp migrate for existing Vite+ projects

### DIFF
--- a/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-hookspath/snap.txt
+++ b/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-hookspath/snap.txt
@@ -2,9 +2,10 @@
 > git config core.hooksPath .husky/_
 > vp migrate --no-interactive # should override husky's core.hooksPath and migrate hooks
 ◇ Updated .
-• Node <semver>  unknown latest
+• Node <semver>  pnpm <semver>
 • 2 config updates applied
 • Git hooks configured
+• Package manager settings configured
 
 > cat package.json # husky/lint-staged should be removed, prepare should be vp config
 {
@@ -15,6 +16,13 @@
   "devDependencies": {
     "vite": "^7.0.0",
     "vite-plus": "latest"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": "<semver>",
+      "onFail": "download"
+    }
   }
 }
 

--- a/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-hookspath/snap.txt
+++ b/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-hookspath/snap.txt
@@ -1,7 +1,7 @@
 > git init
 > git config core.hooksPath .husky/_
 > vp migrate --no-interactive # should override husky's core.hooksPath and migrate hooks
-◇ Updated .
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 • Git hooks configured

--- a/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-lint-staged/snap.txt
@@ -1,9 +1,10 @@
 > git init
 > vp migrate --no-interactive # should still migrate husky/lint-staged even though vite-plus exists
 ◇ Updated .
-• Node <semver>  unknown latest
+• Node <semver>  pnpm <semver>
 • 2 config updates applied
 • Git hooks configured
+• Package manager settings configured
 
 > cat package.json # husky/lint-staged should be removed, prepare should be vp config
 {
@@ -14,6 +15,13 @@
   "devDependencies": {
     "vite": "^7.0.0",
     "vite-plus": "latest"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": "<semver>",
+      "onFail": "download"
+    }
   }
 }
 

--- a/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-already-vite-plus-with-husky-lint-staged/snap.txt
@@ -1,6 +1,6 @@
 > git init
 > vp migrate --no-interactive # should still migrate husky/lint-staged even though vite-plus exists
-◇ Updated .
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 2 config updates applied
 • Git hooks configured

--- a/packages/cli/snap-tests-global/migration-already-vite-plus/package.json
+++ b/packages/cli/snap-tests-global/migration-already-vite-plus/package.json
@@ -2,5 +2,16 @@
   "name": "migration-already-vite-plus",
   "devDependencies": {
     "vite-plus": "latest"
+  },
+  "overrides": {
+    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
+    "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": "11.16.0",
+      "onFail": "download"
+    }
   }
 }

--- a/packages/cli/snap-tests-global/migration-already-vite-plus/snap.txt
+++ b/packages/cli/snap-tests-global/migration-already-vite-plus/snap.txt
@@ -4,7 +4,7 @@ This project is already using Vite+! Happy coding!
 
 > vp migrate --no-interactive --hooks --agent agents # explicit setup should still update existing vite-plus project
 ◇ Updated .
-• Node <semver>  unknown latest
+• Node <semver>  npm <semver>
 • 2 config updates applied
 
 > cat package.json # prepare script should be configured for vp config
@@ -12,6 +12,17 @@ This project is already using Vite+! Happy coding!
   "name": "migration-already-vite-plus",
   "devDependencies": {
     "vite-plus": "latest"
+  },
+  "overrides": {
+    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
+    "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": "<semver>",
+      "onFail": "download"
+    }
   },
   "scripts": {
     "prepare": "vp config"

--- a/packages/cli/snap-tests-global/migration-already-vite-plus/snap.txt
+++ b/packages/cli/snap-tests-global/migration-already-vite-plus/snap.txt
@@ -1,3 +1,21 @@
-> vp migrate --no-interactive # should detect existing vite-plus and exit
+> vp migrate --no-interactive # should detect existing vite-plus and exit without setup defaults
 This project is already using Vite+! Happy coding!
 
+> vp migrate --no-interactive --hooks --agent agents # explicit setup should still update existing vite-plus project
+◇ Updated .
+• Node <semver>  unknown latest
+• 2 config updates applied
+
+> cat package.json # prepare script should be configured for vp config
+{
+  "name": "migration-already-vite-plus",
+  "devDependencies": {
+    "vite-plus": "latest"
+  },
+  "scripts": {
+    "prepare": "vp config"
+  }
+}
+
+> test -f AGENTS.md # explicit agent instructions should be written
+> test -f .vite-hooks/pre-commit # explicit pre-commit hook should be written

--- a/packages/cli/snap-tests-global/migration-already-vite-plus/snap.txt
+++ b/packages/cli/snap-tests-global/migration-already-vite-plus/snap.txt
@@ -1,6 +1,7 @@
 > vp migrate --no-interactive # should detect existing vite-plus and exit without setup defaults
 This project is already using Vite+! Happy coding!
 
+
 > vp migrate --no-interactive --hooks --agent agents # explicit setup should still update existing vite-plus project
 ◇ Updated .
 • Node <semver>  unknown latest

--- a/packages/cli/snap-tests-global/migration-already-vite-plus/steps.json
+++ b/packages/cli/snap-tests-global/migration-already-vite-plus/steps.json
@@ -1,5 +1,11 @@
 {
-  "commands": ["vp migrate --no-interactive # should detect existing vite-plus and exit"],
+  "commands": [
+    "vp migrate --no-interactive # should detect existing vite-plus and exit without setup defaults",
+    "vp migrate --no-interactive --hooks --agent agents # explicit setup should still update existing vite-plus project",
+    "cat package.json # prepare script should be configured for vp config",
+    "test -f AGENTS.md # explicit agent instructions should be written",
+    "test -f .vite-hooks/pre-commit # explicit pre-commit hook should be written"
+  ],
   "ignoredPlatforms": [
     {
       "os": "linux",

--- a/packages/cli/snap-tests-global/migration-eslint-legacy-already-vite-plus/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-legacy-already-vite-plus/snap.txt
@@ -1,5 +1,6 @@
 > vp migrate --no-interactive # should show legacy config warning and already using Vite+
 
 Legacy ESLint configuration detected (.eslintrc). Automatic migration to Oxlint requires ESLint v9+ with flat config format (eslint.config.*). Please upgrade to ESLint v9 first: https://eslint.org/docs/latest/use/migrate-to-9.0.0
-This project is already using Vite+! Happy coding!
-
+◇ Updated .
+• Node <semver>  pnpm <semver>
+• Package manager settings configured

--- a/packages/cli/snap-tests-global/migration-eslint-legacy-already-vite-plus/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-legacy-already-vite-plus/snap.txt
@@ -3,5 +3,4 @@
 Legacy ESLint configuration detected (.eslintrc). Automatic migration to Oxlint requires ESLint v9+ with flat config format (eslint.config.*). Please upgrade to ESLint v9 first: https://eslint.org/docs/latest/use/migrate-to-9.0.0
 ◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
-• 2 config updates applied
 • Package manager settings configured

--- a/packages/cli/snap-tests-global/migration-eslint-legacy-already-vite-plus/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-legacy-already-vite-plus/snap.txt
@@ -1,6 +1,7 @@
 > vp migrate --no-interactive # should show legacy config warning and already using Vite+
 
 Legacy ESLint configuration detected (.eslintrc). Automatic migration to Oxlint requires ESLint v9+ with flat config format (eslint.config.*). Please upgrade to ESLint v9 first: https://eslint.org/docs/latest/use/migrate-to-9.0.0
-◇ Updated .
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
+• 2 config updates applied
 • Package manager settings configured

--- a/packages/cli/snap-tests-global/migration-eslint-lint-staged-mjs/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-lint-staged-mjs/snap.txt
@@ -1,20 +1,11 @@
 > vp migrate --no-interactive # migration should warn about non-JSON lint-staged config
-
-Migrating ESLint config to Oxlint...
-
-ESLint config migrated to .oxlintrc.json
-
-Replacing ESLint comments with Oxlint equivalents...
-
-ESLint comments replaced
-
-✔ Removed eslint.config.mjs
-
-lint-staged.config.mjs — please update eslint references manually
 ◇ Updated .
-• Node <semver>  unknown latest
-• 2 config updates applied
+• Node <semver>  pnpm <semver>
+• 3 config updates applied
 • ESLint rules migrated to Oxlint
+• Package manager settings configured
+! Warnings:
+  - lint-staged.config.mjs — please update eslint references manually
 
 > cat lint-staged.config.mjs # verify non-JSON lint-staged config is preserved unchanged
 export default {

--- a/packages/cli/snap-tests-global/migration-eslint-lint-staged-mjs/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-lint-staged-mjs/snap.txt
@@ -1,5 +1,7 @@
 > vp migrate --no-interactive # migration should warn about non-JSON lint-staged config
-◇ Updated .
+
+⚠ Unsupported lint-staged config format — skipping git hooks setup. Please configure git hooks manually.
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 3 config updates applied
 • ESLint rules migrated to Oxlint

--- a/packages/cli/snap-tests-global/migration-eslint-lint-staged-mjs/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-lint-staged-mjs/snap.txt
@@ -1,6 +1,4 @@
-> vp migrate --no-interactive # migration should warn about non-JSON lint-staged config
-
-⚠ Unsupported lint-staged config format — skipping git hooks setup. Please configure git hooks manually.
+> vp migrate --no-interactive # migration should preserve non-JSON lint-staged config when hooks are not requested
 ◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 3 config updates applied

--- a/packages/cli/snap-tests-global/migration-eslint-lint-staged-mjs/steps.json
+++ b/packages/cli/snap-tests-global/migration-eslint-lint-staged-mjs/steps.json
@@ -1,6 +1,6 @@
 {
   "commands": [
-    "vp migrate --no-interactive # migration should warn about non-JSON lint-staged config",
+    "vp migrate --no-interactive # migration should preserve non-JSON lint-staged config when hooks are not requested",
     "cat lint-staged.config.mjs # verify non-JSON lint-staged config is preserved unchanged"
   ],
   "ignoredPlatforms": [

--- a/packages/cli/snap-tests-global/migration-eslint-rerun-dual-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-rerun-dual-config/snap.txt
@@ -1,20 +1,9 @@
 > vp migrate --no-interactive # should detect vite-plus + eslint and auto-migrate eslint
-
-Migrating ESLint config to Oxlint...
-
-ESLint config migrated to .oxlintrc.json
-
-Replacing ESLint comments with Oxlint equivalents...
-
-ESLint comments replaced
-
-✔ Removed eslint.config.mjs
-
-✔ Removed .eslintrc
 ◇ Updated .
-• Node <semver>  unknown latest
-• 2 config updates applied
+• Node <semver>  pnpm <semver>
+• 4 config updates applied
 • ESLint rules migrated to Oxlint
+• Package manager settings configured
 
 > cat package.json # check eslint removed and scripts rewritten
 {

--- a/packages/cli/snap-tests-global/migration-eslint-rerun-dual-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-rerun-dual-config/snap.txt
@@ -1,7 +1,7 @@
 > vp migrate --no-interactive # should detect vite-plus + eslint and auto-migrate eslint
-◇ Updated .
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
-• 4 config updates applied
+• 5 config updates applied
 • ESLint rules migrated to Oxlint
 • Package manager settings configured
 
@@ -9,7 +9,8 @@
 {
   "name": "migration-eslint-rerun-dual-config",
   "scripts": {
-    "lint": "vp lint ."
+    "lint": "vp lint .",
+    "prepare": "vp config"
   },
   "devDependencies": {
     "vite-plus": "latest"
@@ -29,6 +30,9 @@
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({
+  staged: {
+    "*": "vp check --fix"
+  },
   lint: {
     "plugins": [
       "oxc",
@@ -57,5 +61,4 @@ export default defineConfig({
       }
     ]
   },
-  
 });

--- a/packages/cli/snap-tests-global/migration-eslint-rerun-dual-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-rerun-dual-config/snap.txt
@@ -1,7 +1,7 @@
 > vp migrate --no-interactive # should detect vite-plus + eslint and auto-migrate eslint
 ◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
-• 5 config updates applied
+• 4 config updates applied
 • ESLint rules migrated to Oxlint
 • Package manager settings configured
 
@@ -9,8 +9,7 @@
 {
   "name": "migration-eslint-rerun-dual-config",
   "scripts": {
-    "lint": "vp lint .",
-    "prepare": "vp config"
+    "lint": "vp lint ."
   },
   "devDependencies": {
     "vite-plus": "latest"
@@ -30,9 +29,6 @@
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({
-  staged: {
-    "*": "vp check --fix"
-  },
   lint: {
     "plugins": [
       "oxc",
@@ -61,4 +57,5 @@ export default defineConfig({
       }
     ]
   },
+  
 });

--- a/packages/cli/snap-tests-global/migration-eslint-rerun-mjs/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-rerun-mjs/snap.txt
@@ -1,18 +1,9 @@
 > vp migrate --no-interactive # should detect vite-plus + eslint and auto-migrate eslint
-
-Migrating ESLint config to Oxlint...
-
-ESLint config migrated to .oxlintrc.json
-
-Replacing ESLint comments with Oxlint equivalents...
-
-ESLint comments replaced
-
-✔ Removed eslint.config.mjs
 ◇ Updated .
-• Node <semver>  unknown latest
-• 1 config update applied
+• Node <semver>  pnpm <semver>
+• 2 config updates applied
 • ESLint rules migrated to Oxlint
+• Package manager settings configured
 
 > cat package.json # check eslint removed from devDependencies and scripts rewritten
 {

--- a/packages/cli/snap-tests-global/migration-eslint-rerun-mjs/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-rerun-mjs/snap.txt
@@ -1,7 +1,7 @@
 > vp migrate --no-interactive # should detect vite-plus + eslint and auto-migrate eslint
 ◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
-• 3 config updates applied
+• 2 config updates applied
 • ESLint rules migrated to Oxlint
 • Package manager settings configured
 
@@ -9,8 +9,7 @@
 {
   "name": "migration-eslint-rerun-mjs",
   "scripts": {
-    "lint": "vp lint .",
-    "prepare": "vp config"
+    "lint": "vp lint ."
   },
   "devDependencies": {
     "vite-plus": "latest"
@@ -29,9 +28,6 @@
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({
-  staged: {
-    "*": "vp check --fix"
-  },
   lint: {
     "plugins": [
       "oxc",
@@ -60,4 +56,5 @@ export default defineConfig({
       }
     ]
   },
+  
 });

--- a/packages/cli/snap-tests-global/migration-eslint-rerun-mjs/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-rerun-mjs/snap.txt
@@ -1,7 +1,7 @@
 > vp migrate --no-interactive # should detect vite-plus + eslint and auto-migrate eslint
-◇ Updated .
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
-• 2 config updates applied
+• 3 config updates applied
 • ESLint rules migrated to Oxlint
 • Package manager settings configured
 
@@ -9,7 +9,8 @@
 {
   "name": "migration-eslint-rerun-mjs",
   "scripts": {
-    "lint": "vp lint ."
+    "lint": "vp lint .",
+    "prepare": "vp config"
   },
   "devDependencies": {
     "vite-plus": "latest"
@@ -28,6 +29,9 @@
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({
+  staged: {
+    "*": "vp check --fix"
+  },
   lint: {
     "plugins": [
       "oxc",
@@ -56,5 +60,4 @@ export default defineConfig({
       }
     ]
   },
-  
 });

--- a/packages/cli/snap-tests-global/migration-eslint-rerun/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-rerun/snap.txt
@@ -1,18 +1,9 @@
 > vp migrate --no-interactive # should detect vite-plus + eslint and auto-migrate eslint
-
-Migrating ESLint config to Oxlint...
-
-ESLint config migrated to .oxlintrc.json
-
-Replacing ESLint comments with Oxlint equivalents...
-
-ESLint comments replaced
-
-✔ Removed eslint.config.mjs
 ◇ Updated .
-• Node <semver>  unknown latest
-• 2 config updates applied
+• Node <semver>  pnpm <semver>
+• 3 config updates applied
 • ESLint rules migrated to Oxlint
+• Package manager settings configured
 
 > cat package.json # check eslint removed from devDependencies and scripts rewritten
 {

--- a/packages/cli/snap-tests-global/migration-eslint-rerun/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-rerun/snap.txt
@@ -1,7 +1,7 @@
 > vp migrate --no-interactive # should detect vite-plus + eslint and auto-migrate eslint
 ◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
-• 4 config updates applied
+• 3 config updates applied
 • ESLint rules migrated to Oxlint
 • Package manager settings configured
 
@@ -9,8 +9,7 @@
 {
   "name": "migration-eslint-rerun",
   "scripts": {
-    "lint": "vp lint .",
-    "prepare": "vp config"
+    "lint": "vp lint ."
   },
   "devDependencies": {
     "vite-plus": "latest"
@@ -29,9 +28,6 @@
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({
-  staged: {
-    "*": "vp check --fix"
-  },
   lint: {
     "plugins": [
       "oxc",
@@ -60,4 +56,5 @@ export default defineConfig({
       }
     ]
   },
+  
 });

--- a/packages/cli/snap-tests-global/migration-eslint-rerun/snap.txt
+++ b/packages/cli/snap-tests-global/migration-eslint-rerun/snap.txt
@@ -1,7 +1,7 @@
 > vp migrate --no-interactive # should detect vite-plus + eslint and auto-migrate eslint
-◇ Updated .
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
-• 3 config updates applied
+• 4 config updates applied
 • ESLint rules migrated to Oxlint
 • Package manager settings configured
 
@@ -9,7 +9,8 @@
 {
   "name": "migration-eslint-rerun",
   "scripts": {
-    "lint": "vp lint ."
+    "lint": "vp lint .",
+    "prepare": "vp config"
   },
   "devDependencies": {
     "vite-plus": "latest"
@@ -28,6 +29,9 @@
 import { defineConfig } from 'vite-plus';
 
 export default defineConfig({
+  staged: {
+    "*": "vp check --fix"
+  },
   lint: {
     "plugins": [
       "oxc",
@@ -56,5 +60,4 @@ export default defineConfig({
       }
     ]
   },
-  
 });

--- a/packages/cli/snap-tests-global/migration-partially-installed-vite-plus/package.json
+++ b/packages/cli/snap-tests-global/migration-partially-installed-vite-plus/package.json
@@ -18,20 +18,9 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "@voidzero-dev/vite-plus-core": "^0.1.24",
     "globals": "^17.6.0",
     "typescript": "~6.0.2",
+    "vite": "^8.0.12",
     "vite-plus": "^0.1.24"
-  },
-  "overrides": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
-  },
-  "devEngines": {
-    "packageManager": {
-      "name": "npm",
-      "version": "11.16.0",
-      "onFail": "download"
-    }
   }
 }

--- a/packages/cli/snap-tests-global/migration-partially-installed-vite-plus/package.json
+++ b/packages/cli/snap-tests-global/migration-partially-installed-vite-plus/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "manual-vp-migrate",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "lint": "vp lint .",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6"
+  },
+  "devDependencies": {
+    "@types/node": "^24.12.3",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.1",
+    "@voidzero-dev/vite-plus-core": "^0.1.24",
+    "globals": "^17.6.0",
+    "typescript": "~6.0.2",
+    "vite-plus": "^0.1.24"
+  },
+  "overrides": {
+    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
+    "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": "11.16.0",
+      "onFail": "download"
+    }
+  }
+}

--- a/packages/cli/snap-tests-global/migration-partially-installed-vite-plus/pnpm-lock.yaml
+++ b/packages/cli/snap-tests-global/migration-partially-installed-vite-plus/pnpm-lock.yaml
@@ -1,0 +1,1 @@
+lockfileVersion: '9.0'

--- a/packages/cli/snap-tests-global/migration-partially-installed-vite-plus/snap.txt
+++ b/packages/cli/snap-tests-global/migration-partially-installed-vite-plus/snap.txt
@@ -57,3 +57,7 @@ export default defineConfig({
     "types": ["vite-plus/client"]
   }
 }
+
+> test ! -f AGENTS.md # disabled agent setup should not write instructions
+> test ! -d .vite-hooks # disabled hook setup should not write hooks
+> test ! -d .vscode # disabled editor setup should not write editor config

--- a/packages/cli/snap-tests-global/migration-partially-installed-vite-plus/snap.txt
+++ b/packages/cli/snap-tests-global/migration-partially-installed-vite-plus/snap.txt
@@ -36,7 +36,7 @@
   "devEngines": {
     "packageManager": {
       "name": "npm",
-      "version": "11.16.0",
+      "version": "<semver>",
       "onFail": "download"
     }
   }

--- a/packages/cli/snap-tests-global/migration-partially-installed-vite-plus/snap.txt
+++ b/packages/cli/snap-tests-global/migration-partially-installed-vite-plus/snap.txt
@@ -1,9 +1,10 @@
-> vp migrate --no-interactive --no-hooks --no-agent --no-editor # should finish core rewrites even when vite-plus is already installed
+> vp migrate --no-interactive --no-hooks --no-agent --no-editor # should finish core rewrites even when vite-plus is already installed in a pnpm project
 ◇ Migrated . to Vite+
-• Node <semver>  npm <semver>
+• Node <semver>  pnpm <semver>
 • 1 config update applied, 1 file had imports rewritten
+• Package manager settings configured
 
-> cat package.json # scripts should be rewritten without adding overrides
+> cat package.json # scripts should be rewritten without adding package.json overrides
 {
   "name": "manual-vp-migrate",
   "private": true,
@@ -24,23 +25,35 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "@voidzero-dev/vite-plus-core": "^0.1.24",
     "globals": "^17.6.0",
     "typescript": "~6.0.2",
+    "vite": "^8.0.12",
     "vite-plus": "^0.1.24"
-  },
-  "overrides": {
-    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
   },
   "devEngines": {
     "packageManager": {
-      "name": "npm",
+      "name": "pnpm",
       "version": "<semver>",
       "onFail": "download"
     }
   }
 }
+
+> cat pnpm-workspace.yaml # pnpm overrides and peerDependencyRules should be configured
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest
+  vite-plus: latest
+overrides:
+  vite: 'catalog:'
+  vitest: 'catalog:'
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: '*'
+    vitest: '*'
 
 > cat vite.config.ts # vite imports should be rewritten
 import { defineConfig } from 'vite-plus'

--- a/packages/cli/snap-tests-global/migration-partially-installed-vite-plus/snap.txt
+++ b/packages/cli/snap-tests-global/migration-partially-installed-vite-plus/snap.txt
@@ -1,5 +1,5 @@
 > vp migrate --no-interactive --no-hooks --no-agent --no-editor # should finish core rewrites even when vite-plus is already installed
-◇ Updated .
+◇ Migrated . to Vite+
 • Node <semver>  npm <semver>
 • 1 config update applied, 1 file had imports rewritten
 

--- a/packages/cli/snap-tests-global/migration-partially-installed-vite-plus/snap.txt
+++ b/packages/cli/snap-tests-global/migration-partially-installed-vite-plus/snap.txt
@@ -1,0 +1,59 @@
+> vp migrate --no-interactive --no-hooks --no-agent --no-editor # should finish core rewrites even when vite-plus is already installed
+◇ Updated .
+• Node <semver>  npm <semver>
+• 1 config update applied, 1 file had imports rewritten
+
+> cat package.json # scripts should be rewritten without adding overrides
+{
+  "name": "manual-vp-migrate",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vp dev",
+    "build": "tsc -b && vp build",
+    "lint": "vp lint .",
+    "preview": "vp preview"
+  },
+  "dependencies": {
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6"
+  },
+  "devDependencies": {
+    "@types/node": "^24.12.3",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.1",
+    "@voidzero-dev/vite-plus-core": "^0.1.24",
+    "globals": "^17.6.0",
+    "typescript": "~6.0.2",
+    "vite-plus": "^0.1.24"
+  },
+  "overrides": {
+    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
+    "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": "11.16.0",
+      "onFail": "download"
+    }
+  }
+}
+
+> cat vite.config.ts # vite imports should be rewritten
+import { defineConfig } from 'vite-plus'
+import react from '@vitejs/plugin-react'
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [react()],
+})
+
+> cat tsconfig.app.json # vite/client types should be rewritten
+{
+  "compilerOptions": {
+    "types": ["vite-plus/client"]
+  }
+}

--- a/packages/cli/snap-tests-global/migration-partially-installed-vite-plus/steps.json
+++ b/packages/cli/snap-tests-global/migration-partially-installed-vite-plus/steps.json
@@ -3,6 +3,9 @@
     "vp migrate --no-interactive --no-hooks --no-agent --no-editor # should finish core rewrites even when vite-plus is already installed",
     "cat package.json # scripts should be rewritten without adding overrides",
     "cat vite.config.ts # vite imports should be rewritten",
-    "cat tsconfig.app.json # vite/client types should be rewritten"
+    "cat tsconfig.app.json # vite/client types should be rewritten",
+    "test ! -f AGENTS.md # disabled agent setup should not write instructions",
+    "test ! -d .vite-hooks # disabled hook setup should not write hooks",
+    "test ! -d .vscode # disabled editor setup should not write editor config"
   ]
 }

--- a/packages/cli/snap-tests-global/migration-partially-installed-vite-plus/steps.json
+++ b/packages/cli/snap-tests-global/migration-partially-installed-vite-plus/steps.json
@@ -1,0 +1,8 @@
+{
+  "commands": [
+    "vp migrate --no-interactive --no-hooks --no-agent --no-editor # should finish core rewrites even when vite-plus is already installed",
+    "cat package.json # scripts should be rewritten without adding overrides",
+    "cat vite.config.ts # vite imports should be rewritten",
+    "cat tsconfig.app.json # vite/client types should be rewritten"
+  ]
+}

--- a/packages/cli/snap-tests-global/migration-partially-installed-vite-plus/steps.json
+++ b/packages/cli/snap-tests-global/migration-partially-installed-vite-plus/steps.json
@@ -1,7 +1,8 @@
 {
   "commands": [
-    "vp migrate --no-interactive --no-hooks --no-agent --no-editor # should finish core rewrites even when vite-plus is already installed",
-    "cat package.json # scripts should be rewritten without adding overrides",
+    "vp migrate --no-interactive --no-hooks --no-agent --no-editor # should finish core rewrites even when vite-plus is already installed in a pnpm project",
+    "cat package.json # scripts should be rewritten without adding package.json overrides",
+    "cat pnpm-workspace.yaml # pnpm overrides and peerDependencyRules should be configured",
     "cat vite.config.ts # vite imports should be rewritten",
     "cat tsconfig.app.json # vite/client types should be rewritten",
     "test ! -f AGENTS.md # disabled agent setup should not write instructions",

--- a/packages/cli/snap-tests-global/migration-partially-installed-vite-plus/tsconfig.app.json
+++ b/packages/cli/snap-tests-global/migration-partially-installed-vite-plus/tsconfig.app.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "types": ["vite/client"]
+  }
+}

--- a/packages/cli/snap-tests-global/migration-partially-installed-vite-plus/vite.config.ts
+++ b/packages/cli/snap-tests-global/migration-partially-installed-vite-plus/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [react()],
+})

--- a/packages/cli/snap-tests-global/migration-prettier-rerun/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier-rerun/snap.txt
@@ -1,15 +1,11 @@
 > vp migrate --no-interactive # should detect vite-plus + prettier and auto-migrate prettier
 
 Prettier configuration detected. Auto-migrating to Oxfmt...
-
-Migrating Prettier config to Oxfmt...
-
-Prettier config migrated to .oxfmtrc.json
-
-✔ Removed .prettierrc.json
 ◇ Updated .
-• Node <semver>  unknown latest
+• Node <semver>  pnpm <semver>
+• 1 config update applied
 • Prettier migrated to Oxfmt
+• Package manager settings configured
 
 > cat package.json # check prettier removed from devDependencies and scripts rewritten
 {
@@ -19,6 +15,13 @@ Prettier config migrated to .oxfmtrc.json
   },
   "devDependencies": {
     "vite-plus": "latest"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": "<semver>",
+      "onFail": "download"
+    }
   }
 }
 

--- a/packages/cli/snap-tests-global/migration-prettier-rerun/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier-rerun/snap.txt
@@ -1,9 +1,9 @@
 > vp migrate --no-interactive # should detect vite-plus + prettier and auto-migrate prettier
 
 Prettier configuration detected. Auto-migrating to Oxfmt...
-◇ Updated .
+◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
-• 1 config update applied
+• 2 config updates applied
 • Prettier migrated to Oxfmt
 • Package manager settings configured
 
@@ -11,7 +11,8 @@ Prettier configuration detected. Auto-migrating to Oxfmt...
 {
   "name": "migration-prettier-rerun",
   "scripts": {
-    "format": "vp fmt ."
+    "format": "vp fmt .",
+    "prepare": "vp config"
   },
   "devDependencies": {
     "vite-plus": "latest"
@@ -30,6 +31,9 @@ Prettier configuration detected. Auto-migrating to Oxfmt...
 import { defineConfig } from "vite-plus";
 
 export default defineConfig({
+  staged: {
+    "*": "vp check --fix"
+  },
   fmt: {
     semi: true,
     singleQuote: true,

--- a/packages/cli/snap-tests-global/migration-prettier-rerun/snap.txt
+++ b/packages/cli/snap-tests-global/migration-prettier-rerun/snap.txt
@@ -3,7 +3,7 @@
 Prettier configuration detected. Auto-migrating to Oxfmt...
 ◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
-• 2 config updates applied
+• 1 config update applied
 • Prettier migrated to Oxfmt
 • Package manager settings configured
 
@@ -11,8 +11,7 @@ Prettier configuration detected. Auto-migrating to Oxfmt...
 {
   "name": "migration-prettier-rerun",
   "scripts": {
-    "format": "vp fmt .",
-    "prepare": "vp config"
+    "format": "vp fmt ."
   },
   "devDependencies": {
     "vite-plus": "latest"
@@ -31,9 +30,6 @@ Prettier configuration detected. Auto-migrating to Oxfmt...
 import { defineConfig } from "vite-plus";
 
 export default defineConfig({
-  staged: {
-    "*": "vp check --fix"
-  },
   fmt: {
     semi: true,
     singleQuote: true,

--- a/packages/cli/src/migration/__tests__/migrator.spec.ts
+++ b/packages/cli/src/migration/__tests__/migrator.spec.ts
@@ -1089,6 +1089,29 @@ describe('ensureVitePlusBootstrap', () => {
     expect(fs.existsSync(path.join(tmpDir, '.vite-hooks'))).toBe(false);
     expect(detectVitePlusBootstrapPending(tmpDir, PackageManager.pnpm)).toBe(false);
   });
+
+  it('preserves package.json workspace patterns when creating pnpm-workspace.yaml', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({
+        name: 'test',
+        workspaces: ['packages/*'],
+        devDependencies: { 'vite-plus': 'catalog:' },
+      }),
+    );
+
+    const result = ensureVitePlusBootstrap({
+      ...makeWorkspaceInfo(tmpDir, PackageManager.pnpm),
+      isMonorepo: true,
+      workspacePatterns: ['packages/*'],
+    });
+
+    expect(result.changed).toBe(true);
+    const workspace = readYamlObject(path.join(tmpDir, 'pnpm-workspace.yaml')) as {
+      packages: string[];
+    };
+    expect(workspace.packages).toEqual(['packages/*']);
+  });
 });
 
 describe('rewriteStandaloneProject pnpm workspace yaml', () => {
@@ -2276,6 +2299,21 @@ describe('detectLegacyGitHooksMigrationCandidate', () => {
       }),
     );
     fs.mkdirSync(path.join(tmpDir, '.husky'));
+
+    expect(detectLegacyGitHooksMigrationCandidate(tmpDir)).toBe(false);
+  });
+
+  it('does not treat passive husky or lint-staged dependencies as active hook migration', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({
+        devDependencies: {
+          husky: '^9.1.7',
+          'lint-staged': '^16.2.7',
+          'vite-plus': 'latest',
+        },
+      }),
+    );
 
     expect(detectLegacyGitHooksMigrationCandidate(tmpDir)).toBe(false);
   });

--- a/packages/cli/src/migration/__tests__/migrator.spec.ts
+++ b/packages/cli/src/migration/__tests__/migrator.spec.ts
@@ -33,6 +33,7 @@ const {
   rewriteEslintPackageJson,
   detectIncompatibleEslintIntegration,
   preflightGitHooksSetup,
+  detectLegacyGitHooksMigrationCandidate,
   setPackageManager,
 } = await import('../migrator.js');
 
@@ -2138,6 +2139,44 @@ export default defineConfig({
     expect(viteConfig).not.toContain('singleQuote: false');
     // Redundant standalone file removed.
     expect(fs.existsSync(path.join(tmpDir, '.oxfmtrc.jsonc'))).toBe(false);
+  });
+});
+
+describe('detectLegacyGitHooksMigrationCandidate', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vp-test-legacy-hooks-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('detects leftover husky and lint-staged in an existing Vite+ project', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({
+        scripts: { prepare: 'husky' },
+        devDependencies: { husky: '^9.1.7', 'lint-staged': '^16.2.7', 'vite-plus': 'latest' },
+        'lint-staged': { '*': 'vp check --fix' },
+      }),
+    );
+
+    expect(detectLegacyGitHooksMigrationCandidate(tmpDir)).toBe(true);
+  });
+
+  it('does not treat a completed Vite+ project as needing hook migration', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({
+        scripts: { prepare: 'vp config' },
+        devDependencies: { 'vite-plus': 'latest' },
+      }),
+    );
+    fs.mkdirSync(path.join(tmpDir, '.vite-hooks'));
+
+    expect(detectLegacyGitHooksMigrationCandidate(tmpDir)).toBe(false);
   });
 });
 

--- a/packages/cli/src/migration/__tests__/migrator.spec.ts
+++ b/packages/cli/src/migration/__tests__/migrator.spec.ts
@@ -1142,6 +1142,60 @@ describe('ensureVitePlusBootstrap', () => {
     expect(pkg.pnpm.overrides.vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
   });
 
+  it('uses a concrete vite-plus version for pnpm monorepos that keep pnpm config in package.json', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({
+        name: 'test',
+        dependencies: { 'vite-plus': 'latest' },
+        pnpm: {},
+      }),
+    );
+
+    const result = ensureVitePlusBootstrap({
+      ...makeWorkspaceInfo(tmpDir, PackageManager.pnpm),
+      isMonorepo: true,
+      workspacePatterns: ['packages/*'],
+    });
+
+    expect(result.changed).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, 'pnpm-workspace.yaml'))).toBe(false);
+    const pkg = readJson(path.join(tmpDir, 'package.json')) as {
+      devDependencies: Record<string, string>;
+    };
+    expect(pkg.devDependencies['vite-plus']).toBe('latest');
+  });
+
+  it('uses concrete Vite+ specs for yarn monorepos without a catalog file', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({
+        name: 'test',
+        devDependencies: { 'vite-plus': 'latest', vite: '^7.0.0' },
+        devEngines: {
+          packageManager: { name: 'yarn', version: '4.0.0', onFail: 'download' },
+        },
+      }),
+    );
+
+    expect(detectVitePlusBootstrapPending(tmpDir, PackageManager.yarn)).toBe(true);
+    const result = ensureVitePlusBootstrap({
+      ...makeWorkspaceInfo(tmpDir, PackageManager.yarn),
+      isMonorepo: true,
+      workspacePatterns: ['packages/*'],
+    });
+
+    expect(result.changed).toBe(true);
+    expect(detectVitePlusBootstrapPending(tmpDir, PackageManager.yarn)).toBe(false);
+    const pkg = readJson(path.join(tmpDir, 'package.json')) as {
+      devDependencies: Record<string, string>;
+      resolutions: Record<string, string>;
+    };
+    expect(pkg.devDependencies.vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
+    expect(pkg.devDependencies['vite-plus']).toBe('latest');
+    expect(pkg.resolutions.vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
+  });
+
   it('completes missing pnpm workspace peer dependency rules', () => {
     fs.writeFileSync(
       path.join(tmpDir, 'package.json'),

--- a/packages/cli/src/migration/__tests__/migrator.spec.ts
+++ b/packages/cli/src/migration/__tests__/migrator.spec.ts
@@ -1166,7 +1166,7 @@ describe('ensureVitePlusBootstrap', () => {
     expect(pkg.devDependencies['vite-plus']).toBe('latest');
   });
 
-  it('uses concrete Vite+ specs for yarn monorepos without a catalog file', () => {
+  it('keeps yarn monorepo bootstrap rewrites out of package dependency specs', () => {
     fs.writeFileSync(
       path.join(tmpDir, 'package.json'),
       JSON.stringify({
@@ -1191,7 +1191,7 @@ describe('ensureVitePlusBootstrap', () => {
       devDependencies: Record<string, string>;
       resolutions: Record<string, string>;
     };
-    expect(pkg.devDependencies.vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
+    expect(pkg.devDependencies.vite).toBe('^7.0.0');
     expect(pkg.devDependencies['vite-plus']).toBe('latest');
     expect(pkg.resolutions.vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
   });

--- a/packages/cli/src/migration/__tests__/migrator.spec.ts
+++ b/packages/cli/src/migration/__tests__/migrator.spec.ts
@@ -22,6 +22,8 @@ const {
   rewriteMonorepo,
   rewriteMonorepoProject,
   detectPendingCoreMigration,
+  detectVitePlusBootstrapPending,
+  ensureVitePlusBootstrap,
   finalizeCoreMigrationForExistingVitePlus,
   parseNvmrcVersion,
   detectNodeVersionManagerFile,
@@ -992,10 +994,10 @@ function makeWorkspaceInfo(
     packageManager,
     packageManagerVersion: '10.33.0',
     downloadPackageManager: {
-      name: 'pnpm',
+      name: packageManager,
       installDir: '/tmp',
       binPrefix: '/tmp/bin',
-      packageName: 'pnpm',
+      packageName: packageManager,
       version: '10.33.0',
     },
     packages: [],
@@ -1013,6 +1015,81 @@ function readYaml(filePath: string): string {
 function readYamlObject(filePath: string): Record<string, unknown> {
   return parseYaml(readYaml(filePath)) as Record<string, unknown>;
 }
+
+describe('ensureVitePlusBootstrap', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vp-test-bootstrap-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('adds missing npm overrides and package manager pin for existing Vite+ projects', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ name: 'test', devDependencies: { 'vite-plus': 'latest' } }),
+    );
+
+    expect(detectVitePlusBootstrapPending(tmpDir, PackageManager.npm)).toBe(true);
+
+    const report = createMigrationReport();
+    const result = ensureVitePlusBootstrap(makeWorkspaceInfo(tmpDir, PackageManager.npm), report);
+
+    expect(result.changed).toBe(true);
+    expect(report.packageManagerBootstrapConfigured).toBe(true);
+    expect(detectVitePlusBootstrapPending(tmpDir, PackageManager.npm)).toBe(false);
+
+    const pkg = readJson(path.join(tmpDir, 'package.json')) as {
+      overrides: Record<string, string>;
+      devEngines: { packageManager: { name: string } };
+    };
+    expect(pkg.overrides.vite).toContain('@voidzero-dev/vite-plus-core');
+    expect(pkg.overrides.vitest).toContain('@voidzero-dev/vite-plus-test');
+    expect(pkg.devEngines.packageManager.name).toBe(PackageManager.npm);
+  });
+
+  it('does not rewrite semantic npm overrides that already point at Vite+ packages', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({
+        name: 'test',
+        devDependencies: { 'vite-plus': 'latest' },
+        overrides: {
+          vite: 'npm:@voidzero-dev/vite-plus-core@0.1.0',
+          vitest: 'npm:@voidzero-dev/vite-plus-test@0.1.0',
+        },
+        devEngines: {
+          packageManager: { name: 'npm', version: '10.33.0', onFail: 'download' },
+        },
+      }),
+    );
+    const before = fs.readFileSync(path.join(tmpDir, 'package.json'), 'utf-8');
+
+    expect(detectVitePlusBootstrapPending(tmpDir, PackageManager.npm)).toBe(false);
+    const result = ensureVitePlusBootstrap(makeWorkspaceInfo(tmpDir, PackageManager.npm));
+
+    expect(result.changed).toBe(false);
+    expect(fs.readFileSync(path.join(tmpDir, 'package.json'), 'utf-8')).toBe(before);
+  });
+
+  it('adds missing pnpm workspace overrides without writing optional setup files', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ name: 'test', devDependencies: { 'vite-plus': 'catalog:' } }),
+    );
+
+    const result = ensureVitePlusBootstrap(makeWorkspaceInfo(tmpDir, PackageManager.pnpm));
+
+    expect(result.changed).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, 'pnpm-workspace.yaml'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, 'AGENTS.md'))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, '.vite-hooks'))).toBe(false);
+    expect(detectVitePlusBootstrapPending(tmpDir, PackageManager.pnpm)).toBe(false);
+  });
+});
 
 describe('rewriteStandaloneProject pnpm workspace yaml', () => {
   let tmpDir: string;

--- a/packages/cli/src/migration/__tests__/migrator.spec.ts
+++ b/packages/cli/src/migration/__tests__/migrator.spec.ts
@@ -1075,6 +1075,36 @@ describe('ensureVitePlusBootstrap', () => {
     expect(fs.readFileSync(path.join(tmpDir, 'package.json'), 'utf-8')).toBe(before);
   });
 
+  it('rewrites direct npm Vite dependencies before adding overrides', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({
+        name: 'test',
+        devDependencies: { 'vite-plus': 'latest', vite: '^7.0.0' },
+        dependencies: { vitest: '^3.0.0' },
+        overrides: {
+          vite: 'npm:@voidzero-dev/vite-plus-core@latest',
+          vitest: 'npm:@voidzero-dev/vite-plus-test@latest',
+        },
+        devEngines: {
+          packageManager: { name: 'npm', version: '10.33.0', onFail: 'download' },
+        },
+      }),
+    );
+
+    expect(detectVitePlusBootstrapPending(tmpDir, PackageManager.npm)).toBe(true);
+    const result = ensureVitePlusBootstrap(makeWorkspaceInfo(tmpDir, PackageManager.npm));
+
+    expect(result.changed).toBe(true);
+    expect(detectVitePlusBootstrapPending(tmpDir, PackageManager.npm)).toBe(false);
+    const pkg = readJson(path.join(tmpDir, 'package.json')) as {
+      devDependencies: Record<string, string>;
+      dependencies: Record<string, string>;
+    };
+    expect(pkg.devDependencies.vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
+    expect(pkg.dependencies.vitest).toBe('npm:@voidzero-dev/vite-plus-test@latest');
+  });
+
   it('adds missing pnpm workspace overrides without writing optional setup files', () => {
     fs.writeFileSync(
       path.join(tmpDir, 'package.json'),
@@ -1088,6 +1118,65 @@ describe('ensureVitePlusBootstrap', () => {
     expect(fs.existsSync(path.join(tmpDir, 'AGENTS.md'))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, '.vite-hooks'))).toBe(false);
     expect(detectVitePlusBootstrapPending(tmpDir, PackageManager.pnpm)).toBe(false);
+  });
+
+  it('uses a concrete vite-plus version when pnpm config stays in package.json', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({
+        name: 'test',
+        dependencies: { 'vite-plus': 'latest' },
+        pnpm: {},
+      }),
+    );
+
+    const result = ensureVitePlusBootstrap(makeWorkspaceInfo(tmpDir, PackageManager.pnpm));
+
+    expect(result.changed).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, 'pnpm-workspace.yaml'))).toBe(false);
+    const pkg = readJson(path.join(tmpDir, 'package.json')) as {
+      devDependencies: Record<string, string>;
+      pnpm: { overrides: Record<string, string> };
+    };
+    expect(pkg.devDependencies['vite-plus']).toBe('latest');
+    expect(pkg.pnpm.overrides.vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
+  });
+
+  it('completes missing pnpm workspace peer dependency rules', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({
+        name: 'test',
+        devDependencies: { 'vite-plus': 'catalog:' },
+        devEngines: {
+          packageManager: { name: 'pnpm', version: '10.33.0', onFail: 'download' },
+        },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'pnpm-workspace.yaml'),
+      [
+        'catalog:',
+        '  vite: npm:@voidzero-dev/vite-plus-core@latest',
+        '  vitest: npm:@voidzero-dev/vite-plus-test@latest',
+        '  vite-plus: latest',
+        'overrides:',
+        "  vite: 'catalog:'",
+        "  vitest: 'catalog:'",
+        '',
+      ].join('\n'),
+    );
+
+    expect(detectVitePlusBootstrapPending(tmpDir, PackageManager.pnpm)).toBe(true);
+    const result = ensureVitePlusBootstrap(makeWorkspaceInfo(tmpDir, PackageManager.pnpm));
+
+    expect(result.changed).toBe(true);
+    expect(detectVitePlusBootstrapPending(tmpDir, PackageManager.pnpm)).toBe(false);
+    const workspace = readYamlObject(path.join(tmpDir, 'pnpm-workspace.yaml')) as {
+      peerDependencyRules: { allowAny: string[]; allowedVersions: Record<string, string> };
+    };
+    expect(workspace.peerDependencyRules.allowAny).toEqual(['vite', 'vitest']);
+    expect(workspace.peerDependencyRules.allowedVersions).toEqual({ vite: '*', vitest: '*' });
   });
 
   it('preserves package.json workspace patterns when creating pnpm-workspace.yaml', () => {

--- a/packages/cli/src/migration/__tests__/migrator.spec.ts
+++ b/packages/cli/src/migration/__tests__/migrator.spec.ts
@@ -2178,6 +2178,30 @@ describe('detectLegacyGitHooksMigrationCandidate', () => {
 
     expect(detectLegacyGitHooksMigrationCandidate(tmpDir)).toBe(false);
   });
+
+  it('does not treat standalone lint-staged config as active hook migration', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({
+        devDependencies: { 'vite-plus': 'latest' },
+      }),
+    );
+    fs.writeFileSync(path.join(tmpDir, 'lint-staged.config.mjs'), 'export default {};\n');
+
+    expect(detectLegacyGitHooksMigrationCandidate(tmpDir)).toBe(false);
+  });
+
+  it('does not treat a passive .husky directory as active hook migration', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({
+        devDependencies: { 'vite-plus': 'latest' },
+      }),
+    );
+    fs.mkdirSync(path.join(tmpDir, '.husky'));
+
+    expect(detectLegacyGitHooksMigrationCandidate(tmpDir)).toBe(false);
+  });
 });
 
 describe('preflightGitHooksSetup husky catalog resolution', () => {

--- a/packages/cli/src/migration/__tests__/migrator.spec.ts
+++ b/packages/cli/src/migration/__tests__/migrator.spec.ts
@@ -1105,6 +1105,33 @@ describe('ensureVitePlusBootstrap', () => {
     expect(pkg.dependencies.vitest).toBe('npm:@voidzero-dev/vite-plus-test@latest');
   });
 
+  it('normalizes catalog vite-plus pins for npm projects', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({
+        name: 'test',
+        devDependencies: { 'vite-plus': 'catalog:' },
+        overrides: {
+          vite: 'npm:@voidzero-dev/vite-plus-core@latest',
+          vitest: 'npm:@voidzero-dev/vite-plus-test@latest',
+        },
+        devEngines: {
+          packageManager: { name: 'npm', version: '10.33.0', onFail: 'download' },
+        },
+      }),
+    );
+
+    expect(detectVitePlusBootstrapPending(tmpDir, PackageManager.npm)).toBe(true);
+    const result = ensureVitePlusBootstrap(makeWorkspaceInfo(tmpDir, PackageManager.npm));
+
+    expect(result.changed).toBe(true);
+    expect(detectVitePlusBootstrapPending(tmpDir, PackageManager.npm)).toBe(false);
+    const pkg = readJson(path.join(tmpDir, 'package.json')) as {
+      devDependencies: Record<string, string>;
+    };
+    expect(pkg.devDependencies['vite-plus']).toBe('latest');
+  });
+
   it('adds missing pnpm workspace overrides without writing optional setup files', () => {
     fs.writeFileSync(
       path.join(tmpDir, 'package.json'),

--- a/packages/cli/src/migration/__tests__/migrator.spec.ts
+++ b/packages/cli/src/migration/__tests__/migrator.spec.ts
@@ -1147,6 +1147,47 @@ describe('ensureVitePlusBootstrap', () => {
     expect(detectVitePlusBootstrapPending(tmpDir, PackageManager.pnpm)).toBe(false);
   });
 
+  it('detects missing pnpm workspace catalog entry for vite-plus', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({
+        name: 'test',
+        devDependencies: { 'vite-plus': 'catalog:' },
+        devEngines: {
+          packageManager: { name: 'pnpm', version: '10.33.0', onFail: 'download' },
+        },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'pnpm-workspace.yaml'),
+      [
+        'catalog:',
+        '  vite: npm:@voidzero-dev/vite-plus-core@latest',
+        '  vitest: npm:@voidzero-dev/vite-plus-test@latest',
+        'overrides:',
+        "  vite: 'catalog:'",
+        "  vitest: 'catalog:'",
+        'peerDependencyRules:',
+        '  allowAny:',
+        '    - vite',
+        '    - vitest',
+        '  allowedVersions:',
+        "    vite: '*'",
+        "    vitest: '*'",
+      ].join('\n'),
+    );
+
+    expect(detectVitePlusBootstrapPending(tmpDir, PackageManager.pnpm)).toBe(true);
+    const result = ensureVitePlusBootstrap(makeWorkspaceInfo(tmpDir, PackageManager.pnpm));
+
+    expect(result.changed).toBe(true);
+    expect(detectVitePlusBootstrapPending(tmpDir, PackageManager.pnpm)).toBe(false);
+    const workspace = readYamlObject(path.join(tmpDir, 'pnpm-workspace.yaml')) as {
+      catalog: Record<string, string>;
+    };
+    expect(workspace.catalog['vite-plus']).toBe('latest');
+  });
+
   it('uses a concrete vite-plus version when pnpm config stays in package.json', () => {
     fs.writeFileSync(
       path.join(tmpDir, 'package.json'),

--- a/packages/cli/src/migration/__tests__/migrator.spec.ts
+++ b/packages/cli/src/migration/__tests__/migrator.spec.ts
@@ -1176,6 +1176,45 @@ describe('ensureVitePlusBootstrap', () => {
     expect(detectVitePlusBootstrapPending(tmpDir, PackageManager.pnpm)).toBe(false);
   });
 
+  it('normalizes catalog vite-plus pins outside devDependencies when pnpm config stays in package.json', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({
+        name: 'test',
+        dependencies: { 'vite-plus': 'catalog:' },
+        optionalDependencies: { 'vite-plus': 'catalog:' },
+        devEngines: {
+          packageManager: { name: 'pnpm', version: '10.33.0', onFail: 'download' },
+        },
+        pnpm: {
+          overrides: {
+            vite: 'npm:@voidzero-dev/vite-plus-core@latest',
+            vitest: 'npm:@voidzero-dev/vite-plus-test@latest',
+          },
+          peerDependencyRules: {
+            allowAny: ['vite', 'vitest'],
+            allowedVersions: { vite: '*', vitest: '*' },
+          },
+        },
+      }),
+    );
+
+    expect(detectVitePlusBootstrapPending(tmpDir, PackageManager.pnpm)).toBe(true);
+    const result = ensureVitePlusBootstrap(makeWorkspaceInfo(tmpDir, PackageManager.pnpm));
+
+    expect(result.changed).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, 'pnpm-workspace.yaml'))).toBe(false);
+    const pkg = readJson(path.join(tmpDir, 'package.json')) as {
+      devDependencies: Record<string, string>;
+      dependencies: Record<string, string>;
+      optionalDependencies: Record<string, string>;
+    };
+    expect(pkg.devDependencies['vite-plus']).toBe('latest');
+    expect(pkg.dependencies['vite-plus']).toBe('latest');
+    expect(pkg.optionalDependencies['vite-plus']).toBe('latest');
+    expect(detectVitePlusBootstrapPending(tmpDir, PackageManager.pnpm)).toBe(false);
+  });
+
   it('uses a concrete vite-plus version for pnpm monorepos that keep pnpm config in package.json', () => {
     fs.writeFileSync(
       path.join(tmpDir, 'package.json'),

--- a/packages/cli/src/migration/__tests__/migrator.spec.ts
+++ b/packages/cli/src/migration/__tests__/migrator.spec.ts
@@ -21,6 +21,8 @@ const {
   rewriteStandaloneProject,
   rewriteMonorepo,
   rewriteMonorepoProject,
+  detectPendingCoreMigration,
+  finalizeCoreMigrationForExistingVitePlus,
   parseNvmrcVersion,
   detectNodeVersionManagerFile,
   migrateNodeVersionManagerFile,
@@ -1985,6 +1987,110 @@ describe('rewriteStandaloneProject — tsconfig types rewriting', () => {
     expect((tsconfig.compilerOptions as { types: string[] }).types).toContain(
       'vite-plus/pack/client',
     );
+  });
+});
+
+describe('existing Vite+ core migration finalization', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vp-test-existing-vite-plus-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('detects and finalizes legacy scripts, imports, and tsconfig types without dependency rewrites', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify(
+        {
+          name: 'test',
+          scripts: {
+            dev: 'vite',
+            build: 'tsc -b && vite build',
+            preview: 'vite preview',
+          },
+          devDependencies: {
+            'vite-plus': 'latest',
+            '@voidzero-dev/vite-plus-core': 'latest',
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'vite.config.ts'),
+      "import { defineConfig } from 'vite';\nexport default defineConfig({});\n",
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'tsconfig.app.json'),
+      JSON.stringify({ compilerOptions: { types: ['vite/client'] } }, null, 2),
+    );
+
+    const workspaceInfo = makeWorkspaceInfo(tmpDir, PackageManager.npm);
+    expect(detectPendingCoreMigration(workspaceInfo)).toEqual({
+      scripts: true,
+      tsconfigTypes: true,
+    });
+
+    expect(finalizeCoreMigrationForExistingVitePlus(workspaceInfo, true)).toEqual({
+      scripts: true,
+      tsconfigTypes: true,
+      imports: true,
+    });
+
+    const pkg = readJson(path.join(tmpDir, 'package.json')) as {
+      scripts: Record<string, string>;
+      devDependencies: Record<string, string>;
+      overrides?: Record<string, string>;
+    };
+    expect(pkg.scripts).toMatchObject({
+      dev: 'vp dev',
+      build: 'tsc -b && vp build',
+      preview: 'vp preview',
+    });
+    expect(pkg.devDependencies).toEqual({
+      'vite-plus': 'latest',
+      '@voidzero-dev/vite-plus-core': 'latest',
+    });
+    expect(pkg.overrides).toBeUndefined();
+    expect(fs.readFileSync(path.join(tmpDir, 'vite.config.ts'), 'utf8')).toContain(
+      "from 'vite-plus'",
+    );
+    const tsconfig = readJson(path.join(tmpDir, 'tsconfig.app.json'));
+    expect((tsconfig.compilerOptions as { types: string[] }).types).toEqual(['vite-plus/client']);
+    expect(detectPendingCoreMigration(workspaceInfo)).toEqual({
+      scripts: false,
+      tsconfigTypes: false,
+    });
+  });
+
+  it('detects package-level legacy signals in workspaces', () => {
+    const appDir = path.join(tmpDir, 'packages', 'app');
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ name: 'root', devDependencies: { 'vite-plus': 'latest' } }, null, 2),
+    );
+    fs.writeFileSync(
+      path.join(appDir, 'package.json'),
+      JSON.stringify({ name: 'app', scripts: { dev: 'vite' } }, null, 2),
+    );
+    const workspaceInfo = {
+      ...makeWorkspaceInfo(tmpDir, PackageManager.pnpm),
+      isMonorepo: true,
+      packages: [{ name: 'app', path: 'packages/app' }],
+    };
+
+    expect(detectPendingCoreMigration(workspaceInfo).scripts).toBe(true);
+    expect(finalizeCoreMigrationForExistingVitePlus(workspaceInfo, true).scripts).toBe(true);
+    const appPkg = readJson(path.join(appDir, 'package.json')) as {
+      scripts: Record<string, string>;
+    };
+    expect(appPkg.scripts.dev).toBe('vp dev');
   });
 });
 

--- a/packages/cli/src/migration/__tests__/migrator.spec.ts
+++ b/packages/cli/src/migration/__tests__/migrator.spec.ts
@@ -1142,6 +1142,40 @@ describe('ensureVitePlusBootstrap', () => {
     expect(pkg.pnpm.overrides.vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
   });
 
+  it('normalizes an existing catalog vite-plus pin when pnpm config stays in package.json', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({
+        name: 'test',
+        devDependencies: { 'vite-plus': 'catalog:' },
+        devEngines: {
+          packageManager: { name: 'pnpm', version: '10.33.0', onFail: 'download' },
+        },
+        pnpm: {
+          overrides: {
+            vite: 'npm:@voidzero-dev/vite-plus-core@latest',
+            vitest: 'npm:@voidzero-dev/vite-plus-test@latest',
+          },
+          peerDependencyRules: {
+            allowAny: ['vite', 'vitest'],
+            allowedVersions: { vite: '*', vitest: '*' },
+          },
+        },
+      }),
+    );
+
+    expect(detectVitePlusBootstrapPending(tmpDir, PackageManager.pnpm)).toBe(true);
+    const result = ensureVitePlusBootstrap(makeWorkspaceInfo(tmpDir, PackageManager.pnpm));
+
+    expect(result.changed).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, 'pnpm-workspace.yaml'))).toBe(false);
+    const pkg = readJson(path.join(tmpDir, 'package.json')) as {
+      devDependencies: Record<string, string>;
+    };
+    expect(pkg.devDependencies['vite-plus']).toBe('latest');
+    expect(detectVitePlusBootstrapPending(tmpDir, PackageManager.pnpm)).toBe(false);
+  });
+
   it('uses a concrete vite-plus version for pnpm monorepos that keep pnpm config in package.json', () => {
     fs.writeFileSync(
       path.join(tmpDir, 'package.json'),

--- a/packages/cli/src/migration/__tests__/migrator.spec.ts
+++ b/packages/cli/src/migration/__tests__/migrator.spec.ts
@@ -1220,6 +1220,7 @@ describe('ensureVitePlusBootstrap', () => {
     });
 
     expect(result.changed).toBe(true);
+    expect(result.packageManagerConfig).toBe(true);
     expect(detectVitePlusBootstrapPending(tmpDir, PackageManager.yarn)).toBe(false);
     const pkg = readJson(path.join(tmpDir, 'package.json')) as {
       devDependencies: Record<string, string>;
@@ -1228,6 +1229,14 @@ describe('ensureVitePlusBootstrap', () => {
     expect(pkg.devDependencies.vite).toBe('^7.0.0');
     expect(pkg.devDependencies['vite-plus']).toBe('latest');
     expect(pkg.resolutions.vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
+    const yarnrc = readYamlObject(path.join(tmpDir, '.yarnrc.yml')) as {
+      nodeLinker: string;
+      catalog: Record<string, string>;
+    };
+    expect(yarnrc.nodeLinker).toBe('node-modules');
+    expect(yarnrc.catalog.vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
+    expect(yarnrc.catalog.vitest).toBe('npm:@voidzero-dev/vite-plus-test@latest');
+    expect(yarnrc.catalog['vite-plus']).toBe('latest');
   });
 
   it('completes missing pnpm workspace peer dependency rules', () => {

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -1217,7 +1217,7 @@ async function main() {
         updatedExistingVitePlus: true,
       });
     } else {
-      prompts.outro(`This project is already using Vite+! ${accent(`Happy coding!`)}`);
+      prompts.outro(`This project is already using Vite+! ${accent('Happy coding!')}`);
     }
     return;
   }

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -1230,6 +1230,13 @@ async function main() {
         },
       );
       installDurationMs += installSummary.durationMs;
+      if (installSummary.status === 'failed') {
+        clearMigrationProgress();
+        cancelAndExit(
+          'Dependency installation failed. Run `vp install` manually and re-run `vp migrate`.',
+          1,
+        );
+      }
     }
 
     if (plan.shouldSetupHooks) {

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -1065,7 +1065,7 @@ async function main() {
       !vitePlusBootstrapPending &&
       !hasExistingVitePlusMigrationCandidates(workspaceInfoOptional, options)
     ) {
-      prompts.outro(`This project is already using Vite+! ${accent(`Happy coding!`)}`);
+      prompts.outro(`This project is already using Vite+! ${accent('Happy coding!')}`);
       return;
     }
 

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -56,6 +56,8 @@ import {
   detectNodeVersionManagerFile,
   detectPendingCoreMigration,
   detectPrettierProject,
+  detectVitePlusBootstrapPending,
+  ensureVitePlusBootstrap,
   finalizeCoreMigrationForExistingVitePlus,
   hasFrameworkShim,
   detectLegacyGitHooksMigrationCandidate,
@@ -66,8 +68,6 @@ import {
   migrateNodeVersionManagerFile,
   migratePrettierToOxfmt,
   preflightGitHooksSetup,
-  promptEslintMigration,
-  promptPrettierMigration,
   rewriteMonorepo,
   rewriteStandaloneProject,
   warnIncompatibleEslintIntegration,
@@ -721,6 +721,9 @@ function showMigrationSummary(options: {
   if (report.frameworkShimAdded) {
     log(`${styleText('gray', '•')} TypeScript shim added for framework component files`);
   }
+  if (report.packageManagerBootstrapConfigured) {
+    log(`${styleText('gray', '•')} Package manager settings configured`);
+  }
   if (report.warnings.length > 0) {
     log(`${styleText('yellow', '!')} Warnings:`);
     for (const warning of report.warnings) {
@@ -1039,6 +1042,10 @@ async function main() {
     const legacyGitHooksMigrationCandidate = detectLegacyGitHooksMigrationCandidate(
       workspaceInfoOptional.rootDir,
     );
+    const vitePlusBootstrapPending = detectVitePlusBootstrapPending(
+      workspaceInfoOptional.rootDir,
+      workspaceInfoOptional.packageManager,
+    );
     const coreMigrationResult = finalizeCoreMigrationForExistingVitePlus(
       workspaceInfoOptional,
       true,
@@ -1053,19 +1060,64 @@ async function main() {
       didMigrate = true;
     }
 
-    if (!didMigrate && !hasExistingVitePlusMigrationCandidates(workspaceInfoOptional, options)) {
+    if (
+      !didMigrate &&
+      !vitePlusBootstrapPending &&
+      !hasExistingVitePlusMigrationCandidates(workspaceInfoOptional, options)
+    ) {
       prompts.outro(`This project is already using Vite+! ${accent(`Happy coding!`)}`);
       return;
     }
 
+    const packageManager = vitePlusBootstrapPending
+      ? (workspaceInfoOptional.packageManager ??
+        (await selectPackageManager(options.interactive, true)))
+      : workspaceInfoOptional.packageManager;
+    let downloadedPackageManager: Awaited<ReturnType<typeof downloadPackageManager>> | undefined;
+    let packageManagerVersion = workspaceInfoOptional.packageManagerVersion;
+    const downloadExistingPackageManager = async () => {
+      if (!packageManager) {
+        return undefined;
+      }
+      downloadedPackageManager ??= await downloadPackageManager(
+        packageManager,
+        packageManagerVersion,
+        options.interactive,
+        true,
+      );
+      packageManagerVersion = downloadedPackageManager.version;
+      return downloadedPackageManager;
+    };
+
     const setupOptions = getExistingVitePlusSetupOptions(options, legacyGitHooksMigrationCandidate);
     const plan = await collectMigrationSetupPlan(
       workspaceInfoOptional.rootDir,
-      workspaceInfoOptional.packageManager,
+      packageManager,
       setupOptions,
       workspaceInfoOptional.packages,
-      false,
     );
+
+    let needsInstall = false;
+    let forceInstall = false;
+    if (vitePlusBootstrapPending) {
+      const downloadResult = await downloadExistingPackageManager();
+      if (downloadResult && packageManager) {
+        updateMigrationProgress('Configuring package manager');
+        const bootstrapResult = ensureVitePlusBootstrap(
+          {
+            ...workspaceInfoOptional,
+            packageManager,
+            downloadPackageManager: downloadResult,
+          },
+          report,
+        );
+        didMigrate = bootstrapResult.changed || didMigrate;
+        needsInstall = bootstrapResult.changed || needsInstall;
+        forceInstall =
+          bootstrapResult.changed &&
+          (packageManager === PackageManager.npm || packageManager === PackageManager.bun);
+      }
+    }
 
     const fixBaseUrl = hasBaseUrlInWorkspace(workspaceInfoOptional)
       ? await confirmBaseUrlFix(options.interactive)
@@ -1087,18 +1139,48 @@ async function main() {
     }
     clearMigrationProgress();
 
-    const eslintMigrated = await promptEslintMigration(
-      workspaceInfoOptional.rootDir,
-      options.interactive,
-      workspaceInfoOptional.packages,
-    );
+    let eslintMigrated = false;
+    if (plan.migrateEslint) {
+      updateMigrationProgress('Migrating ESLint');
+      const eslintOk = await migrateEslintToOxlint(
+        workspaceInfoOptional.rootDir,
+        options.interactive,
+        plan.eslintConfigFile,
+        workspaceInfoOptional.packages,
+        { silent: true, report },
+      );
+      if (!eslintOk) {
+        clearMigrationProgress();
+        cancelAndExit('ESLint migration failed. Fix the issue and re-run `vp migrate`.', 1);
+      }
+      eslintMigrated = true;
+    }
 
-    // Check if Prettier migration is needed
-    const prettierMigrated = await promptPrettierMigration(
+    const prettierProject = detectPrettierProject(
       workspaceInfoOptional.rootDir,
-      options.interactive,
       workspaceInfoOptional.packages,
     );
+    let prettierMigrated = false;
+    if (prettierProject.hasDependency && prettierProject.configFile) {
+      const migratePrettier = await confirmPrettierMigration(options.interactive);
+      if (migratePrettier) {
+        updateMigrationProgress('Migrating Prettier');
+        const prettierOk = await migratePrettierToOxfmt(
+          workspaceInfoOptional.rootDir,
+          options.interactive,
+          prettierProject.configFile,
+          workspaceInfoOptional.packages,
+          { silent: true, report },
+        );
+        if (!prettierOk) {
+          clearMigrationProgress();
+          cancelAndExit('Prettier migration failed. Fix the issue and re-run `vp migrate`.', 1);
+        }
+        prettierMigrated = true;
+      }
+    } else if (prettierProject.hasDependency) {
+      warnPackageLevelPrettier();
+    }
 
     // Check if node version manager file migration is needed
     const nodeVersionDetection = detectNodeVersionManagerFile(workspaceInfoOptional.rootDir);
@@ -1115,7 +1197,7 @@ async function main() {
       }
     }
 
-    // Merge configs and reinstall once if any tool migration happened
+    // Merge configs and reinstall once if any tool or bootstrap migration happened
     if (eslintMigrated || prettierMigrated) {
       updateMigrationProgress('Rewriting configs');
       mergeViteConfigFiles(
@@ -1124,49 +1206,35 @@ async function main() {
         report,
         workspaceInfoOptional.packages,
       );
-      updateMigrationProgress('Installing dependencies');
-      // Resolve the actual pnpm version that `vp install` will use so the
-      // auto-install can opt into `--ignore-scripts` on pnpm v11 (which fails
-      // unapproved build scripts with `ERR_PNPM_IGNORED_BUILDS`).
-      let resolvedVersion = workspaceInfoOptional.packageManagerVersion;
-      if (
-        workspaceInfoOptional.packageManager &&
-        !semver.valid(semver.coerce(resolvedVersion) ?? '')
-      ) {
-        const resolved = await downloadPackageManager(
-          workspaceInfoOptional.packageManager,
-          resolvedVersion,
-          options.interactive,
-          true,
-        );
-        resolvedVersion = resolved.version;
-      }
-      const installSummary = await runViteInstall(
-        workspaceInfoOptional.rootDir,
-        options.interactive,
-        undefined,
-        {
-          silent: true,
-          packageManager: workspaceInfoOptional.packageManager,
-          packageManagerVersion: resolvedVersion,
-        },
-      );
-      installDurationMs += installSummary.durationMs;
+      needsInstall = true;
       didMigrate = true;
       report.eslintMigrated = eslintMigrated;
       report.prettierMigrated = prettierMigrated;
     }
 
+    if (needsInstall) {
+      updateMigrationProgress('Installing dependencies');
+      let resolvedVersion = packageManagerVersion;
+      if (packageManager && !semver.valid(semver.coerce(resolvedVersion) ?? '')) {
+        const resolved = downloadedPackageManager ?? (await downloadExistingPackageManager());
+        resolvedVersion = resolved?.version ?? resolvedVersion;
+      }
+      const installSummary = await runViteInstall(
+        workspaceInfoOptional.rootDir,
+        options.interactive,
+        forceInstall ? ['--force'] : undefined,
+        {
+          silent: true,
+          packageManager,
+          packageManagerVersion: resolvedVersion,
+        },
+      );
+      installDurationMs += installSummary.durationMs;
+    }
+
     if (plan.shouldSetupHooks) {
       updateMigrationProgress('Configuring git hooks');
-      if (
-        installGitHooks(
-          workspaceInfoOptional.rootDir,
-          true,
-          report,
-          workspaceInfoOptional.packageManager,
-        )
-      ) {
+      if (installGitHooks(workspaceInfoOptional.rootDir, true, report, packageManager)) {
         didMigrate = true;
       }
     }
@@ -1210,8 +1278,8 @@ async function main() {
       clearMigrationProgress();
       showMigrationSummary({
         projectRoot: workspaceInfoOptional.rootDir,
-        packageManager: resolvedPackageManager,
-        packageManagerVersion: workspaceInfoOptional.packageManagerVersion,
+        packageManager: packageManager ?? resolvedPackageManager,
+        packageManagerVersion,
         installDurationMs,
         report,
         updatedExistingVitePlus: true,

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -754,6 +754,60 @@ async function checkRolldownCompatibility(rootDir: string, report: MigrationRepo
   }
 }
 
+async function downloadSupportedPackageManager(options: {
+  rootDir: string;
+  packageManager: PackageManager;
+  packageManagerVersion: string;
+  interactive: boolean;
+  updateMigrationProgress: (message: string) => void;
+  failMigrationProgress: (message: string) => void;
+}): Promise<Awaited<ReturnType<typeof downloadPackageManager>>> {
+  const {
+    rootDir,
+    packageManager,
+    packageManagerVersion,
+    interactive,
+    updateMigrationProgress,
+    failMigrationProgress,
+  } = options;
+
+  updateMigrationProgress('Preparing migration');
+  const downloadResult = await downloadPackageManager(
+    packageManager,
+    packageManagerVersion,
+    interactive,
+    true,
+  );
+
+  if (
+    packageManager === PackageManager.yarn &&
+    semver.satisfies(downloadResult.version, '>=4.0.0 <4.10.0')
+  ) {
+    updateMigrationProgress('Upgrading Yarn');
+    await upgradeYarn(rootDir, interactive, true);
+  } else if (
+    packageManager === PackageManager.pnpm &&
+    semver.satisfies(downloadResult.version, '< 9.5.0')
+  ) {
+    failMigrationProgress('Migration failed');
+    prompts.log.error(
+      `✘ pnpm@${downloadResult.version} is not supported by auto migration, please upgrade pnpm to >=9.5.0 first`,
+    );
+    cancelAndExit('Vite+ cannot automatically migrate this project yet.', 1);
+  } else if (
+    packageManager === PackageManager.npm &&
+    semver.satisfies(downloadResult.version, '< 8.3.0')
+  ) {
+    failMigrationProgress('Migration failed');
+    prompts.log.error(
+      `✘ npm@${downloadResult.version} is not supported by auto migration, please upgrade npm to >=8.3.0 first`,
+    );
+    cancelAndExit('Vite+ cannot automatically migrate this project yet.', 1);
+  }
+
+  return downloadResult;
+}
+
 async function executeMigrationPlan(
   workspaceInfoOptional: WorkspaceInfoOptional,
   plan: MigrationPlan,
@@ -791,45 +845,19 @@ async function executeMigrationPlan(
   };
 
   // 1. Download package manager + version validation
-  updateMigrationProgress('Preparing migration');
-  const downloadResult = await downloadPackageManager(
-    plan.packageManager,
-    workspaceInfoOptional.packageManagerVersion,
+  const downloadResult = await downloadSupportedPackageManager({
+    rootDir: workspaceInfoOptional.rootDir,
+    packageManager: plan.packageManager,
+    packageManagerVersion: workspaceInfoOptional.packageManagerVersion,
     interactive,
-    true,
-  );
+    updateMigrationProgress,
+    failMigrationProgress,
+  });
   const workspaceInfo: WorkspaceInfo = {
     ...workspaceInfoOptional,
     packageManager: plan.packageManager,
     downloadPackageManager: downloadResult,
   };
-
-  // 2. Upgrade yarn if needed, or validate PM version
-  if (
-    plan.packageManager === PackageManager.yarn &&
-    semver.satisfies(downloadResult.version, '>=4.0.0 <4.10.0')
-  ) {
-    updateMigrationProgress('Upgrading Yarn');
-    await upgradeYarn(workspaceInfo.rootDir, interactive, true);
-  } else if (
-    plan.packageManager === PackageManager.pnpm &&
-    semver.satisfies(downloadResult.version, '< 9.5.0')
-  ) {
-    failMigrationProgress('Migration failed');
-    prompts.log.error(
-      `✘ pnpm@${downloadResult.version} is not supported by auto migration, please upgrade pnpm to >=9.5.0 first`,
-    );
-    cancelAndExit('Vite+ cannot automatically migrate this project yet.', 1);
-  } else if (
-    plan.packageManager === PackageManager.npm &&
-    semver.satisfies(downloadResult.version, '< 8.3.0')
-  ) {
-    failMigrationProgress('Migration failed');
-    prompts.log.error(
-      `✘ npm@${downloadResult.version} is not supported by auto migration, please upgrade npm to >=8.3.0 first`,
-    );
-    cancelAndExit('Vite+ cannot automatically migrate this project yet.', 1);
-  }
 
   // 3. Migrate node version manager file → .node-version (independent of vite version)
   if (plan.migrateNodeVersionFile && plan.nodeVersionDetection) {
@@ -1037,6 +1065,12 @@ async function main() {
         migrationProgressStarted = false;
       }
     };
+    const failMigrationProgress = (message: string) => {
+      if (migrationProgress && migrationProgressStarted) {
+        migrationProgress.error(message);
+        migrationProgressStarted = false;
+      }
+    };
 
     const pendingCoreMigration = detectPendingCoreMigration(workspaceInfoOptional);
     const legacyGitHooksMigrationCandidate = detectLegacyGitHooksMigrationCandidate(
@@ -1079,12 +1113,14 @@ async function main() {
       if (!packageManager) {
         return undefined;
       }
-      downloadedPackageManager ??= await downloadPackageManager(
+      downloadedPackageManager ??= await downloadSupportedPackageManager({
+        rootDir: workspaceInfoOptional.rootDir,
         packageManager,
         packageManagerVersion,
-        options.interactive,
-        true,
-      );
+        interactive: options.interactive,
+        updateMigrationProgress,
+        failMigrationProgress,
+      });
       packageManagerVersion = downloadedPackageManager.version;
       return downloadedPackageManager;
     };

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -58,6 +58,7 @@ import {
   detectPrettierProject,
   finalizeCoreMigrationForExistingVitePlus,
   hasFrameworkShim,
+  detectLegacyGitHooksMigrationCandidate,
   injectLintTypeCheckDefaults,
   installGitHooks,
   mergeViteConfigFiles,
@@ -366,6 +367,7 @@ function hasExistingVitePlusMigrationCandidates(
   const prettierProject = detectPrettierProject(workspaceInfo.rootDir, workspaceInfo.packages);
   return (
     hasExplicitExistingVitePlusSetupRequest(options) ||
+    detectLegacyGitHooksMigrationCandidate(workspaceInfo.rootDir) ||
     hasBaseUrlInWorkspace(workspaceInfo) ||
     eslintProject.hasDependency ||
     prettierProject.hasDependency ||
@@ -536,13 +538,16 @@ async function collectMigrationSetupPlan(
   };
 }
 
-function getExistingVitePlusSetupOptions(options: MigrationOptions): MigrationOptions {
+function getExistingVitePlusSetupOptions(
+  options: MigrationOptions,
+  legacyGitHooksMigrationCandidate: boolean,
+): MigrationOptions {
   if (options.interactive) {
     return options;
   }
   return {
     ...options,
-    hooks: options.hooks ?? false,
+    hooks: options.hooks ?? legacyGitHooksMigrationCandidate,
     agent: options.agent ?? false,
     editor: options.editor ?? false,
   };
@@ -1027,6 +1032,9 @@ async function main() {
     };
 
     const pendingCoreMigration = detectPendingCoreMigration(workspaceInfoOptional);
+    const legacyGitHooksMigrationCandidate = detectLegacyGitHooksMigrationCandidate(
+      workspaceInfoOptional.rootDir,
+    );
     const coreMigrationResult = finalizeCoreMigrationForExistingVitePlus(
       workspaceInfoOptional,
       true,
@@ -1046,7 +1054,7 @@ async function main() {
       return;
     }
 
-    const setupOptions = getExistingVitePlusSetupOptions(options);
+    const setupOptions = getExistingVitePlusSetupOptions(options, legacyGitHooksMigrationCandidate);
     const plan = await collectMigrationSetupPlan(
       workspaceInfoOptional.rootDir,
       workspaceInfoOptional.packageManager,

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -65,7 +65,6 @@ import {
   migrateNodeVersionManagerFile,
   migratePrettierToOxfmt,
   preflightGitHooksSetup,
-  promptEslintMigration,
   promptPrettierMigration,
   rewriteMonorepo,
   rewriteStandaloneProject,
@@ -326,8 +325,7 @@ function parseArgs() {
   };
 }
 
-interface MigrationPlan {
-  packageManager: PackageManager;
+interface MigrationSetupPlan {
   shouldSetupHooks: boolean;
   selectedAgentTargetPaths?: string[];
   agentConflictDecisions: Map<string, 'append' | 'skip'>;
@@ -335,6 +333,10 @@ interface MigrationPlan {
   editorConflictDecisions: Map<string, 'merge' | 'skip'>;
   migrateEslint: boolean;
   eslintConfigFile?: string;
+}
+
+interface MigrationPlan extends MigrationSetupPlan {
+  packageManager: PackageManager;
   migratePrettier: boolean;
   prettierConfigFile?: string;
   fixBaseUrl: boolean;
@@ -343,17 +345,39 @@ interface MigrationPlan {
   frameworkShimFrameworks?: Framework[];
 }
 
-async function collectMigrationPlan(
-  rootDir: string,
-  detectedPackageManager: PackageManager | undefined,
-  options: MigrationOptions,
-  packages?: WorkspacePackage[],
-): Promise<MigrationPlan> {
-  // 1. Package manager selection
-  const packageManager =
-    detectedPackageManager ?? (await selectPackageManager(options.interactive, true));
+function hasEnabledOption(value: string | string[] | false | undefined): boolean {
+  if (Array.isArray(value)) {
+    return value.some((item) => Boolean(item));
+  }
+  return value !== undefined && value !== false && value !== '';
+}
 
-  // 2. Git hooks (including preflight check)
+function hasExplicitExistingVitePlusSetupRequest(options: MigrationOptions): boolean {
+  return (
+    options.hooks === true || hasEnabledOption(options.agent) || hasEnabledOption(options.editor)
+  );
+}
+
+function hasExistingVitePlusMigrationCandidates(
+  workspaceInfo: WorkspaceInfoOptional,
+  options: MigrationOptions,
+): boolean {
+  const eslintProject = detectEslintProject(workspaceInfo.rootDir, workspaceInfo.packages);
+  const prettierProject = detectPrettierProject(workspaceInfo.rootDir, workspaceInfo.packages);
+  return (
+    hasExplicitExistingVitePlusSetupRequest(options) ||
+    hasBaseUrlInWorkspace(workspaceInfo) ||
+    eslintProject.hasDependency ||
+    prettierProject.hasDependency ||
+    detectNodeVersionManagerFile(workspaceInfo.rootDir) !== undefined
+  );
+}
+
+async function collectGitHooksDecision(
+  rootDir: string,
+  packageManager: PackageManager | undefined,
+  options: MigrationOptions,
+): Promise<boolean> {
   let shouldSetupHooks = await promptGitHooks(options);
   if (shouldSetupHooks) {
     const reason = preflightGitHooksSetup(rootDir, packageManager);
@@ -362,8 +386,16 @@ async function collectMigrationPlan(
       shouldSetupHooks = false;
     }
   }
+  return shouldSetupHooks;
+}
 
-  // 3. Agent selection (auto-detect existing agent files to skip the selector prompt)
+async function collectAgentInstructionPlan(
+  rootDir: string,
+  options: MigrationOptions,
+): Promise<{
+  selectedAgentTargetPaths?: string[];
+  agentConflictDecisions: Map<string, 'append' | 'skip'>;
+}> {
   const existingAgentTargetPaths =
     options.agent !== undefined || !options.interactive
       ? undefined
@@ -377,7 +409,6 @@ async function collectMigrationPlan(
           onCancel: () => cancelAndExit(),
         });
 
-  // 4. Agent conflict detection + prompting
   const agentConflicts = await detectAgentConflicts({
     projectRoot: rootDir,
     targetPaths: selectedAgentTargetPaths,
@@ -407,14 +438,22 @@ async function collectMigrationPlan(
     }
   }
 
-  // 5. Editor selection
+  return { selectedAgentTargetPaths, agentConflictDecisions };
+}
+
+async function collectEditorConfigPlan(
+  rootDir: string,
+  options: MigrationOptions,
+): Promise<{
+  selectedEditor?: EditorId;
+  editorConflictDecisions: Map<string, 'merge' | 'skip'>;
+}> {
   const selectedEditor = await selectEditor({
     interactive: options.interactive,
     editor: options.editor,
     onCancel: () => cancelAndExit(),
   });
 
-  // 6. Editor conflict detection + prompting
   const editorConflicts = detectEditorConflicts({
     projectRoot: rootDir,
     editorId: selectedEditor,
@@ -448,7 +487,14 @@ async function collectMigrationPlan(
     }
   }
 
-  // 7. ESLint detection + prompt
+  return { selectedEditor, editorConflictDecisions };
+}
+
+async function collectEslintMigrationDecision(
+  rootDir: string,
+  options: MigrationOptions,
+  packages?: WorkspacePackage[],
+): Promise<{ migrateEslint: boolean; eslintConfigFile?: string }> {
   const eslintProject = detectEslintProject(rootDir, packages);
   const incompatibleEslintIntegration = detectIncompatibleEslintIntegration(rootDir, packages);
   let migrateEslint = false;
@@ -468,7 +514,54 @@ async function collectMigrationPlan(
     warnPackageLevelEslint();
   }
 
-  // 8. Prettier detection + prompt
+  return { migrateEslint, eslintConfigFile: eslintProject.configFile };
+}
+
+async function collectMigrationSetupPlan(
+  rootDir: string,
+  packageManager: PackageManager | undefined,
+  options: MigrationOptions,
+  packages?: WorkspacePackage[],
+): Promise<MigrationSetupPlan> {
+  const shouldSetupHooks = await collectGitHooksDecision(rootDir, packageManager, options);
+  const agentPlan = await collectAgentInstructionPlan(rootDir, options);
+  const editorPlan = await collectEditorConfigPlan(rootDir, options);
+  const eslintPlan = await collectEslintMigrationDecision(rootDir, options, packages);
+
+  return {
+    shouldSetupHooks,
+    ...agentPlan,
+    ...editorPlan,
+    ...eslintPlan,
+  };
+}
+
+function getExistingVitePlusSetupOptions(options: MigrationOptions): MigrationOptions {
+  if (options.interactive) {
+    return options;
+  }
+  return {
+    ...options,
+    hooks: options.hooks ?? false,
+    agent: options.agent ?? false,
+    editor: options.editor ?? false,
+  };
+}
+
+async function collectMigrationPlan(
+  rootDir: string,
+  detectedPackageManager: PackageManager | undefined,
+  options: MigrationOptions,
+  packages?: WorkspacePackage[],
+): Promise<MigrationPlan> {
+  // 1. Package manager selection
+  const packageManager =
+    detectedPackageManager ?? (await selectPackageManager(options.interactive, true));
+
+  // 2. Shared setup/tooling decisions
+  const setupPlan = await collectMigrationSetupPlan(rootDir, packageManager, options, packages);
+
+  // 3. Prettier detection + prompt
   const prettierProject = detectPrettierProject(rootDir, packages);
   let migratePrettier = false;
   if (prettierProject.hasDependency && prettierProject.configFile) {
@@ -520,13 +613,7 @@ async function collectMigrationPlan(
 
   const plan: MigrationPlan = {
     packageManager,
-    shouldSetupHooks,
-    selectedAgentTargetPaths,
-    agentConflictDecisions,
-    selectedEditor,
-    editorConflictDecisions,
-    migrateEslint,
-    eslintConfigFile: eslintProject.configFile,
+    ...setupPlan,
     migratePrettier,
     prettierConfigFile: prettierProject.configFile,
     fixBaseUrl,
@@ -908,7 +995,7 @@ async function main() {
   const workspaceInfoOptional = await detectWorkspace(projectPath);
   const resolvedPackageManager = workspaceInfoOptional.packageManager ?? 'unknown';
 
-  // Early return if already using Vite+ (only ESLint/hooks migration may be needed)
+  // Early return if already using Vite+ (only finalization/setup migrations may be needed)
   // In force-override mode (file: tgz overrides), skip this check and run full migration
   const rootPkg = readNearestPackageJson(
     workspaceInfoOptional.rootDir,
@@ -954,6 +1041,19 @@ async function main() {
       didMigrate = true;
     }
 
+    if (!didMigrate && !hasExistingVitePlusMigrationCandidates(workspaceInfoOptional, options)) {
+      prompts.outro(`This project is already using Vite+! ${accent(`Happy coding!`)}`);
+      return;
+    }
+
+    const setupOptions = getExistingVitePlusSetupOptions(options);
+    const plan = await collectMigrationSetupPlan(
+      workspaceInfoOptional.rootDir,
+      workspaceInfoOptional.packageManager,
+      setupOptions,
+      workspaceInfoOptional.packages,
+    );
+
     const fixBaseUrl = hasBaseUrlInWorkspace(workspaceInfoOptional)
       ? await confirmBaseUrlFix(options.interactive)
       : false;
@@ -974,11 +1074,22 @@ async function main() {
     }
     clearMigrationProgress();
 
-    const eslintMigrated = await promptEslintMigration(
-      workspaceInfoOptional.rootDir,
-      options.interactive,
-      workspaceInfoOptional.packages,
-    );
+    let eslintMigrated = false;
+    if (plan.migrateEslint) {
+      updateMigrationProgress('Migrating ESLint');
+      const eslintOk = await migrateEslintToOxlint(
+        workspaceInfoOptional.rootDir,
+        options.interactive,
+        plan.eslintConfigFile,
+        workspaceInfoOptional.packages,
+        { silent: true, report },
+      );
+      if (!eslintOk) {
+        clearMigrationProgress();
+        cancelAndExit('ESLint migration failed. Fix the issue and re-run `vp migrate`.', 1);
+      }
+      eslintMigrated = true;
+    }
 
     // Check if Prettier migration is needed
     const prettierMigrated = await promptPrettierMigration(
@@ -1044,19 +1155,9 @@ async function main() {
       report.prettierMigrated = prettierMigrated;
     }
 
-    // Check if husky/lint-staged migration is needed
-    const hasHooksToMigrate =
-      rootPkg?.devDependencies?.husky ||
-      rootPkg?.dependencies?.husky ||
-      rootPkg?.devDependencies?.['lint-staged'] ||
-      rootPkg?.dependencies?.['lint-staged'];
-    if (hasHooksToMigrate) {
-      const shouldSetupHooks = await promptGitHooks(options);
-      if (shouldSetupHooks) {
-        updateMigrationProgress('Configuring git hooks');
-      }
+    if (plan.shouldSetupHooks) {
+      updateMigrationProgress('Configuring git hooks');
       if (
-        shouldSetupHooks &&
         installGitHooks(
           workspaceInfoOptional.rootDir,
           true,
@@ -1066,6 +1167,30 @@ async function main() {
       ) {
         didMigrate = true;
       }
+    }
+
+    if (plan.selectedAgentTargetPaths && plan.selectedAgentTargetPaths.length > 0) {
+      updateMigrationProgress('Writing agent instructions');
+      await writeAgentInstructions({
+        projectRoot: workspaceInfoOptional.rootDir,
+        targetPaths: plan.selectedAgentTargetPaths,
+        interactive: options.interactive,
+        conflictDecisions: plan.agentConflictDecisions,
+        silent: true,
+      });
+      didMigrate = true;
+    }
+
+    if (plan.selectedEditor) {
+      updateMigrationProgress('Writing editor configs');
+      await writeEditorConfigs({
+        projectRoot: workspaceInfoOptional.rootDir,
+        editorId: plan.selectedEditor,
+        interactive: options.interactive,
+        conflictDecisions: plan.editorConflictDecisions,
+        silent: true,
+      });
+      didMigrate = true;
     }
 
     // Check for Rolldown-incompatible config patterns (root + workspace packages)

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -1109,7 +1109,7 @@ async function main() {
       workspaceInfoOptional.rootDir,
       workspaceInfoOptional.packageManager,
     );
-    const packageManager = vitePlusBootstrapPending
+    let packageManager: PackageManager | undefined = vitePlusBootstrapPending
       ? (workspaceInfoOptional.packageManager ??
         (await selectPackageManager(options.interactive, true)))
       : workspaceInfoOptional.packageManager;
@@ -1130,9 +1130,13 @@ async function main() {
       packageManagerVersion = downloadedPackageManager.version;
       return downloadedPackageManager;
     };
+    const ensureExistingPackageManager = async () => {
+      packageManager ??= await selectPackageManager(options.interactive, true);
+      return downloadExistingPackageManager();
+    };
 
     if (vitePlusBootstrapPending) {
-      await downloadExistingPackageManager();
+      await ensureExistingPackageManager();
     }
 
     const coreMigrationResult = finalizeCoreMigrationForExistingVitePlus(
@@ -1174,7 +1178,7 @@ async function main() {
     let needsInstall = false;
     let forceInstall = false;
     if (vitePlusBootstrapPending) {
-      const downloadResult = await downloadExistingPackageManager();
+      const downloadResult = await ensureExistingPackageManager();
       if (downloadResult && packageManager) {
         updateMigrationProgress('Configuring package manager');
         const bootstrapResult = ensureVitePlusBootstrap(
@@ -1215,6 +1219,7 @@ async function main() {
 
     let eslintMigrated = false;
     if (plan.migrateEslint) {
+      await ensureExistingPackageManager();
       updateMigrationProgress('Migrating ESLint');
       const eslintOk = await migrateEslintToOxlint(
         workspaceInfoOptional.rootDir,
@@ -1238,6 +1243,7 @@ async function main() {
     if (prettierProject.hasDependency && prettierProject.configFile) {
       const migratePrettier = await confirmPrettierMigration(options.interactive);
       if (migratePrettier) {
+        await ensureExistingPackageManager();
         updateMigrationProgress('Migrating Prettier');
         const prettierOk = await migratePrettierToOxfmt(
           workspaceInfoOptional.rootDir,
@@ -1299,6 +1305,7 @@ async function main() {
     }
 
     if (plan.shouldSetupHooks) {
+      await ensureExistingPackageManager();
       updateMigrationProgress('Configuring git hooks');
       if (installGitHooks(workspaceInfoOptional.rootDir, true, report, packageManager)) {
         didMigrate = true;
@@ -1307,12 +1314,9 @@ async function main() {
     }
 
     if (needsInstall) {
+      const resolved = await ensureExistingPackageManager();
       updateMigrationProgress('Installing dependencies');
-      let resolvedVersion = packageManagerVersion;
-      if (packageManager && !semver.valid(semver.coerce(resolvedVersion) ?? '')) {
-        const resolved = downloadedPackageManager ?? (await downloadExistingPackageManager());
-        resolvedVersion = resolved?.version ?? resolvedVersion;
-      }
+      const resolvedVersion = resolved?.version ?? packageManagerVersion;
       const installSummary = await runViteInstall(
         workspaceInfoOptional.rootDir,
         options.interactive,

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -347,6 +347,69 @@ interface MigrationPlan extends MigrationSetupPlan {
   frameworkShimFrameworks?: Framework[];
 }
 
+function getFrameworkShimCandidates(rootDir: string, packages?: WorkspacePackage[]): Framework[] {
+  const allDetectedFrameworks = new Set<Framework>(detectFramework(rootDir));
+  for (const pkg of packages ?? []) {
+    for (const framework of detectFramework(path.join(rootDir, pkg.path))) {
+      allDetectedFrameworks.add(framework);
+    }
+  }
+
+  return [...allDetectedFrameworks].filter((framework) => {
+    if (detectFramework(rootDir).includes(framework) && !hasFrameworkShim(rootDir, framework)) {
+      return true;
+    }
+    return (packages ?? []).some((pkg) => {
+      const pkgPath = path.join(rootDir, pkg.path);
+      return detectFramework(pkgPath).includes(framework) && !hasFrameworkShim(pkgPath, framework);
+    });
+  });
+}
+
+async function collectFrameworkShimFrameworks(
+  rootDir: string,
+  options: MigrationOptions,
+  packages?: WorkspacePackage[],
+): Promise<Framework[] | undefined> {
+  const frameworkShimFrameworks: Framework[] = [];
+  for (const framework of getFrameworkShimCandidates(rootDir, packages)) {
+    const addShim = await confirmFrameworkShim(framework, options.interactive);
+    if (addShim) {
+      frameworkShimFrameworks.push(framework);
+    }
+  }
+  return frameworkShimFrameworks.length > 0 ? frameworkShimFrameworks : undefined;
+}
+
+function addFrameworkShimsForWorkspace(
+  rootDir: string,
+  frameworks: Framework[] | undefined,
+  packages: WorkspacePackage[] | undefined,
+  report: MigrationReport,
+  updateMigrationProgress: (message: string) => void,
+): boolean {
+  if (!frameworks) {
+    return false;
+  }
+
+  let changed = false;
+  updateMigrationProgress('Adding TypeScript shim');
+  for (const framework of frameworks) {
+    if (detectFramework(rootDir).includes(framework) && !hasFrameworkShim(rootDir, framework)) {
+      addFrameworkShim(rootDir, framework, report);
+      changed = true;
+    }
+    for (const pkg of packages ?? []) {
+      const pkgPath = path.join(rootDir, pkg.path);
+      if (detectFramework(pkgPath).includes(framework) && !hasFrameworkShim(pkgPath, framework)) {
+        addFrameworkShim(pkgPath, framework, report);
+        changed = true;
+      }
+    }
+  }
+  return changed;
+}
+
 function hasEnabledOption(value: string | string[] | false | undefined): boolean {
   if (Array.isArray(value)) {
     return value.some((item) => Boolean(item));
@@ -372,7 +435,8 @@ function hasExistingVitePlusMigrationCandidates(
     hasBaseUrlInWorkspace(workspaceInfo) ||
     eslintProject.hasDependency ||
     prettierProject.hasDependency ||
-    detectNodeVersionManagerFile(workspaceInfo.rootDir) !== undefined
+    detectNodeVersionManagerFile(workspaceInfo.rootDir) !== undefined ||
+    getFrameworkShimCandidates(workspaceInfo.rootDir, workspaceInfo.packages).length > 0
   );
 }
 
@@ -594,30 +658,7 @@ async function collectMigrationPlan(
   }
 
   // 11. Framework shim detection + prompt
-  // Collect unique frameworks from root and all workspace packages
-  const allDetectedFrameworks = new Set<Framework>(detectFramework(rootDir));
-  for (const pkg of packages ?? []) {
-    for (const framework of detectFramework(path.join(rootDir, pkg.path))) {
-      allDetectedFrameworks.add(framework);
-    }
-  }
-  const frameworkShimFrameworks: Framework[] = [];
-  for (const framework of allDetectedFrameworks) {
-    const anyMissingShim =
-      (detectFramework(rootDir).includes(framework) && !hasFrameworkShim(rootDir, framework)) ||
-      (packages ?? []).some((pkg) => {
-        const pkgPath = path.join(rootDir, pkg.path);
-        return (
-          detectFramework(pkgPath).includes(framework) && !hasFrameworkShim(pkgPath, framework)
-        );
-      });
-    if (anyMissingShim) {
-      const addShim = await confirmFrameworkShim(framework, options.interactive);
-      if (addShim) {
-        frameworkShimFrameworks.push(framework);
-      }
-    }
-  }
+  const frameworkShimFrameworks = await collectFrameworkShimFrameworks(rootDir, options, packages);
 
   const plan: MigrationPlan = {
     packageManager,
@@ -627,8 +668,7 @@ async function collectMigrationPlan(
     fixBaseUrl,
     migrateNodeVersionFile,
     nodeVersionDetection,
-    frameworkShimFrameworks:
-      frameworkShimFrameworks.length > 0 ? frameworkShimFrameworks : undefined,
+    frameworkShimFrameworks,
   };
 
   return plan;
@@ -975,23 +1015,13 @@ async function executeMigrationPlan(
   });
 
   // 11. Add framework shims if requested
-  if (plan.frameworkShimFrameworks) {
-    updateMigrationProgress('Adding TypeScript shim');
-    for (const framework of plan.frameworkShimFrameworks) {
-      if (
-        detectFramework(workspaceInfo.rootDir).includes(framework) &&
-        !hasFrameworkShim(workspaceInfo.rootDir, framework)
-      ) {
-        addFrameworkShim(workspaceInfo.rootDir, framework, report);
-      }
-      for (const pkg of workspaceInfo.packages) {
-        const pkgPath = path.join(workspaceInfo.rootDir, pkg.path);
-        if (detectFramework(pkgPath).includes(framework) && !hasFrameworkShim(pkgPath, framework)) {
-          addFrameworkShim(pkgPath, framework, report);
-        }
-      }
-    }
-  }
+  addFrameworkShimsForWorkspace(
+    workspaceInfo.rootDir,
+    plan.frameworkShimFrameworks,
+    workspaceInfo.packages,
+    report,
+    updateMigrationProgress,
+  );
 
   // 12. Reinstall after migration
   // npm needs --force to re-resolve packages with newly added overrides,
@@ -1131,6 +1161,11 @@ async function main() {
       setupOptions,
       workspaceInfoOptional.packages,
     );
+    const frameworkShimFrameworks = await collectFrameworkShimFrameworks(
+      workspaceInfoOptional.rootDir,
+      options,
+      workspaceInfoOptional.packages,
+    );
 
     let needsInstall = false;
     let forceInstall = false;
@@ -1230,6 +1265,18 @@ async function main() {
       ) {
         didMigrate = true;
       }
+    }
+
+    if (
+      addFrameworkShimsForWorkspace(
+        workspaceInfoOptional.rootDir,
+        frameworkShimFrameworks,
+        workspaceInfoOptional.packages,
+        report,
+        updateMigrationProgress,
+      )
+    ) {
+      didMigrate = true;
     }
 
     // Merge configs and reinstall once if any tool or bootstrap migration happened

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -1247,6 +1247,14 @@ async function main() {
       report.prettierMigrated = prettierMigrated;
     }
 
+    if (plan.shouldSetupHooks) {
+      updateMigrationProgress('Configuring git hooks');
+      if (installGitHooks(workspaceInfoOptional.rootDir, true, report, packageManager)) {
+        didMigrate = true;
+        needsInstall = true;
+      }
+    }
+
     if (needsInstall) {
       updateMigrationProgress('Installing dependencies');
       let resolvedVersion = packageManagerVersion;
@@ -1271,13 +1279,6 @@ async function main() {
           'Dependency installation failed. Run `vp install` manually and re-run `vp migrate`.',
           1,
         );
-      }
-    }
-
-    if (plan.shouldSetupHooks) {
-      updateMigrationProgress('Configuring git hooks');
-      if (installGitHooks(workspaceInfoOptional.rootDir, true, report, packageManager)) {
-        didMigrate = true;
       }
     }
 

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -609,7 +609,11 @@ async function collectMigrationSetupPlan(
 function getExistingVitePlusSetupOptions(
   options: MigrationOptions,
   legacyGitHooksMigrationCandidate: boolean,
+  useFullMigrationDefaults = false,
 ): MigrationOptions {
+  if (useFullMigrationDefaults) {
+    return options;
+  }
   return {
     ...options,
     hooks:
@@ -1162,7 +1166,15 @@ async function main() {
       return;
     }
 
-    const setupOptions = getExistingVitePlusSetupOptions(options, legacyGitHooksMigrationCandidate);
+    const useFullMigrationDefaults =
+      vitePlusBootstrapPending ||
+      pendingCoreMigration.scripts ||
+      pendingCoreMigration.tsconfigTypes;
+    const setupOptions = getExistingVitePlusSetupOptions(
+      options,
+      legacyGitHooksMigrationCandidate,
+      useFullMigrationDefaults,
+    );
     const plan = await collectMigrationSetupPlan(
       workspaceInfoOptional.rootDir,
       packageManager,
@@ -1380,7 +1392,7 @@ async function main() {
         packageManagerVersion,
         installDurationMs,
         report,
-        updatedExistingVitePlus: true,
+        updatedExistingVitePlus: !useFullMigrationDefaults,
       });
     } else {
       prompts.outro(`This project is already using Vite+! ${accent('Happy coding!')}`);

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -1159,6 +1159,7 @@ async function main() {
 
     if (
       !didMigrate &&
+      report.warnings.length === 0 &&
       !vitePlusBootstrapPending &&
       !hasExistingVitePlusMigrationCandidates(workspaceInfoOptional, options)
     ) {

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -1166,12 +1166,12 @@ async function main() {
       return;
     }
 
-    const useFullMigrationDefaults =
-      options.interactive &&
-      (vitePlusBootstrapPending ||
-        coreMigrationResult.scripts ||
-        coreMigrationResult.tsconfigTypes ||
-        coreMigrationResult.imports);
+    const fullMigrationSummary =
+      vitePlusBootstrapPending ||
+      coreMigrationResult.scripts ||
+      coreMigrationResult.tsconfigTypes ||
+      coreMigrationResult.imports;
+    const useFullMigrationDefaults = options.interactive && fullMigrationSummary;
     const setupOptions = getExistingVitePlusSetupOptions(
       options,
       legacyGitHooksMigrationCandidate,
@@ -1394,7 +1394,7 @@ async function main() {
         packageManagerVersion,
         installDurationMs,
         report,
-        updatedExistingVitePlus: !useFullMigrationDefaults,
+        updatedExistingVitePlus: !fullMigrationSummary,
       });
     } else {
       prompts.outro(`This project is already using Vite+! ${accent('Happy coding!')}`);

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -66,6 +66,7 @@ import {
   migrateNodeVersionManagerFile,
   migratePrettierToOxfmt,
   preflightGitHooksSetup,
+  promptEslintMigration,
   promptPrettierMigration,
   rewriteMonorepo,
   rewriteStandaloneProject,
@@ -524,11 +525,14 @@ async function collectMigrationSetupPlan(
   packageManager: PackageManager | undefined,
   options: MigrationOptions,
   packages?: WorkspacePackage[],
+  includeEslint = true,
 ): Promise<MigrationSetupPlan> {
   const shouldSetupHooks = await collectGitHooksDecision(rootDir, packageManager, options);
   const agentPlan = await collectAgentInstructionPlan(rootDir, options);
   const editorPlan = await collectEditorConfigPlan(rootDir, options);
-  const eslintPlan = await collectEslintMigrationDecision(rootDir, options, packages);
+  const eslintPlan = includeEslint
+    ? await collectEslintMigrationDecision(rootDir, options, packages)
+    : { migrateEslint: false };
 
   return {
     shouldSetupHooks,
@@ -1060,6 +1064,7 @@ async function main() {
       workspaceInfoOptional.packageManager,
       setupOptions,
       workspaceInfoOptional.packages,
+      false,
     );
 
     const fixBaseUrl = hasBaseUrlInWorkspace(workspaceInfoOptional)
@@ -1082,22 +1087,11 @@ async function main() {
     }
     clearMigrationProgress();
 
-    let eslintMigrated = false;
-    if (plan.migrateEslint) {
-      updateMigrationProgress('Migrating ESLint');
-      const eslintOk = await migrateEslintToOxlint(
-        workspaceInfoOptional.rootDir,
-        options.interactive,
-        plan.eslintConfigFile,
-        workspaceInfoOptional.packages,
-        { silent: true, report },
-      );
-      if (!eslintOk) {
-        clearMigrationProgress();
-        cancelAndExit('ESLint migration failed. Fix the issue and re-run `vp migrate`.', 1);
-      }
-      eslintMigrated = true;
-    }
+    const eslintMigrated = await promptEslintMigration(
+      workspaceInfoOptional.rootDir,
+      options.interactive,
+      workspaceInfoOptional.packages,
+    );
 
     // Check if Prettier migration is needed
     const prettierMigrated = await promptPrettierMigration(

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -1109,6 +1109,32 @@ async function main() {
       workspaceInfoOptional.rootDir,
       workspaceInfoOptional.packageManager,
     );
+    const packageManager = vitePlusBootstrapPending
+      ? (workspaceInfoOptional.packageManager ??
+        (await selectPackageManager(options.interactive, true)))
+      : workspaceInfoOptional.packageManager;
+    let downloadedPackageManager: Awaited<ReturnType<typeof downloadPackageManager>> | undefined;
+    let packageManagerVersion = workspaceInfoOptional.packageManagerVersion;
+    const downloadExistingPackageManager = async () => {
+      if (!packageManager) {
+        return undefined;
+      }
+      downloadedPackageManager ??= await downloadSupportedPackageManager({
+        rootDir: workspaceInfoOptional.rootDir,
+        packageManager,
+        packageManagerVersion,
+        interactive: options.interactive,
+        updateMigrationProgress,
+        failMigrationProgress,
+      });
+      packageManagerVersion = downloadedPackageManager.version;
+      return downloadedPackageManager;
+    };
+
+    if (vitePlusBootstrapPending) {
+      await downloadExistingPackageManager();
+    }
+
     const coreMigrationResult = finalizeCoreMigrationForExistingVitePlus(
       workspaceInfoOptional,
       true,
@@ -1131,28 +1157,6 @@ async function main() {
       prompts.outro(`This project is already using Vite+! ${accent('Happy coding!')}`);
       return;
     }
-
-    const packageManager = vitePlusBootstrapPending
-      ? (workspaceInfoOptional.packageManager ??
-        (await selectPackageManager(options.interactive, true)))
-      : workspaceInfoOptional.packageManager;
-    let downloadedPackageManager: Awaited<ReturnType<typeof downloadPackageManager>> | undefined;
-    let packageManagerVersion = workspaceInfoOptional.packageManagerVersion;
-    const downloadExistingPackageManager = async () => {
-      if (!packageManager) {
-        return undefined;
-      }
-      downloadedPackageManager ??= await downloadSupportedPackageManager({
-        rootDir: workspaceInfoOptional.rootDir,
-        packageManager,
-        packageManagerVersion,
-        interactive: options.interactive,
-        updateMigrationProgress,
-        failMigrationProgress,
-      });
-      packageManagerVersion = downloadedPackageManager.version;
-      return downloadedPackageManager;
-    };
 
     const setupOptions = getExistingVitePlusSetupOptions(options, legacyGitHooksMigrationCandidate);
     const plan = await collectMigrationSetupPlan(

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -546,12 +546,11 @@ function getExistingVitePlusSetupOptions(
   options: MigrationOptions,
   legacyGitHooksMigrationCandidate: boolean,
 ): MigrationOptions {
-  if (options.interactive) {
-    return options;
-  }
   return {
     ...options,
-    hooks: options.hooks ?? legacyGitHooksMigrationCandidate,
+    hooks:
+      options.hooks ??
+      (legacyGitHooksMigrationCandidate ? (options.interactive ? undefined : true) : false),
     agent: options.agent ?? false,
     editor: options.editor ?? false,
   };

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -1168,8 +1168,9 @@ async function main() {
 
     const useFullMigrationDefaults =
       vitePlusBootstrapPending ||
-      pendingCoreMigration.scripts ||
-      pendingCoreMigration.tsconfigTypes;
+      coreMigrationResult.scripts ||
+      coreMigrationResult.tsconfigTypes ||
+      coreMigrationResult.imports;
     const setupOptions = getExistingVitePlusSetupOptions(
       options,
       legacyGitHooksMigrationCandidate,

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -1167,10 +1167,11 @@ async function main() {
     }
 
     const useFullMigrationDefaults =
-      vitePlusBootstrapPending ||
-      coreMigrationResult.scripts ||
-      coreMigrationResult.tsconfigTypes ||
-      coreMigrationResult.imports;
+      options.interactive &&
+      (vitePlusBootstrapPending ||
+        coreMigrationResult.scripts ||
+        coreMigrationResult.tsconfigTypes ||
+        coreMigrationResult.imports);
     const setupOptions = getExistingVitePlusSetupOptions(
       options,
       legacyGitHooksMigrationCandidate,

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -54,7 +54,9 @@ import {
   detectFramework,
   detectIncompatibleEslintIntegration,
   detectNodeVersionManagerFile,
+  detectPendingCoreMigration,
   detectPrettierProject,
+  finalizeCoreMigrationForExistingVitePlus,
   hasFrameworkShim,
   injectLintTypeCheckDefaults,
   installGitHooks,
@@ -936,6 +938,21 @@ async function main() {
         migrationProgressStarted = false;
       }
     };
+
+    const pendingCoreMigration = detectPendingCoreMigration(workspaceInfoOptional);
+    const coreMigrationResult = finalizeCoreMigrationForExistingVitePlus(
+      workspaceInfoOptional,
+      true,
+      report,
+      pendingCoreMigration,
+    );
+    if (
+      coreMigrationResult.scripts ||
+      coreMigrationResult.tsconfigTypes ||
+      coreMigrationResult.imports
+    ) {
+      didMigrate = true;
+    }
 
     const fixBaseUrl = hasBaseUrlInWorkspace(workspaceInfoOptional)
       ? await confirmBaseUrlFix(options.interactive)

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -3015,6 +3015,30 @@ function removeReplacedHookPackages(packageJsonPath: string): void {
   });
 }
 
+export function detectLegacyGitHooksMigrationCandidate(projectPath: string): boolean {
+  const packageJsonPath = path.join(projectPath, 'package.json');
+  if (!fs.existsSync(packageJsonPath)) {
+    return false;
+  }
+  const pkg = readJsonFile(packageJsonPath) as {
+    scripts?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+    dependencies?: Record<string, string>;
+    'lint-staged'?: unknown;
+  };
+  const deps = pkg.devDependencies ?? {};
+  const prodDeps = pkg.dependencies ?? {};
+  return (
+    getOldHooksDir(projectPath) !== undefined ||
+    fs.existsSync(path.join(projectPath, '.husky')) ||
+    REPLACED_HOOK_PACKAGES.some(
+      (name) => deps[name] !== undefined || prodDeps[name] !== undefined,
+    ) ||
+    pkg['lint-staged'] !== undefined ||
+    hasStandaloneLintStagedConfig(projectPath)
+  );
+}
+
 /**
  * Walk up from `startPath` looking for `.git` (directory or file — submodules
  * use a `.git` file).  Returns the directory that contains `.git`, or `null`.

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -2027,6 +2027,9 @@ type BootstrapPackageJson = {
   overrides?: Record<string, string>;
   resolutions?: Record<string, string>;
   devDependencies?: Record<string, string>;
+  dependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
   pnpm?: {
     overrides?: Record<string, string>;
     peerDependencyRules?: {
@@ -2103,6 +2106,35 @@ function hasPackageManagerPin(pkg: BootstrapPackageJson): boolean {
   return Boolean(pkg.packageManager || pkg.devEngines?.packageManager);
 }
 
+function pnpmPeerDependencyRulesSatisfyVitePlus(
+  peerDependencyRules:
+    | { allowAny?: string[]; allowedVersions?: Record<string, string> }
+    | undefined,
+): boolean {
+  const overrideKeys = Object.keys(VITE_PLUS_OVERRIDE_PACKAGES);
+  const allowAny = new Set(peerDependencyRules?.allowAny ?? []);
+  const allowedVersions = peerDependencyRules?.allowedVersions ?? {};
+  return overrideKeys.every((key) => allowAny.has(key) && allowedVersions[key] === '*');
+}
+
+function vitePlusManagedDependenciesPending(
+  pkg: BootstrapPackageJson,
+  catalogDependencyResolver?: CatalogDependencyResolver,
+): boolean {
+  const dependencyGroups = [pkg.devDependencies, pkg.dependencies, pkg.optionalDependencies];
+  return Object.keys(VITE_PLUS_OVERRIDE_PACKAGES).some((dependencyName) =>
+    dependencyGroups.some(
+      (dependencies) =>
+        dependencies?.[dependencyName] !== undefined &&
+        !overrideSpecSatisfiesVitePlus(
+          dependencyName,
+          dependencies[dependencyName],
+          catalogDependencyResolver,
+        ),
+    ),
+  );
+}
+
 function readPnpmWorkspaceCatalogDependencyResolver(
   projectPath: string,
 ): CatalogDependencyResolver | undefined {
@@ -2124,6 +2156,19 @@ function readPnpmWorkspaceOverrides(projectPath: string): Record<string, string>
   }
   const doc = readYamlFile(pnpmWorkspaceYamlPath) as { overrides?: Record<string, string> } | null;
   return doc?.overrides;
+}
+
+function readPnpmWorkspacePeerDependencyRules(
+  projectPath: string,
+): { allowAny?: string[]; allowedVersions?: Record<string, string> } | undefined {
+  const pnpmWorkspaceYamlPath = path.join(projectPath, 'pnpm-workspace.yaml');
+  if (!fs.existsSync(pnpmWorkspaceYamlPath)) {
+    return undefined;
+  }
+  const doc = readYamlFile(pnpmWorkspaceYamlPath) as {
+    peerDependencyRules?: { allowAny?: string[]; allowedVersions?: Record<string, string> };
+  } | null;
+  return doc?.peerDependencyRules;
 }
 
 function ensurePnpmWorkspacePackages(projectPath: string, workspacePatterns: string[]): boolean {
@@ -2184,21 +2229,35 @@ export function detectVitePlusBootstrapPending(
   }
 
   if (packageManager === PackageManager.yarn) {
-    return !overridesSatisfyVitePlus(pkg.resolutions);
+    const resolver = createCatalogDependencyResolver(projectPath, packageManager);
+    return (
+      !overridesSatisfyVitePlus(pkg.resolutions) ||
+      vitePlusManagedDependenciesPending(pkg, resolver)
+    );
   }
   if (packageManager === PackageManager.npm) {
-    return !overridesSatisfyVitePlus(pkg.overrides);
+    return !overridesSatisfyVitePlus(pkg.overrides) || vitePlusManagedDependenciesPending(pkg);
   }
   if (packageManager === PackageManager.bun) {
-    return !overridesSatisfyVitePlus(pkg.overrides, readBunCatalogDependencyResolver(pkg));
+    const resolver = readBunCatalogDependencyResolver(pkg);
+    return (
+      !overridesSatisfyVitePlus(pkg.overrides, resolver) ||
+      vitePlusManagedDependenciesPending(pkg, resolver)
+    );
   }
   if (packageManager === PackageManager.pnpm) {
     if (pkg.pnpm) {
-      return !overridesSatisfyVitePlus(pkg.pnpm.overrides);
+      return (
+        !overridesSatisfyVitePlus(pkg.pnpm.overrides) ||
+        !pnpmPeerDependencyRulesSatisfyVitePlus(pkg.pnpm.peerDependencyRules) ||
+        vitePlusManagedDependenciesPending(pkg)
+      );
     }
-    return !overridesSatisfyVitePlus(
-      readPnpmWorkspaceOverrides(projectPath),
-      readPnpmWorkspaceCatalogDependencyResolver(projectPath),
+    const resolver = readPnpmWorkspaceCatalogDependencyResolver(projectPath);
+    return (
+      !overridesSatisfyVitePlus(readPnpmWorkspaceOverrides(projectPath), resolver) ||
+      !pnpmPeerDependencyRulesSatisfyVitePlus(readPnpmWorkspacePeerDependencyRules(projectPath)) ||
+      vitePlusManagedDependenciesPending(pkg, resolver)
     );
   }
 
@@ -2235,6 +2294,44 @@ function ensureOverrideEntries(
     }
   }
   return { overrides: next, changed };
+}
+
+function ensureVitePlusManagedDependencies(
+  pkg: BootstrapPackageJson,
+  packageManager: PackageManager,
+  supportCatalog: boolean,
+  catalogDependencyResolver?: CatalogDependencyResolver,
+): boolean {
+  let changed = false;
+  const dependencyGroups: {
+    dependencyField: PackageJsonDependencyField;
+    dependencies: Record<string, string> | undefined;
+  }[] = [
+    { dependencyField: 'devDependencies', dependencies: pkg.devDependencies },
+    { dependencyField: 'dependencies', dependencies: pkg.dependencies },
+    { dependencyField: 'optionalDependencies', dependencies: pkg.optionalDependencies },
+  ];
+  for (const [dependencyName, version] of Object.entries(VITE_PLUS_OVERRIDE_PACKAGES)) {
+    for (const { dependencyField, dependencies } of dependencyGroups) {
+      if (
+        dependencies?.[dependencyName] !== undefined &&
+        !overrideSpecSatisfiesVitePlus(
+          dependencyName,
+          dependencies[dependencyName],
+          catalogDependencyResolver,
+        )
+      ) {
+        dependencies[dependencyName] = getCatalogDependencySpec(
+          dependencies[dependencyName],
+          version,
+          supportCatalog,
+          { dependencyField, dependencyName, packageManager, catalogDependencyResolver },
+        );
+        changed = true;
+      }
+    }
+  }
+  return changed;
 }
 
 function ensurePnpmPeerDependencyRules(pkg: BootstrapPackageJson): boolean {
@@ -2277,12 +2374,26 @@ export function ensureVitePlusBootstrap(
       catalogs?: Record<string, Record<string, string>>;
     }
   >(packageJsonPath, (pkg) => {
+    const usePnpmWorkspaceYaml = workspaceInfo.packageManager === PackageManager.pnpm && !pkg.pnpm;
+    const supportCatalog =
+      !VITE_PLUS_VERSION.startsWith('file:') &&
+      (usePnpmWorkspaceYaml ||
+        (workspaceInfo.isMonorepo && workspaceInfo.packageManager !== PackageManager.npm));
+    const catalogDependencyResolver =
+      workspaceInfo.packageManager === PackageManager.bun
+        ? readBunCatalogDependencyResolver(pkg)
+        : createCatalogDependencyResolver(projectPath, workspaceInfo.packageManager);
     let packageJsonChanged = ensureVitePlusDevDependency(
       pkg,
-      workspaceInfo.packageManager === PackageManager.pnpm && !VITE_PLUS_VERSION.startsWith('file:')
-        ? 'catalog:'
-        : VITE_PLUS_VERSION,
+      supportCatalog ? 'catalog:' : VITE_PLUS_VERSION,
     );
+    packageJsonChanged =
+      ensureVitePlusManagedDependencies(
+        pkg,
+        workspaceInfo.packageManager,
+        supportCatalog,
+        catalogDependencyResolver,
+      ) || packageJsonChanged;
 
     if (workspaceInfo.packageManager === PackageManager.yarn) {
       const ensured = ensureOverrideEntries(pkg.resolutions);
@@ -2297,8 +2408,7 @@ export function ensureVitePlusBootstrap(
         packageJsonChanged = true;
       }
     } else if (workspaceInfo.packageManager === PackageManager.bun) {
-      const resolver = readBunCatalogDependencyResolver(pkg);
-      const ensured = ensureOverrideEntries(pkg.overrides, resolver);
+      const ensured = ensureOverrideEntries(pkg.overrides, catalogDependencyResolver);
       if (ensured.changed) {
         pkg.overrides = ensured.overrides;
         packageJsonChanged = true;
@@ -2323,11 +2433,13 @@ export function ensureVitePlusBootstrap(
       const before = fs.existsSync(pnpmWorkspaceYamlPath)
         ? fs.readFileSync(pnpmWorkspaceYamlPath, 'utf-8')
         : undefined;
+      const catalogDependencyResolver = readPnpmWorkspaceCatalogDependencyResolver(projectPath);
       if (
         !overridesSatisfyVitePlus(
           readPnpmWorkspaceOverrides(projectPath),
-          readPnpmWorkspaceCatalogDependencyResolver(projectPath),
-        )
+          catalogDependencyResolver,
+        ) ||
+        !pnpmPeerDependencyRulesSatisfyVitePlus(readPnpmWorkspacePeerDependencyRules(projectPath))
       ) {
         rewritePnpmWorkspaceYaml(projectPath);
       }

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -2126,6 +2126,26 @@ function readPnpmWorkspaceOverrides(projectPath: string): Record<string, string>
   return doc?.overrides;
 }
 
+function ensurePnpmWorkspacePackages(projectPath: string, workspacePatterns: string[]): boolean {
+  if (workspacePatterns.length === 0) {
+    return false;
+  }
+  const pnpmWorkspaceYamlPath = path.join(projectPath, 'pnpm-workspace.yaml');
+  let changed = false;
+  editYamlFile(pnpmWorkspaceYamlPath, (doc) => {
+    if (doc.has('packages')) {
+      return;
+    }
+    const packages = new YAMLSeq<Scalar<string>>();
+    for (const pattern of workspacePatterns) {
+      packages.add(scalarString(pattern));
+    }
+    doc.set('packages', packages);
+    changed = true;
+  });
+  return changed;
+}
+
 function readBunCatalogDependencyResolver(pkg: {
   workspaces?: NpmWorkspaces;
   catalog?: Record<string, string>;
@@ -2310,6 +2330,9 @@ export function ensureVitePlusBootstrap(
         )
       ) {
         rewritePnpmWorkspaceYaml(projectPath);
+      }
+      if (fs.existsSync(pnpmWorkspaceYamlPath)) {
+        ensurePnpmWorkspacePackages(projectPath, workspaceInfo.workspacePatterns);
       }
       const after = fs.existsSync(pnpmWorkspaceYamlPath)
         ? fs.readFileSync(pnpmWorkspaceYamlPath, 'utf-8')
@@ -3333,19 +3356,9 @@ export function detectLegacyGitHooksMigrationCandidate(projectPath: string): boo
   }
   const pkg = readJsonFile(packageJsonPath) as {
     scripts?: Record<string, string>;
-    devDependencies?: Record<string, string>;
-    dependencies?: Record<string, string>;
     'lint-staged'?: unknown;
   };
-  const deps = pkg.devDependencies ?? {};
-  const prodDeps = pkg.dependencies ?? {};
-  return (
-    getOldHooksDir(projectPath) !== undefined ||
-    REPLACED_HOOK_PACKAGES.some(
-      (name) => deps[name] !== undefined || prodDeps[name] !== undefined,
-    ) ||
-    pkg['lint-staged'] !== undefined
-  );
+  return getOldHooksDir(projectPath) !== undefined || pkg['lint-staged'] !== undefined;
 }
 
 /**

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -2116,20 +2116,13 @@ function pnpmPeerDependencyRulesSatisfyVitePlus(
   return overrideKeys.every((key) => allowAny.has(key) && allowedVersions[key] === '*');
 }
 
-function vitePlusManagedDependenciesPending(
-  pkg: BootstrapPackageJson,
-  catalogDependencyResolver?: CatalogDependencyResolver,
-): boolean {
+function npmVitePlusManagedDependenciesPending(pkg: BootstrapPackageJson): boolean {
   const dependencyGroups = [pkg.devDependencies, pkg.dependencies, pkg.optionalDependencies];
   return Object.keys(VITE_PLUS_OVERRIDE_PACKAGES).some((dependencyName) =>
     dependencyGroups.some(
       (dependencies) =>
         dependencies?.[dependencyName] !== undefined &&
-        !overrideSpecSatisfiesVitePlus(
-          dependencyName,
-          dependencies[dependencyName],
-          catalogDependencyResolver,
-        ),
+        !overrideSpecSatisfiesVitePlus(dependencyName, dependencies[dependencyName]),
     ),
   );
 }
@@ -2228,35 +2221,25 @@ export function detectVitePlusBootstrapPending(
   }
 
   if (packageManager === PackageManager.yarn) {
-    const resolver = createCatalogDependencyResolver(projectPath, packageManager);
-    return (
-      !overridesSatisfyVitePlus(pkg.resolutions) ||
-      vitePlusManagedDependenciesPending(pkg, resolver)
-    );
+    return !overridesSatisfyVitePlus(pkg.resolutions);
   }
   if (packageManager === PackageManager.npm) {
-    return !overridesSatisfyVitePlus(pkg.overrides) || vitePlusManagedDependenciesPending(pkg);
+    return !overridesSatisfyVitePlus(pkg.overrides) || npmVitePlusManagedDependenciesPending(pkg);
   }
   if (packageManager === PackageManager.bun) {
-    const resolver = readBunCatalogDependencyResolver(pkg);
-    return (
-      !overridesSatisfyVitePlus(pkg.overrides, resolver) ||
-      vitePlusManagedDependenciesPending(pkg, resolver)
-    );
+    return !overridesSatisfyVitePlus(pkg.overrides, readBunCatalogDependencyResolver(pkg));
   }
   if (packageManager === PackageManager.pnpm) {
     if (pkg.pnpm) {
       return (
         !overridesSatisfyVitePlus(pkg.pnpm.overrides) ||
-        !pnpmPeerDependencyRulesSatisfyVitePlus(pkg.pnpm.peerDependencyRules) ||
-        vitePlusManagedDependenciesPending(pkg)
+        !pnpmPeerDependencyRulesSatisfyVitePlus(pkg.pnpm.peerDependencyRules)
       );
     }
     const resolver = readPnpmWorkspaceCatalogDependencyResolver(projectPath);
     return (
       !overridesSatisfyVitePlus(readPnpmWorkspaceOverrides(projectPath), resolver) ||
-      !pnpmPeerDependencyRulesSatisfyVitePlus(readPnpmWorkspacePeerDependencyRules(projectPath)) ||
-      vitePlusManagedDependenciesPending(pkg, resolver)
+      !pnpmPeerDependencyRulesSatisfyVitePlus(readPnpmWorkspacePeerDependencyRules(projectPath))
     );
   }
 
@@ -2295,37 +2278,16 @@ function ensureOverrideEntries(
   return { overrides: next, changed };
 }
 
-function ensureVitePlusManagedDependencies(
-  pkg: BootstrapPackageJson,
-  packageManager: PackageManager,
-  supportCatalog: boolean,
-  catalogDependencyResolver?: CatalogDependencyResolver,
-): boolean {
+function ensureNpmVitePlusManagedDependencies(pkg: BootstrapPackageJson): boolean {
   let changed = false;
-  const dependencyGroups: {
-    dependencyField: PackageJsonDependencyField;
-    dependencies: Record<string, string> | undefined;
-  }[] = [
-    { dependencyField: 'devDependencies', dependencies: pkg.devDependencies },
-    { dependencyField: 'dependencies', dependencies: pkg.dependencies },
-    { dependencyField: 'optionalDependencies', dependencies: pkg.optionalDependencies },
-  ];
+  const dependencyGroups = [pkg.devDependencies, pkg.dependencies, pkg.optionalDependencies];
   for (const [dependencyName, version] of Object.entries(VITE_PLUS_OVERRIDE_PACKAGES)) {
-    for (const { dependencyField, dependencies } of dependencyGroups) {
+    for (const dependencies of dependencyGroups) {
       if (
         dependencies?.[dependencyName] !== undefined &&
-        !overrideSpecSatisfiesVitePlus(
-          dependencyName,
-          dependencies[dependencyName],
-          catalogDependencyResolver,
-        )
+        !overrideSpecSatisfiesVitePlus(dependencyName, dependencies[dependencyName])
       ) {
-        dependencies[dependencyName] = getCatalogDependencySpec(
-          dependencies[dependencyName],
-          version,
-          supportCatalog,
-          { dependencyField, dependencyName, packageManager, catalogDependencyResolver },
-        );
+        dependencies[dependencyName] = version;
         changed = true;
       }
     }
@@ -2377,21 +2339,13 @@ export function ensureVitePlusBootstrap(
     const supportCatalog =
       !VITE_PLUS_VERSION.startsWith('file:') &&
       (usePnpmWorkspaceYaml || workspaceInfo.packageManager === PackageManager.bun);
-    const catalogDependencyResolver =
-      workspaceInfo.packageManager === PackageManager.bun
-        ? readBunCatalogDependencyResolver(pkg)
-        : createCatalogDependencyResolver(projectPath, workspaceInfo.packageManager);
     let packageJsonChanged = ensureVitePlusDevDependency(
       pkg,
       supportCatalog ? 'catalog:' : VITE_PLUS_VERSION,
     );
-    packageJsonChanged =
-      ensureVitePlusManagedDependencies(
-        pkg,
-        workspaceInfo.packageManager,
-        supportCatalog,
-        catalogDependencyResolver,
-      ) || packageJsonChanged;
+    if (workspaceInfo.packageManager === PackageManager.npm) {
+      packageJsonChanged = ensureNpmVitePlusManagedDependencies(pkg) || packageJsonChanged;
+    }
 
     if (workspaceInfo.packageManager === PackageManager.yarn) {
       const ensured = ensureOverrideEntries(pkg.resolutions);
@@ -2406,7 +2360,7 @@ export function ensureVitePlusBootstrap(
         packageJsonChanged = true;
       }
     } else if (workspaceInfo.packageManager === PackageManager.bun) {
-      const ensured = ensureOverrideEntries(pkg.overrides, catalogDependencyResolver);
+      const ensured = ensureOverrideEntries(pkg.overrides, readBunCatalogDependencyResolver(pkg));
       if (ensured.changed) {
         pkg.overrides = ensured.overrides;
         packageJsonChanged = true;

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -2023,6 +2023,317 @@ export function finalizeCoreMigrationForExistingVitePlus(
   return result;
 }
 
+type BootstrapPackageJson = {
+  overrides?: Record<string, string>;
+  resolutions?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  pnpm?: {
+    overrides?: Record<string, string>;
+    peerDependencyRules?: {
+      allowAny?: string[];
+      allowedVersions?: Record<string, string>;
+    };
+  };
+  packageManager?: string;
+  devEngines?: { packageManager?: unknown; [key: string]: unknown };
+};
+
+export type VitePlusBootstrapResult = {
+  changed: boolean;
+  packageJson: boolean;
+  packageManagerConfig: boolean;
+  packageManagerField: boolean;
+};
+
+function getVitePlusOverridePackageName(dependencyName: string): string | undefined {
+  if (dependencyName === 'vite') {
+    return '@voidzero-dev/vite-plus-core';
+  }
+  if (dependencyName === 'vitest') {
+    return '@voidzero-dev/vite-plus-test';
+  }
+  return undefined;
+}
+
+function isSemanticVitePlusOverrideSpec(dependencyName: string, spec: string | undefined): boolean {
+  if (!spec) {
+    return false;
+  }
+  if (spec === VITE_PLUS_OVERRIDE_PACKAGES[dependencyName]) {
+    return true;
+  }
+  const packageName = getVitePlusOverridePackageName(dependencyName);
+  return packageName !== undefined && spec.includes(packageName);
+}
+
+function overrideSpecSatisfiesVitePlus(
+  dependencyName: string,
+  spec: string | undefined,
+  catalogDependencyResolver?: CatalogDependencyResolver,
+): boolean {
+  if (!spec) {
+    return false;
+  }
+  if (isSemanticVitePlusOverrideSpec(dependencyName, spec)) {
+    return true;
+  }
+  if (!spec.startsWith('catalog:')) {
+    return false;
+  }
+  return isSemanticVitePlusOverrideSpec(
+    dependencyName,
+    catalogDependencyResolver?.(spec, dependencyName),
+  );
+}
+
+function overridesSatisfyVitePlus(
+  overrides: Record<string, string> | undefined,
+  catalogDependencyResolver?: CatalogDependencyResolver,
+): boolean {
+  return Object.keys(VITE_PLUS_OVERRIDE_PACKAGES).every((dependencyName) =>
+    overrideSpecSatisfiesVitePlus(
+      dependencyName,
+      overrides?.[dependencyName],
+      catalogDependencyResolver,
+    ),
+  );
+}
+
+function hasPackageManagerPin(pkg: BootstrapPackageJson): boolean {
+  return Boolean(pkg.packageManager || pkg.devEngines?.packageManager);
+}
+
+function readPnpmWorkspaceCatalogDependencyResolver(
+  projectPath: string,
+): CatalogDependencyResolver | undefined {
+  const pnpmWorkspaceYamlPath = path.join(projectPath, 'pnpm-workspace.yaml');
+  if (!fs.existsSync(pnpmWorkspaceYamlPath)) {
+    return undefined;
+  }
+  const doc = readYamlFile(pnpmWorkspaceYamlPath) as {
+    catalog?: Record<string, string>;
+    catalogs?: Record<string, Record<string, string>>;
+  } | null;
+  return createCatalogDependencyResolverFromCatalogs(doc?.catalog, doc?.catalogs);
+}
+
+function readPnpmWorkspaceOverrides(projectPath: string): Record<string, string> | undefined {
+  const pnpmWorkspaceYamlPath = path.join(projectPath, 'pnpm-workspace.yaml');
+  if (!fs.existsSync(pnpmWorkspaceYamlPath)) {
+    return undefined;
+  }
+  const doc = readYamlFile(pnpmWorkspaceYamlPath) as { overrides?: Record<string, string> } | null;
+  return doc?.overrides;
+}
+
+function readBunCatalogDependencyResolver(pkg: {
+  workspaces?: NpmWorkspaces;
+  catalog?: Record<string, string>;
+  catalogs?: Record<string, Record<string, string>>;
+}): CatalogDependencyResolver {
+  const workspacesObj = pkg.workspaces && !Array.isArray(pkg.workspaces) ? pkg.workspaces : {};
+  const fromWorkspaces = createCatalogDependencyResolverFromCatalogs(
+    workspacesObj.catalog,
+    workspacesObj.catalogs,
+  );
+  const fromPkg = createCatalogDependencyResolverFromCatalogs(pkg.catalog, pkg.catalogs);
+  return (catalogSpec, dependencyName) =>
+    fromWorkspaces(catalogSpec, dependencyName) ?? fromPkg(catalogSpec, dependencyName);
+}
+
+export function detectVitePlusBootstrapPending(
+  projectPath: string,
+  packageManager: PackageManager | undefined,
+): boolean {
+  const packageJsonPath = path.join(projectPath, 'package.json');
+  if (!fs.existsSync(packageJsonPath)) {
+    return false;
+  }
+  const pkg = readJsonFile(packageJsonPath) as BootstrapPackageJson & {
+    workspaces?: NpmWorkspaces;
+    catalog?: Record<string, string>;
+    catalogs?: Record<string, Record<string, string>>;
+  };
+
+  if (!pkg.devDependencies?.[VITE_PLUS_NAME] || !hasPackageManagerPin(pkg)) {
+    return true;
+  }
+
+  if (packageManager === undefined) {
+    return true;
+  }
+
+  if (packageManager === PackageManager.yarn) {
+    return !overridesSatisfyVitePlus(pkg.resolutions);
+  }
+  if (packageManager === PackageManager.npm) {
+    return !overridesSatisfyVitePlus(pkg.overrides);
+  }
+  if (packageManager === PackageManager.bun) {
+    return !overridesSatisfyVitePlus(pkg.overrides, readBunCatalogDependencyResolver(pkg));
+  }
+  if (packageManager === PackageManager.pnpm) {
+    if (pkg.pnpm) {
+      return !overridesSatisfyVitePlus(pkg.pnpm.overrides);
+    }
+    return !overridesSatisfyVitePlus(
+      readPnpmWorkspaceOverrides(projectPath),
+      readPnpmWorkspaceCatalogDependencyResolver(projectPath),
+    );
+  }
+
+  return false;
+}
+
+function ensureVitePlusDevDependency(pkg: BootstrapPackageJson, version: string): boolean {
+  if (pkg.devDependencies?.[VITE_PLUS_NAME]) {
+    return false;
+  }
+  pkg.devDependencies = {
+    ...pkg.devDependencies,
+    [VITE_PLUS_NAME]: version,
+  };
+  return true;
+}
+
+function ensureOverrideEntries(
+  overrides: Record<string, string> | undefined,
+  catalogDependencyResolver?: CatalogDependencyResolver,
+): { overrides: Record<string, string>; changed: boolean } {
+  const next = { ...overrides };
+  let changed = false;
+  for (const [dependencyName, overrideSpec] of Object.entries(VITE_PLUS_OVERRIDE_PACKAGES)) {
+    if (
+      !overrideSpecSatisfiesVitePlus(
+        dependencyName,
+        next[dependencyName],
+        catalogDependencyResolver,
+      )
+    ) {
+      next[dependencyName] = overrideSpec;
+      changed = true;
+    }
+  }
+  return { overrides: next, changed };
+}
+
+function ensurePnpmPeerDependencyRules(pkg: BootstrapPackageJson): boolean {
+  const overrideKeys = Object.keys(VITE_PLUS_OVERRIDE_PACKAGES);
+  pkg.pnpm ??= {};
+  const peerDependencyRules = {
+    ...pkg.pnpm.peerDependencyRules,
+    allowAny: [...new Set([...(pkg.pnpm.peerDependencyRules?.allowAny ?? []), ...overrideKeys])],
+    allowedVersions: {
+      ...pkg.pnpm.peerDependencyRules?.allowedVersions,
+      ...Object.fromEntries(overrideKeys.map((key) => [key, '*'])),
+    },
+  };
+  const changed =
+    JSON.stringify(pkg.pnpm.peerDependencyRules ?? {}) !== JSON.stringify(peerDependencyRules);
+  pkg.pnpm.peerDependencyRules = peerDependencyRules;
+  return changed;
+}
+
+export function ensureVitePlusBootstrap(
+  workspaceInfo: WorkspaceInfo,
+  report?: MigrationReport,
+): VitePlusBootstrapResult {
+  const projectPath = workspaceInfo.rootDir;
+  const packageJsonPath = path.join(projectPath, 'package.json');
+  const result: VitePlusBootstrapResult = {
+    changed: false,
+    packageJson: false,
+    packageManagerConfig: false,
+    packageManagerField: false,
+  };
+  if (!fs.existsSync(packageJsonPath)) {
+    return result;
+  }
+
+  editJsonFile<
+    BootstrapPackageJson & {
+      workspaces?: NpmWorkspaces;
+      catalog?: Record<string, string>;
+      catalogs?: Record<string, Record<string, string>>;
+    }
+  >(packageJsonPath, (pkg) => {
+    let packageJsonChanged = ensureVitePlusDevDependency(
+      pkg,
+      workspaceInfo.packageManager === PackageManager.pnpm && !VITE_PLUS_VERSION.startsWith('file:')
+        ? 'catalog:'
+        : VITE_PLUS_VERSION,
+    );
+
+    if (workspaceInfo.packageManager === PackageManager.yarn) {
+      const ensured = ensureOverrideEntries(pkg.resolutions);
+      if (ensured.changed) {
+        pkg.resolutions = ensured.overrides;
+        packageJsonChanged = true;
+      }
+    } else if (workspaceInfo.packageManager === PackageManager.npm) {
+      const ensured = ensureOverrideEntries(pkg.overrides);
+      if (ensured.changed) {
+        pkg.overrides = ensured.overrides;
+        packageJsonChanged = true;
+      }
+    } else if (workspaceInfo.packageManager === PackageManager.bun) {
+      const resolver = readBunCatalogDependencyResolver(pkg);
+      const ensured = ensureOverrideEntries(pkg.overrides, resolver);
+      if (ensured.changed) {
+        pkg.overrides = ensured.overrides;
+        packageJsonChanged = true;
+      }
+    } else if (workspaceInfo.packageManager === PackageManager.pnpm && pkg.pnpm) {
+      const ensured = ensureOverrideEntries(pkg.pnpm.overrides);
+      if (ensured.changed) {
+        pkg.pnpm.overrides = ensured.overrides;
+        packageJsonChanged = true;
+      }
+      packageJsonChanged = ensurePnpmPeerDependencyRules(pkg) || packageJsonChanged;
+    }
+
+    result.packageJson = packageJsonChanged;
+    return pkg;
+  });
+
+  if (workspaceInfo.packageManager === PackageManager.pnpm) {
+    const pkg = readJsonFile(packageJsonPath) as BootstrapPackageJson;
+    if (!pkg.pnpm) {
+      const pnpmWorkspaceYamlPath = path.join(projectPath, 'pnpm-workspace.yaml');
+      const before = fs.existsSync(pnpmWorkspaceYamlPath)
+        ? fs.readFileSync(pnpmWorkspaceYamlPath, 'utf-8')
+        : undefined;
+      if (
+        !overridesSatisfyVitePlus(
+          readPnpmWorkspaceOverrides(projectPath),
+          readPnpmWorkspaceCatalogDependencyResolver(projectPath),
+        )
+      ) {
+        rewritePnpmWorkspaceYaml(projectPath);
+      }
+      const after = fs.existsSync(pnpmWorkspaceYamlPath)
+        ? fs.readFileSync(pnpmWorkspaceYamlPath, 'utf-8')
+        : undefined;
+      result.packageManagerConfig = before !== after;
+    }
+  } else if (workspaceInfo.packageManager === PackageManager.bun) {
+    const before = fs.readFileSync(packageJsonPath, 'utf-8');
+    rewriteBunCatalog(projectPath);
+    const after = fs.readFileSync(packageJsonPath, 'utf-8');
+    result.packageJson = result.packageJson || before !== after;
+  }
+
+  const beforePackageManager = fs.readFileSync(packageJsonPath, 'utf-8');
+  setPackageManager(projectPath, workspaceInfo.downloadPackageManager);
+  const afterPackageManager = fs.readFileSync(packageJsonPath, 'utf-8');
+  result.packageManagerField = beforePackageManager !== afterPackageManager;
+  result.changed = result.packageJson || result.packageManagerConfig || result.packageManagerField;
+  if (result.changed && report) {
+    report.packageManagerBootstrapConfigured = true;
+  }
+  return result;
+}
+
 export function rewritePackageJson(
   pkg: {
     scripts?: Record<string, string>;

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -2028,7 +2028,6 @@ type BootstrapPackageJson = {
   resolutions?: Record<string, string>;
   devDependencies?: Record<string, string>;
   dependencies?: Record<string, string>;
-  peerDependencies?: Record<string, string>;
   optionalDependencies?: Record<string, string>;
   pnpm?: {
     overrides?: Record<string, string>;
@@ -2377,8 +2376,7 @@ export function ensureVitePlusBootstrap(
     const usePnpmWorkspaceYaml = workspaceInfo.packageManager === PackageManager.pnpm && !pkg.pnpm;
     const supportCatalog =
       !VITE_PLUS_VERSION.startsWith('file:') &&
-      (usePnpmWorkspaceYaml ||
-        (workspaceInfo.isMonorepo && workspaceInfo.packageManager !== PackageManager.npm));
+      (usePnpmWorkspaceYaml || workspaceInfo.packageManager === PackageManager.bun);
     const catalogDependencyResolver =
       workspaceInfo.packageManager === PackageManager.bun
         ? readBunCatalogDependencyResolver(pkg)

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -2167,6 +2167,23 @@ function readPnpmWorkspacePeerDependencyRules(
   return doc?.peerDependencyRules;
 }
 
+function yarnrcSatisfiesVitePlus(projectPath: string): boolean {
+  const yarnrcYmlPath = path.join(projectPath, '.yarnrc.yml');
+  if (!fs.existsSync(yarnrcYmlPath)) {
+    return false;
+  }
+  const doc = readYamlFile(yarnrcYmlPath) as {
+    nodeLinker?: string;
+    catalog?: Record<string, string>;
+  } | null;
+  return (
+    !!doc &&
+    Object.hasOwn(doc, 'nodeLinker') &&
+    overridesSatisfyVitePlus(doc.catalog) &&
+    (VITE_PLUS_VERSION.startsWith('file:') || doc.catalog?.[VITE_PLUS_NAME] === VITE_PLUS_VERSION)
+  );
+}
+
 function ensurePnpmWorkspacePackages(projectPath: string, workspacePatterns: string[]): boolean {
   if (workspacePatterns.length === 0) {
     return false;
@@ -2225,7 +2242,7 @@ export function detectVitePlusBootstrapPending(
   }
 
   if (packageManager === PackageManager.yarn) {
-    return !overridesSatisfyVitePlus(pkg.resolutions);
+    return !overridesSatisfyVitePlus(pkg.resolutions) || !yarnrcSatisfiesVitePlus(projectPath);
   }
   if (packageManager === PackageManager.npm) {
     return !overridesSatisfyVitePlus(pkg.overrides) || npmVitePlusManagedDependenciesPending(pkg);
@@ -2414,6 +2431,14 @@ export function ensureVitePlusBootstrap(
         : undefined;
       result.packageManagerConfig = before !== after;
     }
+  } else if (workspaceInfo.packageManager === PackageManager.yarn) {
+    const yarnrcYmlPath = path.join(projectPath, '.yarnrc.yml');
+    const before = fs.existsSync(yarnrcYmlPath)
+      ? fs.readFileSync(yarnrcYmlPath, 'utf-8')
+      : undefined;
+    rewriteYarnrcYml(projectPath);
+    const after = fs.readFileSync(yarnrcYmlPath, 'utf-8');
+    result.packageManagerConfig = before !== after;
   } else if (workspaceInfo.packageManager === PackageManager.bun) {
     const before = fs.readFileSync(packageJsonPath, 'utf-8');
     rewriteBunCatalog(projectPath);

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -2112,6 +2112,20 @@ function vitePlusDependencyNeedsConcreteVersion(pkg: BootstrapPackageJson): bool
   );
 }
 
+function defaultCatalogVitePlusDependencyPending(
+  pkg: BootstrapPackageJson,
+  catalogDependencyResolver: CatalogDependencyResolver | undefined,
+): boolean {
+  const dependencyGroups = [pkg.devDependencies, pkg.dependencies, pkg.optionalDependencies];
+  return dependencyGroups.some((dependencies) => {
+    const spec = dependencies?.[VITE_PLUS_NAME];
+    if (spec !== 'catalog:' && spec !== 'catalog:default') {
+      return false;
+    }
+    return catalogDependencyResolver?.(spec, VITE_PLUS_NAME) !== VITE_PLUS_VERSION;
+  });
+}
+
 function pnpmPeerDependencyRulesSatisfyVitePlus(
   peerDependencyRules:
     | { allowAny?: string[]; allowedVersions?: Record<string, string> }
@@ -2267,6 +2281,7 @@ export function detectVitePlusBootstrapPending(
     }
     const resolver = readPnpmWorkspaceCatalogDependencyResolver(projectPath);
     return (
+      defaultCatalogVitePlusDependencyPending(pkg, resolver) ||
       !overridesSatisfyVitePlus(readPnpmWorkspaceOverrides(projectPath), resolver) ||
       !pnpmPeerDependencyRulesSatisfyVitePlus(readPnpmWorkspacePeerDependencyRules(projectPath))
     );
@@ -2426,6 +2441,7 @@ export function ensureVitePlusBootstrap(
         : undefined;
       const catalogDependencyResolver = readPnpmWorkspaceCatalogDependencyResolver(projectPath);
       if (
+        defaultCatalogVitePlusDependencyPending(pkg, catalogDependencyResolver) ||
         !overridesSatisfyVitePlus(
           readPnpmWorkspaceOverrides(projectPath),
           catalogDependencyResolver,

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -39,6 +39,7 @@ import { cancelAndExit, getSpinner } from '../utils/prompts.ts';
 import {
   findTsconfigFiles,
   hasBaseUrlInTsconfig,
+  hasTypesToRewriteInTsconfig,
   removeDeprecatedTsconfigFalseOption,
   rewriteTypesInTsconfig,
 } from '../utils/tsconfig.ts';
@@ -891,10 +892,16 @@ function cleanupDeprecatedTsconfigOptions(
   }
 }
 
-function rewriteTsconfigTypes(projectPath: string, silent = false, report?: MigrationReport): void {
+function rewriteTsconfigTypes(
+  projectPath: string,
+  silent = false,
+  report?: MigrationReport,
+): boolean {
+  let changed = false;
   const files = findTsconfigFiles(projectPath);
   for (const filePath of files) {
     if (rewriteTypesInTsconfig(filePath)) {
+      changed = true;
       if (report) {
         report.removedConfigCount++;
       }
@@ -903,6 +910,11 @@ function rewriteTsconfigTypes(projectPath: string, silent = false, report?: Migr
       }
     }
   }
+  return changed;
+}
+
+function hasTsconfigTypesToRewrite(projectPath: string): boolean {
+  return findTsconfigFiles(projectPath).some((filePath) => hasTypesToRewriteInTsconfig(filePath));
 }
 
 // .svelte files are handled by @sveltejs/vite-plugin-svelte (transpilation)
@@ -1913,6 +1925,104 @@ function readPrepareRulesYaml(): string {
   return cachedPrepareRulesYaml;
 }
 
+type CoreMigrationWorkspace = {
+  rootDir: string;
+  packages?: WorkspacePackage[];
+};
+
+export type PendingCoreMigration = {
+  scripts: boolean;
+  tsconfigTypes: boolean;
+};
+
+export type CoreMigrationFinalizationResult = {
+  scripts: boolean;
+  tsconfigTypes: boolean;
+  imports: boolean;
+};
+
+function getCoreMigrationProjectPaths(workspaceInfo: CoreMigrationWorkspace): string[] {
+  return [
+    workspaceInfo.rootDir,
+    ...(workspaceInfo.packages ?? []).map((pkg) => path.join(workspaceInfo.rootDir, pkg.path)),
+  ];
+}
+
+function hasCorePackageScriptRewrites(projectPath: string): boolean {
+  const packageJsonPath = path.join(projectPath, 'package.json');
+  if (!fs.existsSync(packageJsonPath)) {
+    return false;
+  }
+  const pkg = readJsonFile(packageJsonPath) as { scripts?: Record<string, string> };
+  if (!pkg.scripts) {
+    return false;
+  }
+  return !!rewriteScripts(JSON.stringify(pkg.scripts), getScriptRulesYaml(true));
+}
+
+function rewriteCorePackageScripts(projectPath: string): boolean {
+  const packageJsonPath = path.join(projectPath, 'package.json');
+  if (!fs.existsSync(packageJsonPath)) {
+    return false;
+  }
+
+  let changed = false;
+  editJsonFile<{ scripts?: Record<string, string> }>(packageJsonPath, (pkg) => {
+    if (!pkg.scripts) {
+      return undefined;
+    }
+    const updated = rewriteScripts(JSON.stringify(pkg.scripts), getScriptRulesYaml(true));
+    if (!updated) {
+      return undefined;
+    }
+    pkg.scripts = JSON.parse(updated);
+    changed = true;
+    return pkg;
+  });
+  return changed;
+}
+
+export function detectPendingCoreMigration(
+  workspaceInfo: CoreMigrationWorkspace,
+): PendingCoreMigration {
+  const projectPaths = getCoreMigrationProjectPaths(workspaceInfo);
+  return {
+    scripts: projectPaths.some((projectPath) => hasCorePackageScriptRewrites(projectPath)),
+    tsconfigTypes: projectPaths.some((projectPath) => hasTsconfigTypesToRewrite(projectPath)),
+  };
+}
+
+export function finalizeCoreMigrationForExistingVitePlus(
+  workspaceInfo: CoreMigrationWorkspace,
+  silent = false,
+  report?: MigrationReport,
+  pending = detectPendingCoreMigration(workspaceInfo),
+): CoreMigrationFinalizationResult {
+  const projectPaths = getCoreMigrationProjectPaths(workspaceInfo);
+  const result: CoreMigrationFinalizationResult = {
+    scripts: false,
+    tsconfigTypes: false,
+    imports: false,
+  };
+
+  if (pending.scripts) {
+    for (const projectPath of projectPaths) {
+      result.scripts = rewriteCorePackageScripts(projectPath) || result.scripts;
+    }
+  }
+
+  if (pending.tsconfigTypes) {
+    for (const projectPath of projectPaths) {
+      result.tsconfigTypes =
+        rewriteTsconfigTypes(projectPath, silent, report) || result.tsconfigTypes;
+    }
+  }
+
+  result.imports = rewriteAllImports(workspaceInfo.rootDir, silent, report);
+
+  return result;
+}
+
 export function rewritePackageJson(
   pkg: {
     scripts?: Record<string, string>;
@@ -2798,7 +2908,7 @@ function wrapLazyPluginsInViteConfig(
  * This rewrites vite/vitest imports to @voidzero-dev/vite-plus
  * @param projectPath - The root directory to search for files
  */
-function rewriteAllImports(projectPath: string, silent = false, report?: MigrationReport): void {
+function rewriteAllImports(projectPath: string, silent = false, report?: MigrationReport): boolean {
   const result = rewriteImportsInDirectory(projectPath);
   const modified = result.modifiedFiles.length;
   const errors = result.errors.length;
@@ -2833,6 +2943,7 @@ function rewriteAllImports(projectPath: string, silent = false, report?: Migrati
       }
     }
   }
+  return modified > 0;
 }
 
 /**

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -3030,12 +3030,10 @@ export function detectLegacyGitHooksMigrationCandidate(projectPath: string): boo
   const prodDeps = pkg.dependencies ?? {};
   return (
     getOldHooksDir(projectPath) !== undefined ||
-    fs.existsSync(path.join(projectPath, '.husky')) ||
     REPLACED_HOOK_PACKAGES.some(
       (name) => deps[name] !== undefined || prodDeps[name] !== undefined,
     ) ||
-    pkg['lint-staged'] !== undefined ||
-    hasStandaloneLintStagedConfig(projectPath)
+    pkg['lint-staged'] !== undefined
   );
 }
 

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -2105,6 +2105,10 @@ function hasPackageManagerPin(pkg: BootstrapPackageJson): boolean {
   return Boolean(pkg.packageManager || pkg.devEngines?.packageManager);
 }
 
+function vitePlusDevDependencyNeedsConcreteVersion(pkg: BootstrapPackageJson): boolean {
+  return pkg.devDependencies?.[VITE_PLUS_NAME]?.startsWith('catalog:') ?? false;
+}
+
 function pnpmPeerDependencyRulesSatisfyVitePlus(
   peerDependencyRules:
     | { allowAny?: string[]; allowedVersions?: Record<string, string> }
@@ -2232,6 +2236,7 @@ export function detectVitePlusBootstrapPending(
   if (packageManager === PackageManager.pnpm) {
     if (pkg.pnpm) {
       return (
+        vitePlusDevDependencyNeedsConcreteVersion(pkg) ||
         !overridesSatisfyVitePlus(pkg.pnpm.overrides) ||
         !pnpmPeerDependencyRulesSatisfyVitePlus(pkg.pnpm.peerDependencyRules)
       );
@@ -2247,7 +2252,13 @@ export function detectVitePlusBootstrapPending(
 }
 
 function ensureVitePlusDevDependency(pkg: BootstrapPackageJson, version: string): boolean {
-  if (pkg.devDependencies?.[VITE_PLUS_NAME]) {
+  const devDependencies = pkg.devDependencies;
+  const existing = devDependencies?.[VITE_PLUS_NAME];
+  if (existing) {
+    if (version !== 'catalog:' && existing.startsWith('catalog:')) {
+      devDependencies[VITE_PLUS_NAME] = version;
+      return true;
+    }
     return false;
   }
   pkg.devDependencies = {

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -2105,8 +2105,11 @@ function hasPackageManagerPin(pkg: BootstrapPackageJson): boolean {
   return Boolean(pkg.packageManager || pkg.devEngines?.packageManager);
 }
 
-function vitePlusDevDependencyNeedsConcreteVersion(pkg: BootstrapPackageJson): boolean {
-  return pkg.devDependencies?.[VITE_PLUS_NAME]?.startsWith('catalog:') ?? false;
+function vitePlusDependencyNeedsConcreteVersion(pkg: BootstrapPackageJson): boolean {
+  const dependencyGroups = [pkg.devDependencies, pkg.dependencies, pkg.optionalDependencies];
+  return dependencyGroups.some(
+    (dependencies) => dependencies?.[VITE_PLUS_NAME]?.startsWith('catalog:') ?? false,
+  );
 }
 
 function pnpmPeerDependencyRulesSatisfyVitePlus(
@@ -2253,7 +2256,7 @@ export function detectVitePlusBootstrapPending(
   if (packageManager === PackageManager.pnpm) {
     if (pkg.pnpm) {
       return (
-        vitePlusDevDependencyNeedsConcreteVersion(pkg) ||
+        vitePlusDependencyNeedsConcreteVersion(pkg) ||
         !overridesSatisfyVitePlus(pkg.pnpm.overrides) ||
         !pnpmPeerDependencyRulesSatisfyVitePlus(pkg.pnpm.peerDependencyRules)
       );
@@ -2268,15 +2271,19 @@ export function detectVitePlusBootstrapPending(
   return false;
 }
 
-function ensureVitePlusDevDependency(pkg: BootstrapPackageJson, version: string): boolean {
-  const devDependencies = pkg.devDependencies;
-  const existing = devDependencies?.[VITE_PLUS_NAME];
-  if (existing) {
-    if (version !== 'catalog:' && existing.startsWith('catalog:')) {
-      devDependencies[VITE_PLUS_NAME] = version;
-      return true;
+function ensureVitePlusDependencySpecs(pkg: BootstrapPackageJson, version: string): boolean {
+  let changed = false;
+  if (version !== 'catalog:') {
+    const dependencyGroups = [pkg.devDependencies, pkg.dependencies, pkg.optionalDependencies];
+    for (const dependencies of dependencyGroups) {
+      if (dependencies?.[VITE_PLUS_NAME]?.startsWith('catalog:')) {
+        dependencies[VITE_PLUS_NAME] = version;
+        changed = true;
+      }
     }
-    return false;
+  }
+  if (pkg.devDependencies?.[VITE_PLUS_NAME]) {
+    return changed;
   }
   pkg.devDependencies = {
     ...pkg.devDependencies,
@@ -2367,7 +2374,7 @@ export function ensureVitePlusBootstrap(
     const supportCatalog =
       !VITE_PLUS_VERSION.startsWith('file:') &&
       (usePnpmWorkspaceYaml || workspaceInfo.packageManager === PackageManager.bun);
-    let packageJsonChanged = ensureVitePlusDevDependency(
+    let packageJsonChanged = ensureVitePlusDependencySpecs(
       pkg,
       supportCatalog ? 'catalog:' : VITE_PLUS_VERSION,
     );

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -2248,7 +2248,11 @@ export function detectVitePlusBootstrapPending(
     return !overridesSatisfyVitePlus(pkg.resolutions) || !yarnrcSatisfiesVitePlus(projectPath);
   }
   if (packageManager === PackageManager.npm) {
-    return !overridesSatisfyVitePlus(pkg.overrides) || npmVitePlusManagedDependenciesPending(pkg);
+    return (
+      vitePlusDependencyNeedsConcreteVersion(pkg) ||
+      !overridesSatisfyVitePlus(pkg.overrides) ||
+      npmVitePlusManagedDependenciesPending(pkg)
+    );
   }
   if (packageManager === PackageManager.bun) {
     return !overridesSatisfyVitePlus(pkg.overrides, readBunCatalogDependencyResolver(pkg));

--- a/packages/cli/src/migration/report.ts
+++ b/packages/cli/src/migration/report.ts
@@ -13,6 +13,7 @@ export interface MigrationReport {
   nodeVersionFileMigrated: boolean;
   gitHooksConfigured: boolean;
   frameworkShimAdded: boolean;
+  packageManagerBootstrapConfigured: boolean;
   warnings: string[];
   manualSteps: string[];
 }
@@ -33,6 +34,7 @@ export function createMigrationReport(): MigrationReport {
     nodeVersionFileMigrated: false,
     gitHooksConfigured: false,
     frameworkShimAdded: false,
+    packageManagerBootstrapConfigured: false,
     warnings: [],
     manualSteps: [],
   };

--- a/packages/cli/src/utils/tsconfig.ts
+++ b/packages/cli/src/utils/tsconfig.ts
@@ -168,6 +168,30 @@ export function removeDeprecatedTsconfigFalseOption(filePath: string, optionName
   return true;
 }
 
+const TSCONFIG_TYPE_REPLACEMENTS: Record<string, string> = {
+  'tsdown/client': 'vite-plus/pack/client',
+  'vite/client': 'vite-plus/client',
+};
+
+export function hasTypesToRewriteInTsconfig(filePath: string): boolean {
+  let text: string;
+  try {
+    text = fs.readFileSync(filePath, 'utf-8');
+  } catch {
+    return false;
+  }
+
+  const parsed = parseJsonc(text) as {
+    compilerOptions?: { types?: unknown[] };
+  } | null;
+
+  const types = parsed?.compilerOptions?.types;
+  return (
+    Array.isArray(types) &&
+    types.some((t) => typeof t === 'string' && t in TSCONFIG_TYPE_REPLACEMENTS)
+  );
+}
+
 export function rewriteTypesInTsconfig(filePath: string): boolean {
   let text: string;
   try {
@@ -185,14 +209,11 @@ export function rewriteTypesInTsconfig(filePath: string): boolean {
     return false;
   }
 
-  const REPLACEMENTS: Record<string, string> = {
-    'tsdown/client': 'vite-plus/pack/client',
-    'vite/client': 'vite-plus/client',
-  };
-
   const toReplace = types
     .map((t, i) =>
-      typeof t === 'string' && t in REPLACEMENTS ? { i, newVal: REPLACEMENTS[t] } : null,
+      typeof t === 'string' && t in TSCONFIG_TYPE_REPLACEMENTS
+        ? { i, newVal: TSCONFIG_TYPE_REPLACEMENTS[t] }
+        : null,
     )
     .filter((x): x is { i: number; newVal: string } => x !== null);
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -66,6 +66,7 @@ export default defineConfig({
       'packages/cli/snap-tests/check-*/**',
       'packages/cli/snap-tests/fmt-ignore-patterns/src/ignored',
       'packages/cli/snap-tests-global/migration-lint-staged-ts-config',
+      'packages/cli/snap-tests-global/migration-partially-installed-vite-plus/**',
       'ecosystem-ci/*/**',
       'packages/test/**.cjs',
       'packages/test/**.cts',


### PR DESCRIPTION
 ## Summary

 - Treat `vite-plus` in `package.json` as an installation signal, not a migration-complete signal.
 - Complete pending migration work for existing Vite+ projects, including scripts, imports, tsconfig types,
ESLint/Prettier migration, and active legacy hook migration.
 - Add idempotent package manager settings completion for existing Vite+ projects without applying optional
hooks/agent/editor setup unless explicitly requested.
 - Keep fully migrated projects idempotent with the existing “Happy coding!” no-op behavior.

 ## Validation

 - `pnpm -F vite-plus snap-test-global migration-already-vite-plus`
 - `pnpm -F vite-plus snap-test-global migration-partially-installed-vite-plus`
 - `pnpm -F vite-plus snap-test-global migration-eslint-lint-staged-mjs`
 - `vp check --fix packages/cli/src/migration/bin.ts packages/cli/src/migration/migrator.ts packages/cli/src/migration/report.ts packages/cli/src/migration/__tests__/migrator.spec.ts`
 - `vp test run packages/cli/src/migration/__tests__/migrator.spec.ts`
 
closes #1817