### PR TITLE
fix(windows): improve install.ps1 errors for missing VC++ runtime

### DIFF
--- a/packages/cli/install.ps1
+++ b/packages/cli/install.ps1
@@ -90,12 +90,33 @@ function Test-IsInstallStopException {
     return $ErrorRecord.Exception.Message -eq $script:InstallStopSignal
 }
 
+function Test-ShouldKeepShellOpenAfterFailure {
+    # Only `irm ... | iex` typed in an already-open interactive shell should keep the
+    # session alive. CI, script files, and `powershell -Command "..."` must exit non-zero.
+    if ($env:CI -eq "true") {
+        return $false
+    }
+    if ($PSCommandPath) {
+        return $false
+    }
+    if (-not [Environment]::UserInteractive) {
+        return $false
+    }
+    try {
+        $commandLine = (Get-CimInstance Win32_Process -Filter "ProcessId=$PID").CommandLine
+        if ($commandLine -match '(^|\s)-Command(\s|$)') {
+            return $false
+        }
+    } catch {
+        return $false
+    }
+    return $true
+}
+
 function Exit-Installer {
     param([int]$Code = 1)
     $global:LASTEXITCODE = $Code
-    # CI and script-file invocations must propagate a non-zero process exit code.
-    # `irm ... | iex` has no $PSCommandPath; use a catchable stop signal to keep the shell open.
-    if ($env:CI -eq "true" -or $PSCommandPath) {
+    if (-not (Test-ShouldKeepShellOpenAfterFailure)) {
         exit $Code
     }
     throw $script:InstallStopSignal
@@ -823,7 +844,11 @@ exec "`$VP_HOME/current/bin/vp.exe" "`$@"
 try {
     Main
 } catch {
-    if (-not (Test-IsInstallStopException $_)) {
-        throw
+    if (Test-IsInstallStopException $_) {
+        if (Test-ShouldKeepShellOpenAfterFailure) {
+            return
+        }
+        exit $global:LASTEXITCODE
     }
+    throw
 }

--- a/packages/cli/install.ps1
+++ b/packages/cli/install.ps1
@@ -46,11 +46,47 @@ function Write-Warn {
     Write-Host $Message
 }
 
+# Exit code when a Windows native binary cannot load required DLLs (STATUS_DLL_NOT_FOUND).
+$script:DllNotFoundExitCode = -1073741515
+
+function Test-IsDllNotFoundExitCode {
+    param([int]$ExitCode)
+    return $ExitCode -eq $script:DllNotFoundExitCode -or [uint32][int32]$ExitCode -eq 0xC0000135
+}
+
+function Get-DllNotFoundInstallMessage {
+    $arch = if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") { "arm64" } else { "x64" }
+    $vcUrl = if ($arch -eq "arm64") {
+        "https://aka.ms/vs/17/release/vc_redist.arm64.exe"
+    } else {
+        "https://aka.ms/vs/17/release/vc_redist.x64.exe"
+    }
+    return @"
+vp.exe could not start (exit code 0xC0000135).
+This usually means Microsoft Visual C++ 2015-2022 Redistributable ($arch) is not installed.
+
+Install: $vcUrl
+Then re-run: irm https://vite.plus/ps1 | iex
+"@
+}
+
+# Internal stop signal: halts install without re-printing an error we already wrote.
+$script:InstallStopSignal = 'VP_INSTALL_STOP'
+
+function Exit-Installer {
+    param([int]$Code = 1)
+    $global:LASTEXITCODE = $Code
+    if ($env:CI -eq "true") {
+        exit $Code
+    }
+    throw $script:InstallStopSignal
+}
+
 function Write-Error-Exit {
     param([string]$Message)
     Write-Host "error: " -ForegroundColor Red -NoNewline
     Write-Host $Message
-    exit 1
+    Exit-Installer
 }
 
 function Test-ReleaseAgeError {
@@ -114,11 +150,26 @@ function Write-ReleaseAgeOverride {
 }
 
 function Write-InstallFailure {
-    param([string]$LogPath)
+    param(
+        [string]$LogPath,
+        [int]$ExitCode = 0
+    )
+
+    if (Test-IsDllNotFoundExitCode $ExitCode) {
+        $message = Get-DllNotFoundInstallMessage
+        if ($env:CI -eq "true") {
+            Write-Host "error: " -ForegroundColor Red -NoNewline
+            Write-Host $message
+            Exit-Installer
+        }
+        Write-Error-Exit $message
+    }
+
     if ($env:CI -eq "true") {
         Write-Host "error: " -ForegroundColor Red -NoNewline
         Write-Host "Failed to install dependencies. Log output:"
         Get-Content -Path $LogPath | ForEach-Object { Write-Host $_ }
+        Exit-Installer
     } else {
         Write-Error-Exit "Failed to install dependencies. See log for details: $LogPath"
     }
@@ -593,16 +644,14 @@ function Main {
                         $retryExitCode = $LASTEXITCODE
                         $retryOutput | Out-File $installLog
                         if ($retryExitCode -ne 0) {
-                            Write-InstallFailure $installLog
-                            exit 1
+                            Write-InstallFailure -LogPath $installLog -ExitCode $retryExitCode
                         }
                     } else {
                         Write-ReleaseAgeFailure $installLog
-                        exit 1
+                        Exit-Installer
                     }
                 } else {
-                    Write-InstallFailure $installLog
-                    exit 1
+                    Write-InstallFailure -LogPath $installLog -ExitCode $installExitCode
                 }
             }
         } finally {
@@ -749,4 +798,10 @@ exec "`$VP_HOME/current/bin/vp.exe" "`$@"
     Write-Host ""
 }
 
-Main
+try {
+    Main
+} catch {
+    if ($_.Exception.Message -ne $script:InstallStopSignal) {
+        throw
+    }
+}

--- a/packages/cli/install.ps1
+++ b/packages/cli/install.ps1
@@ -51,7 +51,17 @@ $script:DllNotFoundExitCode = -1073741515
 
 function Test-IsDllNotFoundExitCode {
     param([int]$ExitCode)
-    return $ExitCode -eq $script:DllNotFoundExitCode -or [uint32][int32]$ExitCode -eq 0xC0000135
+    if ($ExitCode -eq $script:DllNotFoundExitCode) {
+        return $true
+    }
+    if ($ExitCode -eq 3221225781) {
+        return $true
+    }
+    if ($ExitCode -lt 0) {
+        $hex = '{0:X8}' -f ($ExitCode -band 0xFFFFFFFF)
+        return $hex -eq 'C0000135'
+    }
+    return $false
 }
 
 function Get-DllNotFoundInstallMessage {
@@ -73,10 +83,19 @@ Then re-run: irm https://vite.plus/ps1 | iex
 # Internal stop signal: halts install without re-printing an error we already wrote.
 $script:InstallStopSignal = 'VP_INSTALL_STOP'
 
+function Test-IsInstallStopException {
+    param(
+        [System.Management.Automation.ErrorRecord]$ErrorRecord
+    )
+    return $ErrorRecord.Exception.Message -eq $script:InstallStopSignal
+}
+
 function Exit-Installer {
     param([int]$Code = 1)
     $global:LASTEXITCODE = $Code
-    if ($env:CI -eq "true") {
+    # CI and script-file invocations must propagate a non-zero process exit code.
+    # `irm ... | iex` has no $PSCommandPath; use a catchable stop signal to keep the shell open.
+    if ($env:CI -eq "true" -or $PSCommandPath) {
         exit $Code
     }
     throw $script:InstallStopSignal
@@ -208,6 +227,7 @@ function Get-PackageMetadata {
         try {
             $script:PackageMetadata = Invoke-RestMethod $metadataUrl
         } catch {
+            if (Test-IsInstallStopException $_) { throw }
             # Try to extract npm error message from response
             $errorMsg = $_.ErrorDetails.Message
             if ($errorMsg) {
@@ -217,6 +237,7 @@ function Get-PackageMetadata {
                         Write-Error-Exit "Failed to fetch version '${versionPath}': $($errorJson.error)`n  URL: $metadataUrl"
                     }
                 } catch {
+                    if (Test-IsInstallStopException $_) { throw }
                     # JSON parsing failed, fall through to generic error
                 }
             }
@@ -230,6 +251,7 @@ function Get-PackageMetadata {
             try {
                 $script:PackageMetadata = $script:PackageMetadata | ConvertFrom-Json
             } catch {
+                if (Test-IsInstallStopException $_) { throw }
                 # Not valid JSON - treat as plain string error
                 Write-Error-Exit "Failed to fetch version '${versionPath}': $script:PackageMetadata`n  URL: $metadataUrl"
             }
@@ -801,7 +823,7 @@ exec "`$VP_HOME/current/bin/vp.exe" "`$@"
 try {
     Main
 } catch {
-    if ($_.Exception.Message -ne $script:InstallStopSignal) {
+    if (-not (Test-IsInstallStopException $_)) {
         throw
     }
 }


### PR DESCRIPTION
## Summary

On clean Windows machines without the MSVC runtime, `vp.exe` fails to start during `irm https://vite.plus/ps1 | iex` with exit code `0xC0000135` (STATUS_DLL_NOT_FOUND). The installer previously reported a generic "Failed to install dependencies" with an empty `install.log`, and `exit 1` closed the entire PowerShell window when run via `iex`.

This PR:
- Detects `0xC0000135` after `vp.exe install` fails and prints VC++ 2015–2022 Redistributable install guidance (x64/arm64)
- Replaces bare `exit 1` with a non-CI halt path so interactive `irm | iex` installs keep the shell open without duplicating the error message

All `Write-Error-Exit` paths now keep the interactive shell open when not running under `CI=true`.

## Context

Similar report elsewhere: https://github.com/kirodotdev/Kiro/issues/9752

## Test plan

- [x] Clean Windows without VC++: single clear error, shell stays open (no duplicate message, no window close)
- [ ] Windows with VC++ installed: install completes normally
- [ ] CI path (`CI=true`): still exits with non-zero code