### PR TITLE
fix(migrate): dedupe vite/vitest under pnpm by adding a direct vite dep

### DIFF
--- a/.github/workflows/test-vp-create.yml
+++ b/.github/workflows/test-vp-create.yml
@@ -321,6 +321,9 @@ jobs:
             echo "[$pkg]"; echo "$found"
             if echo "$found" | grep -qE "$pattern"; then
               echo "✗ $pkg is not a single instance (override did not dedupe under pnpm)"
+              echo "----- full \`vp why $pkg\` output -----"
+              echo "$out"
+              echo "---------------------------------------"
               fail=1
             else
               echo "✓ $pkg single instance"

--- a/.github/workflows/test-vp-create.yml
+++ b/.github/workflows/test-vp-create.yml
@@ -300,6 +300,41 @@ jobs:
             esac
           fi
 
+      - name: Verify single dependency instances (pnpm only)
+        if: matrix.package-manager == 'pnpm'
+        working-directory: ${{ runner.temp }}/test-project
+        run: |
+          # The `vite` override must dedupe vite-plus / vite / vitest to a single
+          # instance each. When a peer variation splits the graph (e.g. an upstream
+          # `vite` auto-installed to satisfy vitest's peer in a package without a
+          # direct `vite` dep), `vp why` reports multiple instances. Detection:
+          # - vite-plus / vitest: a split prints "Found 1 version, N instances of <pkg>".
+          # - vite: it is overridden to @voidzero-dev/vite-plus-core, so a clean tree
+          #   only summarises that package; a standalone upstream copy adds a
+          #   "Found <n> version(s) of vite" line.
+          # Tracks voidzero-dev/vite-plus#1932 (currently expected to fail for monorepo).
+          fail=0
+          check() {
+            pkg="$1"; pattern="$2"
+            out=$(vp why "$pkg" 2>&1)
+            found=$(echo "$out" | grep '^Found' || true)
+            echo "[$pkg]"; echo "$found"
+            if echo "$found" | grep -qE "$pattern"; then
+              echo "✗ $pkg is not a single instance (override did not dedupe under pnpm)"
+              fail=1
+            else
+              echo "✓ $pkg single instance"
+            fi
+          }
+          check vite-plus 'instances of vite-plus'
+          check vitest 'instances of vitest'
+          check vite 'of vite$'
+          if [ "$fail" -ne 0 ]; then
+            echo "Expected vite-plus, vite, and vitest to each resolve to a single instance."
+            exit 1
+          fi
+          echo "✓ vite-plus, vite, vitest are all single instances"
+
       - name: Verify local tgz packages installed
         working-directory: ${{ runner.temp }}/test-project
         run: |

--- a/.github/workflows/test-vp-create.yml
+++ b/.github/workflows/test-vp-create.yml
@@ -195,13 +195,6 @@ jobs:
       # `YN0016 ... are quarantined`. The migrate tool is version-pinned to the
       # bundled oxlint, so disable the gate for this test (no-op for npm/pnpm/bun).
       YARN_NPM_MINIMAL_AGE_GATE: '0'
-      # pnpm 11's default `minimumReleaseAge` (~24h) makes the bundled vitest's
-      # auto-installed `vite` peer resolve to the previous upstream release,
-      # which can predate vite's `@voidzero-dev/vite-task-client` integration and
-      # surface a false `vp test` cache miss in "Verify cache". Force 0 so the
-      # latest vite (with the integration) is used. pnpm-only (no-op elsewhere).
-      # Temporary band-aid; real fix tracked in voidzero-dev/vite-plus#1932.
-      PNPM_CONFIG_MINIMUM_RELEASE_AGE: '0'
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 
@@ -312,7 +305,7 @@ jobs:
           # - vite: it is overridden to @voidzero-dev/vite-plus-core, so a clean tree
           #   only summarises that package; a standalone upstream copy adds a
           #   "Found <n> version(s) of vite" line.
