### PR TITLE
[WIP] Deno as a package manager

### DIFF
--- a/crates/vite_install/src/package_manager.rs
+++ b/crates/vite_install/src/package_manager.rs
@@ -46,6 +46,7 @@ pub enum PackageManagerType {
     Yarn,
     Npm,
     Bun,
+    Deno,
 }
 
 impl fmt::Display for PackageManagerType {
@@ -55,6 +56,7 @@ impl fmt::Display for PackageManagerType {
             Self::Yarn => write!(f, "yarn"),
             Self::Npm => write!(f, "npm"),
             Self::Bun => write!(f, "bun"),
+            Self::Deno => write!(f, "deno"),
         }
     }
 }
@@ -69,6 +71,7 @@ impl PackageManagerType {
             "pnpm" | "pnpx" => Some(Self::Pnpm),
             "yarn" | "yarnpkg" => Some(Self::Yarn),
             "bun" | "bunx" => Some(Self::Bun),
+            "deno" => Some(Self::Deno),
             _ => None,
         }
     }
@@ -84,6 +87,7 @@ impl PackageManagerType {
             "yarn" => Some(Self::Yarn),
             "npm" => Some(Self::Npm),
             "bun" => Some(Self::Bun),
+            "deno" => Some(Self::Deno),
             _ => None,
         }
     }
@@ -101,6 +105,7 @@ impl PackageManagerType {
             (_, Self::Pnpm) => "pnpm",
             (_, Self::Yarn) => "yarn",
             (_, Self::Bun) => "bun",
+            (_, Self::Deno) => "deno",
         }
     }
 }
