### PR TITLE
refactor(cli): share tool resolver env assembly

### DIFF
--- a/packages/cli/src/resolve-doc.ts
+++ b/packages/cli/src/resolve-doc.ts
@@ -12,7 +12,7 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { DEFAULT_ENVS } from './utils/constants.ts';
+import { createToolResolution, type ToolResolution } from './utils/tool-resolution.ts';
 
 /**
  * Resolves the VitePress binary path and environment variables.
@@ -23,18 +23,9 @@ import { DEFAULT_ENVS } from './utils/constants.ts';
  *
  * The function points to the bundled VitePress in the CLI's dist directory.
  */
-export async function doc(): Promise<{
-  binPath: string;
-  envs: Record<string, string>;
-}> {
+export async function doc(): Promise<ToolResolution> {
   // VitePress's CLI binary is located at bin/vitepress.js relative to the package root
   const binPath = join(dirname(fileURLToPath(import.meta.url)), 'vitepress', 'node', 'cli.js');
 
-  return {
-    binPath,
-    // TODO: provide envs inference API
-    envs: {
-      ...DEFAULT_ENVS,
-    },
-  };
+  return createToolResolution(binPath);
 }

--- a/packages/cli/src/resolve-fmt.ts
+++ b/packages/cli/src/resolve-fmt.ts
@@ -13,7 +13,8 @@
 
 import { dirname, join } from 'node:path';
 
-import { DEFAULT_ENVS, resolve } from './utils/constants.ts';
+import { resolve } from './utils/constants.ts';
+import { createToolResolution, type ToolResolution } from './utils/tool-resolution.ts';
 
 /**
  * Resolves the oxfmt binary path and environment variables.
@@ -25,10 +26,7 @@ import { DEFAULT_ENVS, resolve } from './utils/constants.ts';
  * The environment variables provide runtime context to oxfmt,
  * including Node.js version information and package manager details.
  */
-export async function fmt(): Promise<{
-  binPath: string;
-  envs: Record<string, string>;
-}> {
+export async function fmt(): Promise<ToolResolution> {
   // Resolve the oxfmt package path first, then navigate to the bin file.
   // The bin/oxfmt subpath is not exported in package.json exports, so we
   // resolve the main entry point and derive the bin path from it.
@@ -37,11 +35,5 @@ export async function fmt(): Promise<{
   const oxfmtMainPath = resolve('oxfmt');
   const binPath = join(dirname(dirname(oxfmtMainPath)), 'bin', 'oxfmt');
 
-  return {
-    binPath,
-    // TODO: provide envs inference API
-    envs: {
-      ...DEFAULT_ENVS,
-    },
-  };
+  return createToolResolution(binPath);
 }

--- a/packages/cli/src/resolve-lint.ts
+++ b/packages/cli/src/resolve-lint.ts
@@ -14,8 +14,8 @@
 import { dirname, join } from 'node:path';
 
 import { resolve } from './utils/constants.ts';
-import { resolveTsgolintExecutable } from './utils/tsgolint-path.ts';
 import { createToolResolution, type ToolResolution } from './utils/tool-resolution.ts';
+import { resolveTsgolintExecutable } from './utils/tsgolint-path.ts';
 
 export { resolveWindowsTsgolintExecutable } from './utils/tsgolint-path.ts';
 

--- a/packages/cli/src/resolve-lint.ts
+++ b/packages/cli/src/resolve-lint.ts
@@ -13,8 +13,9 @@
 
 import { dirname, join } from 'node:path';
 
-import { DEFAULT_ENVS, resolve } from './utils/constants.ts';
+import { resolve } from './utils/constants.ts';
 import { resolveTsgolintExecutable } from './utils/tsgolint-path.ts';
+import { createToolResolution, type ToolResolution } from './utils/tool-resolution.ts';
 
 export { resolveWindowsTsgolintExecutable } from './utils/tsgolint-path.ts';
 
@@ -28,10 +29,7 @@ export { resolveWindowsTsgolintExecutable } from './utils/tsgolint-path.ts';
  * The environment variables provide runtime context to oxlint,
  * including Node.js version information and package manager details.
  */
-export async function lint(): Promise<{
-  binPath: string;
-  envs: Record<string, string>;
-}> {
+export async function lint(): Promise<ToolResolution> {
   // Resolve the oxlint package path first, then navigate to the bin file.
   // The bin/oxlint subpath is not exported in package.json exports, so we
   // resolve the main entry point and derive the bin path from it.
@@ -44,13 +42,7 @@ export async function lint(): Promise<{
     resolve('oxlint-tsgolint/bin/tsgolint'),
     import.meta.url,
   );
-  const result = {
-    binPath,
-    // TODO: provide envs inference API
-    envs: {
-      ...DEFAULT_ENVS,
-      OXLINT_TSGOLINT_PATH: oxlintTsgolintPath,
-    },
-  };
-  return result;
+  return createToolResolution(binPath, {
+    OXLINT_TSGOLINT_PATH: oxlintTsgolintPath,
+  });
 }

--- a/packages/cli/src/resolve-pack.ts
+++ b/packages/cli/src/resolve-pack.ts
@@ -10,7 +10,7 @@
 
 import { join } from 'node:path';
 
-import { DEFAULT_ENVS } from './utils/constants.ts';
+import { createToolResolution, type ToolResolution } from './utils/tool-resolution.ts';
 
 /**
  * Resolves the Tsdown binary path and environment variables.
@@ -21,18 +21,9 @@ import { DEFAULT_ENVS } from './utils/constants.ts';
  *
  * Tsdown is a tool that provides a library for building JavaScript/TypeScript libraries.
  */
-export async function pack(): Promise<{
-  binPath: string;
-  envs: Record<string, string>;
-}> {
+export async function pack(): Promise<ToolResolution> {
   // Resolve the bundled Tsdown CLI
   const binPath = join(import.meta.dirname, 'pack-bin.js');
 
-  return {
-    binPath,
-    // TODO: provide envs inference API
-    envs: {
-      ...DEFAULT_ENVS,
-    },
-  };
+  return createToolResolution(binPath);
 }

--- a/packages/cli/src/utils/tool-resolution.ts
+++ b/packages/cli/src/utils/tool-resolution.ts
@@ -1,0 +1,19 @@
+import { DEFAULT_ENVS } from './constants.ts';
+
+export interface ToolResolution {
+  binPath: string;
+  envs: Record<string, string>;
+}
+
+export function createToolResolution(
+  binPath: string,
+  envs: Record<string, string> = {},
+): ToolResolution {
+  return {
+    binPath,
+    envs: {
+      ...DEFAULT_ENVS,
+      ...envs,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- add a small `createToolResolution` helper for resolver return values
- reuse it from the lint, fmt, doc, and pack tool resolvers
- keep resolver bin paths and extra lint envs unchanged

## Verification

- `git diff --check`
- `pnpm exec tsgo --noEmit -p packages/cli/tsconfig.json`
