### PR TITLE
test: update snapshots for pnpm 11.6 output

### DIFF
--- a/packages/cli/snap-tests-global/command-install-auto-create-package-json/snap.txt
+++ b/packages/cli/snap-tests-global/command-install-auto-create-package-json/snap.txt
@@ -14,6 +14,7 @@ no package.json
 }
 
 > vp add testnpm2 -D && cat package.json # should add package to auto-created package.json
+✓ Lockfile passes supply-chain policies (verified <variable>ms ago)
 Packages: +<variable>
 +
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done

--- a/packages/cli/snap-tests/command-install-auto-create-package-json/snap.txt
+++ b/packages/cli/snap-tests/command-install-auto-create-package-json/snap.txt
@@ -14,6 +14,7 @@ no package.json
 }
 
 > vp add testnpm2 -D && cat package.json # should add package to auto-created package.json
+✓ Lockfile passes supply-chain policies (verified <variable>ms ago)
 Packages: +<variable>
 +
 Progress: resolved <variable>, reused <variable>, downloaded <variable>, added <variable>, done


### PR DESCRIPTION
 ## Summary

 Update snapshots for pnpm 11.6.0’s new cached lockfile verification output:

 ```txt
 +✓ Lockfile passes supply-chain policies (verified <variable>ms ago)
```

The snap fixture runs in an isolated temp project, so it resolves pnpm@latest instead of inheriting the repo root pnpm@10.33.2.

Upstream change: https://github.com/pnpm/pnpm/pull/12326