### PR TITLE
fix(create): run nested app templates from parent dir

### DIFF
--- a/packages/cli/src/create/__tests__/builtin.spec.ts
+++ b/packages/cli/src/create/__tests__/builtin.spec.ts
@@ -127,6 +127,6 @@ describe('executeBuiltinTemplate', () => {
       false,
       false,
     );
-    expect(mockSetPackageName).toHaveBeenCalledWith('/tmp/workspace', 'workspace');
+    expect(mockSetPackageName).toHaveBeenCalledWith(path.join('/tmp/workspace'), 'workspace');
   });
 });

--- a/packages/cli/src/create/__tests__/builtin.spec.ts
+++ b/packages/cli/src/create/__tests__/builtin.spec.ts
@@ -103,4 +103,28 @@ describe('executeBuiltinTemplate', () => {
       '@scope/temperature-symbol',
     );
   });
+
+  it('preserves current-directory application targets', async () => {
+    const { runRemoteTemplateCommand } = await import('../templates/remote.js');
+
+    const result = await executeBuiltinTemplate(workspaceInfo, {
+      ...baseTemplateInfo,
+      command: 'vite:application',
+      packageName: 'workspace',
+      targetDir: '.',
+    });
+
+    expect(result).toEqual({ exitCode: 0, projectDir: '.' });
+    expect(runRemoteTemplateCommand).toHaveBeenCalledWith(
+      workspaceInfo,
+      '/tmp/workspace',
+      expect.objectContaining({
+        command: 'create-vite@latest',
+        args: ['.', '--no-interactive'],
+      }),
+      false,
+      false,
+    );
+    expect(mockSetPackageName).toHaveBeenCalledWith('/tmp/workspace', 'workspace');
+  });
 });

--- a/packages/cli/src/create/__tests__/builtin.spec.ts
+++ b/packages/cli/src/create/__tests__/builtin.spec.ts
@@ -1,104 +1,104 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { executeBuiltinTemplate } from '../templates/builtin.js';
+import { executeBuiltinTemplate } from "../templates/builtin.js";
 
 const { mockLogError, mockSetPackageName } = vi.hoisted(() => ({
   mockLogError: vi.fn(),
   mockSetPackageName: vi.fn(),
 }));
 
