### PR TITLE
fix(command): resolve fspy program paths

### DIFF
--- a/crates/vite_command/src/lib.rs
+++ b/crates/vite_command/src/lib.rs
@@ -206,16 +206,19 @@ where
     S: AsRef<OsStr>,
 {
     let cwd = cwd.as_ref();
+    let (program, prefix_args) = resolve_program(bin_name, envs, cwd)?;
     let args: Vec<OsString> = args.into_iter().map(|s| s.as_ref().to_owned()).collect();
     tracing::debug!(
         target: "vite_command::spawn",
-        bin_name,
+        program = %program.as_path().display(),
+        prefix_args = ?prefix_args,
         args = ?args,
         cwd = %cwd.as_path().display(),
         "spawn (fspy)",
     );
-    let mut cmd = fspy::Command::new(bin_name);
-    cmd.args(&args)
+    let mut cmd = fspy::Command::new(program.as_path());
+    cmd.args(&prefix_args)
+        .args(&args)
         // set system environment variables first
         .envs(std::env::vars_os())
         // then set custom environment variables
@@ -502,7 +505,7 @@ mod tests {
                     .err()
                     .unwrap()
                     .to_string()
-                    .contains("could not resolve the full path of program '\"npm-not-exists\"'")
+                    .contains("Cannot find binary path for command 'npm-not-exists'")
             );
         }
     }


### PR DESCRIPTION
## Summary

- Make `run_command_with_fspy` resolve binaries through the same `resolve_program` path used by `run_command`.
- Preserve Windows `.cmd`/PowerShell prefix handling before spawning through fspy.
- Update the not-found assertion now that fspy commands fail at Vite+ binary resolution consistently.

Closes #1599

## Test Plan

- `git diff --check`
- `RUSTUP_TOOLCHAIN=stable rustfmt --edition 2024 --check crates/vite_command/src/lib.rs`

Attempted but blocked locally:

- `RUSTUP_TOOLCHAIN=stable cargo test -p vite-command run_command_with_fspy -- --nocapture` failed during workspace dependency resolution because this workspace needs nightly `-Z bindeps` for `fspy` from `vite-task`.
- Repo nightly toolchain (`nightly-2026-06-10`) is partially installed locally and `rustup` stalled while downloading the required components.
