### PR TITLE
fix(cli): warn for bare dev at monorepo root

### DIFF
--- a/packages/cli/src/__tests__/monorepo-root-hint.spec.ts
+++ b/packages/cli/src/__tests__/monorepo-root-hint.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  devCommandHasExplicitRoot,
+  formatDevMonorepoRootHint,
+  shouldWarnDevFromMonorepoRoot,
+} from '../monorepo-root-hint.js';
+import type { WorkspaceInfoOptional } from '../types/index.js';
+
+const workspaceInfo: WorkspaceInfoOptional = {
+  rootDir: '/repo',
+  packageManager: undefined,
+  packageManagerVersion: 'latest',
+  isMonorepo: true,
+  monorepoScope: '',
+  workspacePatterns: ['apps/*'],
+  parentDirs: ['apps'],
+  packages: [
+    {
+      name: 'website',
+      path: 'apps/website',
+      version: '1.0.0',
+      dependencies: [],
+      scripts: { dev: 'vp dev' },
+    },
+  ],
+};
+
+describe('devCommandHasExplicitRoot', () => {
+  it('detects a positional Vite root', () => {
+    expect(devCommandHasExplicitRoot(['dev', 'apps/website'])).toBe(true);
+  });
+
+  it('ignores known flag values when looking for a positional root', () => {
+    expect(devCommandHasExplicitRoot(['dev', '--host', '0.0.0.0', '--port', '3000'])).toBe(false);
+  });
+
+  it('handles equals-form flags', () => {
+    expect(devCommandHasExplicitRoot(['dev', '--host=0.0.0.0', '--port=3000'])).toBe(false);
+  });
+});
+
+describe('shouldWarnDevFromMonorepoRoot', () => {
+  it('warns for bare dev from the monorepo root', () => {
+    expect(shouldWarnDevFromMonorepoRoot('dev', ['dev'], '/repo', workspaceInfo)).toBe(true);
+  });
+
+  it('does not warn when dev targets a package directory', () => {
+    expect(
+      shouldWarnDevFromMonorepoRoot('dev', ['dev', 'apps/website'], '/repo', workspaceInfo),
+    ).toBe(false);
+  });
+
+  it('does not warn outside the monorepo root', () => {
+    expect(shouldWarnDevFromMonorepoRoot('dev', ['dev'], '/repo/apps/website', workspaceInfo)).toBe(
+      false,
+    );
+  });
+
+  it('does not warn for help output', () => {
+    expect(shouldWarnDevFromMonorepoRoot('dev', ['dev', '--help'], '/repo', workspaceInfo)).toBe(
+      false,
+    );
+  });
+});
+
+describe('formatDevMonorepoRootHint', () => {
+  it('uses an existing workspace package as the example target', () => {
+    expect(formatDevMonorepoRootHint(workspaceInfo)).toContain('vp dev apps/website');
+  });
+});

