### PR TITLE
docs(team): update Christoph X profile

### DIFF
--- a/docs/_data/team.ts
+++ b/docs/_data/team.ts
@@ -30,7 +30,7 @@ export const core: DefaultTheme.TeamMember[] = [
     name: 'Christoph Nakazawa',
     links: [
       { icon: 'github', link: 'https://github.com/cpojer' },
-      { icon: 'x', link: 'https://x.com/cpojer' },
+      { icon: 'x', link: 'https://x.com/cnakazawa' },
       { icon: 'bluesky', link: 'https://bsky.app/profile/christoph.nkzw.tech' },
     ],
   },


### PR DESCRIPTION
Christoph Nakazawa’s team profile now links to his current X account, `cnakazawa`, instead of the old `cpojer` URL.
