### PR TITLE
fix(migrate): preserve comments in existing editor JSONC configs

### DIFF
--- a/packages/cli/snap-tests/migration-preserve-editor-jsonc-comments/.vscode/extensions.json
+++ b/packages/cli/snap-tests/migration-preserve-editor-jsonc-comments/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    // keep my favorite extension
+    "dbaeumer.vscode-eslint",
+  ],
+}

--- a/packages/cli/snap-tests/migration-preserve-editor-jsonc-comments/.vscode/settings.json
+++ b/packages/cli/snap-tests/migration-preserve-editor-jsonc-comments/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  // Use the project's typescript version
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "editor.codeActionsOnSave": {
+    // keep my organize imports
+    "source.organizeImports": "explicit",
+  },
+}

--- a/packages/cli/snap-tests/migration-preserve-editor-jsonc-comments/package.json
+++ b/packages/cli/snap-tests/migration-preserve-editor-jsonc-comments/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "migration-preserve-editor-jsonc-comments",
+  "version": "0.0.0",
+  "private": true,
+  "devDependencies": {
+    "oxfmt": "1",
+    "oxlint": "1"
+  }
+}

--- a/packages/cli/snap-tests/migration-preserve-editor-jsonc-comments/snap.txt
+++ b/packages/cli/snap-tests/migration-preserve-editor-jsonc-comments/snap.txt
@@ -1,0 +1,39 @@
+> vp migrate --no-interactive --no-hooks --editor vscode 2>&1 # merge must preserve existing .vscode JSONC comments
+◇ Migrated . to Vite+
+• Node <semver>  pnpm <semver>
+
+> cat .vscode/settings.json # top-level and nested comments survive; oxc settings are added without overwriting existing values
+{
+  // Use the project's typescript version
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "editor.codeActionsOnSave": {
+    // keep my organize imports
+    "source.organizeImports": "explicit",
+    "source.fixAll.oxc": "explicit",
+  },
+  "editor.defaultFormatter": "oxc.oxc-vscode",
+  "[javascript]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "oxc.fmt.configPath": "./vite.config.ts",
+  "editor.formatOnSave": true,
+  "editor.formatOnSaveMode": "file",
+}
+
+> cat .vscode/extensions.json # existing recommendation and comment stay; vite-plus extension is appended once
+{
+  "recommendations": [
+    // keep my favorite extension
+    "dbaeumer.vscode-eslint",
+    "VoidZero.vite-plus-extension-pack",
+  ],
+}

--- a/packages/cli/snap-tests/migration-preserve-editor-jsonc-comments/steps.json
+++ b/packages/cli/snap-tests/migration-preserve-editor-jsonc-comments/steps.json
@@ -1,0 +1,7 @@
+{
+  "commands": [
+    "vp migrate --no-interactive --no-hooks --editor vscode 2>&1 # merge must preserve existing .vscode JSONC comments",
+    "cat .vscode/settings.json # top-level and nested comments survive; oxc settings are added without overwriting existing values",
+    "cat .vscode/extensions.json # existing recommendation and comment stay; vite-plus extension is appended once"
+  ]
+}

--- a/packages/cli/snap-tests/migration-preserve-editor-jsonc-comments/vite.config.ts
+++ b/packages/cli/snap-tests/migration-preserve-editor-jsonc-comments/vite.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vite-plus';
+
+export default defineConfig({
+  server: { port: 3000 },
+});

--- a/packages/cli/src/utils/__tests__/editor.spec.ts
+++ b/packages/cli/src/utils/__tests__/editor.spec.ts
@@ -3,6 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import * as prompts from '@voidzero-dev/vite-plus-prompts';
+import { parse as parseJsonc } from 'jsonc-parser';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { detectExistingEditors, selectEditors, writeEditorConfigs } from '../editor.js';
@@ -165,9 +166,13 @@ describe('writeEditorConfigs', () => {
       extraVsCodeSettings: { 'npm.scriptRunner': 'vp' },
     });
 
