### PR TITLE
docs: fix package manager command examples

### DIFF
--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -167,7 +167,7 @@ Examples:
 
 ```bash
 vp pm config get registry
-vp pm cache clean --force
+vp pm cache clean -- --force
 vp pm exec tsc --version
 ```
 

--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -168,7 +168,7 @@ Examples:
 ```bash
 vp pm config get registry
 vp pm cache clean -- --force
-vp pm exec tsc --version
+vp exec tsc --version
 ```
 
 #### Staged publishing

--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -178,7 +178,7 @@ Examples:
 ```bash
 vp pm config get registry
 vp pm cache clean -- --force
-vp exec tsc --version
+vp pm audit --json
 ```
 
 #### Staged publishing


### PR DESCRIPTION
 ## Summary

Fix package manager docs examples to use the correct pass-through separator and `vp exec` command form.