-vi.mock('../templates/remote.js', () => ({
+vi.mock("../templates/remote.js", () => ({
   runRemoteTemplateCommand: vi.fn(),
 }));
 
-vi.mock('@voidzero-dev/vite-plus-prompts', () => ({
+vi.mock("@voidzero-dev/vite-plus-prompts", () => ({
   log: { error: mockLogError },
 }));
 
-vi.mock('../utils.js', () => ({
+vi.mock("../utils.js", () => ({
   setPackageName: mockSetPackageName,
 }));
 
 const workspaceInfo = {
-  rootDir: '/tmp/workspace',
+  rootDir: "/tmp/workspace",
 } as any;
 
 const baseTemplateInfo = {
-  packageName: 'wage-meeting',
-  targetDir: 'wage-meeting',
+  packageName: "wage-meeting",
+  targetDir: "wage-meeting",
   args: [],
   envs: {},
-  type: 'builtin' as any,
+  type: "builtin" as any,
   interactive: false,
 };
 
-describe('executeBuiltinTemplate', () => {
+describe("executeBuiltinTemplate", () => {
   beforeEach(async () => {
     mockLogError.mockClear();
     mockSetPackageName.mockClear();
-    const { runRemoteTemplateCommand } = await import('../templates/remote.js');
+    const { runRemoteTemplateCommand } = await import("../templates/remote.js");
     vi.mocked(runRemoteTemplateCommand).mockReset();
     vi.mocked(runRemoteTemplateCommand).mockResolvedValue({ exitCode: 0 });
   });
 
-  it('returns exitCode 1 for unknown vite: template', async () => {
-    const { runRemoteTemplateCommand } = await import('../templates/remote.js');
+  it("returns exitCode 1 for unknown vite: template", async () => {
+    const { runRemoteTemplateCommand } = await import("../templates/remote.js");
 
     const result = await executeBuiltinTemplate(workspaceInfo, {
       ...baseTemplateInfo,
-      command: 'vite:test',
+      command: "vite:test",
     });
 
     expect(result.exitCode).toBe(1);
     expect(runRemoteTemplateCommand).not.toHaveBeenCalled();
   });
 
-  it('shows error message with template name and --list hint', async () => {
+  it("shows error message with template name and --list hint", async () => {
     await executeBuiltinTemplate(workspaceInfo, {
       ...baseTemplateInfo,
-      command: 'vite:unknown',
+      command: "vite:unknown",
     });
 
     expect(mockLogError).toHaveBeenCalledOnce();
     const message = mockLogError.mock.calls[0][0] as string;
-    expect(message).toContain('vite:unknown');
-    expect(message).toContain('vp create --list');
+    expect(message).toContain("vite:unknown");
+    expect(message).toContain("vp create --list");
   });
 
-  it('does not show error message in silent mode', async () => {
+  it("does not show error message in silent mode", async () => {
     await executeBuiltinTemplate(
       workspaceInfo,
-      { ...baseTemplateInfo, command: 'vite:test' },
+      { ...baseTemplateInfo, command: "vite:test" },
       { silent: true },
     );
 
     expect(mockLogError).not.toHaveBeenCalled();
   });
 
-  it('runs create-vite from the parent directory for nested monorepo applications', async () => {
-    const { runRemoteTemplateCommand } = await import('../templates/remote.js');
+  it("runs create-vite from the parent directory for nested monorepo applications", async () => {
+    const { runRemoteTemplateCommand } = await import("../templates/remote.js");
 
     const result = await executeBuiltinTemplate(workspaceInfo, {
       ...baseTemplateInfo,
-      command: 'vite:application',
-      packageName: '@scope/temperature-symbol',
-      targetDir: 'apps/temperature-symbol',
+      command: "vite:application",
+      packageName: "@scope/temperature-symbol",
+      targetDir: "apps/temperature-symbol",
     });
 
-    expect(result).toEqual({ exitCode: 0, projectDir: 'apps/temperature-symbol' });
+    expect(result).toEqual({ exitCode: 0, projectDir: "apps/temperature-symbol" });
     expect(runRemoteTemplateCommand).toHaveBeenCalledWith(
       workspaceInfo,
-      '/tmp/workspace/apps',
+      "/tmp/workspace/apps",
       expect.objectContaining({
-        command: 'create-vite@latest',
-        args: ['temperature-symbol', '--no-interactive'],
+        command: "create-vite@latest",
+        args: ["temperature-symbol", "--no-interactive"],
       }),
       false,
       false,
     );
     expect(mockSetPackageName).toHaveBeenCalledWith(
-      '/tmp/workspace/apps/temperature-symbol',
-      '@scope/temperature-symbol',
+      "/tmp/workspace/apps/temperature-symbol",
+      "@scope/temperature-symbol",
     );
   });
 });

--- a/packages/cli/src/create/__tests__/builtin.spec.ts
+++ b/packages/cli/src/create/__tests__/builtin.spec.ts
@@ -1,8 +1,11 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { executeBuiltinTemplate } from '../templates/builtin.js';
 
-const { mockLogError } = vi.hoisted(() => ({ mockLogError: vi.fn() }));
+const { mockLogError, mockSetPackageName } = vi.hoisted(() => ({
+  mockLogError: vi.fn(),
+  mockSetPackageName: vi.fn(),
+}));
 
 vi.mock('../templates/remote.js', () => ({
   runRemoteTemplateCommand: vi.fn(),
@@ -10,6 +13,10 @@ vi.mock('../templates/remote.js', () => ({
 
 vi.mock('@voidzero-dev/vite-plus-prompts', () => ({
   log: { error: mockLogError },
+}));
+
+vi.mock('../utils.js', () => ({
+  setPackageName: mockSetPackageName,
 }));
 
 const workspaceInfo = {
@@ -26,6 +33,14 @@ const baseTemplateInfo = {
 };
 
 describe('executeBuiltinTemplate', () => {
+  beforeEach(async () => {
+    mockLogError.mockClear();
+    mockSetPackageName.mockClear();
+    const { runRemoteTemplateCommand } = await import('../templates/remote.js');
+    vi.mocked(runRemoteTemplateCommand).mockReset();
+    vi.mocked(runRemoteTemplateCommand).mockResolvedValue({ exitCode: 0 });
+  });
+
   it('returns exitCode 1 for unknown vite: template', async () => {
     const { runRemoteTemplateCommand } = await import('../templates/remote.js');
 
@@ -39,8 +54,6 @@ describe('executeBuiltinTemplate', () => {
   });
 
   it('shows error message with template name and --list hint', async () => {
-    mockLogError.mockClear();
-
     await executeBuiltinTemplate(workspaceInfo, {
       ...baseTemplateInfo,
       command: 'vite:unknown',
@@ -53,8 +66,6 @@ describe('executeBuiltinTemplate', () => {
   });
 
   it('does not show error message in silent mode', async () => {
-    mockLogError.mockClear();
-
     await executeBuiltinTemplate(
       workspaceInfo,
       { ...baseTemplateInfo, command: 'vite:test' },
@@ -62,5 +73,32 @@ describe('executeBuiltinTemplate', () => {
     );
 
     expect(mockLogError).not.toHaveBeenCalled();
+  });
+
+  it('runs create-vite from the parent directory for nested monorepo applications', async () => {
+    const { runRemoteTemplateCommand } = await import('../templates/remote.js');
+
+    const result = await executeBuiltinTemplate(workspaceInfo, {
+      ...baseTemplateInfo,
+      command: 'vite:application',
+      packageName: '@scope/temperature-symbol',
+      targetDir: 'apps/temperature-symbol',
+    });
+
+    expect(result).toEqual({ exitCode: 0, projectDir: 'apps/temperature-symbol' });
+    expect(runRemoteTemplateCommand).toHaveBeenCalledWith(
+      workspaceInfo,
+      '/tmp/workspace/apps',
+      expect.objectContaining({
+        command: 'create-vite@latest',
+        args: ['temperature-symbol', '--no-interactive'],
+      }),
+      false,
+      false,
+    );
+    expect(mockSetPackageName).toHaveBeenCalledWith(
+      '/tmp/workspace/apps/temperature-symbol',
+      '@scope/temperature-symbol',
+    );
   });
 });

--- a/packages/cli/src/create/__tests__/builtin.spec.ts
+++ b/packages/cli/src/create/__tests__/builtin.spec.ts
@@ -1,104 +1,104 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { executeBuiltinTemplate } from "../templates/builtin.js";
+import { executeBuiltinTemplate } from '../templates/builtin.js';
 
 const { mockLogError, mockSetPackageName } = vi.hoisted(() => ({
   mockLogError: vi.fn(),
   mockSetPackageName: vi.fn(),
 }));
 
-vi.mock("../templates/remote.js", () => ({
+vi.mock('../templates/remote.js', () => ({
   runRemoteTemplateCommand: vi.fn(),
 }));
 
-vi.mock("@voidzero-dev/vite-plus-prompts", () => ({
+vi.mock('@voidzero-dev/vite-plus-prompts', () => ({
   log: { error: mockLogError },
 }));
 
-vi.mock("../utils.js", () => ({
+vi.mock('../utils.js', () => ({
   setPackageName: mockSetPackageName,
 }));
 
 const workspaceInfo = {
-  rootDir: "/tmp/workspace",
+  rootDir: '/tmp/workspace',
 } as any;
 
 const baseTemplateInfo = {
-  packageName: "wage-meeting",
-  targetDir: "wage-meeting",
+  packageName: 'wage-meeting',
+  targetDir: 'wage-meeting',
   args: [],
   envs: {},
-  type: "builtin" as any,
+  type: 'builtin' as any,
   interactive: false,
 };
 
-describe("executeBuiltinTemplate", () => {
+describe('executeBuiltinTemplate', () => {
   beforeEach(async () => {
     mockLogError.mockClear();
     mockSetPackageName.mockClear();
-    const { runRemoteTemplateCommand } = await import("../templates/remote.js");
+    const { runRemoteTemplateCommand } = await import('../templates/remote.js');
     vi.mocked(runRemoteTemplateCommand).mockReset();
     vi.mocked(runRemoteTemplateCommand).mockResolvedValue({ exitCode: 0 });
   });
 
-  it("returns exitCode 1 for unknown vite: template", async () => {
-    const { runRemoteTemplateCommand } = await import("../templates/remote.js");
+  it('returns exitCode 1 for unknown vite: template', async () => {
+    const { runRemoteTemplateCommand } = await import('../templates/remote.js');
 
     const result = await executeBuiltinTemplate(workspaceInfo, {
       ...baseTemplateInfo,
-      command: "vite:test",
+      command: 'vite:test',
     });
 
     expect(result.exitCode).toBe(1);
     expect(runRemoteTemplateCommand).not.toHaveBeenCalled();
   });
 
-  it("shows error message with template name and --list hint", async () => {
+  it('shows error message with template name and --list hint', async () => {
     await executeBuiltinTemplate(workspaceInfo, {
       ...baseTemplateInfo,
-      command: "vite:unknown",
+      command: 'vite:unknown',
     });
 
     expect(mockLogError).toHaveBeenCalledOnce();
     const message = mockLogError.mock.calls[0][0] as string;
-    expect(message).toContain("vite:unknown");
-    expect(message).toContain("vp create --list");
+    expect(message).toContain('vite:unknown');
+    expect(message).toContain('vp create --list');
   });
 
-  it("does not show error message in silent mode", async () => {
+  it('does not show error message in silent mode', async () => {
     await executeBuiltinTemplate(
       workspaceInfo,
-      { ...baseTemplateInfo, command: "vite:test" },
+      { ...baseTemplateInfo, command: 'vite:test' },
       { silent: true },
     );
 
     expect(mockLogError).not.toHaveBeenCalled();
   });
 
-  it("runs create-vite from the parent directory for nested monorepo applications", async () => {
-    const { runRemoteTemplateCommand } = await import("../templates/remote.js");
+  it('runs create-vite from the parent directory for nested monorepo applications', async () => {
+    const { runRemoteTemplateCommand } = await import('../templates/remote.js');
 
     const result = await executeBuiltinTemplate(workspaceInfo, {
       ...baseTemplateInfo,
-      command: "vite:application",
-      packageName: "@scope/temperature-symbol",
-      targetDir: "apps/temperature-symbol",
+      command: 'vite:application',
+      packageName: '@scope/temperature-symbol',
+      targetDir: 'apps/temperature-symbol',
     });
 
-    expect(result).toEqual({ exitCode: 0, projectDir: "apps/temperature-symbol" });
+    expect(result).toEqual({ exitCode: 0, projectDir: 'apps/temperature-symbol' });
     expect(runRemoteTemplateCommand).toHaveBeenCalledWith(
       workspaceInfo,
-      "/tmp/workspace/apps",
+      '/tmp/workspace/apps',
       expect.objectContaining({
-        command: "create-vite@latest",
-        args: ["temperature-symbol", "--no-interactive"],
+        command: 'create-vite@latest',
+        args: ['temperature-symbol', '--no-interactive'],
       }),
       false,
       false,
     );
     expect(mockSetPackageName).toHaveBeenCalledWith(
-      "/tmp/workspace/apps/temperature-symbol",
-      "@scope/temperature-symbol",
+      '/tmp/workspace/apps/temperature-symbol',
+      '@scope/temperature-symbol',
     );
   });
 });

--- a/packages/cli/src/create/__tests__/builtin.spec.ts
+++ b/packages/cli/src/create/__tests__/builtin.spec.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { executeBuiltinTemplate } from '../templates/builtin.js';
@@ -88,7 +90,7 @@ describe('executeBuiltinTemplate', () => {
     expect(result).toEqual({ exitCode: 0, projectDir: 'apps/temperature-symbol' });
     expect(runRemoteTemplateCommand).toHaveBeenCalledWith(
       workspaceInfo,
-      '/tmp/workspace/apps',
+      path.join('/tmp/workspace', 'apps'),
       expect.objectContaining({
         command: 'create-vite@latest',
         args: ['temperature-symbol', '--no-interactive'],
@@ -97,7 +99,7 @@ describe('executeBuiltinTemplate', () => {
       false,
     );
     expect(mockSetPackageName).toHaveBeenCalledWith(
-      '/tmp/workspace/apps/temperature-symbol',
+      path.join('/tmp/workspace', 'apps', 'temperature-symbol'),
       '@scope/temperature-symbol',
     );
   });

--- a/packages/cli/src/create/__tests__/builtin.spec.ts
+++ b/packages/cli/src/create/__tests__/builtin.spec.ts
@@ -85,6 +85,7 @@ describe('executeBuiltinTemplate', () => {
       command: 'vite:application',
       packageName: '@scope/temperature-symbol',
       targetDir: 'apps/temperature-symbol',
+      args: [],
     });
 
     expect(result).toEqual({ exitCode: 0, projectDir: 'apps/temperature-symbol' });
@@ -112,6 +113,7 @@ describe('executeBuiltinTemplate', () => {
       command: 'vite:application',
       packageName: 'workspace',
       targetDir: '.',
+      args: [],
     });
 
     expect(result).toEqual({ exitCode: 0, projectDir: '.' });

--- a/packages/cli/src/create/templates/builtin.ts
+++ b/packages/cli/src/create/templates/builtin.ts
@@ -1,25 +1,25 @@
-import assert from 'node:assert';
-import fs from 'node:fs';
-import path from 'node:path';
+import assert from "node:assert";
+import fs from "node:fs";
+import path from "node:path";
 
-import * as prompts from '@voidzero-dev/vite-plus-prompts';
-import colors from 'picocolors';
+import * as prompts from "@voidzero-dev/vite-plus-prompts";
+import colors from "picocolors";
 
-import type { WorkspaceInfo } from '../../types/index.ts';
-import type { ExecutionWithProjectDir } from '../command.ts';
-import { discoverTemplate } from '../discovery.ts';
-import { setPackageName } from '../utils.ts';
-import { executeGeneratorScaffold } from './generator.ts';
-import { runRemoteTemplateCommand } from './remote.ts';
-import { BuiltinTemplate, type BuiltinTemplateInfo, LibraryTemplateRepo } from './types.ts';
+import type { WorkspaceInfo } from "../../types/index.ts";
+import type { ExecutionWithProjectDir } from "../command.ts";
+import { discoverTemplate } from "../discovery.ts";
+import { setPackageName } from "../utils.ts";
+import { executeGeneratorScaffold } from "./generator.ts";
+import { runRemoteTemplateCommand } from "./remote.ts";
+import { BuiltinTemplate, type BuiltinTemplateInfo, LibraryTemplateRepo } from "./types.ts";
 
 export async function executeBuiltinTemplate(
   workspaceInfo: WorkspaceInfo,
   templateInfo: BuiltinTemplateInfo,
   options?: { silent?: boolean },
 ): Promise<ExecutionWithProjectDir> {
-  assert(templateInfo.targetDir, 'targetDir is required');
-  assert(templateInfo.packageName, 'packageName is required');
+  assert(templateInfo.targetDir, "targetDir is required");
+  assert(templateInfo.packageName, "packageName is required");
 
   if (templateInfo.command === BuiltinTemplate.generator) {
     return await executeGeneratorScaffold(workspaceInfo, templateInfo, options);
@@ -29,14 +29,12 @@ export async function executeBuiltinTemplate(
     const parentDir = path.dirname(templateInfo.targetDir);
     const projectDirName = path.basename(templateInfo.targetDir);
     const cwd =
-      parentDir === '.'
-        ? workspaceInfo.rootDir
-        : path.join(workspaceInfo.rootDir, parentDir);
+      parentDir === "." ? workspaceInfo.rootDir : path.join(workspaceInfo.rootDir, parentDir);
     fs.mkdirSync(cwd, { recursive: true });
 
-    templateInfo.command = 'create-vite@latest';
+    templateInfo.command = "create-vite@latest";
     if (!templateInfo.interactive) {
-      templateInfo.args.push('--no-interactive');
+      templateInfo.args.push("--no-interactive");
     }
     templateInfo.args.unshift(projectDirName);
 
@@ -76,10 +74,10 @@ export async function executeBuiltinTemplate(
   }
 
   // Unknown vite: template (e.g. vite:test) — application was already rewritten to create-vite@latest
-  if (templateInfo.command.startsWith('vite:')) {
+  if (templateInfo.command.startsWith("vite:")) {
     if (!options?.silent) {
       prompts.log.error(
-        `Unknown builtin template "${templateInfo.command}". Run ${colors.yellow('vp create --list')} to see available templates.`,
+        `Unknown builtin template "${templateInfo.command}". Run ${colors.yellow("vp create --list")} to see available templates.`,
       );
     }
     return { exitCode: 1 };

--- a/packages/cli/src/create/templates/builtin.ts
+++ b/packages/cli/src/create/templates/builtin.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert';
+import fs from 'node:fs';
 import path from 'node:path';
 
 import * as prompts from '@voidzero-dev/vite-plus-prompts';
@@ -25,11 +26,33 @@ export async function executeBuiltinTemplate(
   }
 
   if (templateInfo.command === BuiltinTemplate.application) {
+    const parentDir = path.dirname(templateInfo.targetDir);
+    const projectDirName = path.basename(templateInfo.targetDir);
+    const cwd =
+      parentDir === '.'
+        ? workspaceInfo.rootDir
+        : path.join(workspaceInfo.rootDir, parentDir);
+    fs.mkdirSync(cwd, { recursive: true });
+
     templateInfo.command = 'create-vite@latest';
     if (!templateInfo.interactive) {
       templateInfo.args.push('--no-interactive');
     }
-    templateInfo.args.unshift(templateInfo.targetDir);
+    templateInfo.args.unshift(projectDirName);
+
+    const result = await runRemoteTemplateCommand(
+      workspaceInfo,
+      cwd,
+      templateInfo,
+      false,
+      options?.silent ?? false,
+    );
+    if (result.exitCode !== 0) {
+      return { exitCode: result.exitCode };
+    }
+    const fullPath = path.join(workspaceInfo.rootDir, templateInfo.targetDir);
+    setPackageName(fullPath, templateInfo.packageName);
+    return { ...result, projectDir: templateInfo.targetDir };
   } else if (templateInfo.command === BuiltinTemplate.library) {
     // Use degit to download the template directly from GitHub
     const libraryTemplateInfo = discoverTemplate(

--- a/packages/cli/src/create/templates/builtin.ts
+++ b/packages/cli/src/create/templates/builtin.ts
@@ -1,25 +1,25 @@
-import assert from "node:assert";
-import fs from "node:fs";
-import path from "node:path";
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
 
-import * as prompts from "@voidzero-dev/vite-plus-prompts";
-import colors from "picocolors";
+import * as prompts from '@voidzero-dev/vite-plus-prompts';
+import colors from 'picocolors';
 
-import type { WorkspaceInfo } from "../../types/index.ts";
-import type { ExecutionWithProjectDir } from "../command.ts";
-import { discoverTemplate } from "../discovery.ts";
-import { setPackageName } from "../utils.ts";
-import { executeGeneratorScaffold } from "./generator.ts";
-import { runRemoteTemplateCommand } from "./remote.ts";
-import { BuiltinTemplate, type BuiltinTemplateInfo, LibraryTemplateRepo } from "./types.ts";
+import type { WorkspaceInfo } from '../../types/index.ts';
+import type { ExecutionWithProjectDir } from '../command.ts';
+import { discoverTemplate } from '../discovery.ts';
+import { setPackageName } from '../utils.ts';
+import { executeGeneratorScaffold } from './generator.ts';
+import { runRemoteTemplateCommand } from './remote.ts';
+import { BuiltinTemplate, type BuiltinTemplateInfo, LibraryTemplateRepo } from './types.ts';
 
 export async function executeBuiltinTemplate(
   workspaceInfo: WorkspaceInfo,
   templateInfo: BuiltinTemplateInfo,
   options?: { silent?: boolean },
 ): Promise<ExecutionWithProjectDir> {
-  assert(templateInfo.targetDir, "targetDir is required");
-  assert(templateInfo.packageName, "packageName is required");
+  assert(templateInfo.targetDir, 'targetDir is required');
+  assert(templateInfo.packageName, 'packageName is required');
 
   if (templateInfo.command === BuiltinTemplate.generator) {
     return await executeGeneratorScaffold(workspaceInfo, templateInfo, options);
@@ -29,12 +29,12 @@ export async function executeBuiltinTemplate(
     const parentDir = path.dirname(templateInfo.targetDir);
     const projectDirName = path.basename(templateInfo.targetDir);
     const cwd =
-      parentDir === "." ? workspaceInfo.rootDir : path.join(workspaceInfo.rootDir, parentDir);
+      parentDir === '.' ? workspaceInfo.rootDir : path.join(workspaceInfo.rootDir, parentDir);
     fs.mkdirSync(cwd, { recursive: true });
 
-    templateInfo.command = "create-vite@latest";
+    templateInfo.command = 'create-vite@latest';
     if (!templateInfo.interactive) {
-      templateInfo.args.push("--no-interactive");
+      templateInfo.args.push('--no-interactive');
     }
     templateInfo.args.unshift(projectDirName);
 
@@ -74,10 +74,10 @@ export async function executeBuiltinTemplate(
   }
 
   // Unknown vite: template (e.g. vite:test) — application was already rewritten to create-vite@latest
-  if (templateInfo.command.startsWith("vite:")) {
+  if (templateInfo.command.startsWith('vite:')) {
     if (!options?.silent) {
       prompts.log.error(
-        `Unknown builtin template "${templateInfo.command}". Run ${colors.yellow("vp create --list")} to see available templates.`,
+        `Unknown builtin template "${templateInfo.command}". Run ${colors.yellow('vp create --list')} to see available templates.`,
       );
     }
     return { exitCode: 1 };

--- a/packages/cli/src/create/templates/builtin.ts
+++ b/packages/cli/src/create/templates/builtin.ts
@@ -27,7 +27,10 @@ export async function executeBuiltinTemplate(
 
   if (templateInfo.command === BuiltinTemplate.application) {
     const parentDir = path.dirname(templateInfo.targetDir);
-    const projectDirName = path.basename(templateInfo.targetDir);
+    const projectDirName =
+      templateInfo.targetDir === '.'
+        ? templateInfo.targetDir
+        : path.basename(templateInfo.targetDir);
     const cwd =
       parentDir === '.' ? workspaceInfo.rootDir : path.join(workspaceInfo.rootDir, parentDir);
     fs.mkdirSync(cwd, { recursive: true });


### PR DESCRIPTION
## Summary
- fixes `vite:application` creation for nested monorepo targets like `apps/temperature-symbol`
- runs `create-vite` from the target parent directory and passes only the leaf project name
- preserves the full `targetDir` for later package-name rewriting and monorepo integration

Fixes #820.

## Verification
- `git diff --check`
- `pnpm exec tsgo --noEmit -p packages/cli/tsconfig.json`

## Blocked
- `pnpm -F vite-plus test src/create/__tests__/builtin.spec.ts` fails at Vitest startup because the local Vite dist file is missing: `vite/dist/vite/node/index.js`.