### PR TITLE
refactor(vite_install): centralize Yarn v1/berry branching with is_yarn_berry

### DIFF
--- a/crates/vite_install/src/commands/approve_builds.rs
+++ b/crates/vite_install/src/commands/approve_builds.rs
@@ -204,7 +204,8 @@ impl PackageManager {
             }
             PackageManagerType::Yarn => {
                 // Yarn 1 (Classic) runs lifecycle scripts by default; Berry (2+) blocks them.
-                if self.version.starts_with("1.") {
+                let is_berry = self.is_yarn_berry();
+                if !is_berry {
                     output::warn(
                         "yarn (v1) runs lifecycle scripts by default. To restrict them, set \
                          `ignore-scripts=true` in .npmrc and rebuild approved packages with \

--- a/crates/vite_install/src/commands/audit.rs
+++ b/crates/vite_install/src/commands/audit.rs
@@ -93,9 +93,8 @@ impl PackageManager {
                 }
             }
             PackageManagerType::Yarn => {
-                let is_yarn1 = self.version.starts_with("1.");
-
-                if is_yarn1 {
+                let is_berry = self.is_yarn_berry();
+                if !is_berry {
                     if options.fix {
                         output::warn("yarn v1 audit does not support --fix");
                         return None;

--- a/crates/vite_install/src/commands/cache.rs
+++ b/crates/vite_install/src/commands/cache.rs
@@ -91,17 +91,17 @@ impl PackageManager {
             }
             PackageManagerType::Yarn => {
                 bin_name = "yarn".into();
-                let is_yarn1 = self.version.starts_with("1.");
 
                 match options.subcommand {
                     "dir" | "path" => {
-                        if is_yarn1 {
-                            args.push("cache".into());
-                            args.push("dir".into());
-                        } else {
+                        let is_berry = self.is_yarn_berry();
+                        if is_berry {
                             args.push("config".into());
                             args.push("get".into());
                             args.push("cacheFolder".into());
+                        } else {
+                            args.push("cache".into());
+                            args.push("dir".into());
                         }
                     }
                     "clean" => {

--- a/crates/vite_install/src/commands/config.rs
+++ b/crates/vite_install/src/commands/config.rs
@@ -86,12 +86,12 @@ impl PackageManager {
             PackageManagerType::Yarn => {
                 args.push("config".into());
 
-                let is_yarn1 = self.version.starts_with("1.");
+                let is_berry = self.is_yarn_berry();
 
                 // yarn@2+ uses 'unset' instead of 'delete', and no subcommand for 'list'
-                if options.subcommand == "delete" && !is_yarn1 {
+                if options.subcommand == "delete" && is_berry {
                     args.push("unset".into());
-                } else if options.subcommand == "list" && !is_yarn1 {
+                } else if options.subcommand == "list" && is_berry {
                     // yarn@2+: 'yarn config' with no subcommand lists all
                     // Don't add 'list'
                 } else {
@@ -112,7 +112,7 @@ impl PackageManager {
 
                 // Handle --location parameter
                 if let Some(location) = options.location {
-                    if is_yarn1 {
+                    if !is_berry {
                         // yarn@1: use --global for global location
                         if location == "global" {
                             args.push("--global".into());

--- a/crates/vite_install/src/commands/dist_tag.rs
+++ b/crates/vite_install/src/commands/dist_tag.rs
@@ -56,12 +56,12 @@ impl PackageManager {
             }
             PackageManagerType::Yarn => {
                 bin_name = "yarn".into();
-                let is_yarn1 = self.version.starts_with("1.");
+                let is_berry = self.is_yarn_berry();
 
-                if is_yarn1 {
+                if is_berry {
+                    args.push("npm".into());
                     args.push("tag".into());
                 } else {
-                    args.push("npm".into());
                     args.push("tag".into());
                 }
             }

--- a/crates/vite_install/src/commands/dlx.rs
+++ b/crates/vite_install/src/commands/dlx.rs
@@ -45,7 +45,9 @@ impl PackageManager {
             PackageManagerType::Pnpm => self.resolve_pnpm_dlx(options, envs),
             PackageManagerType::Npm => self.resolve_npm_dlx(options, envs),
             PackageManagerType::Yarn => {
-                if self.version.starts_with("1.") {
+                let is_berry = self.is_yarn_berry();
+
+                if !is_berry {
                     // Yarn 1.x doesn't have dlx, fall back to npx
                     self.resolve_npx_fallback(options, envs)
                 } else {

--- a/crates/vite_install/src/commands/list.rs
+++ b/crates/vite_install/src/commands/list.rs
@@ -54,7 +54,7 @@ impl PackageManager {
         options: &ListCommandOptions,
     ) -> Option<ResolveCommandResult> {
         // yarn@2+ does not support list command
-        if self.client == PackageManagerType::Yarn && !self.version.starts_with("1.") {
+        if self.client == PackageManagerType::Yarn && self.is_yarn_berry() {
             output::warn("yarn@2+ does not support 'list' command");
             return None;
         }

--- a/crates/vite_install/src/commands/login.rs
+++ b/crates/vite_install/src/commands/login.rs
@@ -46,9 +46,9 @@ impl PackageManager {
             }
             PackageManagerType::Yarn => {
                 bin_name = "yarn".into();
-                let is_yarn1 = self.version.starts_with("1.");
+                let is_berry = self.is_yarn_berry();
 
-                if is_yarn1 {
+                if !is_berry {
                     args.push("login".into());
                 } else {
                     args.push("npm".into());

--- a/crates/vite_install/src/commands/logout.rs
+++ b/crates/vite_install/src/commands/logout.rs
@@ -46,9 +46,9 @@ impl PackageManager {
             }
             PackageManagerType::Yarn => {
                 bin_name = "yarn".into();
-                let is_yarn1 = self.version.starts_with("1.");
+                let is_berry = self.is_yarn_berry();
 
-                if is_yarn1 {
+                if !is_berry {
                     args.push("logout".into());
                 } else {
                     args.push("npm".into());

--- a/crates/vite_install/src/commands/outdated.rs
+++ b/crates/vite_install/src/commands/outdated.rs
@@ -157,9 +157,10 @@ impl PackageManager {
                 }
                 PackageManagerType::Yarn => {
                     bin_name = "yarn".into();
+                    let is_berry = self.is_yarn_berry();
 
                     // Check if yarn@2+ (uses upgrade-interactive)
-                    if self.version.starts_with("1.") {
+                    if !is_berry {
                         // yarn@1
                         args.push("outdated".into());
 

--- a/crates/vite_install/src/commands/pack.rs
+++ b/crates/vite_install/src/commands/pack.rs
@@ -121,11 +121,11 @@ impl PackageManager {
                 }
             }
             PackageManagerType::Yarn => {
-                let is_yarn1 = self.version.starts_with("1.");
+                let is_berry = self.is_yarn_berry();
                 let has_filters = options.filters.is_some_and(|f| !f.is_empty());
 
                 // yarn@2+ uses 'workspaces foreach' for recursive or filters
-                if !is_yarn1 && (options.recursive || has_filters) {
+                if is_berry && (options.recursive || has_filters) {
                     args.push("workspaces".into());
                     args.push("foreach".into());
                     args.push("--all".into());
@@ -141,19 +141,19 @@ impl PackageManager {
                     args.push("pack".into());
                 } else {
                     // yarn@1 or single package pack
-                    if options.recursive && is_yarn1 {
+                    if options.recursive && !is_berry {
                         output::warn(
                             "yarn@1 does not support recursive pack, ignoring --recursive flag",
                         );
                     }
-                    if has_filters && is_yarn1 {
+                    if has_filters && !is_berry {
                         output::warn("yarn@1 does not support --filter, ignoring --filter flag");
                     }
                     args.push("pack".into());
                 }
 
                 if let Some(out) = options.out {
-                    if is_yarn1 {
+                    if !is_berry {
                         args.push("--filename".into());
                     } else {
                         args.push("--out".into());

--- a/crates/vite_install/src/commands/rebuild.rs
+++ b/crates/vite_install/src/commands/rebuild.rs
@@ -54,9 +54,9 @@ impl PackageManager {
                 args.push("rebuild".into());
             }
             PackageManagerType::Yarn => {
-                let is_yarn1 = self.version.starts_with("1.");
+                let is_berry = self.is_yarn_berry();
 
-                if is_yarn1 {
+                if !is_berry {
                     output::warn("yarn v1 does not support the rebuild command");
                 } else {
                     output::warn("yarn berry does not support the rebuild command");

--- a/crates/vite_install/src/commands/update.rs
+++ b/crates/vite_install/src/commands/update.rs
@@ -91,9 +91,9 @@ impl PackageManager {
                 bin_name = "yarn".into();
 
                 // Determine yarn version
-                let is_yarn_v1 = self.version.starts_with("1.");
+                let is_berry = self.is_yarn_berry();
 
-                if is_yarn_v1 {
+                if !is_berry {
                     // yarn@1: yarn upgrade [--latest]
                     if let Some(filters) = options.filters {
                         args.push("workspace".into());

--- a/crates/vite_install/src/commands/whoami.rs
+++ b/crates/vite_install/src/commands/whoami.rs
@@ -51,9 +51,9 @@ impl PackageManager {
                 args.push("whoami".into());
             }
             PackageManagerType::Yarn => {
-                let is_yarn1 = self.version.starts_with("1.");
+                let is_berry = self.is_yarn_berry();
 
-                if is_yarn1 {
+                if !is_berry {
                     output::warn("yarn v1 does not support the whoami command");
                     return None;
                 }

--- a/crates/vite_install/src/commands/why.rs
+++ b/crates/vite_install/src/commands/why.rs
@@ -126,12 +126,13 @@ impl PackageManager {
                 args.push(options.packages[0].clone());
 
                 // yarn@2+ supports --recursive
-                if options.recursive && !self.version.starts_with("1.") {
+                let is_berry = self.is_yarn_berry();
+                if options.recursive && is_berry {
                     args.push("--recursive".into());
                 }
 
                 // yarn@2+: Add --peers by default unless --exclude-peers is set
-                if !self.version.starts_with("1.") && !options.exclude_peers {
+                if is_berry && !options.exclude_peers {
                     args.push("--peers".into());
                 }
 


### PR DESCRIPTION
## Summary
Refactor Yarn version branching in `vite_install` command handlers to use the shared helper `self.is_yarn_berry()` instead of direct version string checks (`self.version.starts_with("1.")` / `is_yarn_v1`).

## Why
Yarn version branching logic (`v1` vs `berry`) was duplicated across many commands.
This change centralizes the check via `is_yarn_berry()` for better readability and consistency, while keeping behavior unchanged.

## What changed
Replaced direct Yarn v1 checks with `let is_berry = self.is_yarn_berry();`