### PR TITLE
ci: use Release environment for publishing approval

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
 
   Release:
     runs-on: ubuntu-latest
-    environment: release
+    environment: Release
     needs: [check, build-rust, request-approval]
     if: needs.check.outputs.version_changed == 'true'
     permissions:


### PR DESCRIPTION
Release publishing now targets the protected `Release` environment, so the manual approval gate you configured will pause the publish job before packages and the GitHub release go live.

Validation: `git diff --check upstream/main...HEAD`
