### PR TITLE
fix(install): retry truncated downloads in HttpClient::get_bytes

### DIFF
--- a/crates/vite_install/src/request.rs
+++ b/crates/vite_install/src/request.rs
@@ -54,23 +54,14 @@ impl HttpClient {
     /// * `Err(e)` - If the request fails
     pub async fn get_bytes(&self, url: &str) -> Result<Vec<u8>, Error> {
         tracing::debug!("Fetching bytes from: {}", url);
-        let response = self.get(url).await?;
-        Ok(response.bytes().await?.to_vec())
-    }
 
-    async fn get(&self, url: &str) -> Result<Response, Error> {
-        self.get_with_accept(url, None).await
-    }
-
-    async fn get_with_accept(&self, url: &str, accept: Option<&str>) -> Result<Response, Error> {
         let client = vite_shared::shared_http_client();
 
-        let response = (|| async {
-            let mut request = client.get(url);
-            if let Some(accept) = accept {
-                request = request.header(reqwest::header::ACCEPT, accept);
-            }
-            request.send().await?.error_for_status()
+        // Read the body inside the retry so a mid-body connection drop gets
+        // retried instead of failing outright, like `download_file`.
+        let bytes = (|| async {
+            let response = client.get(url).send().await?.error_for_status()?;
+            Ok::<_, Error>(response.bytes().await?)
         })
         .retry(
             ExponentialBuilder::default()
@@ -80,7 +71,7 @@ impl HttpClient {
         )
         .await?;
 
-        Ok(response)
+        Ok(bytes.to_vec())
     }
 
     /// Get JSON data from a URL
@@ -736,6 +727,69 @@ mod tests {
             mock.hits() > 1,
             "a hash mismatch must be retried, but it was only attempted {} time(s)",
             mock.hits()
+        );
+    }
+
+    /// `get_bytes` used to read the body outside the retry, so a connection
+    /// dropped mid-body never got retried. The server truncates the first
+    /// response, then sends the whole body — `get_bytes` should retry and succeed.
+    #[tokio::test]
+    async fn test_get_bytes_retries_on_truncated_body() {
+        use std::sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        };
+
+        use tokio::{
+            io::{AsyncReadExt, AsyncWriteExt},
+            net::TcpListener,
+        };
+
+        let body = b"the complete body payload that must arrive intact";
+        let len = body.len();
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let connections = Arc::new(AtomicUsize::new(0));
+
+        let server_connections = Arc::clone(&connections);
+        let server = tokio::spawn(async move {
+            loop {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let attempt = server_connections.fetch_add(1, Ordering::SeqCst);
+
+                // Drain the request before replying.
+                let mut scratch = [0u8; 1024];
+                let _ = socket.read(&mut scratch).await;
+
+                let head = format!("HTTP/1.1 200 OK\r\nContent-Length: {len}\r\n\r\n");
+                socket.write_all(head.as_bytes()).await.unwrap();
+                if attempt == 0 {
+                    // First attempt: send half the body, then drop the connection.
+                    socket.write_all(&body[..len / 2]).await.unwrap();
+                } else {
+                    // Retry: send the whole body.
+                    socket.write_all(body).await.unwrap();
+                }
+                socket.flush().await.unwrap();
+            }
+        });
+
+        let client = HttpClient::with_config(3, 10);
+        let url = format!("http://{addr}/");
+        let result = client.get_bytes(&url).await;
+
+        server.abort();
+
+        let attempts = connections.load(Ordering::SeqCst);
+        assert!(
+            result.is_ok(),
+            "get_bytes must retry a truncated body and eventually succeed, but got {result:?} after {attempts} attempt(s)"
+        );
+        assert_eq!(result.unwrap(), body);
+        assert!(
+            attempts >= 2,
+            "a body-level failure must be retried, but get_bytes only made {attempts} connection(s)"
         );
     }
 


### PR DESCRIPTION
#### Problem

`HttpClient::get_bytes` read the response body (`response.bytes().await`) **outside** the retry. The retry only wrapped request setup (`send().await?.error_for_status()`), which resolves as soon as the response *headers* arrive — so a connection dropped mid-body (a response truncated relative to its advertised `Content-Length`) surfaced as a hard error that was **never retried**. `download_file` already handles this by streaming the body inside its retry and checking `Content-Length`.

`get_bytes` is the download path for the **platform tarball** in:

- `vp upgrade` — `crates/vite_global_cli/src/commands/upgrade`
- the standalone installer — `crates/vite_installer`

So a transient mid-body drop (flaky wifi, a proxy/CDN closing the connection early) failed the upgrade/install outright with `… end of file before message length reached`, even though a single retry would usually succeed. Node-runtime and package-manager tarball downloads (which go through `download_file`) already retried.

#### Fix

Read the body **inside** the retried closure — one send+body unit, mirroring `download_file` — so a mid-body drop is retried. The now-unused private `get` / `get_with_accept` helpers are removed (`get_with_accept` was only ever called with `accept = None`).

#### Test

`test_get_bytes_retries_on_truncated_body`: a raw `tokio` TCP server truncates the first response (advertises the full `Content-Length`, sends half the body, drops the connection) and serves the full body on the retry. Against the old code it fails with hyper `IncompleteBody` after **1** attempt; with the fix it succeeds after **2**.

#### Reproduce end-to-end with `vp upgrade`

A mock registry truncates the platform tarball on **every** request. The fixed `get_bytes` retries (4 tarball hits); the old one gives up after 1.

```bash
# build vp from this branch
cargo build -p vite_global_cli

# terminal A — truncating mock registry (script below)
node mock-registry.js

# terminal B — a real upgrade against it
# NO_PROXY is needed if you run a local/system HTTP proxy, so loopback isn't intercepted
NO_PROXY=127.0.0.1,localhost target/debug/vp upgrade --registry http://127.0.0.1:8911 --force
```

Watch terminal A's `[tarball] hit #N`:

| build | terminal A | result |
| --- | --- | --- |
| this branch (fixed) | `hit #1 #2 #3 #4` — retried | `Failed to download platform package: … end of file before message length reached` |
| before the fix | `hit #1` — no retry | same error |

Both end with the same error (the mock always truncates); the **hit count** is the difference — on a real flaky network the retry usually succeeds on attempt 2–4.

<details>
<summary><code>mock-registry.js</code></summary>

```js
// Truncates the platform tarball on every request (advertises a full
// Content-Length, sends a few bytes, drops the connection). Fixed get_bytes
// retries -> 4 tarball hits; the buggy one does not -> 1 hit.
const http = require('http');

const PORT = Number(process.env.PORT || 8911);
const VERSION = '9.9.9';
const FULL = 4096; // advertised Content-Length
const SENT = 100; // bytes actually sent before the drop

let tarballHits = 0;

function meta(tarballPath) {
  return JSON.stringify({
    version: VERSION,
    dist: {
      tarball: `http://127.0.0.1:${PORT}${tarballPath}`,
      integrity: 'sha512-AAAA', // never reached: the download always fails first
    },
  });
}