--- a/packages/cli/src/__tests__/monorepo-root-hint.spec.ts
+++ b/packages/cli/src/__tests__/monorepo-root-hint.spec.ts
@@ -20,8 +20,6 @@ const workspaceInfo: WorkspaceInfoOptional = {
       name: 'website',
       path: 'apps/website',
       version: '1.0.0',
-      dependencies: [],
-      scripts: { dev: 'vp dev' },
     },
   ],
 };

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -77,9 +77,13 @@ if (command === 'create') {
     }
 
     if (command === 'dev') {
-      const workspaceInfo = await detectWorkspace(process.cwd());
-      if (shouldWarnDevFromMonorepoRoot(command, args, process.cwd(), workspaceInfo)) {
-        warnMsg(formatDevMonorepoRootHint(workspaceInfo));
+      try {
+        const workspaceInfo = await detectWorkspace(process.cwd());
+        if (shouldWarnDevFromMonorepoRoot(command, args, process.cwd(), workspaceInfo)) {
+          warnMsg(formatDevMonorepoRootHint(workspaceInfo));
+        }
+      } catch {
+        // The monorepo-root hint is best-effort; the Rust core owns command validation.
       }
     }
 

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -22,8 +22,8 @@ import { pack } from './resolve-pack.ts';
 import { test } from './resolve-test.ts';
 import { resolveUniversalViteConfig } from './resolve-vite-config.ts';
 import { vite } from './resolve-vite.ts';
-import { detectWorkspace } from './utils/workspace.ts';
 import { accent, errorMsg, log, warnMsg } from './utils/terminal.ts';
+import { detectWorkspace } from './utils/workspace.ts';
 
 function getErrorMessage(err: unknown): string {
   if (err instanceof Error) {

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -14,6 +14,7 @@ import path from 'node:path';
 
 import { run } from '../binding/index.js';
 import { applyToolInitConfigToViteConfig, inspectInitCommand } from './init-config.ts';
+import { formatDevMonorepoRootHint, shouldWarnDevFromMonorepoRoot } from './monorepo-root-hint.ts';
 import { doc } from './resolve-doc.ts';
 import { fmt } from './resolve-fmt.ts';
 import { lint } from './resolve-lint.ts';
@@ -21,7 +22,8 @@ import { pack } from './resolve-pack.ts';
 import { test } from './resolve-test.ts';
 import { resolveUniversalViteConfig } from './resolve-vite-config.ts';
 import { vite } from './resolve-vite.ts';
-import { accent, errorMsg, log } from './utils/terminal.ts';
+import { detectWorkspace } from './utils/workspace.ts';
+import { accent, errorMsg, log, warnMsg } from './utils/terminal.ts';
 
 function getErrorMessage(err: unknown): string {
   if (err instanceof Error) {
@@ -72,6 +74,13 @@ if (command === 'create') {
         `Skipped initialization: '${accent(initInspection.configKey)}' already exists in '${accent(path.basename(initInspection.existingViteConfigPath))}'.`,
       );
       process.exit(0);
+    }
+
+    if (command === 'dev') {
+      const workspaceInfo = await detectWorkspace(process.cwd());
+      if (shouldWarnDevFromMonorepoRoot(command, args, process.cwd(), workspaceInfo)) {
+        warnMsg(formatDevMonorepoRootHint(workspaceInfo));
+      }
     }
 
     const exitCode = await run({

--- a/packages/cli/src/monorepo-root-hint.ts
+++ b/packages/cli/src/monorepo-root-hint.ts
@@ -1,0 +1,67 @@
+import path from 'node:path';
+
+import type { WorkspaceInfoOptional } from './types/index.ts';
+
+const DEV_ROOT_VALUE_FLAGS = new Set([
+  '-c',
+  '--config',
+  '--host',
+  '--port',
+  '--strictPort',
+  '--base',
+  '--mode',
+  '--logLevel',
+]);
+
+export function devCommandHasExplicitRoot(args: string[]): boolean {
+  const rest = args.slice(1);
+  let skipNext = false;
+
+  for (const arg of rest) {
+    if (skipNext) {
+      skipNext = false;
+      continue;
+    }
+    if (arg === '--') {
+      break;
+    }
+    if (DEV_ROOT_VALUE_FLAGS.has(arg)) {
+      skipNext = true;
+      continue;
+    }
+    if ([...DEV_ROOT_VALUE_FLAGS].some((flag) => arg.startsWith(`${flag}=`))) {
+      continue;
+    }
+    if (!arg.startsWith('-')) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function shouldWarnDevFromMonorepoRoot(
+  command: string | undefined,
+  args: string[],
+  cwd: string,
+  workspaceInfo: WorkspaceInfoOptional,
+): boolean {
+  if (command !== 'dev' || args.includes('--help') || args.includes('-h')) {
+    return false;
+  }
+  if (!workspaceInfo.isMonorepo || devCommandHasExplicitRoot(args)) {
+    return false;
+  }
+
+  return path.resolve(cwd) === path.resolve(workspaceInfo.rootDir);
+}
+
+export function formatDevMonorepoRootHint(workspaceInfo: WorkspaceInfoOptional): string {
+  const example =
+    workspaceInfo.packages[0]?.path ?? `${workspaceInfo.parentDirs[0] ?? 'apps'}/website`;
+  return (
+    `Detected a monorepo root. \`vp dev\` starts Vite in the workspace root, which can look ` +
+    `successful while serving no app. Run \`vp run dev\` to use package tasks, or run ` +
+    `\`vp dev ${example}\` for a specific app.`
+  );
+}


### PR DESCRIPTION
## Summary
- warns when `vp dev` is run bare from a monorepo root
- suggests `vp run dev` or an explicit package directory like `vp dev apps/website`
- leaves the existing Vite dev behavior unchanged while reducing the confusing 404/no-app case

Refs #770.

## Verification
- `git diff --check`
- `pnpm exec tsgo --noEmit -p packages/cli/tsconfig.json`

## Blocked
- `pnpm -F vite-plus test src/__tests__/monorepo-root-hint.spec.ts` fails at Vitest startup because the local Vite dist file is missing: `vite/dist/vite/node/index.js`.