### PR TITLE
docs(pack): document exe peer dependency

### DIFF
--- a/docs/guide/pack.md
+++ b/docs/guide/pack.md
@@ -30,12 +30,12 @@ Use it for:
 - [standalone executables](https://tsdown.dev/options/exe#executable)
 
 ```ts [vite.config.ts]
-import { defineConfig } from 'vite-plus';
+import { defineConfig } from "vite-plus";
 
 export default defineConfig({
   pack: {
     dts: true,
-    format: ['esm', 'cjs'],
+    format: ["esm", "cjs"],
     sourcemap: true,
   },
 });
@@ -47,12 +47,20 @@ export default defineConfig({
 
 Use this when you want to ship a CLI or other Node-based tool as a native executable that runs without requiring Node.js to be installed separately.
 
+Executable builds require tsdown's optional executable package in your project:
+
+```bash
+vp add -D @tsdown/exe tsdown
+```
+
+`@tsdown/exe` imports `tsdown/internal` through its peer dependency on `tsdown`. Vite+ bundles tsdown internally for `vp pack`, but that bundled copy is not exposed as a top-level `tsdown` package for third-party peer dependency resolution. Install both packages explicitly when enabling `pack.exe`.
+
 ```ts [vite.config.ts]
-import { defineConfig } from 'vite-plus';
+import { defineConfig } from "vite-plus";
 
 export default defineConfig({
   pack: {
-    entry: ['src/cli.ts'],
+    entry: ["src/cli.ts"],
     exe: true,
   },
 });


### PR DESCRIPTION
## Summary

- document that `pack.exe` users must install both `@tsdown/exe` and `tsdown`
- explain why Vite+'s bundled tsdown does not satisfy `@tsdown/exe` peer resolution

Addresses #1586 with the documented-workaround path described in the issue.

## Verification

- `pnpm exec oxfmt --check docs/guide/pack.md`
- `node -e "const fs=require('fs'); const text=fs.readFileSync('docs/guide/pack.md','utf8'); for (const s of ['vp add -D @tsdown/exe tsdown','tsdown/internal','peer dependency']) if (!text.includes(s)) throw new Error('missing '+s); console.log('pack exe docs ok')"`
