### PR TITLE
ci: restore released cargo-zigbuild install

### DIFF
--- a/.github/actions/build-upstream/action.yml
+++ b/.github/actions/build-upstream/action.yml
@@ -83,7 +83,7 @@ runs:
 
     - name: Install cargo-zigbuild (musl)
       if: steps.cache-restore.outputs.cache-hit != 'true' && contains(inputs.target, 'musl')
-      uses: taiki-e/install-action@559dd1420485d78e0d019f47bb2b74df4a46849a # v2.62.12
+      uses: taiki-e/install-action@5ab30948b991e8d6aa5a6c1e33c6aea130c6de65 # v2.62.12
       with:
         tool: cargo-zigbuild
 

--- a/.github/actions/build-upstream/action.yml
+++ b/.github/actions/build-upstream/action.yml
@@ -81,15 +81,11 @@ runs:
       with:
         version: 0.15.2
 
-    # Rust nightly-2026-06-10 passes --fix-cortex-a53-843419 to the linker for
-    # aarch64-linux targets, which zig cc rejects. The filter for this arg
-    # (rust-cross/cargo-zigbuild#452) is merged but unreleased, so install from
-    # the pinned git commit. TODO: revert to taiki-e/install-action once
-    # cargo-zigbuild > 0.22.3 is released.
     - name: Install cargo-zigbuild (musl)
       if: steps.cache-restore.outputs.cache-hit != 'true' && contains(inputs.target, 'musl')
-      shell: bash
-      run: cargo install --locked --git https://github.com/rust-cross/cargo-zigbuild --rev 7e791b4be71b9870e0abccedf7885486803cd923 cargo-zigbuild
+      uses: taiki-e/install-action@559dd1420485d78e0d019f47bb2b74df4a46849a # v2.62.12
+      with:
+        tool: cargo-zigbuild
 
     # NAPI builds - only run on cache miss (slow, especially on Windows)
     # Must run before vite-plus TypeScript builds which depend on the bindings


### PR DESCRIPTION
## Summary

Fixes #1814.

- restore `taiki-e/install-action` for the musl `cargo-zigbuild` setup
- remove the temporary git install from `rust-cross/cargo-zigbuild`
- drop the obsolete TODO now that `cargo-zigbuild` has released past `0.22.3`

## Validation

- `gh release list -R rust-cross/cargo-zigbuild --limit 10` shows `v0.23.0` as the latest release
- `git diff --check -- .github/actions/build-upstream/action.yml`
- local action sanity check confirmed `taiki-e/install-action` and `tool: cargo-zigbuild` are present, and the old pinned rev `7e791b4b` is gone

I did not run the full musl CI build locally because this change affects GitHub Actions runner setup rather than local build logic.
