### PR TITLE
fix(install): clean up the temp dir when a package-manager install fails

### DIFF
--- a/crates/vite_install/src/package_manager.rs
+++ b/crates/vite_install/src/package_manager.rs
@@ -871,7 +871,9 @@ pub async fn download_package_manager(
     // Use tempfile::TempDir for robust temporary directory creation
     let parent_dir = target_dir.parent().unwrap();
     tokio::fs::create_dir_all(parent_dir).await?;
-    let target_dir_tmp = tempfile::tempdir_in(parent_dir)?.path().to_path_buf();
+    // Keep the TempDir guard alive so a failure path cleans up the temp dir.
+    let tmp_dir = tempfile::tempdir_in(parent_dir)?;
+    let target_dir_tmp = tmp_dir.path().to_path_buf();
 
     download_and_extract_tgz_with_hash(&tgz_url, &target_dir_tmp, expected_hash).await.map_err(
         |err| {
@@ -987,7 +989,9 @@ async fn download_bun_package_manager(
 
     // Download the platform-specific package directly
     let platform_tgz_url = get_npm_package_tgz_url(platform_package_name, version);
-    let target_dir_tmp = tempfile::tempdir_in(parent_dir)?.path().to_path_buf();
+    // Keep the TempDir guard alive so a failure path cleans up the temp dir.
+    let tmp_dir = tempfile::tempdir_in(parent_dir)?;
+    let target_dir_tmp = tmp_dir.path().to_path_buf();
 
     download_and_extract_tgz_with_hash(&platform_tgz_url, &target_dir_tmp, None).await.map_err(
         |err| {
@@ -3479,5 +3483,48 @@ mod tests {
 
         // Release lock
         lock_file1.unlock().expect("Failed to unlock file 1");
+    }
+
+    /// A failed install must not leak its temporary directory into
+    /// `package_manager/<name>/`. The temp dir is created via a `TempDir` guard,
+    /// so an early return on failure drops it and cleans up.
+    #[tokio::test]
+    async fn test_download_package_manager_cleans_temp_dir_on_failure() {
+        use httpmock::prelude::*;
+
+        let vp_home = create_temp_dir();
+        let server = MockServer::start();
+        // A 200 body that is not a valid gzip: the download succeeds but
+        // extraction fails, so the install errors out after the temp dir exists.
+        server.mock(|when, then| {
+            when.method(GET).path("/pnpm/-/pnpm-10.0.0.tgz");
+            then.status(200)
+                .header("content-type", "application/octet-stream")
+                .body("this is not a valid gzip archive");
+        });
+
+        let _guard = EnvConfig::test_guard(EnvConfig {
+            npm_registry: server.base_url().into(),
+            vite_plus_home: Some(vp_home.path().to_path_buf()),
+            ..EnvConfig::for_test()
+        });
+
+        let result = download_package_manager(PackageManagerType::Pnpm, "10.0.0", None).await;
+        assert!(result.is_err(), "corrupt tarball should fail the install, got {result:?}");
+
+        // The per-install temp dir must be gone after the failure.
+        let pnpm_dir = vp_home.path().join("package_manager").join("pnpm");
+        let leftovers: Vec<_> = fs::read_dir(&pnpm_dir)
+            .map(|rd| {
+                rd.filter_map(Result::ok)
+                    .filter(|e| e.path().is_dir())
+                    .map(|e| e.file_name())
+                    .collect()
+            })
+            .unwrap_or_default();
+        assert!(
+            leftovers.is_empty(),
+            "failed install leaked temp dir(s) in {pnpm_dir:?}: {leftovers:?}"
+        );
     }
 }


### PR DESCRIPTION
#### Problem

Both `download_package_manager` (pnpm/npm/yarn) and `download_bun_package_manager` created their temporary install directory like this:

```rust
let target_dir_tmp = tempfile::tempdir_in(parent_dir)?.path().to_path_buf();
```

`tempfile::tempdir_in` returns a `TempDir` guard whose `Drop` deletes the directory. Here the guard is an **unnamed temporary** that drops at the end of the `let`, so the directory is deleted immediately and only the `PathBuf` survives.

It still worked on the happy path because `download_and_extract_tgz_with_hash` recreates the directory (`create_dir_all`) before writing. But on any failure after that — a download/extract error, or the `package` → bin rename — the function returns early via `?`, leaving the recreated temp dir behind. With the guard already gone, nothing cleans it up, so a `.tmpXXXX` directory leaks into `$VP_HOME/package_manager/<name>/`. Every failed install (flaky network, corrupt download, …) leaks one, and they accumulate forever.

#### Fix

Bind the `TempDir` to a named `tmp_dir` that lives for the whole function:

```rust
let tmp_dir = tempfile::tempdir_in(parent_dir)?;
let target_dir_tmp = tmp_dir.path().to_path_buf();
```

Now any early return drops the guard and removes the temp dir. On success the dir is renamed into its final location first, so the end-of-scope drop hits a `NotFound` on the original path, which `tempfile` ignores — success is unaffected. Applied to both sites.

#### Test

`test_download_package_manager_cleans_temp_dir_on_failure` drives `download_package_manager(Pnpm, "10.0.0", None)` against a mock registry serving a non-gzip tarball (the download succeeds, extraction fails), then asserts no leftover directory remains under `package_manager/pnpm/`. It fails on the old code (a leaked `.tmp*` dir) and passes on the fix. The full `package_manager` module stays green (91 passed).

#### Reproduce

```bash
cargo test -p vite_install --lib \
  package_manager::tests::test_download_package_manager_cleans_temp_dir_on_failure
# If you run a local/system HTTP proxy, prefix with NO_PROXY=127.0.0.1,localhost
# so the loopback mock isn't intercepted (same requirement as the other httpmock
# tests in this crate).
```

To watch the bug itself: temporarily revert the two sites to `let target_dir_tmp = tempfile::tempdir_in(parent_dir)?.path().to_path_buf();` and rerun — the test fails with a leaked `.tmpXXXX` directory under `package_manager/pnpm/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
