### PR TITLE
fix(check): preserve oxlint GitHub reporter

### DIFF
--- a/packages/cli/binding/src/check/analysis.rs
+++ b/packages/cli/binding/src/check/analysis.rs
@@ -247,7 +247,7 @@ pub(super) fn analyze_lint_output(output: &str) -> Option<Result<LintSuccess, Li
 mod tests {
     use serde_json::json;
 
-    use super::{LintMessageKind, analyze_lint_output, lint_config_type_check_enabled};
+    use super::{LintMessageKind, lint_config_type_check_enabled};
 
     #[test]
     fn lint_message_kind_defaults_to_lint_only_without_typecheck() {
@@ -307,22 +307,5 @@ mod tests {
         assert!(!lint_config_type_check_enabled(Some(&json!({
             "options": { "typeAware": true, "typeCheck": false }
         }))));
-    }
-
-    #[test]
-    fn lint_output_allows_github_reporter_annotations_before_summary() {
-        let output = "\
-::warning file=src/example.ts,line=1,col=1,title=oxlint::example annotation
-Found 0 warnings and 0 errors.
-Finished in 12ms on 1 file using 12 threads.
-";
-
-        let result = analyze_lint_output(output)
-            .expect("summary should be parsed")
-            .expect("zero warnings and errors should pass");
-
-        assert_eq!(result.summary.duration, "12ms");
-        assert_eq!(result.summary.files, 1);
-        assert_eq!(result.summary.threads, 12);
     }
 }

--- a/packages/cli/binding/src/check/analysis.rs
+++ b/packages/cli/binding/src/check/analysis.rs
@@ -247,7 +247,7 @@ pub(super) fn analyze_lint_output(output: &str) -> Option<Result<LintSuccess, Li
 mod tests {
     use serde_json::json;
 
-    use super::{LintMessageKind, lint_config_type_check_enabled};
+    use super::{LintMessageKind, analyze_lint_output, lint_config_type_check_enabled};
 
     #[test]
     fn lint_message_kind_defaults_to_lint_only_without_typecheck() {
@@ -307,5 +307,22 @@ mod tests {
         assert!(!lint_config_type_check_enabled(Some(&json!({
             "options": { "typeAware": true, "typeCheck": false }
         }))));
+    }
+
+    #[test]
+    fn lint_output_allows_github_reporter_annotations_before_summary() {
+        let output = "\
+::warning file=src/example.ts,line=1,col=1,title=oxlint::example annotation
+Found 0 warnings and 0 errors.
+Finished in 12ms on 1 file using 12 threads.
+";
+
+        let result = analyze_lint_output(output)
+            .expect("summary should be parsed")
+            .expect("zero warnings and errors should pass");
+
+        assert_eq!(result.summary.duration, "12ms");
+        assert_eq!(result.summary.files, 1);
+        assert_eq!(result.summary.threads, 12);
     }
 }

--- a/packages/cli/binding/src/check/mod.rs
+++ b/packages/cli/binding/src/check/mod.rs
@@ -138,6 +138,8 @@ pub(crate) async fn execute_check(
         if fix && lint_enabled {
             args.push("--fix".to_string());
         }
+        let lint_format = if is_github_actions_env(envs) { "github" } else { "default" };
+        args.push(format!("--format={lint_format}"));
         if !lint_enabled && type_check_enabled {
             args.push("--type-check-only".to_string());
         }
@@ -271,6 +273,10 @@ fn flush_deferred_pass_lines(
     }
 }
 
+fn is_github_actions_env(envs: &FxHashMap<Arc<OsStr>, Arc<OsStr>>) -> bool {
+    envs.get(OsStr::new("GITHUB_ACTIONS")).is_some_and(|value| value.as_ref() == OsStr::new("true"))
+}
+
 /// Combine stdout and stderr from a captured command output.
 fn combine_output(captured: CapturedCommandOutput) -> (ExitStatus, String) {
     let combined = if captured.stderr.is_empty() {
@@ -281,4 +287,27 @@ fn combine_output(captured: CapturedCommandOutput) -> (ExitStatus, String) {
         format!("{}{}", captured.stdout, captured.stderr)
     };
     (captured.status, combined)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{ffi::OsStr, sync::Arc};
+
+    use rustc_hash::FxHashMap;
+
+    use super::is_github_actions_env;
+
+    fn envs(entries: &[(&str, &str)]) -> FxHashMap<Arc<OsStr>, Arc<OsStr>> {
+        entries
+            .iter()
+            .map(|(key, value)| (Arc::from(OsStr::new(key)), Arc::from(OsStr::new(value))))
+            .collect()
+    }
+
+    #[test]
+    fn github_actions_env_requires_true_value() {
+        assert!(is_github_actions_env(&envs(&[("GITHUB_ACTIONS", "true")])));
+        assert!(!is_github_actions_env(&envs(&[("GITHUB_ACTIONS", "false")])));
+        assert!(!is_github_actions_env(&envs(&[])));
+    }
 }

--- a/packages/cli/binding/src/check/mod.rs
+++ b/packages/cli/binding/src/check/mod.rs
@@ -138,8 +138,6 @@ pub(crate) async fn execute_check(
         if fix && lint_enabled {
             args.push("--fix".to_string());
         }
-        let lint_format = if is_github_actions_env(envs) { "github" } else { "default" };
-        args.push(format!("--format={lint_format}"));
         if !lint_enabled && type_check_enabled {
             args.push("--type-check-only".to_string());
         }
@@ -273,10 +271,6 @@ fn flush_deferred_pass_lines(
     }
 }
 
-fn is_github_actions_env(envs: &FxHashMap<Arc<OsStr>, Arc<OsStr>>) -> bool {
-    envs.get(OsStr::new("GITHUB_ACTIONS")).is_some_and(|value| value.as_ref() == OsStr::new("true"))
-}
-
 /// Combine stdout and stderr from a captured command output.
 fn combine_output(captured: CapturedCommandOutput) -> (ExitStatus, String) {
     let combined = if captured.stderr.is_empty() {
@@ -287,27 +281,4 @@ fn combine_output(captured: CapturedCommandOutput) -> (ExitStatus, String) {
         format!("{}{}", captured.stdout, captured.stderr)
     };
     (captured.status, combined)
-}
-
-#[cfg(test)]
-mod tests {
-    use std::{ffi::OsStr, sync::Arc};
-
-    use rustc_hash::FxHashMap;
-
-    use super::is_github_actions_env;
-
-    fn envs(entries: &[(&str, &str)]) -> FxHashMap<Arc<OsStr>, Arc<OsStr>> {
-        entries
-            .iter()
-            .map(|(key, value)| (Arc::from(OsStr::new(key)), Arc::from(OsStr::new(value))))
-            .collect()
-    }
-
-    #[test]
-    fn github_actions_env_requires_true_value() {
-        assert!(is_github_actions_env(&envs(&[("GITHUB_ACTIONS", "true")])));
-        assert!(!is_github_actions_env(&envs(&[("GITHUB_ACTIONS", "false")])));
-        assert!(!is_github_actions_env(&envs(&[])));
-    }
 }

--- a/packages/cli/binding/src/check/mod.rs
+++ b/packages/cli/binding/src/check/mod.rs
@@ -138,12 +138,6 @@ pub(crate) async fn execute_check(
         if fix && lint_enabled {
             args.push("--fix".to_string());
         }
-        // `vp check` parses oxlint's human-readable summary output to print
-        // unified pass/fail lines. When `GITHUB_ACTIONS=true`, oxlint auto-switches
-        // to the GitHub reporter, which omits that summary on success and makes the
-        // parser think linting never started. Force the default reporter here so the
-        // captured output is stable across local and CI environments.
-        args.push("--format=default".to_string());
         if !lint_enabled && type_check_enabled {
             args.push("--type-check-only".to_string());
         }


### PR DESCRIPTION
## Summary

- stop forcing `--format=default` for the oxlint phase in `vp check`
- allow oxlint to use its GitHub Actions reporter again now that upstream includes the summary output needed by `vp check`
- add a parser regression test for GitHub annotation output before the oxlint summary

## Context

Closes #925.

The workaround from #914 was needed because oxlint's GitHub reporter did not emit the human-readable summary that `vp check` parses. The upstream fix landed in oxc-project/oxc#20404, and this repo currently pins oxlint 1.70.0, so the workaround should no longer be needed.

I noticed an older comment saying this would be handled later; I did not find an open PR for #925, so I kept this as the smallest revert-style change.

## Validation

- `gh pr view 20404 -R oxc-project/oxc --json state,mergedAt,mergeCommit`
- `gh pr list -R voidzero-dev/vite-plus --state open --search "925 OR oxlint GitHub reporter OR format=default OR github reporter"`
- `git diff --check -- packages/cli/binding/src/check/mod.rs packages/cli/binding/src/check/analysis.rs`
- `cargo +1.95.0 fmt --check -- packages/cli/binding/src/check/mod.rs packages/cli/binding/src/check/analysis.rs`

Not fully validated locally: `cargo test -p vite-plus-cli lint_output_allows_github_reporter_annotations_before_summary` could not run in this checkout. The pinned nightly toolchain fails before compilation with a missing rustup manifest / rustfmt dylib, and `cargo +1.95.0 test` fails while resolving the pinned `vite-task` git dependency `fspy`.
