### PR TITLE
test(ecosystem-ci): bump bun-vite-template to oxlint jsx-a11y fix

### DIFF
--- a/ecosystem-ci/repo.json
+++ b/ecosystem-ci/repo.json
@@ -106,7 +106,7 @@
   "bun-vite-template": {
     "repository": "https://github.com/why-reproductions-are-required/bun-vite-template.git",
     "branch": "master",
-    "hash": "d84099b4a153c7e0f35e510725b2ceb24c6e09ad"
+    "hash": "c507faecc4338a2d4f51c7a0b7046ed25089d232"
   },
   "vite-plus-vitest-global-type-minimal-repro": {
     "repository": "https://github.com/why-reproductions-are-required/vite-plus-vitest-global-type-minimal-repro.git",


### PR DESCRIPTION
Pin `bun-vite-template` to `c507fae` (master tip), which includes the `eslint.config.js` fix from [why-reproductions-are-required/bun-vite-template#2](https://github.com/why-reproductions-are-required/bun-vite-template/pull/2).

That fix drops the jsx-a11y rule options oxlint 1.70.0 rejects (`includeRoles` on `control-has-associated-label`, the element-map on `no-noninteractive-element-to-interactive-role`), so after `vp migrate` the project's `vp lint` no longer fails with "Failed to parse oxlint configuration file".

Verified locally end-to-end with oxlint 1.70.0: `vp migrate` then `vp run lint` passes.