### PR TITLE
  docs(migrate): clarify Git hook tool migration

### DIFF
--- a/docs/guide/migrate.md
+++ b/docs/guide/migrate.md
@@ -166,6 +166,16 @@ export default defineConfig({
 
 After migrating, remove lint-staged from your dependencies and delete any lint-staged config files. See the [Commit hooks guide](/guide/commit-hooks) and [Staged config reference](/config/staged) for details.
 
+### Git hook tools
+
+The `vp migrate` command can set up Vite+ commit hooks for you, but it doesn't automatically migrate every type of Git hook tool. This automatic migration path is specifically designed to handle Husky and lint-staged-style setups.
+
+If your project currently uses `lefthook`, `simple-git-hooks`, or `yorkie`, `vp migrate` will leave your existing configuration alone and show a warning. This happens even if you choose to set up hooks during the prompt or include the `--hooks` flag.
+
+If you want to move one of those tools over to Vite+ manually, you can follow these steps. First, move your staged-file commands into the `staged` block within `vite.config.ts`. Then, update your lifecycle script so it runs `vp config`. You will also need to create a Vite+ hook at `.vite-hooks/pre-commit` that runs `vp staged`. Finally, once you have confirmed that the Vite+ hook is working as expected, you can remove the old tool's configuration and dependency.
+
+You can find more details about the full Vite+ hook setup in the [Commit hooks guide](/guide/commit-hooks).
+
 ## Examples
 
 ```bash

--- a/docs/guide/migrate.md
+++ b/docs/guide/migrate.md
@@ -168,7 +168,7 @@ After migrating, remove lint-staged from your dependencies and delete any lint-s
 
 ### Git hook tools
 
-The `vp migrate` command can set up Vite+ commit hooks for you, but it doesn't automatically migrate every type of Git hook tool. This automatic migration path is specifically designed to handle Husky and lint-staged-style setups.
+The `vp migrate` command can set up Vite+ commit hooks for you, but it doesn't automatically migrate every type of Git hook tool. This automatic migration path is specifically designed to handle Husky v9+ and lint-staged-style setups. Projects using Husky versions older than 9.0.0 are skipped and should upgrade to Husky v9 before using the automatic migration path.
 
 If your project currently uses `lefthook`, `simple-git-hooks`, or `yorkie`, `vp migrate` will leave your existing configuration alone and show a warning. This happens even if you choose to set up hooks during the prompt or include the `--hooks` flag.
 


### PR DESCRIPTION
resolves #1854

In this PR, I am adding a description to the Migration Guide proposed in #1854. Currently, warnings are issued when using simple-git-hooks, lefthook, or yorkie, but users need to check the RFC to understand the background:

https://github.com/voidzero-dev/vite-plus/blob/abde8abf24914f05744a9fd620e2ce039906cdb5/rfcs/config-and-staged-commands.md?plain=1#L228-L231

This change first documents this specific edge case in the migration guide.

In a subsequent PR, I plan to add a link to these change guidelines within the warning message displayed here:

https://github.com/voidzero-dev/vite-plus/blob/abde8abf24914f05744a9fd620e2ce039906cdb5/packages/cli/src/migration/migrator.ts#L5081-L5085