-          # Tracks voidzero-dev/vite-plus#1932 (currently expected to fail for monorepo).
+          # Regression guard for voidzero-dev/vite-plus#1932 (the pnpm dedupe fix).
           fail=0
           check() {
             pkg="$1"; pattern="$2"

--- a/.github/workflows/test-vp-create.yml
+++ b/.github/workflows/test-vp-create.yml
@@ -306,15 +306,18 @@ jobs:
           #   only summarises that package; a standalone upstream copy adds a
           #   "Found <n> version(s) of vite" line.
           # Regression guard for voidzero-dev/vite-plus#1932 (the pnpm dedupe fix).
+          # `-r` checks every workspace package, not just the root importer, so a
+          # duplicate confined to a sub-package (apps/website, packages/utils) is
+          # still caught.
           fail=0
           check() {
             pkg="$1"; pattern="$2"
-            out=$(vp why "$pkg" 2>&1)
+            out=$(vp why -r "$pkg" 2>&1)
             found=$(echo "$out" | grep '^Found' || true)
             echo "[$pkg]"; echo "$found"
             if echo "$found" | grep -qE "$pattern"; then
               echo "✗ $pkg is not a single instance (override did not dedupe under pnpm)"
-              echo "----- full \`vp why $pkg\` output -----"
+              echo "----- full \`vp why -r $pkg\` output -----"
               echo "$out"
               echo "---------------------------------------"
               fail=1

--- a/packages/cli/snap-tests-global/migration-auto-create-vite-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-auto-create-vite-config/snap.txt
@@ -40,8 +40,8 @@ export default defineConfig({
 > cat package.json # check package.json
 {
   "devDependencies": {
-    "vite-plus": "catalog:",
-    "vite": "catalog:"
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "devEngines": {
     "packageManager": {

--- a/packages/cli/snap-tests-global/migration-auto-create-vite-config/snap.txt
+++ b/packages/cli/snap-tests-global/migration-auto-create-vite-config/snap.txt
@@ -40,7 +40,8 @@ export default defineConfig({
 > cat package.json # check package.json
 {
   "devDependencies": {
-    "vite-plus": "catalog:"
+    "vite-plus": "catalog:",
+    "vite": "catalog:"
   },
   "devEngines": {
     "packageManager": {

--- a/packages/cli/snap-tests-global/migration-baseurl-tsconfig/snap.txt
+++ b/packages/cli/snap-tests-global/migration-baseurl-tsconfig/snap.txt
@@ -43,7 +43,8 @@ export default defineConfig({
 > cat package.json # check package.json
 {
   "devDependencies": {
-    "vite-plus": "catalog:"
+    "vite-plus": "catalog:",
+    "vite": "catalog:"
   },
   "devEngines": {
     "packageManager": {

--- a/packages/cli/snap-tests-global/migration-baseurl-tsconfig/snap.txt
+++ b/packages/cli/snap-tests-global/migration-baseurl-tsconfig/snap.txt
@@ -43,8 +43,8 @@ export default defineConfig({
 > cat package.json # check package.json
 {
   "devDependencies": {
-    "vite-plus": "catalog:",
-    "vite": "catalog:"
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "devEngines": {
     "packageManager": {

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-json/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-json/snap.txt
@@ -83,8 +83,8 @@ Documentation: https://viteplus.dev/guide/migrate
 {
   "name": "migration-lintstagedrc",
   "devDependencies": {
-    "vite-plus": "catalog:",
-    "vite": "catalog:"
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "devEngines": {
     "packageManager": {

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-json/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-json/snap.txt
@@ -83,7 +83,8 @@ Documentation: https://viteplus.dev/guide/migrate
 {
   "name": "migration-lintstagedrc",
   "devDependencies": {
-    "vite-plus": "catalog:"
+    "vite-plus": "catalog:",
+    "vite": "catalog:"
   },
   "devEngines": {
     "packageManager": {

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-not-support/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-not-support/snap.txt
@@ -30,7 +30,8 @@ export default {
   "devDependencies": {
     "husky": "^9.1.7",
     "lint-staged": "^16.2.6",
-    "vite-plus": "catalog:"
+    "vite-plus": "catalog:",
+    "vite": "catalog:"
   },
   "devEngines": {
     "packageManager": {

--- a/packages/cli/snap-tests-global/migration-lintstagedrc-not-support/snap.txt
+++ b/packages/cli/snap-tests-global/migration-lintstagedrc-not-support/snap.txt
@@ -30,8 +30,8 @@ export default {
   "devDependencies": {
     "husky": "^9.1.7",
     "lint-staged": "^16.2.6",
-    "vite-plus": "catalog:",
-    "vite": "catalog:"
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "devEngines": {
     "packageManager": {

--- a/packages/cli/snap-tests-global/migration-monorepo-pnpm/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-pnpm/snap.txt
@@ -158,8 +158,8 @@ minimumReleaseAgeExclude:
     "lint": "vp lint --fix"
   },
   "devDependencies": {
-    "vite-plus": "catalog:",
-    "vite": "catalog:"
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   }
 }
 

--- a/packages/cli/snap-tests-global/migration-monorepo-pnpm/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-pnpm/snap.txt
@@ -158,7 +158,8 @@ minimumReleaseAgeExclude:
     "lint": "vp lint --fix"
   },
   "devDependencies": {
-    "vite-plus": "catalog:"
+    "vite-plus": "catalog:",
+    "vite": "catalog:"
   }
 }
 

--- a/packages/cli/snap-tests-global/migration-monorepo-root-vitest-adjacent/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-root-vitest-adjacent/snap.txt
@@ -13,6 +13,7 @@
   "devDependencies": {
     "vitest-browser-svelte": "^2.1.0",
     "vite-plus": "catalog:",
+    "vite": "catalog:",
     "vitest": "catalog:"
   },
   "devEngines": {

--- a/packages/cli/snap-tests-global/migration-monorepo-root-vitest-adjacent/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-root-vitest-adjacent/snap.txt
@@ -11,9 +11,9 @@
     "prepare": "vp config"
   },
   "devDependencies": {
+    "vite": "catalog:",
     "vitest-browser-svelte": "^2.1.0",
     "vite-plus": "catalog:",
-    "vite": "catalog:",
     "vitest": "catalog:"
   },
   "devEngines": {

--- a/packages/cli/snap-tests-global/migration-monorepo-skip-vite-peer-dependency/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-skip-vite-peer-dependency/snap.txt
@@ -30,7 +30,8 @@ export default defineConfig({
 {
   "name": "migration-monorepo-skip-vite-peer-dependency",
   "devDependencies": {
-    "vite-plus": "catalog:"
+    "vite-plus": "catalog:",
+    "vite": "catalog:"
   },
   "devEngines": {
     "packageManager": {
@@ -51,6 +52,7 @@ export default defineConfig({
     "vite": "^6.0.0"
   },
   "devDependencies": {
-    "vite-plus": "catalog:"
+    "vite-plus": "catalog:",
+    "vite": "catalog:"
   }
 }

--- a/packages/cli/snap-tests-global/migration-monorepo-skip-vite-peer-dependency/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-skip-vite-peer-dependency/snap.txt
@@ -52,7 +52,6 @@ export default defineConfig({
     "vite": "^6.0.0"
   },
   "devDependencies": {
-    "vite-plus": "catalog:",
-    "vite": "catalog:"
+    "vite-plus": "catalog:"
   }
 }

--- a/packages/cli/snap-tests-global/migration-monorepo-skip-vite-peer-dependency/snap.txt
+++ b/packages/cli/snap-tests-global/migration-monorepo-skip-vite-peer-dependency/snap.txt
@@ -30,8 +30,8 @@ export default defineConfig({
 {
   "name": "migration-monorepo-skip-vite-peer-dependency",
   "devDependencies": {
-    "vite-plus": "catalog:",
-    "vite": "catalog:"
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "devEngines": {
     "packageManager": {

--- a/packages/cli/snap-tests-global/migration-oxlintrc-json-with-comments/snap.txt
+++ b/packages/cli/snap-tests-global/migration-oxlintrc-json-with-comments/snap.txt
@@ -38,8 +38,8 @@ export default defineConfig({
 > cat package.json # check package.json
 {
   "devDependencies": {
-    "vite-plus": "catalog:",
-    "vite": "catalog:"
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "devEngines": {
     "packageManager": {

--- a/packages/cli/snap-tests-global/migration-oxlintrc-json-with-comments/snap.txt
+++ b/packages/cli/snap-tests-global/migration-oxlintrc-json-with-comments/snap.txt
@@ -38,7 +38,8 @@ export default defineConfig({
 > cat package.json # check package.json
 {
   "devDependencies": {
-    "vite-plus": "catalog:"
+    "vite-plus": "catalog:",
+    "vite": "catalog:"
   },
   "devEngines": {
     "packageManager": {

--- a/packages/cli/snap-tests-global/migration-oxlintrc-jsonc/snap.txt
+++ b/packages/cli/snap-tests-global/migration-oxlintrc-jsonc/snap.txt
@@ -40,8 +40,8 @@ export default defineConfig({
 > cat package.json # check package.json
 {
   "devDependencies": {
-    "vite-plus": "catalog:",
-    "vite": "catalog:"
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "devEngines": {
     "packageManager": {

--- a/packages/cli/snap-tests-global/migration-oxlintrc-jsonc/snap.txt
+++ b/packages/cli/snap-tests-global/migration-oxlintrc-jsonc/snap.txt
@@ -40,7 +40,8 @@ export default defineConfig({
 > cat package.json # check package.json
 {
   "devDependencies": {
-    "vite-plus": "catalog:"
+    "vite-plus": "catalog:",
+    "vite": "catalog:"
   },
   "devEngines": {
     "packageManager": {

--- a/packages/cli/snap-tests-global/migration-rewrite-declare-module/snap.txt
+++ b/packages/cli/snap-tests-global/migration-rewrite-declare-module/snap.txt
@@ -38,8 +38,8 @@ declare module 'vitest/config' {
 {
   "name": "migration-rewrite-declare-module",
   "devDependencies": {
-    "vite-plus": "catalog:",
-    "vite": "catalog:"
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "devEngines": {
     "packageManager": {

--- a/packages/cli/snap-tests-global/migration-rewrite-declare-module/snap.txt
+++ b/packages/cli/snap-tests-global/migration-rewrite-declare-module/snap.txt
@@ -38,7 +38,8 @@ declare module 'vitest/config' {
 {
   "name": "migration-rewrite-declare-module",
   "devDependencies": {
-    "vite-plus": "catalog:"
+    "vite-plus": "catalog:",
+    "vite": "catalog:"
   },
   "devEngines": {
     "packageManager": {

--- a/packages/cli/snap-tests-global/migration-skip-vite-peer-dependency/snap.txt
+++ b/packages/cli/snap-tests-global/migration-skip-vite-peer-dependency/snap.txt
@@ -33,8 +33,7 @@ export default defineConfig({
     "vite": "^6.0.0"
   },
   "devDependencies": {
-    "vite-plus": "catalog:",
-    "vite": "catalog:"
+    "vite-plus": "catalog:"
   },
   "devEngines": {
     "packageManager": {

--- a/packages/cli/snap-tests-global/migration-skip-vite-peer-dependency/snap.txt
+++ b/packages/cli/snap-tests-global/migration-skip-vite-peer-dependency/snap.txt
@@ -33,7 +33,8 @@ export default defineConfig({
     "vite": "^6.0.0"
   },
   "devDependencies": {
-    "vite-plus": "catalog:"
+    "vite-plus": "catalog:",
+    "vite": "catalog:"
   },
   "devEngines": {
     "packageManager": {

--- a/packages/cli/snap-tests-global/migration-subpath/snap.txt
+++ b/packages/cli/snap-tests-global/migration-subpath/snap.txt
@@ -19,7 +19,8 @@
     ]
   },
   "devDependencies": {
-    "vite-plus": "catalog:"
+    "vite-plus": "catalog:",
+    "vite": "catalog:"
   },
   "devEngines": {
     "packageManager": {

--- a/packages/cli/snap-tests-global/migration-subpath/snap.txt
+++ b/packages/cli/snap-tests-global/migration-subpath/snap.txt
@@ -19,8 +19,8 @@
     ]
   },
   "devDependencies": {
-    "vite-plus": "catalog:",
-    "vite": "catalog:"
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   },
   "devEngines": {
     "packageManager": {

--- a/packages/cli/snap-tests-global/new-vite-monorepo/snap.txt
+++ b/packages/cli/snap-tests-global/new-vite-monorepo/snap.txt
@@ -21,6 +21,7 @@ vite.config.ts
     "prepare": "vp config"
   },
   "devDependencies": {
+    "vite": "catalog:",
     "vite-plus": "catalog:"
   },
   "devEngines": {
@@ -162,6 +163,7 @@ website
     "@typescript/native-preview": "7.0.0-dev.20260509.2",
     "bumpp": "^11.1.0",
     "typescript": "^6.0.3",
+    "vite": "catalog:",
     "vite-plus": "catalog:"
   }
 }
@@ -250,6 +252,7 @@ vite.config.ts
     "prepare": "vp config"
   },
   "devDependencies": {
+    "vite": "catalog:",
     "vite-plus": "catalog:"
   },
   "devEngines": {

--- a/packages/cli/snap-tests/create-org-bundled/snap.txt
+++ b/packages/cli/snap-tests/create-org-bundled/snap.txt
@@ -12,6 +12,7 @@
     "prepare": "vp config"
   },
   "devDependencies": {
+    "vite": "catalog:",
     "vite-plus": "catalog:"
   },
   "devEngines": {

--- a/packages/cli/src/migration/__tests__/__snapshots__/migrator.spec.ts.snap
+++ b/packages/cli/src/migration/__tests__/__snapshots__/migrator.spec.ts.snap
@@ -17,6 +17,7 @@ exports[`rewritePackageJson > should rewrite devDependencies and dependencies on
     "foo": "1.0.0",
   },
   "devDependencies": {
+    "vite": "catalog:",
     "vite-plus": "catalog:",
   },
 }
@@ -28,6 +29,7 @@ exports[`rewritePackageJson > should rewrite devDependencies and dependencies on
     "foo": "1.0.0",
   },
   "devDependencies": {
+    "vite": "npm:@voidzero-dev/vite-plus-core@latest",
     "vite-plus": "latest",
   },
 }

--- a/packages/cli/src/migration/__tests__/migrator.spec.ts
+++ b/packages/cli/src/migration/__tests__/migrator.spec.ts
@@ -214,6 +214,8 @@ describe('rewritePackageJson', () => {
       };
       rewritePackageJson(sub, PackageManager.pnpm, true);
       expect(sub.devDependencies.vite).toBe('catalog:');
+      // inserted in sorted position (oxfmt sorts package.json), not appended
+      expect(Object.keys(sub.devDependencies)).toEqual(['vite', 'vite-plus']);
 
       // standalone (no catalog) -> mirror the override target directly
       const standalone: { devDependencies: Record<string, string> } = {

--- a/packages/cli/src/migration/__tests__/migrator.spec.ts
+++ b/packages/cli/src/migration/__tests__/migrator.spec.ts
@@ -202,6 +202,52 @@ describe('rewritePackageJson', () => {
     }
   });
 
+  // #1932: under pnpm, any package that depends on vite-plus needs a direct
+  // `vite` so vitest's required `vite` peer binds to the override
+  // (@voidzero-dev/vite-plus-core); otherwise pnpm's autoInstallPeers installs a
+  // second upstream vite and splits vite-plus / vite / vitest into duplicates.
+  it('adds a direct `vite` devDep when a package depends on vite-plus under pnpm (#1932)', () => {
+    // monorepo sub-package -> catalog: (catalog.vite is written by rewriteCatalog)
+    const sub: { devDependencies: Record<string, string> } = {
+      devDependencies: { 'vite-plus': 'catalog:' },
+    };
+    rewritePackageJson(sub, PackageManager.pnpm, true);
+    expect(sub.devDependencies.vite).toBe('catalog:');
+
+    // standalone (no catalog) -> mirror the override target directly
+    const standalone: { devDependencies: Record<string, string> } = {
+      devDependencies: { 'vite-plus': 'latest' },
+    };
+    rewritePackageJson(standalone, PackageManager.pnpm);
+    expect(standalone.devDependencies.vite).toBe(VITE_PLUS_OVERRIDE_PACKAGES.vite);
+  });
+
+  it('does not add a direct `vite` for npm/yarn/bun (they dedupe via overrides/resolutions) (#1932)', () => {
+    for (const pm of [PackageManager.npm, PackageManager.yarn, PackageManager.bun]) {
+      const pkg: { devDependencies: Record<string, string> } = {
+        devDependencies: { 'vite-plus': pm === PackageManager.npm ? '^0.1.20' : 'catalog:' },
+      };
+      rewritePackageJson(pkg, pm, true);
+      expect(pkg.devDependencies.vite).toBeUndefined();
+    }
+  });
+
+  it('does not add `vite` for a pnpm package that does not depend on vite-plus (#1932)', () => {
+    const pkg: { devDependencies: Record<string, string> } = {
+      devDependencies: { typescript: '^5' },
+    };
+    rewritePackageJson(pkg, PackageManager.pnpm, true);
+    expect(pkg.devDependencies.vite).toBeUndefined();
+  });
+
+  it('keeps an existing direct `vite` instead of overwriting it under pnpm (#1932)', () => {
+    const pkg: { devDependencies: Record<string, string> } = {
+      devDependencies: { 'vite-plus': 'catalog:', vite: 'catalog:vite7' },
+    };
+    rewritePackageJson(pkg, PackageManager.pnpm, true);
+    expect(pkg.devDependencies.vite).toBe('catalog:vite7');
+  });
+
   it('preserves protocol-prefixed vite-plus specs (catalog:named, workspace:, link:, github:) in catalog-supporting monorepos', async () => {
     for (const existing of [
       'catalog:next',
@@ -425,19 +471,26 @@ describe('rewritePackageJson', () => {
     expect(pkg.devDependencies).not.toHaveProperty('vite');
   });
 
-  it('does not inject a direct vite devDependency for non-npm provider projects', async () => {
-    // pnpm/yarn use symlink/PnP layouts that already expose the `vite` override
-    // to the provider subtree, so the npm-only direct-`vite` workaround must not
-    // fire for them.
-    const pkg = {
+  it('injects a direct vite devDependency for pnpm projects depending on vite-plus, but not yarn/bun (#1932)', async () => {
+    // pnpm needs a direct `vite` so vitest's `vite` peer binds to the override
+    // instead of pnpm auto-installing a separate upstream vite (#1932). yarn/bun
+    // redirect the transitive/peer vite via resolutions/overrides, so they do not
+    // get a direct `vite` here (the bun workspace root is handled separately).
+    const makePkg = () => ({
       devDependencies: {
         '@vitest/browser-playwright': '^4.0.0',
         playwright: '^1.60.0',
         vitest: '^4.0.0',
       },
-    };
-    rewritePackageJson(pkg, PackageManager.pnpm);
-    expect(pkg.devDependencies).not.toHaveProperty('vite');
+    });
+    const pnpmPkg = makePkg();
+    rewritePackageJson(pnpmPkg, PackageManager.pnpm);
+    expect(pnpmPkg.devDependencies).toHaveProperty('vite', VITE_PLUS_OVERRIDE_PACKAGES.vite);
+    for (const pm of [PackageManager.yarn, PackageManager.bun]) {
+      const pkg = makePkg();
+      rewritePackageJson(pkg, pm);
+      expect(pkg.devDependencies).not.toHaveProperty('vite');
+    }
   });
 
   it('normalizes a pre-existing direct vite dep to the override target for an npm provider project', async () => {

--- a/packages/cli/src/migration/__tests__/migrator.spec.ts
+++ b/packages/cli/src/migration/__tests__/migrator.spec.ts
@@ -202,74 +202,79 @@ describe('rewritePackageJson', () => {
     }
   });
 
-  // #1932: under pnpm, any package that depends on vite-plus needs a direct
-  // `vite` so vitest's required `vite` peer binds to the override
-  // (@voidzero-dev/vite-plus-core); otherwise pnpm's autoInstallPeers installs a
-  // second upstream vite and splits vite-plus / vite / vitest into duplicates.
-  it('adds a direct `vite` devDep when a package depends on vite-plus under pnpm (#1932)', () => {
-    // monorepo sub-package -> catalog: (catalog.vite is written by rewriteCatalog)
-    const sub: { devDependencies: Record<string, string> } = {
-      devDependencies: { 'vite-plus': 'catalog:' },
-    };
-    rewritePackageJson(sub, PackageManager.pnpm, true);
-    expect(sub.devDependencies.vite).toBe('catalog:');
-
-    // standalone (no catalog) -> mirror the override target directly
-    const standalone: { devDependencies: Record<string, string> } = {
-      devDependencies: { 'vite-plus': 'latest' },
-    };
-    rewritePackageJson(standalone, PackageManager.pnpm);
-    expect(standalone.devDependencies.vite).toBe(VITE_PLUS_OVERRIDE_PACKAGES.vite);
-  });
-
-  it('does not add a direct `vite` for npm/yarn/bun (they dedupe via overrides/resolutions) (#1932)', () => {
-    for (const pm of [PackageManager.npm, PackageManager.yarn, PackageManager.bun]) {
-      const pkg: { devDependencies: Record<string, string> } = {
-        devDependencies: { 'vite-plus': pm === PackageManager.npm ? '^0.1.20' : 'catalog:' },
+  // Under pnpm, a package that depends on vite-plus needs a direct `vite` so
+  // vitest's required `vite` peer binds to the override (@voidzero-dev/vite-plus-core);
+  // otherwise pnpm's autoInstallPeers installs a second upstream vite and splits
+  // vite-plus / vite / vitest into duplicate instances.
+  describe('pnpm direct-vite dedupe (#1932)', () => {
+    it('adds a direct `vite` devDep when a package depends on vite-plus under pnpm', () => {
+      // monorepo sub-package -> catalog: (catalog.vite is written by rewriteCatalog)
+      const sub: { devDependencies: Record<string, string> } = {
+        devDependencies: { 'vite-plus': 'catalog:' },
       };
-      rewritePackageJson(pkg, pm, true);
+      rewritePackageJson(sub, PackageManager.pnpm, true);
+      expect(sub.devDependencies.vite).toBe('catalog:');
+
+      // standalone (no catalog) -> mirror the override target directly
+      const standalone: { devDependencies: Record<string, string> } = {
+        devDependencies: { 'vite-plus': 'latest' },
+      };
+      rewritePackageJson(standalone, PackageManager.pnpm);
+      expect(standalone.devDependencies.vite).toBe(VITE_PLUS_OVERRIDE_PACKAGES.vite);
+    });
+
+    it('does not add a direct `vite` for npm/yarn/bun (they dedupe via overrides/resolutions)', () => {
+      for (const pm of [PackageManager.npm, PackageManager.yarn, PackageManager.bun]) {
+        const pkg: { devDependencies: Record<string, string> } = {
+          devDependencies: { 'vite-plus': pm === PackageManager.npm ? '^0.1.20' : 'catalog:' },
+        };
+        rewritePackageJson(pkg, pm, true);
+        expect(pkg.devDependencies.vite).toBeUndefined();
+      }
+    });
+
+    it('does not add `vite` for a pnpm package that does not depend on vite-plus', () => {
+      const pkg: { devDependencies: Record<string, string> } = {
+        devDependencies: { typescript: '^5' },
+      };
+      rewritePackageJson(pkg, PackageManager.pnpm, true);
       expect(pkg.devDependencies.vite).toBeUndefined();
-    }
-  });
+    });
 
-  it('does not add `vite` for a pnpm package that does not depend on vite-plus (#1932)', () => {
-    const pkg: { devDependencies: Record<string, string> } = {
-      devDependencies: { typescript: '^5' },
-    };
-    rewritePackageJson(pkg, PackageManager.pnpm, true);
-    expect(pkg.devDependencies.vite).toBeUndefined();
-  });
+    it('keeps an existing direct `vite` instead of overwriting it under pnpm', () => {
+      const pkg: { devDependencies: Record<string, string> } = {
+        devDependencies: { 'vite-plus': 'catalog:', vite: 'catalog:vite7' },
+      };
+      rewritePackageJson(pkg, PackageManager.pnpm, true);
+      expect(pkg.devDependencies.vite).toBe('catalog:vite7');
+    });
 
-  it('keeps an existing direct `vite` instead of overwriting it under pnpm (#1932)', () => {
-    const pkg: { devDependencies: Record<string, string> } = {
-      devDependencies: { 'vite-plus': 'catalog:', vite: 'catalog:vite7' },
-    };
-    rewritePackageJson(pkg, PackageManager.pnpm, true);
-    expect(pkg.devDependencies.vite).toBe('catalog:vite7');
-  });
+    it('does not inject a direct vite when vite is only a peerDependency under pnpm', () => {
+      // A vite plugin that pins `vite` as a peer must keep its own contract;
+      // injecting vite-plus-core as a concrete devDep would conflict with it.
+      const pkg: {
+        devDependencies: Record<string, string>;
+        peerDependencies: Record<string, string>;
+      } = {
+        devDependencies: { 'vite-plus': 'catalog:' },
+        peerDependencies: { vite: '^6.0.0' },
+      };
+      rewritePackageJson(pkg, PackageManager.pnpm, true);
+      expect(pkg.devDependencies.vite).toBeUndefined();
+      expect(pkg.peerDependencies.vite).toBe('^6.0.0');
+    });
 
-  it('does not inject a direct vite when vite is only a peerDependency under pnpm (#1932)', () => {
-    // A vite plugin that pins `vite` as a peer must keep its own contract;
-    // injecting vite-plus-core as a concrete devDep would conflict with it.
-    const pkg: {
-      devDependencies: Record<string, string>;
-      peerDependencies: Record<string, string>;
-    } = {
-      devDependencies: { 'vite-plus': 'catalog:' },
-      peerDependencies: { vite: '^6.0.0' },
-    };
-    rewritePackageJson(pkg, PackageManager.pnpm, true);
-    expect(pkg.devDependencies.vite).toBeUndefined();
-    expect(pkg.peerDependencies.vite).toBe('^6.0.0');
-  });
-
-  it('does not add a second vite when an empty-string vite spec is already declared under pnpm (#1932)', () => {
-    const pkg: { dependencies: Record<string, string>; devDependencies: Record<string, string> } = {
-      dependencies: { vite: '' },
-      devDependencies: { 'vite-plus': 'catalog:' },
-    };
-    rewritePackageJson(pkg, PackageManager.pnpm, true);
-    expect(pkg.devDependencies.vite).toBeUndefined();
+    it('does not add a second vite when an empty-string vite spec is already declared under pnpm', () => {
+      const pkg: {
+        dependencies: Record<string, string>;
+        devDependencies: Record<string, string>;
+      } = {
+        dependencies: { vite: '' },
+        devDependencies: { 'vite-plus': 'catalog:' },
+      };
+      rewritePackageJson(pkg, PackageManager.pnpm, true);
+      expect(pkg.devDependencies.vite).toBeUndefined();
+    });
   });
 
   it('preserves protocol-prefixed vite-plus specs (catalog:named, workspace:, link:, github:) in catalog-supporting monorepos', async () => {
@@ -495,11 +500,11 @@ describe('rewritePackageJson', () => {
     expect(pkg.devDependencies).not.toHaveProperty('vite');
   });
 
-  it('injects a direct vite devDependency for pnpm projects depending on vite-plus, but not yarn/bun (#1932)', async () => {
+  it('injects a direct vite devDependency for pnpm projects depending on vite-plus, but not yarn/bun', async () => {
     // pnpm needs a direct `vite` so vitest's `vite` peer binds to the override
-    // instead of pnpm auto-installing a separate upstream vite (#1932). yarn/bun
-    // redirect the transitive/peer vite via resolutions/overrides, so they do not
-    // get a direct `vite` here (the bun workspace root is handled separately).
+    // instead of pnpm auto-installing a separate upstream vite. yarn/bun redirect
+    // the transitive/peer vite via resolutions/overrides, so they do not get a
+    // direct `vite` here (the bun workspace root is handled separately).
     for (const pm of [PackageManager.pnpm, PackageManager.yarn, PackageManager.bun]) {
       const pkg: { devDependencies: Record<string, string> } = {
         devDependencies: {

--- a/packages/cli/src/migration/__tests__/migrator.spec.ts
+++ b/packages/cli/src/migration/__tests__/migrator.spec.ts
@@ -476,20 +476,20 @@ describe('rewritePackageJson', () => {
     // instead of pnpm auto-installing a separate upstream vite (#1932). yarn/bun
     // redirect the transitive/peer vite via resolutions/overrides, so they do not
     // get a direct `vite` here (the bun workspace root is handled separately).
-    const makePkg = () => ({
-      devDependencies: {
-        '@vitest/browser-playwright': '^4.0.0',
-        playwright: '^1.60.0',
-        vitest: '^4.0.0',
-      },
-    });
-    const pnpmPkg = makePkg();
-    rewritePackageJson(pnpmPkg, PackageManager.pnpm);
-    expect(pnpmPkg.devDependencies).toHaveProperty('vite', VITE_PLUS_OVERRIDE_PACKAGES.vite);
-    for (const pm of [PackageManager.yarn, PackageManager.bun]) {
-      const pkg = makePkg();
+    for (const pm of [PackageManager.pnpm, PackageManager.yarn, PackageManager.bun]) {
+      const pkg: { devDependencies: Record<string, string> } = {
+        devDependencies: {
+          '@vitest/browser-playwright': '^4.0.0',
+          playwright: '^1.60.0',
+          vitest: '^4.0.0',
+        },
+      };
       rewritePackageJson(pkg, pm);
-      expect(pkg.devDependencies).not.toHaveProperty('vite');
+      if (pm === PackageManager.pnpm) {
+        expect(pkg.devDependencies).toHaveProperty('vite', VITE_PLUS_OVERRIDE_PACKAGES.vite);
+      } else {
+        expect(pkg.devDependencies).not.toHaveProperty('vite');
+      }
     }
   });
 

--- a/packages/cli/src/migration/__tests__/migrator.spec.ts
+++ b/packages/cli/src/migration/__tests__/migrator.spec.ts
@@ -248,6 +248,30 @@ describe('rewritePackageJson', () => {
     expect(pkg.devDependencies.vite).toBe('catalog:vite7');
   });
 
+  it('does not inject a direct vite when vite is only a peerDependency under pnpm (#1932)', () => {
+    // A vite plugin that pins `vite` as a peer must keep its own contract;
+    // injecting vite-plus-core as a concrete devDep would conflict with it.
+    const pkg: {
+      devDependencies: Record<string, string>;
+      peerDependencies: Record<string, string>;
+    } = {
+      devDependencies: { 'vite-plus': 'catalog:' },
+      peerDependencies: { vite: '^6.0.0' },
+    };
+    rewritePackageJson(pkg, PackageManager.pnpm, true);
+    expect(pkg.devDependencies.vite).toBeUndefined();
+    expect(pkg.peerDependencies.vite).toBe('^6.0.0');
+  });
+
+  it('does not add a second vite when an empty-string vite spec is already declared under pnpm (#1932)', () => {
+    const pkg: { dependencies: Record<string, string>; devDependencies: Record<string, string> } = {
+      dependencies: { vite: '' },
+      devDependencies: { 'vite-plus': 'catalog:' },
+    };
+    rewritePackageJson(pkg, PackageManager.pnpm, true);
+    expect(pkg.devDependencies.vite).toBeUndefined();
+  });
+
   it('preserves protocol-prefixed vite-plus specs (catalog:named, workspace:, link:, github:) in catalog-supporting monorepos', async () => {
     for (const existing of [
       'catalog:next',

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -4110,12 +4110,17 @@ export function rewritePackageJson(
     if (dependsOnVitePlus && !viteAlreadyDirect) {
       pkg.devDependencies = {
         ...pkg.devDependencies,
-        vite: getCatalogDependencySpec(undefined, VITE_PLUS_OVERRIDE_PACKAGES.vite, supportCatalog, {
-          dependencyField: 'devDependencies',
-          dependencyName: 'vite',
-          packageManager,
-          catalogDependencyResolver,
-        }),
+        vite: getCatalogDependencySpec(
+          undefined,
+          VITE_PLUS_OVERRIDE_PACKAGES.vite,
+          supportCatalog,
+          {
+            dependencyField: 'devDependencies',
+            dependencyName: 'vite',
+            packageManager,
+            catalogDependencyResolver,
+          },
+        ),
       };
     }
   }

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -1629,8 +1629,8 @@ export function rewriteStandaloneProject(
         [VITE_PLUS_NAME]: version,
       };
     }
-    // #1932: vite-plus may be injected above (after rewritePackageJson ran), so
-    // ensure the direct `vite` here too under pnpm (see ensureDirectViteForPnpm).
+    // This caller injects vite-plus after rewritePackageJson returned, so the
+    // direct-`vite` pass must run here too.
     ensureDirectViteForPnpm(
       pkg,
       packageManager,
@@ -3042,8 +3042,6 @@ function rewriteRootWorkspacePackageJson(
             : 'catalog:',
       };
     }
-    // #1932: the root depends on vite-plus too, so under pnpm it needs a direct
-    // `vite` for the override to bind vitest's peer (see ensureDirectViteForPnpm).
     ensureDirectViteForPnpm(pkg, packageManager, true);
     return pkg;
   });
@@ -4137,8 +4135,6 @@ export function rewritePackageJson(
       [VITE_PLUS_NAME]: canonicalVitePlusSpec,
     };
   }
-  // #1932: under pnpm, a package that depends on vite-plus needs a direct `vite`
-  // so the override binds vitest's peer (see ensureDirectViteForPnpm).
   ensureDirectViteForPnpm(pkg, packageManager, supportCatalog);
   // Add `vitest` as a direct devDependency when:
   //  - a remaining dependency likely peer-depends on vitest (e.g.

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -2985,6 +2985,22 @@ function rewriteRootWorkspacePackageJson(
             : 'catalog:',
       };
     }
+    // #1932: under pnpm the root also depends on vite-plus (-> vitest), so it
+    // needs a direct `vite` for the override to bind vitest's peer; otherwise
+    // pnpm auto-installs a separate upstream vite and splits the graph into
+    // duplicate instances. Mirror the override as a direct devDep, like the bun
+    // branch above. pnpm-only (npm/yarn/bun dedupe via overrides/resolutions).
+    if (
+      packageManager === PackageManager.pnpm &&
+      !pkg.dependencies?.vite &&
+      !pkg.devDependencies?.vite &&
+      !pkg.optionalDependencies?.vite
+    ) {
+      pkg.devDependencies = {
+        ...pkg.devDependencies,
+        vite: getCatalogDependencySpec(undefined, VITE_PLUS_OVERRIDE_PACKAGES.vite, true),
+      };
+    }
     return pkg;
   });
 
@@ -4076,6 +4092,32 @@ export function rewritePackageJson(
       ...pkg.devDependencies,
       [VITE_PLUS_NAME]: canonicalVitePlusSpec,
     };
+  }
+  // #1932: under pnpm, any package that depends on `vite-plus` (which bundles
+  // `vitest`) needs a DIRECT `vite` devDep so the `vite` override binds vitest's
+  // required `vite` peer to @voidzero-dev/vite-plus-core. Without a direct edge,
+  // pnpm's `autoInstallPeers` fabricates a separate upstream `vite` to satisfy the
+  // peer, splitting vite-plus / vite / vitest into duplicate instances (a 2nd vite
+  // also misses vite's `@voidzero-dev/vite-task-client` integration, breaking the
+  // `vp test` cache). npm/yarn/bun redirect the transitive/peer vite via root
+  // overrides/resolutions (and drop the aliased vite), so this is pnpm-only —
+  // mirroring the bun root-package fix in `rewriteRootWorkspacePackageJson`.
+  if (packageManager === PackageManager.pnpm && VITE_PLUS_OVERRIDE_PACKAGES.vite) {
+    const dependsOnVitePlus =
+      !!pkg.dependencies?.[VITE_PLUS_NAME] || !!pkg.devDependencies?.[VITE_PLUS_NAME];
+    const viteAlreadyDirect =
+      pkg.dependencies?.vite ?? pkg.devDependencies?.vite ?? pkg.optionalDependencies?.vite;
+    if (dependsOnVitePlus && !viteAlreadyDirect) {
+      pkg.devDependencies = {
+        ...pkg.devDependencies,
+        vite: getCatalogDependencySpec(undefined, VITE_PLUS_OVERRIDE_PACKAGES.vite, supportCatalog, {
+          dependencyField: 'devDependencies',
+          dependencyName: 'vite',
+          packageManager,
+          catalogDependencyResolver,
+        }),
+      };
+    }
   }
   // Add `vitest` as a direct devDependency when:
   //  - a remaining dependency likely peer-depends on vitest (e.g.

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -1635,7 +1635,6 @@ export function rewriteStandaloneProject(
       pkg,
       packageManager,
       usePnpmWorkspaceYaml && packageManager !== PackageManager.npm,
-      catalogDependencyResolver,
     );
     return pkg;
   });
@@ -2592,7 +2591,6 @@ function ensureDirectViteForPnpm(
   },
   packageManager: PackageManager,
   supportCatalog: boolean,
-  catalogDependencyResolver?: CatalogDependencyResolver,
 ): boolean {
   const viteOverride = VITE_PLUS_OVERRIDE_PACKAGES.vite;
   if (packageManager !== PackageManager.pnpm || !viteOverride) {
@@ -2609,15 +2607,12 @@ function ensureDirectViteForPnpm(
   if (!dependsOnVitePlus || viteAlreadyDirect) {
     return false;
   }
-  pkg.devDependencies = {
-    ...pkg.devDependencies,
-    vite: getCatalogDependencySpec(undefined, viteOverride, supportCatalog, {
-      dependencyField: 'devDependencies',
-      dependencyName: 'vite',
-      packageManager,
-      catalogDependencyResolver,
-    }),
-  };
+  // The catalog-vs-alias choice is driven entirely by supportCatalog and the
+  // (file:/npm:) override spec; the extra getCatalogDependencySpec options only
+  // matter for an existing value or a peerDependencies field, neither of which
+  // applies here (we only reach this for a fresh devDependencies entry).
+  pkg.devDependencies ??= {};
+  pkg.devDependencies.vite = getCatalogDependencySpec(undefined, viteOverride, supportCatalog);
   return true;
 }
 
@@ -3049,7 +3044,7 @@ function rewriteRootWorkspacePackageJson(
     }
     // #1932: the root depends on vite-plus too, so under pnpm it needs a direct
     // `vite` for the override to bind vitest's peer (see ensureDirectViteForPnpm).
-    ensureDirectViteForPnpm(pkg, packageManager, true, catalogDependencyResolver);
+    ensureDirectViteForPnpm(pkg, packageManager, true);
     return pkg;
   });
 
@@ -4144,7 +4139,7 @@ export function rewritePackageJson(
   }
   // #1932: under pnpm, a package that depends on vite-plus needs a direct `vite`
   // so the override binds vitest's peer (see ensureDirectViteForPnpm).
-  ensureDirectViteForPnpm(pkg, packageManager, supportCatalog, catalogDependencyResolver);
+  ensureDirectViteForPnpm(pkg, packageManager, supportCatalog);
   // Add `vitest` as a direct devDependency when:
   //  - a remaining dependency likely peer-depends on vitest (e.g.
   //    vitest-browser-svelte), OR

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -2611,8 +2611,14 @@ function ensureDirectViteForPnpm(
   // (file:/npm:) override spec; the extra getCatalogDependencySpec options only
   // matter for an existing value or a peerDependencies field, neither of which
   // applies here (we only reach this for a fresh devDependencies entry).
-  pkg.devDependencies ??= {};
-  pkg.devDependencies.vite = getCatalogDependencySpec(undefined, viteOverride, supportCatalog);
+  const viteSpec = getCatalogDependencySpec(undefined, viteOverride, supportCatalog);
+  // Insert `vite` in sorted position rather than appending it: oxfmt sorts
+  // package.json dependencies and `vp migrate` has no later format pass, so an
+  // out-of-order key would fail a follow-up `vp check`.
+  const entries: [string, string][] = Object.entries(pkg.devDependencies ?? {});
+  const insertAt = entries.findIndex(([name]) => name > 'vite');
+  entries.splice(insertAt === -1 ? entries.length : insertAt, 0, ['vite', viteSpec]);
+  pkg.devDependencies = Object.fromEntries(entries);
   return true;
 }
 

--- a/packages/cli/src/migration/migrator.ts
+++ b/packages/cli/src/migration/migrator.ts
@@ -1629,6 +1629,14 @@ export function rewriteStandaloneProject(
         [VITE_PLUS_NAME]: version,
       };
     }
+    // #1932: vite-plus may be injected above (after rewritePackageJson ran), so
+    // ensure the direct `vite` here too under pnpm (see ensureDirectViteForPnpm).
+    ensureDirectViteForPnpm(
+      pkg,
+      packageManager,
+      usePnpmWorkspaceYaml && packageManager !== PackageManager.npm,
+      catalogDependencyResolver,
+    );
     return pkg;
   });
 
@@ -2559,6 +2567,60 @@ function getCatalogDependencySpec(
   return currentValue?.startsWith('catalog:') ? currentValue : 'catalog:';
 }
 
+/**
+ * #1932: under pnpm, an importer that depends on `vite-plus` (which bundles
+ * `vitest`) needs a DIRECT `vite` devDep so the `vite` override binds vitest's
+ * required `vite` peer to @voidzero-dev/vite-plus-core. Without a direct edge,
+ * pnpm's `autoInstallPeers` fabricates a separate upstream `vite` to satisfy the
+ * peer, splitting vite-plus / vite / vitest into duplicate instances (the extra
+ * vite also lacks vite's `@voidzero-dev/vite-task-client` integration, breaking
+ * the `vp test` cache). npm/yarn/bun redirect transitive/peer vite via root
+ * overrides/resolutions (and drop the aliased vite), so this is pnpm-only,
+ * mirroring the bun root-package branch in `rewriteRootWorkspacePackageJson`.
+ *
+ * A package that already declares `vite` in ANY dependency field, including
+ * `peerDependencies` (e.g. a vite plugin pinning `vite ^6`), is left untouched
+ * so its existing version contract is preserved. Call this AFTER `vite-plus`
+ * has been ensured in the package, so the dependency check sees it.
+ */
+function ensureDirectViteForPnpm(
+  pkg: {
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+    optionalDependencies?: Record<string, string>;
+    peerDependencies?: Record<string, string>;
+  },
+  packageManager: PackageManager,
+  supportCatalog: boolean,
+  catalogDependencyResolver?: CatalogDependencyResolver,
+): boolean {
+  const viteOverride = VITE_PLUS_OVERRIDE_PACKAGES.vite;
+  if (packageManager !== PackageManager.pnpm || !viteOverride) {
+    return false;
+  }
+  const dependsOnVitePlus =
+    pkg.dependencies?.[VITE_PLUS_NAME] !== undefined ||
+    pkg.devDependencies?.[VITE_PLUS_NAME] !== undefined;
+  const viteAlreadyDirect =
+    pkg.dependencies?.vite !== undefined ||
+    pkg.devDependencies?.vite !== undefined ||
+    pkg.optionalDependencies?.vite !== undefined ||
+    pkg.peerDependencies?.vite !== undefined;
+  if (!dependsOnVitePlus || viteAlreadyDirect) {
+    return false;
+  }
+  pkg.devDependencies = {
+    ...pkg.devDependencies,
+    vite: getCatalogDependencySpec(undefined, viteOverride, supportCatalog, {
+      dependencyField: 'devDependencies',
+      dependencyName: 'vite',
+      packageManager,
+      catalogDependencyResolver,
+    }),
+  };
+  return true;
+}
+
 function isVitePlusOverrideSpec(value: string): boolean {
   return (
     Object.values(VITE_PLUS_OVERRIDE_PACKAGES).includes(value) ||
@@ -2985,22 +3047,9 @@ function rewriteRootWorkspacePackageJson(
             : 'catalog:',
       };
     }
-    // #1932: under pnpm the root also depends on vite-plus (-> vitest), so it
-    // needs a direct `vite` for the override to bind vitest's peer; otherwise
-    // pnpm auto-installs a separate upstream vite and splits the graph into
-    // duplicate instances. Mirror the override as a direct devDep, like the bun
-    // branch above. pnpm-only (npm/yarn/bun dedupe via overrides/resolutions).
-    if (
-      packageManager === PackageManager.pnpm &&
-      !pkg.dependencies?.vite &&
-      !pkg.devDependencies?.vite &&
-      !pkg.optionalDependencies?.vite
-    ) {
-      pkg.devDependencies = {
-        ...pkg.devDependencies,
-        vite: getCatalogDependencySpec(undefined, VITE_PLUS_OVERRIDE_PACKAGES.vite, true),
-      };
-    }
+    // #1932: the root depends on vite-plus too, so under pnpm it needs a direct
+    // `vite` for the override to bind vitest's peer (see ensureDirectViteForPnpm).
+    ensureDirectViteForPnpm(pkg, packageManager, true, catalogDependencyResolver);
     return pkg;
   });
 
@@ -4093,37 +4142,9 @@ export function rewritePackageJson(
       [VITE_PLUS_NAME]: canonicalVitePlusSpec,
     };
   }
-  // #1932: under pnpm, any package that depends on `vite-plus` (which bundles
-  // `vitest`) needs a DIRECT `vite` devDep so the `vite` override binds vitest's
-  // required `vite` peer to @voidzero-dev/vite-plus-core. Without a direct edge,
-  // pnpm's `autoInstallPeers` fabricates a separate upstream `vite` to satisfy the
-  // peer, splitting vite-plus / vite / vitest into duplicate instances (a 2nd vite
-  // also misses vite's `@voidzero-dev/vite-task-client` integration, breaking the
-  // `vp test` cache). npm/yarn/bun redirect the transitive/peer vite via root
-  // overrides/resolutions (and drop the aliased vite), so this is pnpm-only —
-  // mirroring the bun root-package fix in `rewriteRootWorkspacePackageJson`.
-  if (packageManager === PackageManager.pnpm && VITE_PLUS_OVERRIDE_PACKAGES.vite) {
-    const dependsOnVitePlus =
-      !!pkg.dependencies?.[VITE_PLUS_NAME] || !!pkg.devDependencies?.[VITE_PLUS_NAME];
-    const viteAlreadyDirect =
-      pkg.dependencies?.vite ?? pkg.devDependencies?.vite ?? pkg.optionalDependencies?.vite;
-    if (dependsOnVitePlus && !viteAlreadyDirect) {
-      pkg.devDependencies = {
-        ...pkg.devDependencies,
-        vite: getCatalogDependencySpec(
-          undefined,
-          VITE_PLUS_OVERRIDE_PACKAGES.vite,
-          supportCatalog,
-          {
-            dependencyField: 'devDependencies',
-            dependencyName: 'vite',
-            packageManager,
-            catalogDependencyResolver,
-          },
-        ),
-      };
-    }
-  }
+  // #1932: under pnpm, a package that depends on vite-plus needs a direct `vite`
+  // so the override binds vitest's peer (see ensureDirectViteForPnpm).
+  ensureDirectViteForPnpm(pkg, packageManager, supportCatalog, catalogDependencyResolver);
   // Add `vitest` as a direct devDependency when:
   //  - a remaining dependency likely peer-depends on vitest (e.g.
   //    vitest-browser-svelte), OR


### PR DESCRIPTION
Closes #1932.

Under pnpm, a created/migrated monorepo resolved vite-plus / vite / vitest to 2 instances each: packages depending on vite-plus without a direct `vite` (the workspace root and `packages/utils`) left vitest's `vite` peer for pnpm's autoInstallPeers to satisfy with a second, upstream vite. That upstream vite lacks vite's vite-task-client integration, which broke the `vp test` cache.

Fix (pnpm-only, in the migrator): wherever vite-plus is depended upon, add a direct `vite` devDep aliased to the override target so vitest's peer binds to @voidzero-dev/vite-plus-core. npm/yarn/bun already redirect the transitive/peer vite via root overrides/resolutions, so they are untouched.

Also adds a "Verify single dependency instances" CI guard, drops the temporary `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0` band-aid from #1774, and covers the cases with unit tests.
