### PR TITLE
docs(team): add JongKyung X profile

### DIFF
--- a/docs/_data/team.ts
+++ b/docs/_data/team.ts
@@ -113,6 +113,7 @@ export const core: DefaultTheme.TeamMember[] = [
     name: 'JongKyung Lee',
     links: [
       { icon: 'github', link: 'https://github.com/jong-kyung' },
+      { icon: 'x', link: 'https://x.com/jongkyung_dev' },
       { icon: 'linkedin', link: 'https://www.linkedin.com/in/jong-kyung' },
     ],
   },


### PR DESCRIPTION
Adds jong-kyung's X profile to the team data so the VitePress team page can show it alongside GitHub and LinkedIn.
