### PR TITLE
docs: center the README logo and fix its size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="/logo-dark.svg">
-  <source media="(prefers-color-scheme: light)" srcset="/logo.svg">
-  <img alt="Vite+" src="/logo.svg">
-</picture>
+<p align="center">
+  <a href="https://viteplus.dev" target="_blank" rel="noopener noreferrer">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="/logo-dark.svg">
+      <source media="(prefers-color-scheme: light)" srcset="/logo.svg">
+      <img alt="Vite+" src="/logo.svg" height="60">
+    </picture>
+  </a>
+</p>
 
 **The Unified Toolchain for the Web**
 _runtime and package management, create, dev, check, test, build, pack, and monorepo task caching in a single dependency_


### PR DESCRIPTION
## Problem

The README logo renders too small and left-aligned:

```html
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="/logo-dark.svg">
  <source media="(prefers-color-scheme: light)" srcset="/logo.svg">
  <img alt="Vite+" src="/logo.svg">
</picture>
```

`logo.svg` / `logo-dark.svg` have an intrinsic size of `103×15` (`viewBox="0 0 103 15"`). Embedding the `<img>` with no size constraint makes GitHub render it at that intrinsic ~15px height — roughly one line of body text — and the wordmark sits left-aligned rather than as a hero banner.

## Fix

Mirror the [vitejs/vite README](https://github.com/vitejs/vite) header treatment:

- center the logo in `<p align="center">`
- link it to the homepage (https://viteplus.dev)
- pin `height="60"` on the `<img>` (same value vite uses); at the 103:15 aspect ratio it renders ~412px wide

```html
<p align="center">
  <a href="https://viteplus.dev" target="_blank" rel="noopener noreferrer">
    <picture>
      <source media="(prefers-color-scheme: dark)" srcset="/logo-dark.svg">
      <source media="(prefers-color-scheme: light)" srcset="/logo.svg">
      <img alt="Vite+" src="/logo.svg" height="60">
    </picture>
  </a>
</p>
```

The dark/light `<source>` mapping and the relative SVG paths are unchanged. Verified the markup survives GitHub's HTML sanitizer (the `align` and `height` attributes are preserved).