### PR TITLE
fix(create): drop src-only tsconfig include

### DIFF
--- a/packages/cli/snap-tests-global/new-create-vite/snap.txt
+++ b/packages/cli/snap-tests-global/new-create-vite/snap.txt
@@ -2,6 +2,9 @@
 > ls vite-plus-application/package.json # check package.json
 vite-plus-application/package.json
 
+> node -e "const fs = require('node:fs'); const tsconfig = JSON.parse(fs.readFileSync('vite-plus-application/tsconfig.json', 'utf8')); if ('include' in tsconfig) { console.error('ERROR: src-only include still exists'); process.exit(1); } console.log('src-only include removed');" # check default tsconfig include removed
+src-only include removed
+
 > test -f vite-plus-application/.vscode/settings.json && echo '.vscode/settings.json exists' # check VS Code settings created
 .vscode/settings.json exists
 

--- a/packages/cli/snap-tests-global/new-create-vite/steps.json
+++ b/packages/cli/snap-tests-global/new-create-vite/steps.json
@@ -5,6 +5,7 @@
       "ignoreOutput": true
     },
     "ls vite-plus-application/package.json # check package.json",
+    "node -e \"const fs = require('node:fs'); const tsconfig = JSON.parse(fs.readFileSync('vite-plus-application/tsconfig.json', 'utf8')); if ('include' in tsconfig) { console.error('ERROR: src-only include still exists'); process.exit(1); } console.log('src-only include removed');\" # check default tsconfig include removed",
     "test -f vite-plus-application/.vscode/settings.json && echo '.vscode/settings.json exists' # check VS Code settings created",
     "test -f vite-plus-application/.vscode/extensions.json && echo '.vscode/extensions.json exists' # check VS Code extensions created",
     "node -e \"const { spawnSync } = require('node:child_process'); const file = '.vscode/settings.json'; const result = spawnSync('git', ['-C', 'vite-plus-application', 'check-ignore', '--no-index', file], { stdio: 'ignore' }); const status = result.status; if (status === 1) { console.log(file + ' trackable'); } else { console.log(status === 0 ? 'ERROR: ' + file + ' ignored' : 'ERROR: git check-ignore failed with status ' + status); process.exit(status || 1); }\" # check VS Code settings are trackable",

--- a/packages/cli/src/create/__tests__/utils.spec.ts
+++ b/packages/cli/src/create/__tests__/utils.spec.ts
@@ -1,8 +1,8 @@
-import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   deriveDefaultPackageName,
@@ -14,122 +14,122 @@ import {
   renameFiles,
   removeSrcOnlyTsconfigInclude,
   shouldConfigureEditorsForCreate,
-} from '../utils.js';
+} from "../utils.js";
 
