### PR TITLE
fix(cli): expose vpr package bin

### DIFF
--- a/packages/cli/bin/vpr
+++ b/packages/cli/bin/vpr
@@ -6,4 +6,4 @@ if (module.enableCompileCache) {
 }
 
 process.argv.splice(2, 0, 'run');
-import '../dist/bin.js';
+await import('../dist/bin.js');

--- a/packages/cli/bin/vpr
+++ b/packages/cli/bin/vpr
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+import module from 'node:module';
+if (module.enableCompileCache) {
+  module.enableCompileCache();
+}
+
+process.argv.splice(2, 0, 'run');
+import '../dist/bin.js';

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,7 +16,8 @@
   "bin": {
     "oxfmt": "./bin/oxfmt",
     "oxlint": "./bin/oxlint",
-    "vp": "./bin/vp"
+    "vp": "./bin/vp",
+    "vpr": "./bin/vpr"
   },
   "files": [
     "AGENTS.md",

--- a/packages/cli/snap-tests/command-vpr/args.mjs
+++ b/packages/cli/snap-tests/command-vpr/args.mjs
@@ -1,0 +1,4 @@
+// Print arguments passed to this script, one per line
+for (const arg of process.argv.slice(2)) {
+  console.log(arg);
+}

--- a/packages/cli/snap-tests/command-vpr/package.json
+++ b/packages/cli/snap-tests/command-vpr/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "command-vpr",
+  "version": "1.0.0",
+  "scripts": {
+    "hello": "node args.mjs hello from script",
+    "greet": "node args.mjs greet"
+  },
+  "packageManager": "pnpm@10.19.0"
+}

--- a/packages/cli/snap-tests/command-vpr/snap.txt
+++ b/packages/cli/snap-tests/command-vpr/snap.txt
@@ -1,39 +1,43 @@
 > vpr -h # should show vp run help
+Run tasks
+
 Usage: vp run [OPTIONS] [TASK_SPECIFIER] [ADDITIONAL_ARGS]...
 
-Run tasks.
-
 Arguments:
-  [TASK_SPECIFIER]      `packageName#taskName` or `taskName`. If omitted, lists all available tasks
-  [ADDITIONAL_ARGS]...  Additional arguments to pass to the tasks
+  [TASK_SPECIFIER] [ADDITIONAL_ARGS]...
+          Task to run, as `packageName#taskName` or just `taskName`.
+          Any arguments after the task name are forwarded to the task process.
+          Running `vp run` without a task name shows an interactive task selector.
 
 Options:
