### PR TITLE
test(env): snapshot list-remote json markers

### DIFF
--- a/packages/cli/snap-tests-global/command-env-list-remote/snap.txt
+++ b/packages/cli/snap-tests-global/command-env-list-remote/snap.txt
@@ -5,7 +5,2222 @@ Installed Node.js v<semver>
 > vp env default lts # Set it as the global default (stored as the `lts` alias)
 ✓ Default Node.js version set to lts (currently <semver>)
 
-> vp env list-remote --lts --json | node -e "const {versions}=JSON.parse(require('fs').readFileSync(0,'utf8')); console.log('installed marked:', versions.some(v=>v.installed)); console.log('current marked:', versions.some(v=>v.current)); console.log('default marked:', versions.some(v=>v.default));" # installed/current/default flags should all resolve, including the `lts` default alias
-installed marked: true
-current marked: true
-default marked: true
+> vp env list-remote --lts --json # installed/current/default flags should all resolve, including the `lts` default alias
+{
+  "versions": [
+    {
+      "version": "6.9.0",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "6.9.1",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "6.9.2",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "6.9.3",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "6.9.4",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "6.9.5",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "6.10.0",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "6.10.1",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "6.10.2",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "6.10.3",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "6.11.0",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "6.11.1",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "6.11.2",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "6.11.3",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "6.11.4",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "6.11.5",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "6.12.0",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "6.12.1",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "6.12.2",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "6.12.3",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "6.13.0",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "6.13.1",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "6.14.0",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "6.14.1",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "6.14.2",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "6.14.3",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "6.14.4",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "6.15.0",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "6.15.1",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "6.16.0",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "6.17.0",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "6.17.1",
+      "lts": "Boron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "8.9.0",
+      "lts": "Carbon",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "8.9.1",
+      "lts": "Carbon",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "8.9.2",
+      "lts": "Carbon",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "8.9.3",
+      "lts": "Carbon",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "8.9.4",
+      "lts": "Carbon",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "8.10.0",
+      "lts": "Carbon",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "8.11.0",
+      "lts": "Carbon",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "8.11.1",
+      "lts": "Carbon",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "8.11.2",
+      "lts": "Carbon",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "8.11.3",
+      "lts": "Carbon",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "8.11.4",
+      "lts": "Carbon",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "8.12.0",
+      "lts": "Carbon",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "8.13.0",
+      "lts": "Carbon",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "8.14.0",
+      "lts": "Carbon",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "8.14.1",
+      "lts": "Carbon",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "8.15.0",
+      "lts": "Carbon",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "8.15.1",
+      "lts": "Carbon",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "8.16.0",
+      "lts": "Carbon",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "8.16.1",
+      "lts": "Carbon",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "8.16.2",
+      "lts": "Carbon",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "8.17.0",
+      "lts": "Carbon",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "10.13.0",
+      "lts": "Dubnium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "10.14.0",
+      "lts": "Dubnium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "10.14.1",
+      "lts": "Dubnium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "10.14.2",
+      "lts": "Dubnium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "10.15.0",
+      "lts": "Dubnium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "10.15.1",
+      "lts": "Dubnium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "10.15.2",
+      "lts": "Dubnium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "10.15.3",
+      "lts": "Dubnium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "10.16.0",
+      "lts": "Dubnium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "10.16.1",
+      "lts": "Dubnium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "10.16.2",
+      "lts": "Dubnium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "10.16.3",
+      "lts": "Dubnium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "10.17.0",
+      "lts": "Dubnium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "10.18.0",
+      "lts": "Dubnium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "10.18.1",
+      "lts": "Dubnium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "10.19.0",
+      "lts": "Dubnium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "10.20.0",
+      "lts": "Dubnium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "10.20.1",
+      "lts": "Dubnium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "10.21.0",
+      "lts": "Dubnium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "10.22.0",
+      "lts": "Dubnium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "10.22.1",
+      "lts": "Dubnium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "10.23.0",
+      "lts": "Dubnium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "10.23.1",
+      "lts": "Dubnium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "10.23.2",
+      "lts": "Dubnium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "10.23.3",
+      "lts": "Dubnium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "10.24.0",
+      "lts": "Dubnium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "10.24.1",
+      "lts": "Dubnium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.13.0",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.13.1",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.14.0",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.14.1",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.15.0",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.16.0",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.16.1",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.16.2",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.16.3",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.17.0",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.18.0",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.18.1",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.18.2",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.18.3",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.18.4",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.19.0",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.19.1",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.20.0",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.20.1",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.20.2",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.21.0",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.22.0",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.22.1",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.22.2",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.22.3",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.22.4",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.22.5",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.22.6",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.22.7",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.22.8",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.22.9",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.22.10",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.22.11",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "12.22.12",
+      "lts": "Erbium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "14.15.0",
+      "lts": "Fermium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "14.15.1",
+      "lts": "Fermium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "14.15.2",
+      "lts": "Fermium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "14.15.3",
+      "lts": "Fermium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "14.15.4",
+      "lts": "Fermium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "14.15.5",
+      "lts": "Fermium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "14.16.0",
+      "lts": "Fermium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "14.16.1",
+      "lts": "Fermium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "14.17.0",
+      "lts": "Fermium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "14.17.1",
+      "lts": "Fermium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "14.17.2",
+      "lts": "Fermium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "14.17.3",
+      "lts": "Fermium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "14.17.4",
+      "lts": "Fermium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "14.17.5",
+      "lts": "Fermium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "14.17.6",
+      "lts": "Fermium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "14.18.0",
+      "lts": "Fermium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "14.18.1",
+      "lts": "Fermium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "14.18.2",
+      "lts": "Fermium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "14.18.3",
+      "lts": "Fermium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "14.19.0",
+      "lts": "Fermium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "14.19.1",
+      "lts": "Fermium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "14.19.2",
+      "lts": "Fermium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "14.19.3",
+      "lts": "Fermium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "14.20.0",
+      "lts": "Fermium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "14.20.1",
+      "lts": "Fermium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "14.21.0",
+      "lts": "Fermium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "14.21.1",
+      "lts": "Fermium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "14.21.2",
+      "lts": "Fermium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "14.21.3",
+      "lts": "Fermium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "16.13.0",
+      "lts": "Gallium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "16.13.1",
+      "lts": "Gallium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "16.13.2",
+      "lts": "Gallium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "16.14.0",
+      "lts": "Gallium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "16.14.1",
+      "lts": "Gallium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "16.14.2",
+      "lts": "Gallium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "16.15.0",
+      "lts": "Gallium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "16.15.1",
+      "lts": "Gallium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "16.16.0",
+      "lts": "Gallium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "16.17.0",
+      "lts": "Gallium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "16.17.1",
+      "lts": "Gallium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "16.18.0",
+      "lts": "Gallium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "16.18.1",
+      "lts": "Gallium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "16.19.0",
+      "lts": "Gallium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "16.19.1",
+      "lts": "Gallium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "16.20.0",
+      "lts": "Gallium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "16.20.1",
+      "lts": "Gallium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "16.20.2",
+      "lts": "Gallium",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "18.12.0",
+      "lts": "Hydrogen",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "18.12.1",
+      "lts": "Hydrogen",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "18.13.0",
+      "lts": "Hydrogen",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "18.14.0",
+      "lts": "Hydrogen",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "18.14.1",
+      "lts": "Hydrogen",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "18.14.2",
+      "lts": "Hydrogen",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "18.15.0",
+      "lts": "Hydrogen",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "18.16.0",
+      "lts": "Hydrogen",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "18.16.1",
+      "lts": "Hydrogen",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "18.17.0",
+      "lts": "Hydrogen",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "18.17.1",
+      "lts": "Hydrogen",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "18.18.0",
+      "lts": "Hydrogen",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "18.18.1",
+      "lts": "Hydrogen",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "18.18.2",
+      "lts": "Hydrogen",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "18.19.0",
+      "lts": "Hydrogen",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "18.19.1",
+      "lts": "Hydrogen",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "18.20.0",
+      "lts": "Hydrogen",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "18.20.1",
+      "lts": "Hydrogen",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "18.20.2",
+      "lts": "Hydrogen",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "18.20.3",
+      "lts": "Hydrogen",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "18.20.4",
+      "lts": "Hydrogen",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "18.20.5",
+      "lts": "Hydrogen",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "18.20.6",
+      "lts": "Hydrogen",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "18.20.7",
+      "lts": "Hydrogen",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "18.20.8",
+      "lts": "Hydrogen",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "20.9.0",
+      "lts": "Iron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "20.10.0",
+      "lts": "Iron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "20.11.0",
+      "lts": "Iron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "20.11.1",
+      "lts": "Iron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "20.12.0",
+      "lts": "Iron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "20.12.1",
+      "lts": "Iron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "20.12.2",
+      "lts": "Iron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "20.13.0",
+      "lts": "Iron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": true,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "20.13.1",
+      "lts": "Iron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "20.14.0",
+      "lts": "Iron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "20.15.0",
+      "lts": "Iron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "20.15.1",
+      "lts": "Iron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "20.16.0",
+      "lts": "Iron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "20.17.0",
+      "lts": "Iron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "20.18.0",
+      "lts": "Iron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": true,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "20.18.1",
+      "lts": "Iron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "20.18.2",
+      "lts": "Iron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "20.18.3",
+      "lts": "Iron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "20.19.0",
+      "lts": "Iron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "20.19.1",
+      "lts": "Iron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "20.19.2",
+      "lts": "Iron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "20.19.3",
+      "lts": "Iron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "20.19.4",
+      "lts": "Iron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "20.19.5",
+      "lts": "Iron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "20.19.6",
+      "lts": "Iron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": true,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "20.20.0",
+      "lts": "Iron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "20.20.1",
+      "lts": "Iron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "20.20.2",
+      "lts": "Iron",
+      "latest": false,
+      "latest_lts": false,
+      "installed": true,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "22.11.0",
+      "lts": "Jod",
+      "latest": false,
+      "latest_lts": false,
+      "installed": true,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "22.12.0",
+      "lts": "Jod",
+      "latest": false,
+      "latest_lts": false,
+      "installed": true,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "22.13.0",
+      "lts": "Jod",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "22.13.1",
+      "lts": "Jod",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "22.14.0",
+      "lts": "Jod",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "22.15.0",
+      "lts": "Jod",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "22.15.1",
+      "lts": "Jod",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "22.16.0",
+      "lts": "Jod",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "22.17.0",
+      "lts": "Jod",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "22.17.1",
+      "lts": "Jod",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "22.18.0",
+      "lts": "Jod",
+      "latest": false,
+      "latest_lts": false,
+      "installed": true,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "22.19.0",
+      "lts": "Jod",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "22.20.0",
+      "lts": "Jod",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "22.21.0",
+      "lts": "Jod",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "22.21.1",
+      "lts": "Jod",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "22.22.0",
+      "lts": "Jod",
+      "latest": false,
+      "latest_lts": false,
+      "installed": true,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "22.22.1",
+      "lts": "Jod",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "22.22.2",
+      "lts": "Jod",
+      "latest": false,
+      "latest_lts": false,
+      "installed": true,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "22.22.3",
+      "lts": "Jod",
+      "latest": false,
+      "latest_lts": false,
+      "installed": true,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "22.23.0",
+      "lts": "Jod",
+      "latest": false,
+      "latest_lts": false,
+      "installed": true,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "22.23.1",
+      "lts": "Jod",
+      "latest": false,
+      "latest_lts": false,
+      "installed": true,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "24.11.0",
+      "lts": "Krypton",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "24.11.1",
+      "lts": "Krypton",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "24.12.0",
+      "lts": "Krypton",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "24.13.0",
+      "lts": "Krypton",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "24.13.1",
+      "lts": "Krypton",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "24.14.0",
+      "lts": "Krypton",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "24.14.1",
+      "lts": "Krypton",
+      "latest": false,
+      "latest_lts": false,
+      "installed": true,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "24.15.0",
+      "lts": "Krypton",
+      "latest": false,
+      "latest_lts": false,
+      "installed": false,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "24.16.0",
+      "lts": "Krypton",
+      "latest": false,
+      "latest_lts": false,
+      "installed": true,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "24.17.0",
+      "lts": "Krypton",
+      "latest": false,
+      "latest_lts": false,
+      "installed": true,
+      "current": false,
+      "default": false
+    },
+    {
+      "version": "24.18.0",
+      "lts": "Krypton",
+      "latest": false,
+      "latest_lts": true,
+      "installed": true,
+      "current": true,
+      "default": true
+    }
+  ]
+}

--- a/packages/cli/snap-tests-global/command-env-list-remote/steps.json
+++ b/packages/cli/snap-tests-global/command-env-list-remote/steps.json
@@ -5,6 +5,6 @@
   "commands": [
     "vp env install lts # Install an LTS Node.js version locally",
     "vp env default lts # Set it as the global default (stored as the `lts` alias)",
-    "vp env list-remote --lts --json | node -e \"const {versions}=JSON.parse(require('fs').readFileSync(0,'utf8')); console.log('installed marked:', versions.some(v=>v.installed)); console.log('current marked:', versions.some(v=>v.current)); console.log('default marked:', versions.some(v=>v.default));\" # installed/current/default flags should all resolve, including the `lts` default alias"
+    "vp env list-remote --lts --json # installed/current/default flags should all resolve, including the `lts` default alias"
   ]
 }


### PR DESCRIPTION
 ### Description

Follow-up to #1907. Preserve the raw `vp env list-remote --lts --json` output in the global snap test so the JSON marker fields stay covered.

 ### Testing
 - `pnpm -F vite-plus snap-test-global command-env-list-remote`