@@ -312,6 +317,17 @@ pub fn get_package_manager_type_and_version(
     let bun_lockb_path = workspace_root.path.join("bun.lockb");
     if is_exists_file(&bun_lockb_path)? {
         return Ok((PackageManagerType::Bun, version, None, source));
+    }
+
+    // if deno.json, deno.jsonc, or deno.lock exists, use deno@latest (experimental)
+    let deno_json_path = workspace_root.path.join("deno.json");
+    let deno_jsonc_path = workspace_root.path.join("deno.jsonc");
+    let deno_lock_path = workspace_root.path.join("deno.lock");
+    if is_exists_file(&deno_json_path)?
+        || is_exists_file(&deno_jsonc_path)?
+        || is_exists_file(&deno_lock_path)?
+    {
+        return Ok((PackageManagerType::Deno, version, None, source));
     }
 
     // if .pnpmfile.cjs exists, use pnpm@latest
@@ -813,6 +829,15 @@ pub async fn download_package_manager(
     version_or_latest: &str,
     expected_hash: Option<&str>,
 ) -> Result<(AbsolutePathBuf, Str, Str), Error> {
+    // Deno is expected to be installed system-wide; Vite+ does not download it.
+    if matches!(package_manager_type, PackageManagerType::Deno) {
+        return Err(Error::UnsupportedPackageManager(
+            "Deno package manager support is experimental and not yet fully implemented. \
+             Please install Deno separately and follow https://github.com/voidzero-dev/vite-plus/issues/1886."
+                .into(),
+        ));
+    }
+
     let version: Str = if version_or_latest == "latest" {
         get_latest_version(package_manager_type).await?
     } else if Version::parse(version_or_latest).is_ok() {
@@ -1112,6 +1137,11 @@ async fn create_shim_files(
             let bin_prefix = bin_prefix.as_ref();
             return create_bun_shim_files(bin_prefix).await;
         }
+        PackageManagerType::Deno => {
+            // deno is a native binary distributed separately; shims are not
+            // created here. The system `deno` binary is invoked directly.
+            return Ok(());
+        }
     }
 
     let bin_prefix = bin_prefix.as_ref();
@@ -1253,6 +1283,7 @@ fn interactive_package_manager_menu() -> Result<PackageManagerType, Error> {
         ("npm", PackageManagerType::Npm),
         ("yarn", PackageManagerType::Yarn),
         ("bun", PackageManagerType::Bun),
+        ("deno (experimental)", PackageManagerType::Deno),
     ];
 
     let mut selected_index = 0;
@@ -1377,16 +1408,17 @@ fn interactive_package_manager_menu() -> Result<PackageManagerType, Error> {
     terminal::disable_raw_mode()?;
     execute!(io::stdout(), cursor::Show, cursor::MoveDown(options.len() as u16), Print("\n"))?;
 
-    // Print selection confirmation
-    if let Ok(pm) = &result {
-        let name = match pm {
-            PackageManagerType::Pnpm => "pnpm",
-            PackageManagerType::Npm => "npm",
-            PackageManagerType::Yarn => "yarn",
-            PackageManagerType::Bun => "bun",
-        };
-        println!("\n✓ Selected package manager: {name}\n");
-    }
+        // Print selection confirmation
+        if let Ok(pm) = &result {
+            let name = match pm {
+                PackageManagerType::Pnpm => "pnpm",
+                PackageManagerType::Npm => "npm",
+                PackageManagerType::Yarn => "yarn",
+                PackageManagerType::Bun => "bun",
+                PackageManagerType::Deno => "deno",
+            };
+            println!("\n✓ Selected package manager: {name}\n");
+        }
 
     result
 }
@@ -1425,6 +1457,7 @@ fn simple_text_prompt() -> Result<PackageManagerType, Error> {
         ("npm", PackageManagerType::Npm),
         ("yarn", PackageManagerType::Yarn),
         ("bun", PackageManagerType::Bun),
+        ("deno", PackageManagerType::Deno),
     ];
 
     println!("\nNo package manager detected. Please select one:");

--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-Use Vite+ to manage dependencies across pnpm, npm, Yarn, and Bun. Instead of switching between `pnpm install`, `npm install`, `yarn install`, and `bun install`, you can keep using `vp install`, `vp add`, `vp remove`, and the rest of the Vite+ package-management commands.
+Use Vite+ to manage dependencies across pnpm, npm, Yarn, Bun, and Deno (experimental). Instead of switching between `pnpm install`, `npm install`, `yarn install`, `bun install`, and `deno install`, you can keep using `vp install`, `vp add`, `vp remove`, and the rest of the Vite+ package-management commands.
 
 Vite+ detects the package manager from the workspace root in this order:
 
@@ -15,9 +15,10 @@ Vite+ detects the package manager from the workspace root in this order:
 5. `yarn.lock` or `.yarnrc.yml`
 6. `package-lock.json`
 7. `bun.lock` or `bun.lockb`
-8. `.pnpmfile.cjs` or `pnpmfile.cjs`
-9. `bunfig.toml`
-10. `yarn.config.cjs`
+8. `deno.json`, `deno.jsonc`, or `deno.lock` (experimental)
+9. `.pnpmfile.cjs` or `pnpmfile.cjs`
+10. `bunfig.toml`
+11. `yarn.config.cjs`
 
 If none of those files are present, `vp` falls back to `pnpm` by default. Vite+ automatically downloads the matching package manager and uses it for the command you ran. When detection comes from lockfiles or config files, the resolved version is written to `devEngines.packageManager` so future runs are deterministic; projects that already declare `packageManager` or `devEngines.packageManager` are left as-is.
 

--- a/packages/cli/src/types/package.ts
+++ b/packages/cli/src/types/package.ts
@@ -3,6 +3,7 @@ export const PackageManager = {
   npm: 'npm',
   yarn: 'yarn',
   bun: 'bun',
+  deno: 'deno',
 } as const;
 export type PackageManager = (typeof PackageManager)[keyof typeof PackageManager];
 

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -56,6 +56,7 @@ export async function selectPackageManager(interactive?: boolean, silent = false
         { value: PackageManager.yarn },
         { value: PackageManager.npm },
         { value: PackageManager.bun },
+        { value: PackageManager.deno },
       ],
       initialValue: PackageManager.pnpm,
     });
