### PR TITLE
fix(migrate): summarize skipped git hooks

### DIFF
--- a/packages/cli/snap-tests-global/migration-existing-husky-v8-hooks/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-husky-v8-hooks/snap.txt
@@ -5,6 +5,8 @@
 ◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 1 config update applied
+→ Manual follow-up:
+  - Git hooks were not migrated: Detected husky <9.0.0 — please upgrade to husky v9+ first, then re-run migration.
 
 > cat package.json # husky/lint-staged should remain in devDeps, prepare should stay as husky
 {

--- a/packages/cli/snap-tests-global/migration-existing-husky-v8-multi-hooks/snap.txt
+++ b/packages/cli/snap-tests-global/migration-existing-husky-v8-multi-hooks/snap.txt
@@ -5,6 +5,8 @@
 ◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 1 config update applied
+→ Manual follow-up:
+  - Git hooks were not migrated: Detected husky <9.0.0 — please upgrade to husky v9+ first, then re-run migration.
 
 > cat package.json # husky/lint-staged should remain in devDeps, prepare should stay as husky
 {

--- a/packages/cli/snap-tests-global/migration-husky-latest-dist-tag/snap.txt
+++ b/packages/cli/snap-tests-global/migration-husky-latest-dist-tag/snap.txt
@@ -5,6 +5,8 @@
 ◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 1 config update applied
+→ Manual follow-up:
+  - Git hooks were not migrated: Could not determine husky version from "latest" — please specify a semver-compatible version (e.g., "^9.0.0") and re-run migration.
 
 > cat package.json # husky should still be in devDeps
 {

--- a/packages/cli/snap-tests-global/migration-husky-v8-preserves-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-husky-v8-preserves-lint-staged/snap.txt
@@ -5,6 +5,8 @@
 ◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 1 config update applied
+→ Manual follow-up:
+  - Git hooks were not migrated: Detected husky <9.0.0 — please upgrade to husky v9+ first, then re-run migration.
 
 > cat package.json # lint-staged config should still be in package.json
 {

--- a/packages/cli/snap-tests-global/migration-lint-staged-ts-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lint-staged-ts-config/snap.txt
@@ -5,6 +5,8 @@
 ◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 1 config update applied
+→ Manual follow-up:
+  - Git hooks were not migrated: Unsupported lint-staged config format — skipping git hooks setup. Please configure git hooks manually.
 
 > cat package.json # check lint-staged NOT added to package.json, husky/lint-staged removed from devDependencies
 {

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-not-support/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-not-support/snap.txt
@@ -5,6 +5,8 @@
 ◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 1 config update applied
+→ Manual follow-up:
+  - Git hooks were not migrated: Unsupported lint-staged config format — skipping git hooks setup. Please configure git hooks manually.
 
 > cat .lintstagedrc # check .lintstagedrc is not updated
 '*.js':

--- a/packages/cli/snap-tests-global/migration-monorepo-husky-v8-preserves-lint-staged/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-husky-v8-preserves-lint-staged/snap.txt
@@ -4,6 +4,8 @@
 ◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 1 config update applied
+→ Manual follow-up:
+  - Git hooks were not migrated: Detected husky <9.0.0 — please upgrade to husky v9+ first, then re-run migration.
 
 > cat package.json # root lint-staged config should still be in package.json
 {

--- a/packages/cli/snap-tests-global/migration-other-hook-tool/snap.txt
+++ b/packages/cli/snap-tests-global/migration-other-hook-tool/snap.txt
@@ -4,6 +4,8 @@
 ◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 1 config update applied
+→ Manual follow-up:
+  - Git hooks were not migrated: Detected simple-git-hooks — skipping git hooks setup. Please configure git hooks manually.
 
 > cat package.json # lint-staged config, scripts, and simple-git-hooks config should all be preserved
 {

--- a/packages/cli/snap-tests-global/migration-partially-migrated-pre-commit/snap.txt
+++ b/packages/cli/snap-tests-global/migration-partially-migrated-pre-commit/snap.txt
@@ -5,6 +5,8 @@
 ◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 1 config update applied
+→ Manual follow-up:
+  - Git hooks were not migrated: Detected husky <9.0.0 — please upgrade to husky v9+ first, then re-run migration.
 
 > cat package.json # husky/lint-staged should remain in devDeps, prepare should stay as husky
 {

--- a/packages/cli/snap-tests-global/migration-subpath/snap.txt
+++ b/packages/cli/snap-tests-global/migration-subpath/snap.txt
@@ -5,6 +5,8 @@
 ◇ Migrated foo to Vite+
 • Node <semver>  pnpm <semver>
 • 1 config update applied
+→ Manual follow-up:
+  - Git hooks were not migrated: Subdirectory project detected — skipping git hooks setup. Configure hooks at the repository root.
 
 > cat foo/package.json # check package.json
 {

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -78,7 +78,12 @@ import {
   type Framework,
   type NodeVersionManagerDetection,
 } from './migrator.ts';
-import { addMigrationWarning, createMigrationReport, type MigrationReport } from './report.ts';
+import {
+  addManualStep,
+  addMigrationWarning,
+  createMigrationReport,
+  type MigrationReport,
+} from './report.ts';
 
 async function confirmNodeVersionFileMigration(
   interactive: boolean,
@@ -330,6 +335,7 @@ function parseArgs() {
 
 interface MigrationSetupPlan {
   shouldSetupHooks: boolean;
+  gitHooksSkipReason?: string;
   selectedAgentTargetPaths?: string[];
   agentConflictDecisions: Map<string, 'append' | 'skip'>;
   selectedEditor?: EditorId;
@@ -445,16 +451,18 @@ async function collectGitHooksDecision(
   rootDir: string,
   packageManager: PackageManager | undefined,
   options: MigrationOptions,
-): Promise<boolean> {
+): Promise<{ shouldSetupHooks: boolean; gitHooksSkipReason?: string }> {
   let shouldSetupHooks = await promptGitHooks(options);
+  let gitHooksSkipReason: string | undefined;
   if (shouldSetupHooks) {
     const reason = preflightGitHooksSetup(rootDir, packageManager);
     if (reason) {
       prompts.log.warn(`⚠ ${reason}`);
+      gitHooksSkipReason = reason;
       shouldSetupHooks = false;
     }
   }
-  return shouldSetupHooks;
+  return { shouldSetupHooks, gitHooksSkipReason };
 }
 
 async function collectAgentInstructionPlan(
@@ -592,7 +600,7 @@ async function collectMigrationSetupPlan(
   packages?: WorkspacePackage[],
   includeEslint = true,
 ): Promise<MigrationSetupPlan> {
-  const shouldSetupHooks = await collectGitHooksDecision(rootDir, packageManager, options);
+  const gitHooksPlan = await collectGitHooksDecision(rootDir, packageManager, options);
   const agentPlan = await collectAgentInstructionPlan(rootDir, options);
   const editorPlan = await collectEditorConfigPlan(rootDir, options);
   const eslintPlan = includeEslint
@@ -600,7 +608,7 @@ async function collectMigrationSetupPlan(
     : { migrateEslint: false };
 
   return {
-    shouldSetupHooks,
+    ...gitHooksPlan,
     ...agentPlan,
     ...editorPlan,
     ...eslintPlan,
@@ -1022,6 +1030,9 @@ async function executeMigrationPlan(
   // Without hooks, lint-staged config must stay in package.json so existing
   // .husky/pre-commit scripts that invoke `npx lint-staged` keep working.
   const skipStagedMigration = !plan.shouldSetupHooks;
+  if (plan.gitHooksSkipReason) {
+    addManualStep(report, `Git hooks were not migrated: ${plan.gitHooksSkipReason}`);
+  }
 
   // 7. Rewrite configs
   updateMigrationProgress('Rewriting configs');


### PR DESCRIPTION
## Summary

- keep the inline preflight warning when git hook migration is skipped
- carry the skip reason into the migration plan
- show the skipped hook setup in the final Manual follow-up summary

Closes #1854

## Verification

- `git diff --check`
- `pnpm exec tsgo --noEmit -p packages/cli/tsconfig.json`

## Notes

`pnpm -F vite-plus test src/migration/__tests__/migrator.spec.ts -- --runInBand` could not start in this checkout because Vitest resolves the local Vite workspace package and `vite/dist/vite/node/index.js` has not been built. This is the same local workspace-dist blocker seen while preparing #1863.