-  -r, --recursive          Select all packages in the workspace
-  -t, --transitive         Select the current package and its transitive dependencies
-  -w, --workspace-root     Select the workspace root package
-  -F, --filter <FILTERS>   Match packages by name, directory, or glob pattern
-  --fail-if-no-match       Exit with a non-zero status if a filter matches no packages
-  --ignore-depends-on      Do not run dependencies specified in `dependsOn` fields
-  -v, --verbose            Show full detailed summary after execution
-  --cache                  Force caching on for all tasks and scripts
-  --no-cache               Force caching off for all tasks and scripts
-  --log <MODE>             Set output mode: interleaved, labeled, or grouped
-  --concurrency-limit <N>  Maximum number of tasks to run concurrently (default: 4)
-  --parallel               Run tasks without dependency ordering (unlimited concurrency by default)
-  --last-details           Display the detailed summary of the last run
-  -h, --help               Print help (see more with '--help')
-
-Filter Patterns:
-  --filter <pattern>        Select by package name (e.g. foo, @scope/*)
-  --filter ./<dir>          Select packages under a directory
-  --filter {<dir>}          Same as ./<dir>, but allows traversal suffixes
-  --filter <pattern>...     Select package and its dependencies
-  --filter ...<pattern>     Select package and its dependents
-  --filter <pattern>^...    Select only the dependencies (exclude the package itself)
-  --filter !<pattern>       Exclude packages matching the pattern
-
-Documentation: https://viteplus.dev/guide/run
-
+  -r, --recursive
+          Select all packages in the workspace
+  -t, --transitive
+          Select the current package and its transitive dependencies
+  -w, --workspace-root
+          Select the workspace root package
+  -F, --filter <FILTERS>
+          Match packages by name, directory, or glob pattern
+      --fail-if-no-match
+          Exit with a non-zero status if a `--filter` expression matches no packages
+      --ignore-depends-on
+          Do not run dependencies specified in `dependsOn` fields
+  -v, --verbose
+          Show full detailed summary after execution
+      --cache
+          Force caching on for all tasks and scripts
+      --no-cache
+          Force caching off for all tasks and scripts
+      --log <LOG>
+          How task output is displayed [default: interleaved] [possible values: interleaved, labeled, grouped]
+      --concurrency-limit <CONCURRENCY_LIMIT>
+          Maximum number of tasks to run concurrently. Defaults to 4
+      --parallel
+          Run tasks without dependency ordering. Sets concurrency to unlimited unless `--concurrency-limit` is also specified
+      --last-details
+          Display the detailed summary of the last run
+  -h, --help
+          Print help (see more with '--help')
 
 > vpr hello # should run script via vpr shorthand
 $ node args.mjs hello from script ⊘ cache disabled

--- a/packages/cli/snap-tests/command-vpr/snap.txt
+++ b/packages/cli/snap-tests/command-vpr/snap.txt
@@ -1,0 +1,53 @@
+> vpr -h # should show vp run help
+Usage: vp run [OPTIONS] [TASK_SPECIFIER] [ADDITIONAL_ARGS]...
+
+Run tasks.
+
+Arguments:
+  [TASK_SPECIFIER]      `packageName#taskName` or `taskName`. If omitted, lists all available tasks
+  [ADDITIONAL_ARGS]...  Additional arguments to pass to the tasks
+
+Options:
+  -r, --recursive          Select all packages in the workspace
+  -t, --transitive         Select the current package and its transitive dependencies
+  -w, --workspace-root     Select the workspace root package
+  -F, --filter <FILTERS>   Match packages by name, directory, or glob pattern
+  --fail-if-no-match       Exit with a non-zero status if a filter matches no packages
+  --ignore-depends-on      Do not run dependencies specified in `dependsOn` fields
+  -v, --verbose            Show full detailed summary after execution
+  --cache                  Force caching on for all tasks and scripts
+  --no-cache               Force caching off for all tasks and scripts
+  --log <MODE>             Set output mode: interleaved, labeled, or grouped
+  --concurrency-limit <N>  Maximum number of tasks to run concurrently (default: 4)
+  --parallel               Run tasks without dependency ordering (unlimited concurrency by default)
+  --last-details           Display the detailed summary of the last run
+  -h, --help               Print help (see more with '--help')
+
+Filter Patterns:
+  --filter <pattern>        Select by package name (e.g. foo, @scope/*)
+  --filter ./<dir>          Select packages under a directory
+  --filter {<dir>}          Same as ./<dir>, but allows traversal suffixes
+  --filter <pattern>...     Select package and its dependencies
+  --filter ...<pattern>     Select package and its dependents
+  --filter <pattern>^...    Select only the dependencies (exclude the package itself)
+  --filter !<pattern>       Exclude packages matching the pattern
+
+Documentation: https://viteplus.dev/guide/run
+
+
+> vpr hello # should run script via vpr shorthand
+$ node args.mjs hello from script ⊘ cache disabled
+hello
+from
+script
+
+
+> vpr greet --arg1 value1 # should pass through additional args
+$ node args.mjs greet --arg1 value1 ⊘ cache disabled
+greet
+--arg1
+value1
+
+
+[1]> vpr nonexistent # should show pnpm missing script error
+Task "nonexistent" not found.

--- a/packages/cli/snap-tests/command-vpr/steps.json
+++ b/packages/cli/snap-tests/command-vpr/steps.json
@@ -1,0 +1,9 @@
+{
+  "ignoredPlatforms": ["win32"],
+  "commands": [
+    "vpr -h # should show vp run help",
+    "vpr hello # should run script via vpr shorthand",
+    "vpr greet --arg1 value1 # should pass through additional args",
+    "vpr nonexistent # should show pnpm missing script error"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a package-level vpr bin so clean installs get node_modules/.bin/vpr
- make the vpr wrapper delegate to the existing CLI as vp run
- add a local snap fixture matching the existing global vpr coverage

Fixes #1827.

## Verification
- node -e "const pkg=require('./packages/cli/package.json'); if (pkg.bin.vpr !== './bin/vpr') throw new Error('missing vpr bin'); console.log(pkg.bin.vpr)"
- test -x packages/cli/bin/vpr
- node -e "const fs=require('fs'); const text=fs.readFileSync('packages/cli/bin/vpr','utf8'); if (!text.includes('process.argv.splice(2, 0, \'run\')')) throw new Error('vpr does not inject run'); if (!text.includes('import \'../dist/bin.js\'')) throw new Error('vpr does not load CLI'); console.log('vpr wrapper ok')"
- pnpm exec oxfmt --check packages/cli/bin/vpr packages/cli/package.json packages/cli/snap-tests/command-vpr/steps.json packages/cli/snap-tests/command-vpr/package.json

Note: I attempted pnpm -F vite-plus build-ts before running the snap test, but this local checkout cannot build because the vendored rolldown workspace has no generated dist/native binding after sync-remote failed with git index-pack errors. The change itself is covered by static checks and mirrors the existing global command-vpr snap fixture.