@@ -80,6 +81,18 @@ export async function downloadPackageManager(
   interactive?: boolean,
   silent = false,
 ) {
+  // Deno is expected to be installed system-wide; do not try to download it
+  // from the npm registry.
+  if (packageManager === PackageManager.deno) {
+    return {
+      name: PackageManager.deno,
+      version: 'system',
+      binPrefix: '',
+      installDir: '',
+      packageName: PackageManager.deno,
+    };
+  }
+
   const spinner = silent ? getSilentSpinner() : getSpinner(interactive);
   spinner.start(`${packageManager}@${version} installing...`);
   const downloadResult = await downloadPackageManagerBinding({


### PR DESCRIPTION
# RFC: Deno as a Vite+ Package Manager

## Summary

Add `deno` to Vite+ as a first-class package manager alongside `npm`, `pnpm`,
`yarn`, and `bun`. When Vite+ detects a Deno project, `vp install` should invoke
`deno install` and subsequent `vp` commands should respect Deno's
`deno.lock` / `deno.json` workspace model.

## Motivation

Deno 2 fully supports `package.json`, `node_modules`, and npm dependencies. For
Deno-native projects, the only missing piece of a unified toolchain is a
single-command entry point. Vite+ already provides that for Node/npm projects;
extending it to Deno would make Vite+ a true "Unified Toolchain for the Web"
rather than a Node-only toolchain.

openElement is a Deno-origin Web Components full-stack framework that already
uses Vite and Nitro. It is an ideal dogfood: ESM-first, Web Standards-first,
multi-package workspace, with no desire to migrate to Node/npm. Having Vite+
recognize Deno would let such projects keep their runtime and package manager
while gaining a unified dev/build/check/test/pack entry point.

## Scope

### Package-manager detection

Detect Deno when any of the following are present (in descending priority):

1. `packageManager: "deno@x.y.z"` in `package.json`
2. `devEngines.packageManager.name === "deno"` in `package.json`
3. `deno.json` / `deno.jsonc` at the workspace root
4. `deno.lock` at the workspace root
5. `deno` binary available on PATH (fallback)

### `vp install`

When Deno is detected, invoke:

```bash
deno install
```

Pass through extra args (`--frozen`, `--allow-scripts`, etc.) where semantically
compatible.

### Enum / selector updates

Add `deno` to the internal `PackageManager` enum and the interactive
`selectPackageManager` picker.

### Guards for Deno-specific behavior

Deno does not use:

- `.yarnrc.yml` / yarn resolutions
- `pnpm-workspace.yaml` / pnpm overrides / pnpm catalogs
- `.bunfig.toml` / bun untrusted builds
- `package-lock.json`

Vite+ should skip these code paths for Deno instead of falling through to an
npm/pnpm/yarn/bun branch.

## Non-Goals

- **Not** making Deno a Vite+ managed runtime (`vp env` installing Deno). Deno
  is used as a system package manager, like npm/pnpm/yarn/bun already are.
- **Not** replacing `deno.json` with `package.json` workspaces. Deno's
  `deno.json` workspace convention should remain valid.
- **Not** full command parity in the first iteration. `vp add/remove/update` can
  be deferred; `vp install` is the MVP.
- **Not** altering Vite's bundling/runtime behavior. Vite itself still runs on
  Node; this proposal is about package-manager dispatch.

## Case Study: openElement

openElement is a Web Components full-stack framework built on Deno. It has:

- 11 packages in a `deno.json` workspace
- `deno.lock` as the lockfile
- npm dependencies via `npm:` specifiers
- Vite and Nitro already in use

Current behavior when running `vp install` on openElement:

- Vite+ does not recognize `deno.json` / `deno.lock`.
- It falls back to `pnpm` and creates `pnpm-lock.yaml`.
- This is wrong for a Deno-first project.

Expected behavior:

- Vite+ detects Deno.
- `vp install` runs `deno install`.
- `deno.lock` remains the source of truth.

Repository: https://github.com/open-element/openelement

## Implementation Notes

Audit of `vite-plus@0.2.1` suggests:

- Package-manager detection is exported from the Rust binding as
  `detectWorkspace`, returning `packageManagerName`.
- `vp install` command dispatch is handled by the Rust `run`/`runCommand`
  binding.
- The JS bundle hardcodes `PackageManager = { pnpm, npm, yarn, bun }` and
  pattern-matches it in many places.

Therefore the change is split across:

1. **Rust core**: extend `detectWorkspace` with Deno signals; map `vp install`
   to `deno install`.
2. **JS bundle**: add `deno` to the enum/selector; add guards in
   rewriting/bootstrap logic so Deno is not mis-handled.

## Suggested Detection Order Update

Update `docs/guide/install.md` to list Deno signals after `bun.lock`/`bun.lockb`
and before the fallback:

```text
1. packageManager in package.json
2. devEngines.packageManager in package.json
3. pnpm-workspace.yaml
4. pnpm-lock.yaml
5. yarn.lock or .yarnrc.yml
6. package-lock.json
7. bun.lock or bun.lockb
8. deno.json / deno.jsonc / deno.lock   <-- new
9. .pnpmfile.cjs or pnpmfile.cjs
10. bunfig.toml
11. yarn.config.cjs
```

## Open Questions

1. Should Vite+ write `devEngines.packageManager` when bootstrapping a Deno
   project, or should it prefer recording the package manager in `deno.json`?
2. How should Vite+ handle Deno workspaces (`deno.json` `workspace` array)?
3. Should `vp install` on Deno pass `--frozen` by default to match pnpm/yarn
   behavior, or rely on Deno's own defaults?
4. What is the recommended way to test Deno detection without shipping a Deno
   binary in CI?

## Related

- Deno 2 `package.json` and `node_modules` support:
  https://docs.deno.com/runtime/fundamentals/configuration/
- Vite+ package manager docs: https://viteplus.dev/guide/install
- openElement dogfood observations: (to be linked after publication)
