### PR TITLE
docs(config): align config overview with sidebar

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -10,10 +10,11 @@ export default defineConfig({
   build: {},
   preview: {},
 
-  test: {},
-  lint: {},
-  fmt: {},
+  create: {},
   run: {},
+  fmt: {},
+  lint: {},
+  test: {},
   pack: {},
   staged: {},
 });
@@ -23,9 +24,10 @@ export default defineConfig({
 
 Vite+ extends the basic Vite configuration with these additions:
 
-- [`lint`](/config/lint) for Oxlint
-- [`fmt`](/config/fmt) for Oxfmt
-- [`test`](/config/test) for Vitest
+- [`create`](/config/create) for project and template scaffolding defaults
 - [`run`](/config/run) for Vite Task
+- [`fmt`](/config/fmt) for Oxfmt
+- [`lint`](/config/lint) for Oxlint
+- [`test`](/config/test) for Vitest
 - [`pack`](/config/pack) for tsdown
 - [`staged`](/config/staged) for staged-file checks


### PR DESCRIPTION
The config overview now surfaces every config reference reachable from the sidebar. `create` is alongside the other Vite+ blocks, and the example `vite.config.ts` block follows the same order.
