### PR TITLE
docs(env): update env help output

### DIFF
--- a/crates/vite_global_cli/src/cli.rs
+++ b/crates/vite_global_cli/src/cli.rs
@@ -253,35 +253,6 @@ impl Commands {
 
 /// Arguments for the `env` command
 #[derive(clap::Args, Debug)]
-#[command(after_help = "\
-Examples:
-  Setup:
-    vp env setup                  # Create shims for node, npm, npx, corepack
-    vp env on                     # Use vite-plus managed Node.js
-    vp env print                  # Print shell snippet for this session
-
-  Manage:
-    vp env pin lts                # Pin to latest LTS version
-    vp env install                # Install version from .node-version / package.json
-    vp env use 20                 # Use Node.js 20 for this shell session
-    vp env use --unset            # Remove session override
-
-  Inspect:
-    vp env current                # Show current resolved environment
-    vp env current --json         # JSON output for automation
-    vp env doctor                 # Check environment configuration
-    vp env which node             # Show which node binary will be used
-    vp env list-remote --lts      # List only LTS versions
-
-  Execute:
-    vp env exec --node lts npm i  # Execute 'npm i' with latest LTS
-    vp env exec node -v           # Shim mode (version auto-resolved)
-
-Related Commands:
-  vp install -g <package>       # Install a package globally
-  vp uninstall -g <package>     # Uninstall a package globally
-  vp update -g [package]        # Update global packages
-  vp list -g [package]          # List global packages")]
 pub struct EnvArgs {
     /// Subcommand (e.g., 'default', 'setup', 'doctor', 'which')
     #[command(subcommand)]

--- a/crates/vite_global_cli/src/help.rs
+++ b/crates/vite_global_cli/src/help.rs
@@ -612,6 +612,7 @@ fn env_help_doc() -> HelpDoc {
                     "  vp install -g <package>       # Install a package globally",
                     "  vp uninstall -g <package>     # Uninstall a package globally",
                     "  vp update -g [package]        # Update global packages",
+                    "  vp outdated -g [package]      # List outdated packages",
                     "  vp list -g [package]          # List global packages",
                 ],
             ),

--- a/packages/cli/snap-tests-global/cli-helper-message/snap.txt
+++ b/packages/cli/snap-tests-global/cli-helper-message/snap.txt
@@ -397,6 +397,7 @@ Related Commands:
   vp install -g <package>       # Install a package globally
   vp uninstall -g <package>     # Uninstall a package globally
   vp update -g [package]        # Update global packages
+  vp outdated -g [package]      # List outdated packages
   vp list -g [package]          # List global packages
 
 Documentation: https://viteplus.dev/guide/env
@@ -420,4 +421,3 @@ Options:
   -h, --help             Print help
 
 Documentation: https://viteplus.dev/guide/upgrade
-

--- a/packages/cli/snap-tests-global/cli-helper-message/snap.txt
+++ b/packages/cli/snap-tests-global/cli-helper-message/snap.txt
@@ -421,3 +421,4 @@ Options:
   -h, --help             Print help
 
 Documentation: https://viteplus.dev/guide/upgrade
+


### PR DESCRIPTION
This pull request includes two adjustment:

1. We've already defined `env_help_doc` function to show colored document, manual `#[command(after_help = "")]` becomes duplicated dead code. This PR removed it.
2. Add missing `vp outdated -g` command in env help output.