-    const settings = JSON.parse(
-      fs.readFileSync(path.join(projectRoot, '.vscode', 'settings.json'), 'utf8'),
-    ) as Record<string, unknown>;
+    const resultText = fs.readFileSync(path.join(projectRoot, '.vscode', 'settings.json'), 'utf8');
+
+    // Comments survive the merge
+    expect(resultText).toContain('// JSONC comment');
+    expect(resultText).toContain('// preserve existing key');
+
+    const settings = parseJsonc(resultText) as Record<string, unknown>;
 
     // Existing key is preserved (merge never overwrites)
     expect(settings['editor.formatOnSave']).toBe(false);
@@ -186,6 +191,252 @@ describe('writeEditorConfigs', () => {
     const codeActions = settings['editor.codeActionsOnSave'] as Record<string, unknown>;
     expect(codeActions['source.organizeImports']).toBe('explicit');
     expect(codeActions['source.fixAll.oxc']).toBe('explicit');
+  });
+
+  it('preserves a top-level comment before an existing setting (Vue Core style)', async () => {
+    const projectRoot = createTempDir();
+
+    const vscodeDir = path.join(projectRoot, '.vscode');
+    fs.mkdirSync(vscodeDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(vscodeDir, 'settings.json'),
+      `{
+  // Use the project's typescript version
+  "typescript.tsdk": "node_modules/typescript/lib"
+}
+`,
+      'utf8',
+    );
+
+    await writeEditorConfigs({
+      projectRoot,
+      editorId: 'vscode',
+      interactive: false,
+      silent: true,
+    });
+
+    const resultText = fs.readFileSync(path.join(projectRoot, '.vscode', 'settings.json'), 'utf8');
+
+    expect(resultText).toContain("// Use the project's typescript version");
+
+    const settings = parseJsonc(resultText) as Record<string, unknown>;
+    expect(settings['typescript.tsdk']).toBe('node_modules/typescript/lib');
+    expect(settings['editor.defaultFormatter']).toBe('oxc.oxc-vscode');
+  });
+
+  it('preserves a nested comment while adding source.fixAll.oxc', async () => {
+    const projectRoot = createTempDir();
+
+    const vscodeDir = path.join(projectRoot, '.vscode');
+    fs.mkdirSync(vscodeDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(vscodeDir, 'settings.json'),
+      `{
+  "editor.codeActionsOnSave": {
+    // keep my organize imports
+    "source.organizeImports": "explicit"
+  }
+}
+`,
+      'utf8',
+    );
+
+    await writeEditorConfigs({
+      projectRoot,
+      editorId: 'vscode',
+      interactive: false,
+      silent: true,
+    });
+
+    const resultText = fs.readFileSync(path.join(projectRoot, '.vscode', 'settings.json'), 'utf8');
+
+    expect(resultText).toContain('// keep my organize imports');
+
+    const settings = parseJsonc(resultText) as Record<string, unknown>;
+    const codeActions = settings['editor.codeActionsOnSave'] as Record<string, unknown>;
+    expect(codeActions['source.organizeImports']).toBe('explicit');
+    expect(codeActions['source.fixAll.oxc']).toBe('explicit');
+  });
+
+  it('never overwrites existing values during merge', async () => {
+    const projectRoot = createTempDir();
+
+    const vscodeDir = path.join(projectRoot, '.vscode');
+    fs.mkdirSync(vscodeDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(vscodeDir, 'settings.json'),
+      `{
+  "editor.formatOnSave": false,
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}
+`,
+      'utf8',
+    );
+
+    await writeEditorConfigs({
+      projectRoot,
+      editorId: 'vscode',
+      interactive: false,
+      silent: true,
+    });
+
+    const settings = parseJsonc(
+      fs.readFileSync(path.join(projectRoot, '.vscode', 'settings.json'), 'utf8'),
+    ) as Record<string, unknown>;
+
+    expect(settings['editor.formatOnSave']).toBe(false);
+    expect(settings['[typescript]']).toEqual({
+      'editor.defaultFormatter': 'esbenp.prettier-vscode',
+    });
+  });
+
+  it('keeps trailing-comma JSONC valid after merge', async () => {
+    const projectRoot = createTempDir();
+
+    const vscodeDir = path.join(projectRoot, '.vscode');
+    fs.mkdirSync(vscodeDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(vscodeDir, 'settings.json'),
+      `{
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": "explicit",
+  },
+}
+`,
+      'utf8',
+    );
+
+    await writeEditorConfigs({
+      projectRoot,
+      editorId: 'vscode',
+      interactive: false,
+      silent: true,
+    });
+
+    const settings = parseJsonc(
+      fs.readFileSync(path.join(projectRoot, '.vscode', 'settings.json'), 'utf8'),
+    ) as Record<string, unknown>;
+
+    expect(settings['editor.defaultFormatter']).toBe('oxc.oxc-vscode');
+    const codeActions = settings['editor.codeActionsOnSave'] as Record<string, unknown>;
+    expect(codeActions['source.organizeImports']).toBe('explicit');
+    expect(codeActions['source.fixAll.oxc']).toBe('explicit');
+  });
+
+  it('appends extension recommendation without losing comments or duplicating', async () => {
+    const projectRoot = createTempDir();
+
+    const vscodeDir = path.join(projectRoot, '.vscode');
+    fs.mkdirSync(vscodeDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(vscodeDir, 'extensions.json'),
+      `{
+  "recommendations": [
+    // keep my favorite extension
+    "dbaeumer.vscode-eslint",
+  ],
+}
+`,
+      'utf8',
+    );
+
+    await writeEditorConfigs({
+      projectRoot,
+      editorId: 'vscode',
+      interactive: false,
+      silent: true,
+    });
+
+    const resultText = fs.readFileSync(
+      path.join(projectRoot, '.vscode', 'extensions.json'),
+      'utf8',
+    );
+
+    expect(resultText).toContain('// keep my favorite extension');
+
+    const extensions = parseJsonc(resultText) as { recommendations: string[] };
+    expect(extensions.recommendations).toContain('dbaeumer.vscode-eslint');
+    expect(
+      extensions.recommendations.filter((r) => r === 'VoidZero.vite-plus-extension-pack'),
+    ).toHaveLength(1);
+  });
+
+  it('is idempotent: a second merge makes no textual change', async () => {
+    const projectRoot = createTempDir();
+
+    const vscodeDir = path.join(projectRoot, '.vscode');
+    fs.mkdirSync(vscodeDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(vscodeDir, 'settings.json'),
+      `{
+  // JSONC comment
+  "editor.formatOnSave": false,
+}
+`,
+      'utf8',
+    );
+
+    const settingsPath = path.join(projectRoot, '.vscode', 'settings.json');
+
+    await writeEditorConfigs({
+      projectRoot,
+      editorId: 'vscode',
+      interactive: false,
+      silent: true,
+    });
+    const afterFirst = fs.readFileSync(settingsPath, 'utf8');
+
+    await writeEditorConfigs({
+      projectRoot,
+      editorId: 'vscode',
+      interactive: false,
+      silent: true,
+    });
+    const afterSecond = fs.readFileSync(settingsPath, 'utf8');
+
+    expect(afterSecond).toBe(afterFirst);
+  });
+
+  it('preserves an existing Zed JSONC comment while adding nested settings', async () => {
+    const projectRoot = createTempDir();
+
+    const zedDir = path.join(projectRoot, '.zed');
+    fs.mkdirSync(zedDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(zedDir, 'settings.json'),
+      `{
+  // my zed settings
+  "lsp": {
+    "oxlint": {
+      // keep this comment
+      "initialization_options": {}
+    }
+  }
+}
+`,
+      'utf8',
+    );
+
+    await writeEditorConfigs({
+      projectRoot,
+      editorId: 'zed',
+      interactive: false,
+      silent: true,
+    });
+
+    const resultText = fs.readFileSync(path.join(projectRoot, '.zed', 'settings.json'), 'utf8');
+
+    expect(resultText).toContain('// my zed settings');
+    expect(resultText).toContain('// keep this comment');
+
+    const settings = parseJsonc(resultText) as {
+      lsp?: { oxfmt?: { initialization_options?: { settings?: Record<string, unknown> } } };
+    };
+    expect(settings.lsp?.oxfmt?.initialization_options?.settings?.['fmt.configPath']).toBe(
+      './vite.config.ts',
+    );
   });
 
   it('does not apply extraVsCodeSettings to zed editor', async () => {

--- a/packages/cli/src/utils/editor.ts
+++ b/packages/cli/src/utils/editor.ts
@@ -4,11 +4,16 @@ import path from 'node:path';
 import { styleText } from 'node:util';
 
 import * as prompts from '@voidzero-dev/vite-plus-prompts';
-import detectIndent from 'detect-indent';
-import { detectNewline } from 'detect-newline';
-import { applyEdits, type FormattingOptions, modify, parse as parseJsonc } from 'jsonc-parser';
+import {
+  applyEdits,
+  type FormattingOptions,
+  type JSONPath,
+  modify,
+  type ModificationOptions,
+  parse as parseJsonc,
+} from 'jsonc-parser';
 
-import { writeJsonFile } from './json.ts';
+import { detectFormattingOptions, writeJsonFile } from './json.ts';
 
 // Language-specific overrides because user-level [lang] settings beat the workspace default
 const VSCODE_LANGUAGE_OVERRIDES = {
@@ -490,14 +495,14 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-function detectFormattingOptions(text: string): FormattingOptions {
-  const detected = detectIndent(text);
-  const eol = detectNewline(text) ?? '\n';
-  return {
-    insertSpaces: detected.type !== 'tab',
-    tabSize: detected.amount || 2,
-    eol,
-  };
+/** Apply a single `jsonc-parser` modification to `text` and return the patched text. */
+function applyJsoncEdit(
+  text: string,
+  path: JSONPath,
+  value: unknown,
+  options: ModificationOptions,
+): string {
+  return applyEdits(text, modify(text, path, value, options));
 }
 
 /**
@@ -515,15 +520,12 @@ function mergeSettingsText(
   const insertMissing = (
     existingNode: Record<string, unknown>,
     incomingNode: Record<string, unknown>,
-    basePath: (string | number)[],
+    basePath: JSONPath,
   ) => {
     for (const [key, value] of Object.entries(incomingNode)) {
       const fullPath = [...basePath, key];
       if (!(key in existingNode)) {
-        currentText = applyEdits(
-          currentText,
-          modify(currentText, fullPath, value, { formattingOptions }),
-        );
+        currentText = applyJsoncEdit(currentText, fullPath, value, { formattingOptions });
       } else if (isPlainObject(existingNode[key]) && isPlainObject(value)) {
         insertMissing(existingNode[key], value, fullPath);
       }
@@ -551,7 +553,7 @@ function mergeExtensionsText(
 
   // No existing recommendations key: insert the incoming array as-is.
   if (!('recommendations' in existing)) {
-    return applyEdits(text, modify(text, ['recommendations'], incomingRecs, { formattingOptions }));
+    return applyJsoncEdit(text, ['recommendations'], incomingRecs, { formattingOptions });
   }
 
   // Unexpected non-array value: existing user value wins, leave it untouched.
@@ -559,20 +561,17 @@ function mergeExtensionsText(
     return text;
   }
 
-  const existingRecs = existingValue as unknown[];
+  const existingRecs = new Set<unknown>(existingValue);
   let currentText = text;
-  let nextIndex = existingRecs.length;
+  let nextIndex = existingValue.length;
   for (const rec of incomingRecs) {
-    if (existingRecs.includes(rec)) {
+    if (existingRecs.has(rec)) {
       continue;
     }
-    currentText = applyEdits(
-      currentText,
-      modify(currentText, ['recommendations', nextIndex], rec, {
-        formattingOptions,
-        isArrayInsertion: true,
-      }),
-    );
+    currentText = applyJsoncEdit(currentText, ['recommendations', nextIndex], rec, {
+      formattingOptions,
+      isArrayInsertion: true,
+    });
     nextIndex++;
   }
   return currentText;

--- a/packages/cli/src/utils/editor.ts
+++ b/packages/cli/src/utils/editor.ts
@@ -4,8 +4,11 @@ import path from 'node:path';
 import { styleText } from 'node:util';
 
 import * as prompts from '@voidzero-dev/vite-plus-prompts';
+import detectIndent from 'detect-indent';
+import { detectNewline } from 'detect-newline';
+import { applyEdits, type FormattingOptions, modify, parse as parseJsonc } from 'jsonc-parser';
 
-import { readJsonFile, writeJsonFile } from './json.ts';
+import { writeJsonFile } from './json.ts';
 
 // Language-specific overrides because user-level [lang] settings beat the workspace default
 const VSCODE_LANGUAGE_OVERRIDES = {
@@ -444,6 +447,12 @@ function normalizeEditorSelection(editorId: EditorSelection): EditorId[] {
   return [...new Set(Array.isArray(editorId) ? editorId : [editorId])];
 }
 
+/**
+ * Merge incoming settings into an existing editor JSON/JSONC file by patching the
+ * original text with `jsonc-parser` instead of re-serializing a merged object.
+ * This preserves comments, key order, trailing commas, and untouched formatting.
+ * Existing values always win; only missing keys/branches are inserted.
+ */
 function mergeAndWriteEditorConfig(
   filePath: string,
   incoming: Record<string, unknown>,
@@ -451,58 +460,122 @@ function mergeAndWriteEditorConfig(
   displayPath: string,
   silent = false,
 ) {
-  const existing = readJsonFile(filePath, true);
-  const merged = mergeEditorConfigs(existing, incoming, fileName);
-  writeJsonFile(filePath, merged);
+  const originalText = fs.readFileSync(filePath, 'utf-8');
+  const existing = parseJsonc(originalText) as unknown;
+  if (!isPlainObject(existing)) {
+    throw new Error(`Cannot merge editor config: ${displayPath} is not a JSON object`);
+  }
+
+  const formattingOptions = detectFormattingOptions(originalText);
+  const newText =
+    fileName === 'extensions.json'
+      ? mergeExtensionsText(originalText, existing, incoming, formattingOptions)
+      : mergeSettingsText(originalText, existing, incoming, formattingOptions);
+
+  // Do not rewrite when the merge produced no changes (keeps the operation idempotent).
+  if (newText === originalText) {
+    if (!silent) {
+      prompts.log.info(`No changes needed for ${displayPath}`);
+    }
+    return;
+  }
+
+  fs.writeFileSync(filePath, newText, 'utf-8');
   if (!silent) {
     prompts.log.success(`Merged editor config into ${displayPath}`);
   }
 }
 
-function mergeEditorConfigs(
-  existing: Record<string, unknown>,
-  incoming: Record<string, unknown>,
-  fileName: string,
-): Record<string, unknown> {
-  if (fileName === 'extensions.json') {
-    const existingRecs = Array.isArray(existing['recommendations'])
-      ? (existing['recommendations'] as string[])
-      : [];
-    const incomingRecs = Array.isArray(incoming['recommendations'])
-      ? (incoming['recommendations'] as string[])
-      : [];
-    return {
-      ...existing,
-      recommendations: [...new Set([...existingRecs, ...incomingRecs])],
-    };
-  }
-
-  return deepMerge(existing, incoming);
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-function deepMerge(
-  target: Record<string, unknown>,
-  source: Record<string, unknown>,
-): Record<string, unknown> {
-  const result = { ...target };
-  for (const [key, value] of Object.entries(source)) {
-    if (!(key in result)) {
-      result[key] = value;
-    } else if (
-      typeof result[key] === 'object' &&
-      result[key] !== null &&
-      !Array.isArray(result[key]) &&
-      typeof value === 'object' &&
-      value !== null &&
-      !Array.isArray(value)
-    ) {
-      result[key] = deepMerge(
-        result[key] as Record<string, unknown>,
-        value as Record<string, unknown>,
-      );
+function detectFormattingOptions(text: string): FormattingOptions {
+  const detected = detectIndent(text);
+  const eol = detectNewline(text) ?? '\n';
+  return {
+    insertSpaces: detected.type !== 'tab',
+    tabSize: detected.amount || 2,
+    eol,
+  };
+}
+
+/**
+ * Deep-merge missing keys from `incoming` into the existing text. Inserts a whole
+ * branch when it is absent, and recurses only when both sides are non-array objects
+ * so comments inside existing branches are preserved.
+ */
+function mergeSettingsText(
+  text: string,
+  existing: Record<string, unknown>,
+  incoming: Record<string, unknown>,
+  formattingOptions: FormattingOptions,
+): string {
+  let currentText = text;
+  const insertMissing = (
+    existingNode: Record<string, unknown>,
+    incomingNode: Record<string, unknown>,
+    basePath: (string | number)[],
+  ) => {
+    for (const [key, value] of Object.entries(incomingNode)) {
+      const fullPath = [...basePath, key];
+      if (!(key in existingNode)) {
+        currentText = applyEdits(
+          currentText,
+          modify(currentText, fullPath, value, { formattingOptions }),
+        );
+      } else if (isPlainObject(existingNode[key]) && isPlainObject(value)) {
+        insertMissing(existingNode[key], value, fullPath);
+      }
+      // Otherwise the existing value wins and is left untouched.
     }
+  };
+  insertMissing(existing, incoming, []);
+  return currentText;
+}
+
+/**
+ * For `extensions.json`, append missing recommendations without rebuilding the array,
+ * so comments inside the array survive. Existing entries always win.
+ */
+function mergeExtensionsText(
+  text: string,
+  existing: Record<string, unknown>,
+  incoming: Record<string, unknown>,
+  formattingOptions: FormattingOptions,
+): string {
+  const incomingRecs = Array.isArray(incoming['recommendations'])
+    ? (incoming['recommendations'] as unknown[])
+    : [];
+  const existingValue = existing['recommendations'];
+
+  // No existing recommendations key: insert the incoming array as-is.
+  if (!('recommendations' in existing)) {
+    return applyEdits(text, modify(text, ['recommendations'], incomingRecs, { formattingOptions }));
   }
-  return result;
+
+  // Unexpected non-array value: existing user value wins, leave it untouched.
+  if (!Array.isArray(existingValue)) {
+    return text;
+  }
+
+  const existingRecs = existingValue as unknown[];
+  let currentText = text;
+  let nextIndex = existingRecs.length;
+  for (const rec of incomingRecs) {
+    if (existingRecs.includes(rec)) {
+      continue;
+    }
+    currentText = applyEdits(
+      currentText,
+      modify(currentText, ['recommendations', nextIndex], rec, {
+        formattingOptions,
+        isArrayInsertion: true,
+      }),
+    );
+    nextIndex++;
+  }
+  return currentText;
 }
 
 function resolveEditorId(editor: string): EditorId | undefined {

--- a/packages/cli/src/utils/json.ts
+++ b/packages/cli/src/utils/json.ts
@@ -2,7 +2,20 @@ import fs from 'node:fs';
 
 import detectIndent from 'detect-indent';
 import { detectNewline } from 'detect-newline';
-import { parse as parseJsonc } from 'jsonc-parser';
+import { type FormattingOptions, parse as parseJsonc } from 'jsonc-parser';
+
+/**
+ * Derive `jsonc-parser` formatting options from existing file text so inserted
+ * fragments match the file's indentation and newline style.
+ */
+export function detectFormattingOptions(text: string): FormattingOptions {
+  const detected = detectIndent(text);
+  return {
+    insertSpaces: detected.type !== 'tab',
+    tabSize: detected.amount || 2,
+    eol: detectNewline(text) ?? '\n',
+  };
+}
 
 export function readJsonFile(file: string, allowComments?: boolean): Record<string, unknown> {
   const content = fs.readFileSync(file, 'utf-8');

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -65,6 +65,8 @@ export default defineConfig({
       '**/tmp/**',
       'packages/cli/snap-tests/check-*/**',
       'packages/cli/snap-tests/fmt-ignore-patterns/src/ignored',
+      // JSONC fixtures intentionally keep comments and trailing commas
+      'packages/cli/snap-tests/migration-preserve-editor-jsonc-comments/.vscode/**',
       'packages/cli/snap-tests-global/migration-lint-staged-ts-config',
       'packages/cli/snap-tests-global/migration-partially-installed-vite-plus/**',
       'ecosystem-ci/*/**',


### PR DESCRIPTION
## Problem

`vp migrate` dropped comments from existing `.vscode` / `.zed` JSON(C) files. The merge parsed the file into an object and re-serialized it with `JSON.stringify`, losing comments, key order, and trailing commas.

## Fix

Patch the original text with `jsonc-parser` (`modify` + `applyEdits`) instead of serializing a merged object. Only missing keys/branches are inserted; existing values, comments, and formatting are left untouched. Extension recommendations are appended without rebuilding the array, and a no-op merge no longer rewrites the file.

## Tests

- Strengthened `editor.spec.ts` to assert comment text survives, plus cases for nested comments, existing-values-win, trailing commas, extension dedup, idempotence, and Zed.
- Added snap test `migration-preserve-editor-jsonc-comments`.