const server = http.createServer((req, res) => {
  const url = req.url;

  // Platform tarball: truncate every time.
  if (url === '/platform.tgz') {
    tarballHits += 1;
    console.log(`[tarball] hit #${tarballHits}  ->  send ${SENT}/${FULL} bytes then drop the connection`);
    const sock = res.socket;
    sock.write(
      'HTTP/1.1 200 OK\r\n' +
        'Content-Type: application/octet-stream\r\n' +
        `Content-Length: ${FULL}\r\n` +
        'Connection: close\r\n' +
        '\r\n',
    );
    sock.write(Buffer.alloc(SENT, 0x41));
    setTimeout(() => sock.destroy(), 80); // flush, then mid-body connection drop
    return;
  }

  console.log(`[meta] ${req.method} ${url}`);

  // Platform package metadata: /@voidzero-dev/vite-plus-cli-<suffix>/<version>
  if (url.includes('/vite-plus-cli-')) {
    res.writeHead(200, { 'content-type': 'application/json' });
    res.end(meta('/platform.tgz'));
    return;
  }

  // Main package metadata: /vite-plus/<tag-or-version>
  if (url.startsWith('/vite-plus/')) {
    res.writeHead(200, { 'content-type': 'application/json' });
    res.end(meta('/main.tgz'));
    return;
  }

  res.writeHead(404, { 'content-type': 'text/plain' });
  res.end('not found');
});

server.listen(PORT, '127.0.0.1', () => {
  console.log(`mock registry listening on http://127.0.0.1:${PORT}`);
});
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
