### PR TITLE
  fix(migration): link git hook warning to migration guide

### DIFF
--- a/packages/cli/snap-tests-global/migration-other-hook-tool/snap.txt
+++ b/packages/cli/snap-tests-global/migration-other-hook-tool/snap.txt
@@ -1,6 +1,6 @@
 > vp migrate --no-interactive # hooks should be skipped due to simple-git-hooks
 
-⚠ Detected simple-git-hooks — skipping git hooks setup. Please configure git hooks manually.
+⚠ Detected simple-git-hooks — skipping git hooks setup. Please configure git hooks manually, see https://viteplus.dev/guide/migrate#git-hook-tools
 ◇ Migrated . to Vite+
 • Node <semver>  pnpm <semver>
 • 1 config update applied

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -5080,7 +5080,7 @@ export function preflightGitHooksSetup(
   const prodDeps = pkgContent.dependencies as Record<string, string> | undefined;
   for (const tool of OTHER_HOOK_TOOLS) {
     if (deps?.[tool] || prodDeps?.[tool] || pkgContent[tool]) {
-      return `Detected ${tool} — skipping git hooks setup. Please configure git hooks manually.`;
+      return `Detected ${tool} — skipping git hooks setup. Please configure git hooks manually, see https://viteplus.dev/guide/migrate#git-hook-tools`;
     }
   }
   const huskyReason = checkUnsupportedHuskyVersion(projectPath, deps, prodDeps, packageManager);


### PR DESCRIPTION
relates: #1901

Add a link message to the warning so that users can refer to the migration guide for GitHook Tools implemented in #1901.

https://viteplus.dev/guide/migrate#git-hook-tools