-describe('getProjectDirFromPackageName', () => {
-  it('should get project dir from package name', () => {
-    expect(getProjectDirFromPackageName('@my/package')).toBe('package');
-    expect(getProjectDirFromPackageName('my-package')).toBe('my-package');
+describe("getProjectDirFromPackageName", () => {
+  it("should get project dir from package name", () => {
+    expect(getProjectDirFromPackageName("@my/package")).toBe("package");
+    expect(getProjectDirFromPackageName("my-package")).toBe("my-package");
   });
 });
 
-describe('editor configuration policy', () => {
-  it('normalizes repeated editor options to a single editor value', () => {
-    expect(normalizeEditorOption('vscode')).toBe('vscode');
-    expect(normalizeEditorOption(['vscode', 'zed'])).toBe('zed');
-    expect(normalizeEditorOption(['vscode', false])).toBe(false);
-    expect(normalizeEditorOption([undefined, 'vscode'])).toBe('vscode');
+describe("editor configuration policy", () => {
+  it("normalizes repeated editor options to a single editor value", () => {
+    expect(normalizeEditorOption("vscode")).toBe("vscode");
+    expect(normalizeEditorOption(["vscode", "zed"])).toBe("zed");
+    expect(normalizeEditorOption(["vscode", false])).toBe(false);
+    expect(normalizeEditorOption([undefined, "vscode"])).toBe("vscode");
   });
 
-  it('allows automatic editor configuration outside existing monorepos', () => {
+  it("allows automatic editor configuration outside existing monorepos", () => {
     expect(shouldConfigureEditorsForCreate({ isMonorepo: false, editor: undefined })).toBe(true);
   });
 
-  it('skips automatic editor configuration inside existing monorepos', () => {
+  it("skips automatic editor configuration inside existing monorepos", () => {
     expect(shouldConfigureEditorsForCreate({ isMonorepo: true, editor: undefined })).toBe(false);
   });
 
-  it('allows explicit editor opt-in inside existing monorepos', () => {
-    expect(shouldConfigureEditorsForCreate({ isMonorepo: true, editor: 'vscode' })).toBe(true);
-    expect(shouldConfigureEditorsForCreate({ isMonorepo: true, editor: '   ' })).toBe(false);
+  it("allows explicit editor opt-in inside existing monorepos", () => {
+    expect(shouldConfigureEditorsForCreate({ isMonorepo: true, editor: "vscode" })).toBe(true);
+    expect(shouldConfigureEditorsForCreate({ isMonorepo: true, editor: "   " })).toBe(false);
   });
 
-  it('keeps --no-editor as an explicit opt-out in every workspace mode', () => {
+  it("keeps --no-editor as an explicit opt-out in every workspace mode", () => {
     expect(shouldConfigureEditorsForCreate({ isMonorepo: false, editor: false })).toBe(false);
     expect(shouldConfigureEditorsForCreate({ isMonorepo: true, editor: false })).toBe(false);
   });
 });
 
-describe('formatTargetDir', () => {
+describe("formatTargetDir", () => {
   it('should format "." as current directory with empty package name', () => {
-    expect(formatTargetDir('.')).toEqual({
-      directory: '.',
-      packageName: '',
+    expect(formatTargetDir(".")).toEqual({
+      directory: ".",
+      packageName: "",
     });
   });
 
   it('should format "./" as current directory with empty package name', () => {
-    expect(formatTargetDir('./')).toEqual({
-      directory: '.',
-      packageName: '',
+    expect(formatTargetDir("./")).toEqual({
+      directory: ".",
+      packageName: "",
     });
   });
 
-  it('should format target dir with invalid input', () => {
-    expect(formatTargetDir('/foo/bar')).matchSnapshot();
-    expect(formatTargetDir('@scope/')).matchSnapshot();
-    expect(formatTargetDir('../../foo/bar')).matchSnapshot();
+  it("should format target dir with invalid input", () => {
+    expect(formatTargetDir("/foo/bar")).matchSnapshot();
+    expect(formatTargetDir("@scope/")).matchSnapshot();
+    expect(formatTargetDir("../../foo/bar")).matchSnapshot();
   });
 
   // Should work on all platforms (including Windows) - directory must always use forward slashes
-  it('should format target dir with valid input', () => {
-    expect(formatTargetDir('./my-package')).matchSnapshot();
-    expect(formatTargetDir('my-package')).matchSnapshot();
-    expect(formatTargetDir('@my-scope/my-package')).matchSnapshot();
-    expect(formatTargetDir('foo/@my-scope/my-package')).matchSnapshot();
-    expect(formatTargetDir('./foo/@my-scope/my-package')).matchSnapshot();
-    expect(formatTargetDir('./foo/bar/@scope/my-package')).matchSnapshot();
-    expect(formatTargetDir('./foo/bar/@scope/my-package/')).matchSnapshot();
-    expect(formatTargetDir('./foo/bar/@scope/my-package/sub-package')).matchSnapshot();
+  it("should format target dir with valid input", () => {
+    expect(formatTargetDir("./my-package")).matchSnapshot();
+    expect(formatTargetDir("my-package")).matchSnapshot();
+    expect(formatTargetDir("@my-scope/my-package")).matchSnapshot();
+    expect(formatTargetDir("foo/@my-scope/my-package")).matchSnapshot();
+    expect(formatTargetDir("./foo/@my-scope/my-package")).matchSnapshot();
+    expect(formatTargetDir("./foo/bar/@scope/my-package")).matchSnapshot();
+    expect(formatTargetDir("./foo/bar/@scope/my-package/")).matchSnapshot();
+    expect(formatTargetDir("./foo/bar/@scope/my-package/sub-package")).matchSnapshot();
   });
 
   // Regression test for https://github.com/voidzero-dev/vite-plus/issues/938
   // On Windows, path.join/normalize produce backslashes which break when passed as CLI args.
   // Nested paths are the critical cases since they involve path separators.
-  it('should always use forward slashes in directory (issue #938)', () => {
-    expect(formatTargetDir('foo/@my-scope/my-package').directory).toBe('foo/my-package');
-    expect(formatTargetDir('./foo/bar/@scope/my-package').directory).toBe('foo/bar/my-package');
-    expect(formatTargetDir('./foo/bar/@scope/my-package/sub-package').directory).toBe(
-      'foo/bar/@scope/my-package/sub-package',
+  it("should always use forward slashes in directory (issue #938)", () => {
+    expect(formatTargetDir("foo/@my-scope/my-package").directory).toBe("foo/my-package");
+    expect(formatTargetDir("./foo/bar/@scope/my-package").directory).toBe("foo/bar/my-package");
+    expect(formatTargetDir("./foo/bar/@scope/my-package/sub-package").directory).toBe(
+      "foo/bar/@scope/my-package/sub-package",
     );
   });
 
-  it('should format target dir with invalid package name', () => {
-    expect(formatTargetDir('my-package@').error).matchSnapshot();
-    expect(formatTargetDir('my-package@1.0.0').error).matchSnapshot();
+  it("should format target dir with invalid package name", () => {
+    expect(formatTargetDir("my-package@").error).matchSnapshot();
+    expect(formatTargetDir("my-package@1.0.0").error).matchSnapshot();
   });
 });
 
-describe('deriveDefaultPackageName', () => {
-  it('should derive package name from directory basename', () => {
-    expect(deriveDefaultPackageName('/home/user/my-app', undefined, 'fallback')).toBe('my-app');
+describe("deriveDefaultPackageName", () => {
+  it("should derive package name from directory basename", () => {
+    expect(deriveDefaultPackageName("/home/user/my-app", undefined, "fallback")).toBe("my-app");
   });
 
-  it('should derive scoped package name when scope is provided', () => {
-    expect(deriveDefaultPackageName('/home/user/my-app', '@my-scope', 'fallback')).toBe(
-      '@my-scope/my-app',
+  it("should derive scoped package name when scope is provided", () => {
+    expect(deriveDefaultPackageName("/home/user/my-app", "@my-scope", "fallback")).toBe(
+      "@my-scope/my-app",
     );
   });
 
-  it('should fallback to random name when directory name is invalid', () => {
-    const result = deriveDefaultPackageName('/home/user/.hidden', undefined, 'vite-plus-app');
+  it("should fallback to random name when directory name is invalid", () => {
+    const result = deriveDefaultPackageName("/home/user/.hidden", undefined, "vite-plus-app");
     // directory name starts with '.', so a random name is generated instead
-    expect(result).not.toBe('.hidden');
+    expect(result).not.toBe(".hidden");
     expect(result.length).toBeGreaterThan(0);
   });
 
-  it('should fallback when directory is filesystem root', () => {
-    const result = deriveDefaultPackageName('/', undefined, 'vite-plus-app');
+  it("should fallback when directory is filesystem root", () => {
+    const result = deriveDefaultPackageName("/", undefined, "vite-plus-app");
     // basename of '/' is empty, so a random name is generated
     expect(result.length).toBeGreaterThan(0);
   });
 });
 
-describe('removeSrcOnlyTsconfigInclude', () => {
+describe("removeSrcOnlyTsconfigInclude", () => {
   let projectDir: string;
 
   beforeEach(() => {
-    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vp-tsconfig-include-'));
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "vp-tsconfig-include-"));
   });
 
   afterEach(() => {
@@ -137,19 +137,19 @@ describe('removeSrcOnlyTsconfigInclude', () => {
   });
 
   function writeTsconfig(tsconfig: unknown): void {
-    fs.writeFileSync(path.join(projectDir, 'tsconfig.json'), JSON.stringify(tsconfig, null, 2));
+    fs.writeFileSync(path.join(projectDir, "tsconfig.json"), JSON.stringify(tsconfig, null, 2));
   }
 
   function readTsconfig(): Record<string, unknown> {
-    return JSON.parse(fs.readFileSync(path.join(projectDir, 'tsconfig.json'), 'utf-8'));
+    return JSON.parse(fs.readFileSync(path.join(projectDir, "tsconfig.json"), "utf-8"));
   }
 
-  it('removes the default src-only include', () => {
+  it("removes the default src-only include", () => {
     writeTsconfig({
       compilerOptions: {
         strict: true,
       },
-      include: ['src'],
+      include: ["src"],
     });
 
     removeSrcOnlyTsconfigInclude(projectDir);
@@ -161,12 +161,34 @@ describe('removeSrcOnlyTsconfigInclude', () => {
     });
   });
 
-  it('keeps custom include patterns', () => {
+  it("handles JSONC tsconfig files", () => {
+    fs.writeFileSync(
+      path.join(projectDir, "tsconfig.json"),
+      `{
+  // Vite templates allow comments and trailing commas here.
+  "compilerOptions": {
+    "strict": true,
+  },
+  "include": ["src"],
+}
+`,
+    );
+
+    removeSrcOnlyTsconfigInclude(projectDir);
+
+    expect(readTsconfig()).toEqual({
+      compilerOptions: {
+        strict: true,
+      },
+    });
+  });
+
+  it("keeps custom include patterns", () => {
     const tsconfig = {
       compilerOptions: {
         strict: true,
       },
-      include: ['src', 'tests'],
+      include: ["src", "tests"],
     };
     writeTsconfig(tsconfig);
 
@@ -175,16 +197,16 @@ describe('removeSrcOnlyTsconfigInclude', () => {
     expect(readTsconfig()).toEqual(tsconfig);
   });
 
-  it('ignores projects without a tsconfig', () => {
+  it("ignores projects without a tsconfig", () => {
     expect(() => removeSrcOnlyTsconfigInclude(projectDir)).not.toThrow();
   });
 });
 
-describe('ensureGitignoreNodeModules', () => {
+describe("ensureGitignoreNodeModules", () => {
   let projectDir: string;
 
   beforeEach(() => {
-    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vp-gitignore-'));
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "vp-gitignore-"));
   });
 
   afterEach(() => {
@@ -192,65 +214,65 @@ describe('ensureGitignoreNodeModules', () => {
   });
 
   function gitignore(): string {
-    return fs.readFileSync(path.join(projectDir, '.gitignore'), 'utf-8');
+    return fs.readFileSync(path.join(projectDir, ".gitignore"), "utf-8");
   }
 
-  it('creates a fresh `.gitignore` with `node_modules` when none exists', () => {
+  it("creates a fresh `.gitignore` with `node_modules` when none exists", () => {
     ensureGitignoreNodeModules(projectDir);
-    expect(gitignore()).toBe('node_modules\n');
+    expect(gitignore()).toBe("node_modules\n");
   });
 
-  it('appends `node_modules` to an existing `.gitignore` that omits it', () => {
-    fs.writeFileSync(path.join(projectDir, '.gitignore'), 'dist\n*.log\n');
+  it("appends `node_modules` to an existing `.gitignore` that omits it", () => {
+    fs.writeFileSync(path.join(projectDir, ".gitignore"), "dist\n*.log\n");
     ensureGitignoreNodeModules(projectDir);
-    expect(gitignore()).toBe('dist\n*.log\nnode_modules\n');
+    expect(gitignore()).toBe("dist\n*.log\nnode_modules\n");
   });
 
-  it('terminates the last line first when the existing file lacks a trailing newline', () => {
-    fs.writeFileSync(path.join(projectDir, '.gitignore'), 'dist');
+  it("terminates the last line first when the existing file lacks a trailing newline", () => {
+    fs.writeFileSync(path.join(projectDir, ".gitignore"), "dist");
     ensureGitignoreNodeModules(projectDir);
-    expect(gitignore()).toBe('dist\nnode_modules\n');
+    expect(gitignore()).toBe("dist\nnode_modules\n");
   });
 
-  it('is a no-op when `node_modules` already appears as a standalone line', () => {
-    const existing = '# Logs\n*.log\nnode_modules\ndist\n';
-    fs.writeFileSync(path.join(projectDir, '.gitignore'), existing);
+  it("is a no-op when `node_modules` already appears as a standalone line", () => {
+    const existing = "# Logs\n*.log\nnode_modules\ndist\n";
+    fs.writeFileSync(path.join(projectDir, ".gitignore"), existing);
     ensureGitignoreNodeModules(projectDir);
     expect(gitignore()).toBe(existing);
   });
 
-  it('treats `node_modules/` (with trailing slash) as a match', () => {
-    const existing = 'node_modules/\ndist\n';
-    fs.writeFileSync(path.join(projectDir, '.gitignore'), existing);
+  it("treats `node_modules/` (with trailing slash) as a match", () => {
+    const existing = "node_modules/\ndist\n";
+    fs.writeFileSync(path.join(projectDir, ".gitignore"), existing);
     ensureGitignoreNodeModules(projectDir);
     expect(gitignore()).toBe(existing);
   });
 
-  it('handles CRLF line endings without re-appending', () => {
-    const existing = 'node_modules\r\ndist\r\n';
-    fs.writeFileSync(path.join(projectDir, '.gitignore'), existing);
+  it("handles CRLF line endings without re-appending", () => {
+    const existing = "node_modules\r\ndist\r\n";
+    fs.writeFileSync(path.join(projectDir, ".gitignore"), existing);
     ensureGitignoreNodeModules(projectDir);
     expect(gitignore()).toBe(existing);
   });
 
-  it('does not consider a `node_modules/sub` subpath as already excluded', () => {
-    fs.writeFileSync(path.join(projectDir, '.gitignore'), 'node_modules/sub\n');
+  it("does not consider a `node_modules/sub` subpath as already excluded", () => {
+    fs.writeFileSync(path.join(projectDir, ".gitignore"), "node_modules/sub\n");
     ensureGitignoreNodeModules(projectDir);
-    expect(gitignore()).toBe('node_modules/sub\nnode_modules\n');
+    expect(gitignore()).toBe("node_modules/sub\nnode_modules\n");
   });
 
-  it('does not match `!node_modules` (an explicit un-ignore override)', () => {
-    fs.writeFileSync(path.join(projectDir, '.gitignore'), '!node_modules\n');
+  it("does not match `!node_modules` (an explicit un-ignore override)", () => {
+    fs.writeFileSync(path.join(projectDir, ".gitignore"), "!node_modules\n");
     ensureGitignoreNodeModules(projectDir);
-    expect(gitignore()).toBe('!node_modules\nnode_modules\n');
+    expect(gitignore()).toBe("!node_modules\nnode_modules\n");
   });
 });
 
-describe('ensureGitignoreVsCodeEditorConfigs', () => {
+describe("ensureGitignoreVsCodeEditorConfigs", () => {
   let projectDir: string;
 
   beforeEach(() => {
-    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vp-vscode-gitignore-'));
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "vp-vscode-gitignore-"));
   });
 
   afterEach(() => {
@@ -258,117 +280,117 @@ describe('ensureGitignoreVsCodeEditorConfigs', () => {
   });
 
   function gitignore(): string {
-    return fs.readFileSync(path.join(projectDir, '.gitignore'), 'utf-8');
+    return fs.readFileSync(path.join(projectDir, ".gitignore"), "utf-8");
   }
 
   function writeGitignore(content: string): void {
-    fs.writeFileSync(path.join(projectDir, '.gitignore'), content);
+    fs.writeFileSync(path.join(projectDir, ".gitignore"), content);
   }
 
   function writeVsCodeSettings(): void {
-    fs.mkdirSync(path.join(projectDir, '.vscode'), { recursive: true });
-    fs.writeFileSync(path.join(projectDir, '.vscode', 'settings.json'), '{}\n');
+    fs.mkdirSync(path.join(projectDir, ".vscode"), { recursive: true });
+    fs.writeFileSync(path.join(projectDir, ".vscode", "settings.json"), "{}\n");
   }
 
-  const vscodeUnignoreBlock = '!.vscode/\n!.vscode/settings.json\n!.vscode/extensions.json\n';
+  const vscodeUnignoreBlock = "!.vscode/\n!.vscode/settings.json\n!.vscode/extensions.json\n";
 
-  it('unignores VS Code settings when `.vscode/*` is ignored', () => {
+  it("unignores VS Code settings when `.vscode/*` is ignored", () => {
     writeVsCodeSettings();
-    writeGitignore('.vscode/*\n!.vscode/extensions.json\n');
+    writeGitignore(".vscode/*\n!.vscode/extensions.json\n");
     ensureGitignoreVsCodeEditorConfigs(projectDir);
     expect(gitignore()).toBe(`.vscode/*\n!.vscode/extensions.json\n${vscodeUnignoreBlock}`);
   });
 
-  it('unignores generated VS Code config files for root-anchored contents ignores', () => {
+  it("unignores generated VS Code config files for root-anchored contents ignores", () => {
     writeVsCodeSettings();
-    writeGitignore('/.vscode/*\n');
+    writeGitignore("/.vscode/*\n");
     ensureGitignoreVsCodeEditorConfigs(projectDir);
     expect(gitignore()).toBe(`/.vscode/*\n${vscodeUnignoreBlock}`);
   });
 
-  it('appends VS Code directory and config unignores for directory-level VS Code ignores', () => {
+  it("appends VS Code directory and config unignores for directory-level VS Code ignores", () => {
     writeVsCodeSettings();
-    writeGitignore('.vscode/\n');
+    writeGitignore(".vscode/\n");
     ensureGitignoreVsCodeEditorConfigs(projectDir);
     expect(gitignore()).toBe(`.vscode/\n${vscodeUnignoreBlock}`);
   });
 
-  it('appends VS Code directory and config unignores for root-anchored directory-level VS Code ignores', () => {
+  it("appends VS Code directory and config unignores for root-anchored directory-level VS Code ignores", () => {
     writeVsCodeSettings();
-    writeGitignore('/.vscode\n');
+    writeGitignore("/.vscode\n");
     ensureGitignoreVsCodeEditorConfigs(projectDir);
     expect(gitignore()).toBe(`/.vscode\n${vscodeUnignoreBlock}`);
   });
 
-  it('appends VS Code config unignores after explicit VS Code settings ignores', () => {
+  it("appends VS Code config unignores after explicit VS Code settings ignores", () => {
     writeVsCodeSettings();
-    writeGitignore('.vscode/*\n.vscode/settings.json\n');
+    writeGitignore(".vscode/*\n.vscode/settings.json\n");
     ensureGitignoreVsCodeEditorConfigs(projectDir);
     expect(gitignore()).toBe(`.vscode/*\n.vscode/settings.json\n${vscodeUnignoreBlock}`);
   });
 
-  it('appends VS Code config unignores after explicit VS Code extensions ignores', () => {
+  it("appends VS Code config unignores after explicit VS Code extensions ignores", () => {
     writeVsCodeSettings();
-    writeGitignore('.vscode/*\n/.vscode/extensions.json\n');
+    writeGitignore(".vscode/*\n/.vscode/extensions.json\n");
     ensureGitignoreVsCodeEditorConfigs(projectDir);
     expect(gitignore()).toBe(`.vscode/*\n/.vscode/extensions.json\n${vscodeUnignoreBlock}`);
   });
 
-  it('appends VS Code config unignores when all generated config files are explicitly ignored', () => {
+  it("appends VS Code config unignores when all generated config files are explicitly ignored", () => {
     writeVsCodeSettings();
-    writeGitignore('.vscode/*\n.vscode/settings.json\n.vscode/extensions.json\n');
+    writeGitignore(".vscode/*\n.vscode/settings.json\n.vscode/extensions.json\n");
     ensureGitignoreVsCodeEditorConfigs(projectDir);
     expect(gitignore()).toBe(
       `.vscode/*\n.vscode/settings.json\n.vscode/extensions.json\n${vscodeUnignoreBlock}`,
     );
   });
 
-  it('appends the full block when settings are already unignored without the EOF block', () => {
+  it("appends the full block when settings are already unignored without the EOF block", () => {
     writeVsCodeSettings();
-    writeGitignore('.vscode/*\n!.vscode/settings.json\n');
+    writeGitignore(".vscode/*\n!.vscode/settings.json\n");
     ensureGitignoreVsCodeEditorConfigs(projectDir);
     expect(gitignore()).toBe(`.vscode/*\n!.vscode/settings.json\n${vscodeUnignoreBlock}`);
   });
 
-  it('re-appends the full block when later ignore rules override generated config unignores', () => {
+  it("re-appends the full block when later ignore rules override generated config unignores", () => {
     writeVsCodeSettings();
-    writeGitignore('!.vscode/settings.json\n!.vscode/extensions.json\n.vscode/*\n');
+    writeGitignore("!.vscode/settings.json\n!.vscode/extensions.json\n.vscode/*\n");
     ensureGitignoreVsCodeEditorConfigs(projectDir);
     expect(gitignore()).toBe(
       `!.vscode/settings.json\n!.vscode/extensions.json\n.vscode/*\n${vscodeUnignoreBlock}`,
     );
   });
 
-  it('appends VS Code config unignores even without a broad VS Code ignore', () => {
+  it("appends VS Code config unignores even without a broad VS Code ignore", () => {
     writeVsCodeSettings();
-    writeGitignore('dist\n');
+    writeGitignore("dist\n");
     ensureGitignoreVsCodeEditorConfigs(projectDir);
     expect(gitignore()).toBe(`dist\n${vscodeUnignoreBlock}`);
   });
 
-  it('does not create `.gitignore` when none exists', () => {
+  it("does not create `.gitignore` when none exists", () => {
     writeVsCodeSettings();
     ensureGitignoreVsCodeEditorConfigs(projectDir);
-    expect(fs.existsSync(path.join(projectDir, '.gitignore'))).toBe(false);
+    expect(fs.existsSync(path.join(projectDir, ".gitignore"))).toBe(false);
   });
 
-  it('does not change `.gitignore` when VS Code settings do not exist', () => {
-    const existing = '.vscode/*\n';
+  it("does not change `.gitignore` when VS Code settings do not exist", () => {
+    const existing = ".vscode/*\n";
     writeGitignore(existing);
     ensureGitignoreVsCodeEditorConfigs(projectDir);
     expect(gitignore()).toBe(existing);
   });
 
-  it('terminates the last line before appending VS Code config unignores', () => {
+  it("terminates the last line before appending VS Code config unignores", () => {
     writeVsCodeSettings();
-    writeGitignore('.vscode/*');
+    writeGitignore(".vscode/*");
     ensureGitignoreVsCodeEditorConfigs(projectDir);
     expect(gitignore()).toBe(`.vscode/*\n${vscodeUnignoreBlock}`);
   });
 
-  it('is idempotent', () => {
+  it("is idempotent", () => {
     writeVsCodeSettings();
-    writeGitignore('.vscode/*\n');
+    writeGitignore(".vscode/*\n");
     ensureGitignoreVsCodeEditorConfigs(projectDir);
     const afterFirstRun = gitignore();
     ensureGitignoreVsCodeEditorConfigs(projectDir);
@@ -376,11 +398,11 @@ describe('ensureGitignoreVsCodeEditorConfigs', () => {
   });
 });
 
-describe('renameFiles', () => {
+describe("renameFiles", () => {
   let projectDir: string;
 
   beforeEach(() => {
-    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vp-rename-'));
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "vp-rename-"));
   });
 
   afterEach(() => {
@@ -392,38 +414,38 @@ describe('renameFiles', () => {
   }
 
   function read(name: string): string {
-    return fs.readFileSync(path.join(projectDir, name), 'utf-8');
+    return fs.readFileSync(path.join(projectDir, name), "utf-8");
   }
 
   function exists(name: string): boolean {
     return fs.existsSync(path.join(projectDir, name));
   }
 
-  it('renames `_gitignore` to `.gitignore`', () => {
-    write('_gitignore', 'node_modules\n');
+  it("renames `_gitignore` to `.gitignore`", () => {
+    write("_gitignore", "node_modules\n");
     renameFiles(projectDir);
-    expect(exists('_gitignore')).toBe(false);
-    expect(read('.gitignore')).toBe('node_modules\n');
+    expect(exists("_gitignore")).toBe(false);
+    expect(read(".gitignore")).toBe("node_modules\n");
   });
 
-  it('renames `_npmrc` and `_yarnrc.yml`', () => {
-    write('_npmrc', 'auto-install-peers=true\n');
-    write('_yarnrc.yml', 'nodeLinker: node-modules\n');
+  it("renames `_npmrc` and `_yarnrc.yml`", () => {
+    write("_npmrc", "auto-install-peers=true\n");
+    write("_yarnrc.yml", "nodeLinker: node-modules\n");
     renameFiles(projectDir);
-    expect(exists('_npmrc')).toBe(false);
-    expect(exists('_yarnrc.yml')).toBe(false);
-    expect(read('.npmrc')).toBe('auto-install-peers=true\n');
-    expect(read('.yarnrc.yml')).toBe('nodeLinker: node-modules\n');
+    expect(exists("_npmrc")).toBe(false);
+    expect(exists("_yarnrc.yml")).toBe(false);
+    expect(read(".npmrc")).toBe("auto-install-peers=true\n");
+    expect(read(".yarnrc.yml")).toBe("nodeLinker: node-modules\n");
   });
 
-  it('is a no-op when no source files exist', () => {
+  it("is a no-op when no source files exist", () => {
     expect(() => renameFiles(projectDir)).not.toThrow();
     expect(fs.readdirSync(projectDir)).toEqual([]);
   });
 
-  it('leaves unmapped underscore files untouched', () => {
-    write('_foo', 'bar\n');
+  it("leaves unmapped underscore files untouched", () => {
+    write("_foo", "bar\n");
     renameFiles(projectDir);
-    expect(read('_foo')).toBe('bar\n');
+    expect(read("_foo")).toBe("bar\n");
   });
 });

--- a/packages/cli/src/create/__tests__/utils.spec.ts
+++ b/packages/cli/src/create/__tests__/utils.spec.ts
@@ -12,6 +12,7 @@ import {
   getProjectDirFromPackageName,
   normalizeEditorOption,
   renameFiles,
+  removeSrcOnlyTsconfigInclude,
   shouldConfigureEditorsForCreate,
 } from '../utils.js';
 
@@ -121,6 +122,61 @@ describe('deriveDefaultPackageName', () => {
     const result = deriveDefaultPackageName('/', undefined, 'vite-plus-app');
     // basename of '/' is empty, so a random name is generated
     expect(result.length).toBeGreaterThan(0);
+  });
+});
+
+describe('removeSrcOnlyTsconfigInclude', () => {
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vp-tsconfig-include-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  function writeTsconfig(tsconfig: unknown): void {
+    fs.writeFileSync(path.join(projectDir, 'tsconfig.json'), JSON.stringify(tsconfig, null, 2));
+  }
+
+  function readTsconfig(): Record<string, unknown> {
+    return JSON.parse(fs.readFileSync(path.join(projectDir, 'tsconfig.json'), 'utf-8'));
+  }
+
+  it('removes the default src-only include', () => {
+    writeTsconfig({
+      compilerOptions: {
+        strict: true,
+      },
+      include: ['src'],
+    });
+
+    removeSrcOnlyTsconfigInclude(projectDir);
+
+    expect(readTsconfig()).toEqual({
+      compilerOptions: {
+        strict: true,
+      },
+    });
+  });
+
+  it('keeps custom include patterns', () => {
+    const tsconfig = {
+      compilerOptions: {
+        strict: true,
+      },
+      include: ['src', 'tests'],
+    };
+    writeTsconfig(tsconfig);
+
+    removeSrcOnlyTsconfigInclude(projectDir);
+
+    expect(readTsconfig()).toEqual(tsconfig);
+  });
+
+  it('ignores projects without a tsconfig', () => {
+    expect(() => removeSrcOnlyTsconfigInclude(projectDir)).not.toThrow();
   });
 });
 

--- a/packages/cli/src/create/__tests__/utils.spec.ts
+++ b/packages/cli/src/create/__tests__/utils.spec.ts
@@ -1,8 +1,8 @@
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
   deriveDefaultPackageName,
@@ -14,122 +14,122 @@ import {
   renameFiles,
   removeSrcOnlyTsconfigInclude,
   shouldConfigureEditorsForCreate,
-} from "../utils.js";
+} from '../utils.js';
 
-describe("getProjectDirFromPackageName", () => {
-  it("should get project dir from package name", () => {
-    expect(getProjectDirFromPackageName("@my/package")).toBe("package");
-    expect(getProjectDirFromPackageName("my-package")).toBe("my-package");
+describe('getProjectDirFromPackageName', () => {
+  it('should get project dir from package name', () => {
+    expect(getProjectDirFromPackageName('@my/package')).toBe('package');
+    expect(getProjectDirFromPackageName('my-package')).toBe('my-package');
   });
 });
 
-describe("editor configuration policy", () => {
-  it("normalizes repeated editor options to a single editor value", () => {
-    expect(normalizeEditorOption("vscode")).toBe("vscode");
-    expect(normalizeEditorOption(["vscode", "zed"])).toBe("zed");
-    expect(normalizeEditorOption(["vscode", false])).toBe(false);
-    expect(normalizeEditorOption([undefined, "vscode"])).toBe("vscode");
+describe('editor configuration policy', () => {
+  it('normalizes repeated editor options to a single editor value', () => {
+    expect(normalizeEditorOption('vscode')).toBe('vscode');
+    expect(normalizeEditorOption(['vscode', 'zed'])).toBe('zed');
+    expect(normalizeEditorOption(['vscode', false])).toBe(false);
+    expect(normalizeEditorOption([undefined, 'vscode'])).toBe('vscode');
   });
 
-  it("allows automatic editor configuration outside existing monorepos", () => {
+  it('allows automatic editor configuration outside existing monorepos', () => {
     expect(shouldConfigureEditorsForCreate({ isMonorepo: false, editor: undefined })).toBe(true);
   });
 
-  it("skips automatic editor configuration inside existing monorepos", () => {
+  it('skips automatic editor configuration inside existing monorepos', () => {
     expect(shouldConfigureEditorsForCreate({ isMonorepo: true, editor: undefined })).toBe(false);
   });
 
-  it("allows explicit editor opt-in inside existing monorepos", () => {
-    expect(shouldConfigureEditorsForCreate({ isMonorepo: true, editor: "vscode" })).toBe(true);
-    expect(shouldConfigureEditorsForCreate({ isMonorepo: true, editor: "   " })).toBe(false);
+  it('allows explicit editor opt-in inside existing monorepos', () => {
+    expect(shouldConfigureEditorsForCreate({ isMonorepo: true, editor: 'vscode' })).toBe(true);
+    expect(shouldConfigureEditorsForCreate({ isMonorepo: true, editor: '   ' })).toBe(false);
   });
 
-  it("keeps --no-editor as an explicit opt-out in every workspace mode", () => {
+  it('keeps --no-editor as an explicit opt-out in every workspace mode', () => {
     expect(shouldConfigureEditorsForCreate({ isMonorepo: false, editor: false })).toBe(false);
     expect(shouldConfigureEditorsForCreate({ isMonorepo: true, editor: false })).toBe(false);
   });
 });
 
-describe("formatTargetDir", () => {
+describe('formatTargetDir', () => {
   it('should format "." as current directory with empty package name', () => {
-    expect(formatTargetDir(".")).toEqual({
-      directory: ".",
-      packageName: "",
+    expect(formatTargetDir('.')).toEqual({
+      directory: '.',
+      packageName: '',
     });
   });
 
   it('should format "./" as current directory with empty package name', () => {
-    expect(formatTargetDir("./")).toEqual({
-      directory: ".",
-      packageName: "",
+    expect(formatTargetDir('./')).toEqual({
+      directory: '.',
+      packageName: '',
     });
   });
 
-  it("should format target dir with invalid input", () => {
-    expect(formatTargetDir("/foo/bar")).matchSnapshot();
-    expect(formatTargetDir("@scope/")).matchSnapshot();
-    expect(formatTargetDir("../../foo/bar")).matchSnapshot();
+  it('should format target dir with invalid input', () => {
+    expect(formatTargetDir('/foo/bar')).matchSnapshot();
+    expect(formatTargetDir('@scope/')).matchSnapshot();
+    expect(formatTargetDir('../../foo/bar')).matchSnapshot();
   });
 
   // Should work on all platforms (including Windows) - directory must always use forward slashes
-  it("should format target dir with valid input", () => {
-    expect(formatTargetDir("./my-package")).matchSnapshot();
-    expect(formatTargetDir("my-package")).matchSnapshot();
-    expect(formatTargetDir("@my-scope/my-package")).matchSnapshot();
-    expect(formatTargetDir("foo/@my-scope/my-package")).matchSnapshot();
-    expect(formatTargetDir("./foo/@my-scope/my-package")).matchSnapshot();
-    expect(formatTargetDir("./foo/bar/@scope/my-package")).matchSnapshot();
-    expect(formatTargetDir("./foo/bar/@scope/my-package/")).matchSnapshot();
-    expect(formatTargetDir("./foo/bar/@scope/my-package/sub-package")).matchSnapshot();
+  it('should format target dir with valid input', () => {
+    expect(formatTargetDir('./my-package')).matchSnapshot();
+    expect(formatTargetDir('my-package')).matchSnapshot();
+    expect(formatTargetDir('@my-scope/my-package')).matchSnapshot();
+    expect(formatTargetDir('foo/@my-scope/my-package')).matchSnapshot();
+    expect(formatTargetDir('./foo/@my-scope/my-package')).matchSnapshot();
+    expect(formatTargetDir('./foo/bar/@scope/my-package')).matchSnapshot();
+    expect(formatTargetDir('./foo/bar/@scope/my-package/')).matchSnapshot();
+    expect(formatTargetDir('./foo/bar/@scope/my-package/sub-package')).matchSnapshot();
   });
 
   // Regression test for https://github.com/voidzero-dev/vite-plus/issues/938
   // On Windows, path.join/normalize produce backslashes which break when passed as CLI args.
   // Nested paths are the critical cases since they involve path separators.
-  it("should always use forward slashes in directory (issue #938)", () => {
-    expect(formatTargetDir("foo/@my-scope/my-package").directory).toBe("foo/my-package");
-    expect(formatTargetDir("./foo/bar/@scope/my-package").directory).toBe("foo/bar/my-package");
-    expect(formatTargetDir("./foo/bar/@scope/my-package/sub-package").directory).toBe(
-      "foo/bar/@scope/my-package/sub-package",
+  it('should always use forward slashes in directory (issue #938)', () => {
+    expect(formatTargetDir('foo/@my-scope/my-package').directory).toBe('foo/my-package');
+    expect(formatTargetDir('./foo/bar/@scope/my-package').directory).toBe('foo/bar/my-package');
+    expect(formatTargetDir('./foo/bar/@scope/my-package/sub-package').directory).toBe(
+      'foo/bar/@scope/my-package/sub-package',
     );
   });
 
-  it("should format target dir with invalid package name", () => {
-    expect(formatTargetDir("my-package@").error).matchSnapshot();
-    expect(formatTargetDir("my-package@1.0.0").error).matchSnapshot();
+  it('should format target dir with invalid package name', () => {
+    expect(formatTargetDir('my-package@').error).matchSnapshot();
+    expect(formatTargetDir('my-package@1.0.0').error).matchSnapshot();
   });
 });
 
-describe("deriveDefaultPackageName", () => {
-  it("should derive package name from directory basename", () => {
-    expect(deriveDefaultPackageName("/home/user/my-app", undefined, "fallback")).toBe("my-app");
+describe('deriveDefaultPackageName', () => {
+  it('should derive package name from directory basename', () => {
+    expect(deriveDefaultPackageName('/home/user/my-app', undefined, 'fallback')).toBe('my-app');
   });
 
-  it("should derive scoped package name when scope is provided", () => {
-    expect(deriveDefaultPackageName("/home/user/my-app", "@my-scope", "fallback")).toBe(
-      "@my-scope/my-app",
+  it('should derive scoped package name when scope is provided', () => {
+    expect(deriveDefaultPackageName('/home/user/my-app', '@my-scope', 'fallback')).toBe(
+      '@my-scope/my-app',
     );
   });
 
-  it("should fallback to random name when directory name is invalid", () => {
-    const result = deriveDefaultPackageName("/home/user/.hidden", undefined, "vite-plus-app");
+  it('should fallback to random name when directory name is invalid', () => {
+    const result = deriveDefaultPackageName('/home/user/.hidden', undefined, 'vite-plus-app');
     // directory name starts with '.', so a random name is generated instead
-    expect(result).not.toBe(".hidden");
+    expect(result).not.toBe('.hidden');
     expect(result.length).toBeGreaterThan(0);
   });
 
-  it("should fallback when directory is filesystem root", () => {
-    const result = deriveDefaultPackageName("/", undefined, "vite-plus-app");
+  it('should fallback when directory is filesystem root', () => {
+    const result = deriveDefaultPackageName('/', undefined, 'vite-plus-app');
     // basename of '/' is empty, so a random name is generated
     expect(result.length).toBeGreaterThan(0);
   });
 });
 
-describe("removeSrcOnlyTsconfigInclude", () => {
+describe('removeSrcOnlyTsconfigInclude', () => {
   let projectDir: string;
 
   beforeEach(() => {
-    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "vp-tsconfig-include-"));
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vp-tsconfig-include-'));
   });
 
   afterEach(() => {
@@ -137,19 +137,19 @@ describe("removeSrcOnlyTsconfigInclude", () => {
   });
 
   function writeTsconfig(tsconfig: unknown): void {
-    fs.writeFileSync(path.join(projectDir, "tsconfig.json"), JSON.stringify(tsconfig, null, 2));
+    fs.writeFileSync(path.join(projectDir, 'tsconfig.json'), JSON.stringify(tsconfig, null, 2));
   }
 
   function readTsconfig(): Record<string, unknown> {
-    return JSON.parse(fs.readFileSync(path.join(projectDir, "tsconfig.json"), "utf-8"));
+    return JSON.parse(fs.readFileSync(path.join(projectDir, 'tsconfig.json'), 'utf-8'));
   }
 
-  it("removes the default src-only include", () => {
+  it('removes the default src-only include', () => {
     writeTsconfig({
       compilerOptions: {
         strict: true,
       },
-      include: ["src"],
+      include: ['src'],
     });
 
     removeSrcOnlyTsconfigInclude(projectDir);
@@ -161,9 +161,9 @@ describe("removeSrcOnlyTsconfigInclude", () => {
     });
   });
 
-  it("handles JSONC tsconfig files", () => {
+  it('handles JSONC tsconfig files', () => {
     fs.writeFileSync(
-      path.join(projectDir, "tsconfig.json"),
+      path.join(projectDir, 'tsconfig.json'),
       `{
   // Vite templates allow comments and trailing commas here.
   "compilerOptions": {
@@ -183,12 +183,12 @@ describe("removeSrcOnlyTsconfigInclude", () => {
     });
   });
 
-  it("keeps custom include patterns", () => {
+  it('keeps custom include patterns', () => {
     const tsconfig = {
       compilerOptions: {
         strict: true,
       },
-      include: ["src", "tests"],
+      include: ['src', 'tests'],
     };
     writeTsconfig(tsconfig);
 
@@ -197,16 +197,16 @@ describe("removeSrcOnlyTsconfigInclude", () => {
     expect(readTsconfig()).toEqual(tsconfig);
   });
 
-  it("ignores projects without a tsconfig", () => {
+  it('ignores projects without a tsconfig', () => {
     expect(() => removeSrcOnlyTsconfigInclude(projectDir)).not.toThrow();
   });
 });
 
-describe("ensureGitignoreNodeModules", () => {
+describe('ensureGitignoreNodeModules', () => {
   let projectDir: string;
 
   beforeEach(() => {
-    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "vp-gitignore-"));
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vp-gitignore-'));
   });
 
   afterEach(() => {
@@ -214,65 +214,65 @@ describe("ensureGitignoreNodeModules", () => {
   });
 
   function gitignore(): string {
-    return fs.readFileSync(path.join(projectDir, ".gitignore"), "utf-8");
+    return fs.readFileSync(path.join(projectDir, '.gitignore'), 'utf-8');
   }
 
-  it("creates a fresh `.gitignore` with `node_modules` when none exists", () => {
+  it('creates a fresh `.gitignore` with `node_modules` when none exists', () => {
     ensureGitignoreNodeModules(projectDir);
-    expect(gitignore()).toBe("node_modules\n");
+    expect(gitignore()).toBe('node_modules\n');
   });
 
-  it("appends `node_modules` to an existing `.gitignore` that omits it", () => {
-    fs.writeFileSync(path.join(projectDir, ".gitignore"), "dist\n*.log\n");
+  it('appends `node_modules` to an existing `.gitignore` that omits it', () => {
+    fs.writeFileSync(path.join(projectDir, '.gitignore'), 'dist\n*.log\n');
     ensureGitignoreNodeModules(projectDir);
-    expect(gitignore()).toBe("dist\n*.log\nnode_modules\n");
+    expect(gitignore()).toBe('dist\n*.log\nnode_modules\n');
   });
 
-  it("terminates the last line first when the existing file lacks a trailing newline", () => {
-    fs.writeFileSync(path.join(projectDir, ".gitignore"), "dist");
+  it('terminates the last line first when the existing file lacks a trailing newline', () => {
+    fs.writeFileSync(path.join(projectDir, '.gitignore'), 'dist');
     ensureGitignoreNodeModules(projectDir);
-    expect(gitignore()).toBe("dist\nnode_modules\n");
+    expect(gitignore()).toBe('dist\nnode_modules\n');
   });
 
-  it("is a no-op when `node_modules` already appears as a standalone line", () => {
-    const existing = "# Logs\n*.log\nnode_modules\ndist\n";
-    fs.writeFileSync(path.join(projectDir, ".gitignore"), existing);
+  it('is a no-op when `node_modules` already appears as a standalone line', () => {
+    const existing = '# Logs\n*.log\nnode_modules\ndist\n';
+    fs.writeFileSync(path.join(projectDir, '.gitignore'), existing);
     ensureGitignoreNodeModules(projectDir);
     expect(gitignore()).toBe(existing);
   });
 
-  it("treats `node_modules/` (with trailing slash) as a match", () => {
-    const existing = "node_modules/\ndist\n";
-    fs.writeFileSync(path.join(projectDir, ".gitignore"), existing);
+  it('treats `node_modules/` (with trailing slash) as a match', () => {
+    const existing = 'node_modules/\ndist\n';
+    fs.writeFileSync(path.join(projectDir, '.gitignore'), existing);
     ensureGitignoreNodeModules(projectDir);
     expect(gitignore()).toBe(existing);
   });
 
-  it("handles CRLF line endings without re-appending", () => {
-    const existing = "node_modules\r\ndist\r\n";
-    fs.writeFileSync(path.join(projectDir, ".gitignore"), existing);
+  it('handles CRLF line endings without re-appending', () => {
+    const existing = 'node_modules\r\ndist\r\n';
+    fs.writeFileSync(path.join(projectDir, '.gitignore'), existing);
     ensureGitignoreNodeModules(projectDir);
     expect(gitignore()).toBe(existing);
   });
 
-  it("does not consider a `node_modules/sub` subpath as already excluded", () => {
-    fs.writeFileSync(path.join(projectDir, ".gitignore"), "node_modules/sub\n");
+  it('does not consider a `node_modules/sub` subpath as already excluded', () => {
+    fs.writeFileSync(path.join(projectDir, '.gitignore'), 'node_modules/sub\n');
     ensureGitignoreNodeModules(projectDir);
-    expect(gitignore()).toBe("node_modules/sub\nnode_modules\n");
+    expect(gitignore()).toBe('node_modules/sub\nnode_modules\n');
   });
 
-  it("does not match `!node_modules` (an explicit un-ignore override)", () => {
-    fs.writeFileSync(path.join(projectDir, ".gitignore"), "!node_modules\n");
+  it('does not match `!node_modules` (an explicit un-ignore override)', () => {
+    fs.writeFileSync(path.join(projectDir, '.gitignore'), '!node_modules\n');
     ensureGitignoreNodeModules(projectDir);
-    expect(gitignore()).toBe("!node_modules\nnode_modules\n");
+    expect(gitignore()).toBe('!node_modules\nnode_modules\n');
   });
 });
 
-describe("ensureGitignoreVsCodeEditorConfigs", () => {
+describe('ensureGitignoreVsCodeEditorConfigs', () => {
   let projectDir: string;
 
   beforeEach(() => {
-    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "vp-vscode-gitignore-"));
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vp-vscode-gitignore-'));
   });
 
   afterEach(() => {
@@ -280,117 +280,117 @@ describe("ensureGitignoreVsCodeEditorConfigs", () => {
   });
 
   function gitignore(): string {
-    return fs.readFileSync(path.join(projectDir, ".gitignore"), "utf-8");
+    return fs.readFileSync(path.join(projectDir, '.gitignore'), 'utf-8');
   }
 
   function writeGitignore(content: string): void {
-    fs.writeFileSync(path.join(projectDir, ".gitignore"), content);
+    fs.writeFileSync(path.join(projectDir, '.gitignore'), content);
   }
 
   function writeVsCodeSettings(): void {
-    fs.mkdirSync(path.join(projectDir, ".vscode"), { recursive: true });
-    fs.writeFileSync(path.join(projectDir, ".vscode", "settings.json"), "{}\n");
+    fs.mkdirSync(path.join(projectDir, '.vscode'), { recursive: true });
+    fs.writeFileSync(path.join(projectDir, '.vscode', 'settings.json'), '{}\n');
   }
 
-  const vscodeUnignoreBlock = "!.vscode/\n!.vscode/settings.json\n!.vscode/extensions.json\n";
+  const vscodeUnignoreBlock = '!.vscode/\n!.vscode/settings.json\n!.vscode/extensions.json\n';
 
-  it("unignores VS Code settings when `.vscode/*` is ignored", () => {
+  it('unignores VS Code settings when `.vscode/*` is ignored', () => {
     writeVsCodeSettings();
-    writeGitignore(".vscode/*\n!.vscode/extensions.json\n");
+    writeGitignore('.vscode/*\n!.vscode/extensions.json\n');
     ensureGitignoreVsCodeEditorConfigs(projectDir);
     expect(gitignore()).toBe(`.vscode/*\n!.vscode/extensions.json\n${vscodeUnignoreBlock}`);
   });
 
-  it("unignores generated VS Code config files for root-anchored contents ignores", () => {
+  it('unignores generated VS Code config files for root-anchored contents ignores', () => {
     writeVsCodeSettings();
-    writeGitignore("/.vscode/*\n");
+    writeGitignore('/.vscode/*\n');
     ensureGitignoreVsCodeEditorConfigs(projectDir);
     expect(gitignore()).toBe(`/.vscode/*\n${vscodeUnignoreBlock}`);
   });
 
-  it("appends VS Code directory and config unignores for directory-level VS Code ignores", () => {
+  it('appends VS Code directory and config unignores for directory-level VS Code ignores', () => {
     writeVsCodeSettings();
-    writeGitignore(".vscode/\n");
+    writeGitignore('.vscode/\n');
     ensureGitignoreVsCodeEditorConfigs(projectDir);
     expect(gitignore()).toBe(`.vscode/\n${vscodeUnignoreBlock}`);
   });
 
-  it("appends VS Code directory and config unignores for root-anchored directory-level VS Code ignores", () => {
+  it('appends VS Code directory and config unignores for root-anchored directory-level VS Code ignores', () => {
     writeVsCodeSettings();
-    writeGitignore("/.vscode\n");
+    writeGitignore('/.vscode\n');
     ensureGitignoreVsCodeEditorConfigs(projectDir);
     expect(gitignore()).toBe(`/.vscode\n${vscodeUnignoreBlock}`);
   });
 
-  it("appends VS Code config unignores after explicit VS Code settings ignores", () => {
+  it('appends VS Code config unignores after explicit VS Code settings ignores', () => {
     writeVsCodeSettings();
-    writeGitignore(".vscode/*\n.vscode/settings.json\n");
+    writeGitignore('.vscode/*\n.vscode/settings.json\n');
     ensureGitignoreVsCodeEditorConfigs(projectDir);
     expect(gitignore()).toBe(`.vscode/*\n.vscode/settings.json\n${vscodeUnignoreBlock}`);
   });
 
-  it("appends VS Code config unignores after explicit VS Code extensions ignores", () => {
+  it('appends VS Code config unignores after explicit VS Code extensions ignores', () => {
     writeVsCodeSettings();
-    writeGitignore(".vscode/*\n/.vscode/extensions.json\n");
+    writeGitignore('.vscode/*\n/.vscode/extensions.json\n');
     ensureGitignoreVsCodeEditorConfigs(projectDir);
     expect(gitignore()).toBe(`.vscode/*\n/.vscode/extensions.json\n${vscodeUnignoreBlock}`);
   });
 
-  it("appends VS Code config unignores when all generated config files are explicitly ignored", () => {
+  it('appends VS Code config unignores when all generated config files are explicitly ignored', () => {
     writeVsCodeSettings();
-    writeGitignore(".vscode/*\n.vscode/settings.json\n.vscode/extensions.json\n");
+    writeGitignore('.vscode/*\n.vscode/settings.json\n.vscode/extensions.json\n');
     ensureGitignoreVsCodeEditorConfigs(projectDir);
     expect(gitignore()).toBe(
       `.vscode/*\n.vscode/settings.json\n.vscode/extensions.json\n${vscodeUnignoreBlock}`,
     );
   });
 
-  it("appends the full block when settings are already unignored without the EOF block", () => {
+  it('appends the full block when settings are already unignored without the EOF block', () => {
     writeVsCodeSettings();
-    writeGitignore(".vscode/*\n!.vscode/settings.json\n");
+    writeGitignore('.vscode/*\n!.vscode/settings.json\n');
     ensureGitignoreVsCodeEditorConfigs(projectDir);
     expect(gitignore()).toBe(`.vscode/*\n!.vscode/settings.json\n${vscodeUnignoreBlock}`);
   });
 
-  it("re-appends the full block when later ignore rules override generated config unignores", () => {
+  it('re-appends the full block when later ignore rules override generated config unignores', () => {
     writeVsCodeSettings();
-    writeGitignore("!.vscode/settings.json\n!.vscode/extensions.json\n.vscode/*\n");
+    writeGitignore('!.vscode/settings.json\n!.vscode/extensions.json\n.vscode/*\n');
     ensureGitignoreVsCodeEditorConfigs(projectDir);
     expect(gitignore()).toBe(
       `!.vscode/settings.json\n!.vscode/extensions.json\n.vscode/*\n${vscodeUnignoreBlock}`,
     );
   });
 
-  it("appends VS Code config unignores even without a broad VS Code ignore", () => {
+  it('appends VS Code config unignores even without a broad VS Code ignore', () => {
     writeVsCodeSettings();
-    writeGitignore("dist\n");
+    writeGitignore('dist\n');
     ensureGitignoreVsCodeEditorConfigs(projectDir);
     expect(gitignore()).toBe(`dist\n${vscodeUnignoreBlock}`);
   });
 
-  it("does not create `.gitignore` when none exists", () => {
+  it('does not create `.gitignore` when none exists', () => {
     writeVsCodeSettings();
     ensureGitignoreVsCodeEditorConfigs(projectDir);
-    expect(fs.existsSync(path.join(projectDir, ".gitignore"))).toBe(false);
+    expect(fs.existsSync(path.join(projectDir, '.gitignore'))).toBe(false);
   });
 
-  it("does not change `.gitignore` when VS Code settings do not exist", () => {
-    const existing = ".vscode/*\n";
+  it('does not change `.gitignore` when VS Code settings do not exist', () => {
+    const existing = '.vscode/*\n';
     writeGitignore(existing);
     ensureGitignoreVsCodeEditorConfigs(projectDir);
     expect(gitignore()).toBe(existing);
   });
 
-  it("terminates the last line before appending VS Code config unignores", () => {
+  it('terminates the last line before appending VS Code config unignores', () => {
     writeVsCodeSettings();
-    writeGitignore(".vscode/*");
+    writeGitignore('.vscode/*');
     ensureGitignoreVsCodeEditorConfigs(projectDir);
     expect(gitignore()).toBe(`.vscode/*\n${vscodeUnignoreBlock}`);
   });
 
-  it("is idempotent", () => {
+  it('is idempotent', () => {
     writeVsCodeSettings();
-    writeGitignore(".vscode/*\n");
+    writeGitignore('.vscode/*\n');
     ensureGitignoreVsCodeEditorConfigs(projectDir);
     const afterFirstRun = gitignore();
     ensureGitignoreVsCodeEditorConfigs(projectDir);
@@ -398,11 +398,11 @@ describe("ensureGitignoreVsCodeEditorConfigs", () => {
   });
 });
 
-describe("renameFiles", () => {
+describe('renameFiles', () => {
   let projectDir: string;
 
   beforeEach(() => {
-    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "vp-rename-"));
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vp-rename-'));
   });
 
   afterEach(() => {
@@ -414,38 +414,38 @@ describe("renameFiles", () => {
   }
 
   function read(name: string): string {
-    return fs.readFileSync(path.join(projectDir, name), "utf-8");
+    return fs.readFileSync(path.join(projectDir, name), 'utf-8');
   }
 
   function exists(name: string): boolean {
     return fs.existsSync(path.join(projectDir, name));
   }
 
-  it("renames `_gitignore` to `.gitignore`", () => {
-    write("_gitignore", "node_modules\n");
+  it('renames `_gitignore` to `.gitignore`', () => {
+    write('_gitignore', 'node_modules\n');
     renameFiles(projectDir);
-    expect(exists("_gitignore")).toBe(false);
-    expect(read(".gitignore")).toBe("node_modules\n");
+    expect(exists('_gitignore')).toBe(false);
+    expect(read('.gitignore')).toBe('node_modules\n');
   });
 
-  it("renames `_npmrc` and `_yarnrc.yml`", () => {
-    write("_npmrc", "auto-install-peers=true\n");
-    write("_yarnrc.yml", "nodeLinker: node-modules\n");
+  it('renames `_npmrc` and `_yarnrc.yml`', () => {
+    write('_npmrc', 'auto-install-peers=true\n');
+    write('_yarnrc.yml', 'nodeLinker: node-modules\n');
     renameFiles(projectDir);
-    expect(exists("_npmrc")).toBe(false);
-    expect(exists("_yarnrc.yml")).toBe(false);
-    expect(read(".npmrc")).toBe("auto-install-peers=true\n");
-    expect(read(".yarnrc.yml")).toBe("nodeLinker: node-modules\n");
+    expect(exists('_npmrc')).toBe(false);
+    expect(exists('_yarnrc.yml')).toBe(false);
+    expect(read('.npmrc')).toBe('auto-install-peers=true\n');
+    expect(read('.yarnrc.yml')).toBe('nodeLinker: node-modules\n');
   });
 
-  it("is a no-op when no source files exist", () => {
+  it('is a no-op when no source files exist', () => {
     expect(() => renameFiles(projectDir)).not.toThrow();
     expect(fs.readdirSync(projectDir)).toEqual([]);
   });
 
-  it("leaves unmapped underscore files untouched", () => {
-    write("_foo", "bar\n");
+  it('leaves unmapped underscore files untouched', () => {
+    write('_foo', 'bar\n');
     renameFiles(projectDir);
-    expect(read("_foo")).toBe("bar\n");
+    expect(read('_foo')).toBe('bar\n');
   });
 });

--- a/packages/cli/src/create/templates/builtin.ts
+++ b/packages/cli/src/create/templates/builtin.ts
@@ -7,7 +7,7 @@ import colors from 'picocolors';
 import type { WorkspaceInfo } from '../../types/index.ts';
 import type { ExecutionWithProjectDir } from '../command.ts';
 import { discoverTemplate } from '../discovery.ts';
-import { setPackageName } from '../utils.ts';
+import { removeSrcOnlyTsconfigInclude, setPackageName } from '../utils.ts';
 import { executeGeneratorScaffold } from './generator.ts';
 import { runRemoteTemplateCommand } from './remote.ts';
 import { BuiltinTemplate, type BuiltinTemplateInfo, LibraryTemplateRepo } from './types.ts';
@@ -49,6 +49,7 @@ export async function executeBuiltinTemplate(
     }
     const fullPath = path.join(workspaceInfo.rootDir, templateInfo.targetDir);
     setPackageName(fullPath, templateInfo.packageName);
+    removeSrcOnlyTsconfigInclude(fullPath);
     return { ...result, projectDir: templateInfo.targetDir };
   }
 
@@ -76,6 +77,9 @@ export async function executeBuiltinTemplate(
   const fullPath = path.join(workspaceInfo.rootDir, templateInfo.targetDir);
   // set package name in the project directory
   setPackageName(fullPath, templateInfo.packageName);
+  if (templateInfo.command === 'create-vite@latest') {
+    removeSrcOnlyTsconfigInclude(fullPath);
+  }
 
   return {
     ...result,

--- a/packages/cli/src/create/templates/monorepo.ts
+++ b/packages/cli/src/create/templates/monorepo.ts
@@ -10,7 +10,13 @@ import { editJsonFile } from '../../utils/json.ts';
 import { templatesDir } from '../../utils/path.ts';
 import type { ExecutionWithProjectDir } from '../command.ts';
 import { discoverTemplate } from '../discovery.ts';
-import { copyDir, formatDisplayTargetDir, renameFiles, setPackageName } from '../utils.ts';
+import {
+  copyDir,
+  formatDisplayTargetDir,
+  removeSrcOnlyTsconfigInclude,
+  renameFiles,
+  setPackageName,
+} from '../utils.ts';
 import { runRemoteTemplateCommand } from './remote.ts';
 import { type BuiltinTemplateInfo, LibraryTemplateRepo } from './types.ts';
 
@@ -116,6 +122,7 @@ export async function executeMonorepoTemplate(
     : 'website';
   const appProjectPath = path.join(fullPath, InitialMonorepoAppDir);
   setPackageName(appProjectPath, appPackageName);
+  removeSrcOnlyTsconfigInclude(appProjectPath);
   // Perform auto-migration on the created app
   rewriteMonorepoProject(
     appProjectPath,
@@ -150,6 +157,7 @@ export async function executeMonorepoTemplate(
     : 'utils';
   const libraryProjectPath = path.join(fullPath, libraryDir);
   setPackageName(libraryProjectPath, libraryPackageName);
+  removeSrcOnlyTsconfigInclude(libraryProjectPath);
   // Perform auto-migration on the created library
   rewriteMonorepoProject(
     libraryProjectPath,

--- a/packages/cli/src/create/utils.ts
+++ b/packages/cli/src/create/utils.ts
@@ -145,6 +145,25 @@ export function setPackageName(projectDir: string, packageName: string) {
   });
 }
 
+export function removeSrcOnlyTsconfigInclude(projectDir: string): void {
+  const tsconfigPath = path.join(projectDir, 'tsconfig.json');
+  if (!fs.existsSync(tsconfigPath)) {
+    return;
+  }
+
+  editJsonFile<{ include?: unknown }>(tsconfigPath, (tsconfig) => {
+    if (
+      Array.isArray(tsconfig.include) &&
+      tsconfig.include.length === 1 &&
+      tsconfig.include[0] === 'src'
+    ) {
+      delete tsconfig.include;
+      return tsconfig;
+    }
+    return undefined;
+  });
+}
+
 const RENAME_FILES = {
   _gitignore: '.gitignore',
   _npmrc: '.npmrc',

--- a/packages/cli/src/create/utils.ts
+++ b/packages/cli/src/create/utils.ts
@@ -1,16 +1,16 @@
-import fs from 'node:fs';
-import path from 'node:path';
+import fs from "node:fs";
+import path from "node:path";
 
-import validateNpmPackageName from 'validate-npm-package-name';
+import validateNpmPackageName from "validate-npm-package-name";
 
-import { editJsonFile } from '../utils/json.ts';
-import { getRandomProjectName } from './random-name.ts';
+import { editJsonFile } from "../utils/json.ts";
+import { getRandomProjectName } from "./random-name.ts";
 
 export type CreateEditorOption = string | false | undefined;
 type ParsedCreateEditorOption = CreateEditorOption | CreateEditorOption[];
 
 function hasExplicitEditorOptIn(editor: CreateEditorOption): boolean {
-  return typeof editor === 'string' && editor.trim() !== '';
+  return typeof editor === "string" && editor.trim() !== "";
 }
 
 export function normalizeEditorOption(editor: ParsedCreateEditorOption): CreateEditorOption {
@@ -20,7 +20,7 @@ export function normalizeEditorOption(editor: ParsedCreateEditorOption): CreateE
   if (editor.includes(false)) {
     return false;
   }
-  return editor.findLast((value): value is string => typeof value === 'string');
+  return editor.findLast((value): value is string => typeof value === "string");
 }
 
 export function shouldConfigureEditorsForCreate({
@@ -88,28 +88,28 @@ export function formatTargetDir(input: string): {
   let targetDir = path.normalize(input.trim());
 
   // "." or "./" means current directory — valid directory, but no package name derivable
-  if (targetDir === '.' || targetDir === `.${path.sep}`) {
-    return { directory: '.', packageName: '' };
+  if (targetDir === "." || targetDir === `.${path.sep}`) {
+    return { directory: ".", packageName: "" };
   }
 
   const parsed = path.parse(targetDir);
   if (parsed.root || path.isAbsolute(targetDir)) {
     return {
-      directory: '',
-      packageName: '',
-      error: 'Absolute path is not allowed',
+      directory: "",
+      packageName: "",
+      error: "Absolute path is not allowed",
     };
   }
-  if (targetDir.includes('..')) {
+  if (targetDir.includes("..")) {
     return {
-      directory: '',
-      packageName: '',
+      directory: "",
+      packageName: "",
       error: 'Relative path contains ".." which is not allowed',
     };
   }
   let packageName = parsed.base;
   const parentName = path.basename(parsed.dir);
-  if (parentName.startsWith('@')) {
+  if (parentName.startsWith("@")) {
     // skip scope directory
     // ./@my-scope/my-package -> ./my-package
     targetDir = path.join(path.dirname(parsed.dir), packageName);
@@ -118,56 +118,60 @@ export function formatTargetDir(input: string): {
   const result = validateNpmPackageName(packageName);
   if (!result.validForNewPackages) {
     // invalid package name
-    const message = result.errors?.[0] ?? result.warnings?.[0] ?? 'Invalid package name';
+    const message = result.errors?.[0] ?? result.warnings?.[0] ?? "Invalid package name";
     return {
-      directory: '',
-      packageName: '',
+      directory: "",
+      packageName: "",
       error: `Parsed package name "${packageName}" is invalid: ${message}`,
     };
   }
-  return { directory: targetDir.split(path.sep).join('/'), packageName };
+  return { directory: targetDir.split(path.sep).join("/"), packageName };
 }
 
 // Get the project directory from the project name
 // If the project name is a scoped package name, return the second part
 // Otherwise, return the project name
 export function getProjectDirFromPackageName(packageName: string) {
-  if (packageName.startsWith('@')) {
-    return packageName.split('/')[1];
+  if (packageName.startsWith("@")) {
+    return packageName.split("/")[1];
   }
   return packageName;
 }
 
 export function setPackageName(projectDir: string, packageName: string) {
-  editJsonFile<{ name?: string }>(path.join(projectDir, 'package.json'), (pkg) => {
+  editJsonFile<{ name?: string }>(path.join(projectDir, "package.json"), (pkg) => {
     pkg.name = packageName;
     return pkg;
   });
 }
 
 export function removeSrcOnlyTsconfigInclude(projectDir: string): void {
-  const tsconfigPath = path.join(projectDir, 'tsconfig.json');
+  const tsconfigPath = path.join(projectDir, "tsconfig.json");
   if (!fs.existsSync(tsconfigPath)) {
     return;
   }
 
-  editJsonFile<{ include?: unknown }>(tsconfigPath, (tsconfig) => {
-    if (
-      Array.isArray(tsconfig.include) &&
-      tsconfig.include.length === 1 &&
-      tsconfig.include[0] === 'src'
-    ) {
-      delete tsconfig.include;
-      return tsconfig;
-    }
-    return undefined;
-  });
+  editJsonFile<{ include?: unknown }>(
+    tsconfigPath,
+    (tsconfig) => {
+      if (
+        Array.isArray(tsconfig.include) &&
+        tsconfig.include.length === 1 &&
+        tsconfig.include[0] === "src"
+      ) {
+        delete tsconfig.include;
+        return tsconfig;
+      }
+      return undefined;
+    },
+    true,
+  );
 }
 
 const RENAME_FILES = {
-  _gitignore: '.gitignore',
-  _npmrc: '.npmrc',
-  '_yarnrc.yml': '.yarnrc.yml',
+  _gitignore: ".gitignore",
+  _npmrc: ".npmrc",
+  "_yarnrc.yml": ".yarnrc.yml",
 } as const;
 
 /** Rename underscore-prefixed scaffold files to their dotfile names in `projectDir`. */
@@ -189,24 +193,24 @@ export function renameFiles(projectDir: string): void {
  * `.gitignore` already lists `node_modules`.
  */
 export function ensureGitignoreNodeModules(projectDir: string): void {
-  const gitignorePath = path.join(projectDir, '.gitignore');
-  let content = '';
+  const gitignorePath = path.join(projectDir, ".gitignore");
+  let content = "";
   try {
-    content = fs.readFileSync(gitignorePath, 'utf-8');
+    content = fs.readFileSync(gitignorePath, "utf-8");
   } catch {
     // No existing .gitignore — we'll write a fresh one below.
   }
   if (/^\s*node_modules\/?\s*$/m.test(content)) {
     return;
   }
-  const prefix = content === '' || content.endsWith('\n') ? '' : '\n';
+  const prefix = content === "" || content.endsWith("\n") ? "" : "\n";
   fs.appendFileSync(gitignorePath, `${prefix}node_modules\n`);
 }
 
-const VSCODE_SETTINGS_PATH = '.vscode/settings.json';
-const VSCODE_EXTENSIONS_PATH = '.vscode/extensions.json';
+const VSCODE_SETTINGS_PATH = ".vscode/settings.json";
+const VSCODE_EXTENSIONS_PATH = ".vscode/extensions.json";
 const VSCODE_CONFIG_UNIGNORE_BLOCK = [
-  '!.vscode/',
+  "!.vscode/",
   `!${VSCODE_SETTINGS_PATH}`,
   `!${VSCODE_EXTENSIONS_PATH}`,
 ] as const;
@@ -219,10 +223,10 @@ export function ensureGitignoreVsCodeEditorConfigs(projectDir: string): void {
     return;
   }
 
-  const gitignorePath = path.join(projectDir, '.gitignore');
+  const gitignorePath = path.join(projectDir, ".gitignore");
   let content: string;
   try {
-    content = fs.readFileSync(gitignorePath, 'utf-8');
+    content = fs.readFileSync(gitignorePath, "utf-8");
   } catch {
     return;
   }
@@ -231,7 +235,7 @@ export function ensureGitignoreVsCodeEditorConfigs(projectDir: string): void {
 }
 
 function appendGitignoreVsCodeEditorConfigsBlock(gitignorePath: string, content: string): void {
-  if (content.trimEnd().endsWith(VSCODE_CONFIG_UNIGNORE_BLOCK.join('\n'))) {
+  if (content.trimEnd().endsWith(VSCODE_CONFIG_UNIGNORE_BLOCK.join("\n"))) {
     return;
   }
   appendGitignoreLines(gitignorePath, content, VSCODE_CONFIG_UNIGNORE_BLOCK);
@@ -245,20 +249,20 @@ function appendGitignoreLines(
   if (lines.length === 0) {
     return;
   }
-  const prefix = content === '' || content.endsWith('\n') ? '' : '\n';
-  fs.appendFileSync(gitignorePath, `${prefix}${lines.join('\n')}\n`);
+  const prefix = content === "" || content.endsWith("\n") ? "" : "\n";
+  fs.appendFileSync(gitignorePath, `${prefix}${lines.join("\n")}\n`);
 }
 
 export function formatDisplayTargetDir(targetDir: string) {
-  const normalized = targetDir.split(path.sep).join('/');
-  if (normalized === '' || normalized === '.') {
-    return './';
+  const normalized = targetDir.split(path.sep).join("/");
+  if (normalized === "" || normalized === ".") {
+    return "./";
   }
   if (
-    normalized.startsWith('./') ||
-    normalized.startsWith('../') ||
-    normalized.startsWith('/') ||
-    normalized.startsWith('~')
+    normalized.startsWith("./") ||
+    normalized.startsWith("../") ||
+    normalized.startsWith("/") ||
+    normalized.startsWith("~")
   ) {
     return normalized;
   }

--- a/packages/cli/src/create/utils.ts
+++ b/packages/cli/src/create/utils.ts
@@ -1,16 +1,16 @@
-import fs from "node:fs";
-import path from "node:path";
+import fs from 'node:fs';
+import path from 'node:path';
 
-import validateNpmPackageName from "validate-npm-package-name";
+import validateNpmPackageName from 'validate-npm-package-name';
 
-import { editJsonFile } from "../utils/json.ts";
-import { getRandomProjectName } from "./random-name.ts";
+import { editJsonFile } from '../utils/json.ts';
+import { getRandomProjectName } from './random-name.ts';
 
 export type CreateEditorOption = string | false | undefined;
 type ParsedCreateEditorOption = CreateEditorOption | CreateEditorOption[];
 
 function hasExplicitEditorOptIn(editor: CreateEditorOption): boolean {
-  return typeof editor === "string" && editor.trim() !== "";
+  return typeof editor === 'string' && editor.trim() !== '';
 }
 
 export function normalizeEditorOption(editor: ParsedCreateEditorOption): CreateEditorOption {
@@ -20,7 +20,7 @@ export function normalizeEditorOption(editor: ParsedCreateEditorOption): CreateE
   if (editor.includes(false)) {
     return false;
   }
-  return editor.findLast((value): value is string => typeof value === "string");
+  return editor.findLast((value): value is string => typeof value === 'string');
 }
 
 export function shouldConfigureEditorsForCreate({
@@ -88,28 +88,28 @@ export function formatTargetDir(input: string): {
   let targetDir = path.normalize(input.trim());
 
   // "." or "./" means current directory — valid directory, but no package name derivable
-  if (targetDir === "." || targetDir === `.${path.sep}`) {
-    return { directory: ".", packageName: "" };
+  if (targetDir === '.' || targetDir === `.${path.sep}`) {
+    return { directory: '.', packageName: '' };
   }
 
   const parsed = path.parse(targetDir);
   if (parsed.root || path.isAbsolute(targetDir)) {
     return {
-      directory: "",
-      packageName: "",
-      error: "Absolute path is not allowed",
+      directory: '',
+      packageName: '',
+      error: 'Absolute path is not allowed',
     };
   }
-  if (targetDir.includes("..")) {
+  if (targetDir.includes('..')) {
     return {
-      directory: "",
-      packageName: "",
+      directory: '',
+      packageName: '',
       error: 'Relative path contains ".." which is not allowed',
     };
   }
   let packageName = parsed.base;
   const parentName = path.basename(parsed.dir);
-  if (parentName.startsWith("@")) {
+  if (parentName.startsWith('@')) {
     // skip scope directory
     // ./@my-scope/my-package -> ./my-package
     targetDir = path.join(path.dirname(parsed.dir), packageName);
@@ -118,35 +118,35 @@ export function formatTargetDir(input: string): {
   const result = validateNpmPackageName(packageName);
   if (!result.validForNewPackages) {
     // invalid package name
-    const message = result.errors?.[0] ?? result.warnings?.[0] ?? "Invalid package name";
+    const message = result.errors?.[0] ?? result.warnings?.[0] ?? 'Invalid package name';
     return {
-      directory: "",
-      packageName: "",
+      directory: '',
+      packageName: '',
       error: `Parsed package name "${packageName}" is invalid: ${message}`,
     };
   }
-  return { directory: targetDir.split(path.sep).join("/"), packageName };
+  return { directory: targetDir.split(path.sep).join('/'), packageName };
 }
 
 // Get the project directory from the project name
 // If the project name is a scoped package name, return the second part
 // Otherwise, return the project name
 export function getProjectDirFromPackageName(packageName: string) {
-  if (packageName.startsWith("@")) {
-    return packageName.split("/")[1];
+  if (packageName.startsWith('@')) {
+    return packageName.split('/')[1];
   }
   return packageName;
 }
 
 export function setPackageName(projectDir: string, packageName: string) {
-  editJsonFile<{ name?: string }>(path.join(projectDir, "package.json"), (pkg) => {
+  editJsonFile<{ name?: string }>(path.join(projectDir, 'package.json'), (pkg) => {
     pkg.name = packageName;
     return pkg;
   });
 }
 
 export function removeSrcOnlyTsconfigInclude(projectDir: string): void {
-  const tsconfigPath = path.join(projectDir, "tsconfig.json");
+  const tsconfigPath = path.join(projectDir, 'tsconfig.json');
   if (!fs.existsSync(tsconfigPath)) {
     return;
   }
@@ -157,7 +157,7 @@ export function removeSrcOnlyTsconfigInclude(projectDir: string): void {
       if (
         Array.isArray(tsconfig.include) &&
         tsconfig.include.length === 1 &&
-        tsconfig.include[0] === "src"
+        tsconfig.include[0] === 'src'
       ) {
         delete tsconfig.include;
         return tsconfig;
@@ -169,9 +169,9 @@ export function removeSrcOnlyTsconfigInclude(projectDir: string): void {
 }
 
 const RENAME_FILES = {
-  _gitignore: ".gitignore",
-  _npmrc: ".npmrc",
-  "_yarnrc.yml": ".yarnrc.yml",
+  _gitignore: '.gitignore',
+  _npmrc: '.npmrc',
+  '_yarnrc.yml': '.yarnrc.yml',
 } as const;
 
 /** Rename underscore-prefixed scaffold files to their dotfile names in `projectDir`. */
@@ -193,24 +193,24 @@ export function renameFiles(projectDir: string): void {
  * `.gitignore` already lists `node_modules`.
  */
 export function ensureGitignoreNodeModules(projectDir: string): void {
-  const gitignorePath = path.join(projectDir, ".gitignore");
-  let content = "";
+  const gitignorePath = path.join(projectDir, '.gitignore');
+  let content = '';
   try {
-    content = fs.readFileSync(gitignorePath, "utf-8");
+    content = fs.readFileSync(gitignorePath, 'utf-8');
   } catch {
     // No existing .gitignore — we'll write a fresh one below.
   }
   if (/^\s*node_modules\/?\s*$/m.test(content)) {
     return;
   }
-  const prefix = content === "" || content.endsWith("\n") ? "" : "\n";
+  const prefix = content === '' || content.endsWith('\n') ? '' : '\n';
   fs.appendFileSync(gitignorePath, `${prefix}node_modules\n`);
 }
 
-const VSCODE_SETTINGS_PATH = ".vscode/settings.json";
-const VSCODE_EXTENSIONS_PATH = ".vscode/extensions.json";
+const VSCODE_SETTINGS_PATH = '.vscode/settings.json';
+const VSCODE_EXTENSIONS_PATH = '.vscode/extensions.json';
 const VSCODE_CONFIG_UNIGNORE_BLOCK = [
-  "!.vscode/",
+  '!.vscode/',
   `!${VSCODE_SETTINGS_PATH}`,
   `!${VSCODE_EXTENSIONS_PATH}`,
 ] as const;
@@ -223,10 +223,10 @@ export function ensureGitignoreVsCodeEditorConfigs(projectDir: string): void {
     return;
   }
 
-  const gitignorePath = path.join(projectDir, ".gitignore");
+  const gitignorePath = path.join(projectDir, '.gitignore');
   let content: string;
   try {
-    content = fs.readFileSync(gitignorePath, "utf-8");
+    content = fs.readFileSync(gitignorePath, 'utf-8');
   } catch {
     return;
   }
@@ -235,7 +235,7 @@ export function ensureGitignoreVsCodeEditorConfigs(projectDir: string): void {
 }
 
 function appendGitignoreVsCodeEditorConfigsBlock(gitignorePath: string, content: string): void {
-  if (content.trimEnd().endsWith(VSCODE_CONFIG_UNIGNORE_BLOCK.join("\n"))) {
+  if (content.trimEnd().endsWith(VSCODE_CONFIG_UNIGNORE_BLOCK.join('\n'))) {
     return;
   }
   appendGitignoreLines(gitignorePath, content, VSCODE_CONFIG_UNIGNORE_BLOCK);
@@ -249,20 +249,20 @@ function appendGitignoreLines(
   if (lines.length === 0) {
     return;
   }
-  const prefix = content === "" || content.endsWith("\n") ? "" : "\n";
-  fs.appendFileSync(gitignorePath, `${prefix}${lines.join("\n")}\n`);
+  const prefix = content === '' || content.endsWith('\n') ? '' : '\n';
+  fs.appendFileSync(gitignorePath, `${prefix}${lines.join('\n')}\n`);
 }
 
 export function formatDisplayTargetDir(targetDir: string) {
-  const normalized = targetDir.split(path.sep).join("/");
-  if (normalized === "" || normalized === ".") {
-    return "./";
+  const normalized = targetDir.split(path.sep).join('/');
+  if (normalized === '' || normalized === '.') {
+    return './';
   }
   if (
-    normalized.startsWith("./") ||
-    normalized.startsWith("../") ||
-    normalized.startsWith("/") ||
-    normalized.startsWith("~")
+    normalized.startsWith('./') ||
+    normalized.startsWith('../') ||
+    normalized.startsWith('/') ||
+    normalized.startsWith('~')
   ) {
     return normalized;
   }

--- a/packages/cli/src/utils/json.ts
+++ b/packages/cli/src/utils/json.ts
@@ -1,32 +1,33 @@
-import fs from 'node:fs';
+import fs from "node:fs";
 
-import detectIndent from 'detect-indent';
-import { detectNewline } from 'detect-newline';
-import { parse as parseJsonc } from 'jsonc-parser';
+import detectIndent from "detect-indent";
+import { detectNewline } from "detect-newline";
+import { parse as parseJsonc } from "jsonc-parser";
 
 export function readJsonFile(file: string, allowComments?: boolean): Record<string, unknown> {
-  const content = fs.readFileSync(file, 'utf-8');
+  const content = fs.readFileSync(file, "utf-8");
   const parseFunction = allowComments ? parseJsonc : JSON.parse;
   return parseFunction(content);
 }
 
 export function writeJsonFile(file: string, data: Record<string, unknown>) {
-  let newline = '\n';
-  let indent = '  ';
+  let newline = "\n";
+  let indent = "  ";
   if (fs.existsSync(file)) {
-    const content = fs.readFileSync(file, 'utf-8');
+    const content = fs.readFileSync(file, "utf-8");
     // keep the original newline and indent
     indent = detectIndent(content).indent;
-    newline = detectNewline(content) ?? '';
+    newline = detectNewline(content) ?? "";
   }
-  fs.writeFileSync(file, JSON.stringify(data, null, indent) + newline, 'utf-8');
+  fs.writeFileSync(file, JSON.stringify(data, null, indent) + newline, "utf-8");
 }
 
 export function editJsonFile<T extends Record<string, unknown> = Record<string, unknown>>(
   file: string,
   callback: (content: T) => T | undefined,
+  allowComments?: boolean,
 ) {
-  const json = readJsonFile(file) as T;
+  const json = readJsonFile(file, allowComments) as T;
   const newJson = callback(json);
   if (newJson) {
     writeJsonFile(file, newJson);

--- a/packages/cli/src/utils/json.ts
+++ b/packages/cli/src/utils/json.ts
@@ -1,25 +1,25 @@
-import fs from "node:fs";
+import fs from 'node:fs';
 
-import detectIndent from "detect-indent";
-import { detectNewline } from "detect-newline";
-import { parse as parseJsonc } from "jsonc-parser";
+import detectIndent from 'detect-indent';
+import { detectNewline } from 'detect-newline';
+import { parse as parseJsonc } from 'jsonc-parser';
 
 export function readJsonFile(file: string, allowComments?: boolean): Record<string, unknown> {
-  const content = fs.readFileSync(file, "utf-8");
+  const content = fs.readFileSync(file, 'utf-8');
   const parseFunction = allowComments ? parseJsonc : JSON.parse;
   return parseFunction(content);
 }
 
 export function writeJsonFile(file: string, data: Record<string, unknown>) {
-  let newline = "\n";
-  let indent = "  ";
+  let newline = '\n';
+  let indent = '  ';
   if (fs.existsSync(file)) {
-    const content = fs.readFileSync(file, "utf-8");
+    const content = fs.readFileSync(file, 'utf-8');
     // keep the original newline and indent
     indent = detectIndent(content).indent;
-    newline = detectNewline(content) ?? "";
+    newline = detectNewline(content) ?? '';
   }
-  fs.writeFileSync(file, JSON.stringify(data, null, indent) + newline, "utf-8");
+  fs.writeFileSync(file, JSON.stringify(data, null, indent) + newline, 'utf-8');
 }
 
 export function editJsonFile<T extends Record<string, unknown> = Record<string, unknown>>(


### PR DESCRIPTION
## Summary

- remove generated `tsconfig.json` `include: ["src"]` when Vite+ creates builtin application/library projects
- apply the same cleanup to the default app/library created by `vite:monorepo`
- add unit coverage for the src-only include cleanup helper

Closes #1308

## Verification

- `git diff --check`
- `pnpm exec oxnode tmp/check-remove-src-include.ts` (temporary smoke script; removed before commit)

## Notes

I could not run `pnpm -F vite-plus test src/create/__tests__/utils.spec.ts` in this checkout because local workspace dependencies are not built: Vitest resolves the local Vite package and fails on missing `vite/dist/vite/node/index.js`; trying `pnpm -F vite build` then fails on missing local `rolldown/packages/rolldown/dist/cli.mjs`.
