### PR TITLE
chore(deps): bump vite-task to pick up the Windows ps1 stdin gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -156,7 +156,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1865,7 +1865,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2099,7 +2099,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2299,7 +2299,7 @@ dependencies = [
 [[package]]
 name = "fspy"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=8daa9bb72faa89b745cb58c087b416b15d3bddc5#8daa9bb72faa89b745cb58c087b416b15d3bddc5"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
 dependencies = [
  "anyhow",
  "bstr",
@@ -2334,7 +2334,7 @@ dependencies = [
 [[package]]
 name = "fspy_detours_sys"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=8daa9bb72faa89b745cb58c087b416b15d3bddc5#8daa9bb72faa89b745cb58c087b416b15d3bddc5"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
 dependencies = [
  "cc",
  "winapi",
@@ -2343,7 +2343,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=8daa9bb72faa89b745cb58c087b416b15d3bddc5#8daa9bb72faa89b745cb58c087b416b15d3bddc5"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
 dependencies = [
  "anyhow",
  "bstr",
@@ -2358,7 +2358,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_windows"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=8daa9bb72faa89b745cb58c087b416b15d3bddc5#8daa9bb72faa89b745cb58c087b416b15d3bddc5"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
 dependencies = [
  "constcat",
  "fspy_detours_sys",
@@ -2374,7 +2374,7 @@ dependencies = [
 [[package]]
 name = "fspy_seccomp_unotify"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=8daa9bb72faa89b745cb58c087b416b15d3bddc5#8daa9bb72faa89b745cb58c087b416b15d3bddc5"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
 dependencies = [
  "futures-util",
  "libc",
@@ -2391,7 +2391,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=8daa9bb72faa89b745cb58c087b416b15d3bddc5#8daa9bb72faa89b745cb58c087b416b15d3bddc5"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -2410,7 +2410,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=8daa9bb72faa89b745cb58c087b416b15d3bddc5#8daa9bb72faa89b745cb58c087b416b15d3bddc5"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3149,7 +3149,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3319,7 +3319,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
 dependencies = [
  "scopeguard",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3552,7 +3552,7 @@ dependencies = [
 [[package]]
 name = "materialized_artifact"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=8daa9bb72faa89b745cb58c087b416b15d3bddc5#8daa9bb72faa89b745cb58c087b416b15d3bddc5"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
 dependencies = [
  "tempfile",
 ]
@@ -3560,7 +3560,7 @@ dependencies = [
 [[package]]
 name = "materialized_artifact_build"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=8daa9bb72faa89b745cb58c087b416b15d3bddc5#8daa9bb72faa89b745cb58c087b416b15d3bddc5"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
 dependencies = [
  "xxhash-rust",
 ]
@@ -3784,7 +3784,7 @@ dependencies = [
 [[package]]
 name = "native_str"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=8daa9bb72faa89b745cb58c087b416b15d3bddc5#8daa9bb72faa89b745cb58c087b416b15d3bddc5"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
 dependencies = [
  "bumpalo",
  "bytemuck",
@@ -3909,7 +3909,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5078,7 +5078,7 @@ dependencies = [
  "aes-gcm",
  "aes-kw",
  "argon2",
- "base64 0.22.1",
+ "base64 0.21.7",
  "bitfields",
  "block-padding",
  "blowfish",
@@ -5460,7 +5460,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal_test_client"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=8daa9bb72faa89b745cb58c087b416b15d3bddc5#8daa9bb72faa89b745cb58c087b416b15d3bddc5"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
 
 [[package]]
 name = "quote"
@@ -6731,7 +6731,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6787,7 +6787,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7336,7 +7336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7546,7 +7546,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7576,7 +7576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8341,7 +8341,7 @@ dependencies = [
 [[package]]
 name = "vite_glob"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=8daa9bb72faa89b745cb58c087b416b15d3bddc5#8daa9bb72faa89b745cb58c087b416b15d3bddc5"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
 dependencies = [
  "globset",
  "thiserror 2.0.18",
@@ -8389,7 +8389,7 @@ dependencies = [
 [[package]]
 name = "vite_graph_ser"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=8daa9bb72faa89b745cb58c087b416b15d3bddc5#8daa9bb72faa89b745cb58c087b416b15d3bddc5"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
 dependencies = [
  "petgraph 0.8.3",
  "serde",
@@ -8489,7 +8489,7 @@ dependencies = [
 [[package]]
 name = "vite_path"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=8daa9bb72faa89b745cb58c087b416b15d3bddc5#8daa9bb72faa89b745cb58c087b416b15d3bddc5"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
 dependencies = [
  "diff-struct",
  "os_str_bytes",
@@ -8521,7 +8521,7 @@ dependencies = [
 [[package]]
 name = "vite_powershell"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=8daa9bb72faa89b745cb58c087b416b15d3bddc5#8daa9bb72faa89b745cb58c087b416b15d3bddc5"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
 dependencies = [
  "vite_path",
  "which",
@@ -8530,7 +8530,7 @@ dependencies = [
 [[package]]
 name = "vite_select"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=8daa9bb72faa89b745cb58c087b416b15d3bddc5#8daa9bb72faa89b745cb58c087b416b15d3bddc5"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -8584,7 +8584,7 @@ dependencies = [
 [[package]]
 name = "vite_shell"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=8daa9bb72faa89b745cb58c087b416b15d3bddc5#8daa9bb72faa89b745cb58c087b416b15d3bddc5"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
 dependencies = [
  "brush-parser 0.4.0",
  "diff-struct",
@@ -8611,7 +8611,7 @@ dependencies = [
 [[package]]
 name = "vite_str"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=8daa9bb72faa89b745cb58c087b416b15d3bddc5#8daa9bb72faa89b745cb58c087b416b15d3bddc5"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
 dependencies = [
  "compact_str",
  "diff-struct",
@@ -8622,7 +8622,7 @@ dependencies = [
 [[package]]
 name = "vite_task"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=8daa9bb72faa89b745cb58c087b416b15d3bddc5#8daa9bb72faa89b745cb58c087b416b15d3bddc5"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
 dependencies = [
  "anstream",
  "anyhow",
@@ -8671,7 +8671,7 @@ dependencies = [
 [[package]]
 name = "vite_task_client"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=8daa9bb72faa89b745cb58c087b416b15d3bddc5#8daa9bb72faa89b745cb58c087b416b15d3bddc5"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
 dependencies = [
  "native_str",
  "rustc-hash",
@@ -8684,7 +8684,7 @@ dependencies = [
 [[package]]
 name = "vite_task_client_napi"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=8daa9bb72faa89b745cb58c087b416b15d3bddc5#8daa9bb72faa89b745cb58c087b416b15d3bddc5"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
 dependencies = [
  "napi",
  "napi-build",
@@ -8696,7 +8696,7 @@ dependencies = [
 [[package]]
 name = "vite_task_graph"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=8daa9bb72faa89b745cb58c087b416b15d3bddc5#8daa9bb72faa89b745cb58c087b416b15d3bddc5"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8718,7 +8718,7 @@ dependencies = [
 [[package]]
 name = "vite_task_ipc_shared"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=8daa9bb72faa89b745cb58c087b416b15d3bddc5#8daa9bb72faa89b745cb58c087b416b15d3bddc5"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
 dependencies = [
  "native_str",
  "rustc-hash",
@@ -8728,7 +8728,7 @@ dependencies = [
 [[package]]
 name = "vite_task_plan"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=8daa9bb72faa89b745cb58c087b416b15d3bddc5#8daa9bb72faa89b745cb58c087b416b15d3bddc5"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8756,7 +8756,7 @@ dependencies = [
 [[package]]
 name = "vite_task_server"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=8daa9bb72faa89b745cb58c087b416b15d3bddc5#8daa9bb72faa89b745cb58c087b416b15d3bddc5"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
 dependencies = [
  "futures",
  "native_str",
@@ -8780,7 +8780,7 @@ version = "0.0.0"
 [[package]]
 name = "vite_workspace"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=8daa9bb72faa89b745cb58c087b416b15d3bddc5#8daa9bb72faa89b745cb58c087b416b15d3bddc5"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
 dependencies = [
  "clap",
  "petgraph 0.8.3",
@@ -9058,7 +9058,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9494,7 +9494,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -156,7 +156,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1865,7 +1865,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2099,7 +2099,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2299,7 +2299,7 @@ dependencies = [
 [[package]]
 name = "fspy"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
 dependencies = [
  "anyhow",
  "bstr",
@@ -2334,7 +2334,7 @@ dependencies = [
 [[package]]
 name = "fspy_detours_sys"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
 dependencies = [
  "cc",
  "winapi",
@@ -2343,7 +2343,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
 dependencies = [
  "anyhow",
  "bstr",
@@ -2358,7 +2358,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_windows"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
 dependencies = [
  "constcat",
  "fspy_detours_sys",
@@ -2374,7 +2374,7 @@ dependencies = [
 [[package]]
 name = "fspy_seccomp_unotify"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
 dependencies = [
  "futures-util",
  "libc",
@@ -2391,7 +2391,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -2410,7 +2410,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3149,7 +3149,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3319,7 +3319,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
 dependencies = [
  "scopeguard",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3552,7 +3552,7 @@ dependencies = [
 [[package]]
 name = "materialized_artifact"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
 dependencies = [
  "tempfile",
 ]
@@ -3560,7 +3560,7 @@ dependencies = [
 [[package]]
 name = "materialized_artifact_build"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
 dependencies = [
  "xxhash-rust",
 ]
@@ -3784,7 +3784,7 @@ dependencies = [
 [[package]]
 name = "native_str"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
 dependencies = [
  "bumpalo",
  "bytemuck",
@@ -3909,7 +3909,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5460,7 +5460,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal_test_client"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
 
 [[package]]
 name = "quote"
@@ -6731,7 +6731,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6787,7 +6787,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7336,7 +7336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7546,7 +7546,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7576,7 +7576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8341,7 +8341,7 @@ dependencies = [
 [[package]]
 name = "vite_glob"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
 dependencies = [
  "globset",
  "thiserror 2.0.18",
@@ -8389,7 +8389,7 @@ dependencies = [
 [[package]]
 name = "vite_graph_ser"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
 dependencies = [
  "petgraph 0.8.3",
  "serde",
@@ -8489,7 +8489,7 @@ dependencies = [
 [[package]]
 name = "vite_path"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
 dependencies = [
  "diff-struct",
  "os_str_bytes",
@@ -8521,7 +8521,7 @@ dependencies = [
 [[package]]
 name = "vite_powershell"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
 dependencies = [
  "vite_path",
  "which",
@@ -8530,7 +8530,7 @@ dependencies = [
 [[package]]
 name = "vite_select"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -8584,7 +8584,7 @@ dependencies = [
 [[package]]
 name = "vite_shell"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
 dependencies = [
  "brush-parser 0.4.0",
  "diff-struct",
@@ -8611,7 +8611,7 @@ dependencies = [
 [[package]]
 name = "vite_str"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
 dependencies = [
  "compact_str",
  "diff-struct",
@@ -8622,7 +8622,7 @@ dependencies = [
 [[package]]
 name = "vite_task"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
 dependencies = [
  "anstream",
  "anyhow",
@@ -8671,7 +8671,7 @@ dependencies = [
 [[package]]
 name = "vite_task_client"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
 dependencies = [
  "native_str",
  "rustc-hash",
@@ -8684,7 +8684,7 @@ dependencies = [
 [[package]]
 name = "vite_task_client_napi"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
 dependencies = [
  "napi",
  "napi-build",
@@ -8696,7 +8696,7 @@ dependencies = [
 [[package]]
 name = "vite_task_graph"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8718,7 +8718,7 @@ dependencies = [
 [[package]]
 name = "vite_task_ipc_shared"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
 dependencies = [
  "native_str",
  "rustc-hash",
@@ -8728,7 +8728,7 @@ dependencies = [
 [[package]]
 name = "vite_task_plan"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8756,7 +8756,7 @@ dependencies = [
 [[package]]
 name = "vite_task_server"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
 dependencies = [
  "futures",
  "native_str",
@@ -8780,7 +8780,7 @@ version = "0.0.0"
 [[package]]
 name = "vite_workspace"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
 dependencies = [
  "clap",
  "petgraph 0.8.3",
@@ -9058,7 +9058,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9494,7 +9494,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -156,7 +156,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1865,7 +1865,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2099,7 +2099,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2299,7 +2299,7 @@ dependencies = [
 [[package]]
 name = "fspy"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
 dependencies = [
  "anyhow",
  "bstr",
@@ -2334,7 +2334,7 @@ dependencies = [
 [[package]]
 name = "fspy_detours_sys"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
 dependencies = [
  "cc",
  "winapi",
@@ -2343,7 +2343,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
 dependencies = [
  "anyhow",
  "bstr",
@@ -2358,7 +2358,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_windows"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
 dependencies = [
  "constcat",
  "fspy_detours_sys",
@@ -2374,7 +2374,7 @@ dependencies = [
 [[package]]
 name = "fspy_seccomp_unotify"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
 dependencies = [
  "futures-util",
  "libc",
@@ -2391,7 +2391,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -2410,7 +2410,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3149,7 +3149,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3319,7 +3319,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
 dependencies = [
  "scopeguard",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3552,7 +3552,7 @@ dependencies = [
 [[package]]
 name = "materialized_artifact"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
 dependencies = [
  "tempfile",
 ]
@@ -3560,7 +3560,7 @@ dependencies = [
 [[package]]
 name = "materialized_artifact_build"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
 dependencies = [
  "xxhash-rust",
 ]
@@ -3784,7 +3784,7 @@ dependencies = [
 [[package]]
 name = "native_str"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
 dependencies = [
  "bumpalo",
  "bytemuck",
@@ -3909,7 +3909,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5460,7 +5460,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal_test_client"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
 
 [[package]]
 name = "quote"
@@ -6731,7 +6731,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6787,7 +6787,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7336,7 +7336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7546,7 +7546,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7576,7 +7576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8341,7 +8341,7 @@ dependencies = [
 [[package]]
 name = "vite_glob"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
 dependencies = [
  "globset",
  "thiserror 2.0.18",
@@ -8389,7 +8389,7 @@ dependencies = [
 [[package]]
 name = "vite_graph_ser"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
 dependencies = [
  "petgraph 0.8.3",
  "serde",
@@ -8489,7 +8489,7 @@ dependencies = [
 [[package]]
 name = "vite_path"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
 dependencies = [
  "diff-struct",
  "os_str_bytes",
@@ -8521,7 +8521,7 @@ dependencies = [
 [[package]]
 name = "vite_powershell"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
 dependencies = [
  "vite_path",
  "which",
@@ -8530,7 +8530,7 @@ dependencies = [
 [[package]]
 name = "vite_select"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -8584,7 +8584,7 @@ dependencies = [
 [[package]]
 name = "vite_shell"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
 dependencies = [
  "brush-parser 0.4.0",
  "diff-struct",
@@ -8611,7 +8611,7 @@ dependencies = [
 [[package]]
 name = "vite_str"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
 dependencies = [
  "compact_str",
  "diff-struct",
@@ -8622,7 +8622,7 @@ dependencies = [
 [[package]]
 name = "vite_task"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
 dependencies = [
  "anstream",
  "anyhow",
@@ -8671,7 +8671,7 @@ dependencies = [
 [[package]]
 name = "vite_task_client"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
 dependencies = [
  "native_str",
  "rustc-hash",
@@ -8684,7 +8684,7 @@ dependencies = [
 [[package]]
 name = "vite_task_client_napi"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
 dependencies = [
  "napi",
  "napi-build",
@@ -8696,7 +8696,7 @@ dependencies = [
 [[package]]
 name = "vite_task_graph"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8718,7 +8718,7 @@ dependencies = [
 [[package]]
 name = "vite_task_ipc_shared"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
 dependencies = [
  "native_str",
  "rustc-hash",
@@ -8728,7 +8728,7 @@ dependencies = [
 [[package]]
 name = "vite_task_plan"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8756,7 +8756,7 @@ dependencies = [
 [[package]]
 name = "vite_task_server"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
 dependencies = [
  "futures",
  "native_str",
@@ -8780,7 +8780,7 @@ version = "0.0.0"
 [[package]]
 name = "vite_workspace"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0c5c6236c9ae3b16c7fd02574d3f87537a938eee#0c5c6236c9ae3b16c7fd02574d3f87537a938eee"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=0068d09b24f8f1c27eb1aee3901058c784942ce4#0068d09b24f8f1c27eb1aee3901058c784942ce4"
 dependencies = [
  "clap",
  "petgraph 0.8.3",
@@ -9058,7 +9058,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9494,7 +9494,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,7 @@ dunce = "1.0.5"
 fast-glob = "1.0.0"
 flate2 = { version = "=1.1.9", features = ["zlib-rs"] }
 form_urlencoded = "1.2.1"
-fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "0068d09b24f8f1c27eb1aee3901058c784942ce4" }
+fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "6cfa6e47a1a5fdadd215e1556766cc753603a539" }
 futures = "0.3.31"
 futures-util = "0.3.31"
 glob = "0.3.2"
@@ -304,11 +304,11 @@ vite_pm_cli = { path = "crates/vite_pm_cli" }
 vite_setup = { path = "crates/vite_setup" }
 vite_shared = { path = "crates/vite_shared" }
 vite_static_config = { path = "crates/vite_static_config" }
-vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "0068d09b24f8f1c27eb1aee3901058c784942ce4" }
-vite_powershell = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "0068d09b24f8f1c27eb1aee3901058c784942ce4" }
-vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "0068d09b24f8f1c27eb1aee3901058c784942ce4" }
-vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "0068d09b24f8f1c27eb1aee3901058c784942ce4" }
-vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "0068d09b24f8f1c27eb1aee3901058c784942ce4" }
+vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "6cfa6e47a1a5fdadd215e1556766cc753603a539" }
+vite_powershell = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "6cfa6e47a1a5fdadd215e1556766cc753603a539" }
+vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "6cfa6e47a1a5fdadd215e1556766cc753603a539" }
+vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "6cfa6e47a1a5fdadd215e1556766cc753603a539" }
+vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "6cfa6e47a1a5fdadd215e1556766cc753603a539" }
 walkdir = "2.5.0"
 wax = "0.6.0"
 which = "8.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,7 @@ dunce = "1.0.5"
 fast-glob = "1.0.0"
 flate2 = { version = "=1.1.9", features = ["zlib-rs"] }
 form_urlencoded = "1.2.1"
-fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "0c5c6236c9ae3b16c7fd02574d3f87537a938eee" }
+fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "0068d09b24f8f1c27eb1aee3901058c784942ce4" }
 futures = "0.3.31"
 futures-util = "0.3.31"
 glob = "0.3.2"
@@ -304,11 +304,11 @@ vite_pm_cli = { path = "crates/vite_pm_cli" }
 vite_setup = { path = "crates/vite_setup" }
 vite_shared = { path = "crates/vite_shared" }
 vite_static_config = { path = "crates/vite_static_config" }
-vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "0c5c6236c9ae3b16c7fd02574d3f87537a938eee" }
-vite_powershell = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "0c5c6236c9ae3b16c7fd02574d3f87537a938eee" }
-vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "0c5c6236c9ae3b16c7fd02574d3f87537a938eee" }
-vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "0c5c6236c9ae3b16c7fd02574d3f87537a938eee" }
-vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "0c5c6236c9ae3b16c7fd02574d3f87537a938eee" }
+vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "0068d09b24f8f1c27eb1aee3901058c784942ce4" }
+vite_powershell = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "0068d09b24f8f1c27eb1aee3901058c784942ce4" }
+vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "0068d09b24f8f1c27eb1aee3901058c784942ce4" }
+vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "0068d09b24f8f1c27eb1aee3901058c784942ce4" }
+vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "0068d09b24f8f1c27eb1aee3901058c784942ce4" }
 walkdir = "2.5.0"
 wax = "0.6.0"
 which = "8.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,7 @@ dunce = "1.0.5"
 fast-glob = "1.0.0"
 flate2 = { version = "=1.1.9", features = ["zlib-rs"] }
 form_urlencoded = "1.2.1"
-fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "8daa9bb72faa89b745cb58c087b416b15d3bddc5" }
+fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "0c5c6236c9ae3b16c7fd02574d3f87537a938eee" }
 futures = "0.3.31"
 futures-util = "0.3.31"
 glob = "0.3.2"
@@ -304,11 +304,11 @@ vite_pm_cli = { path = "crates/vite_pm_cli" }
 vite_setup = { path = "crates/vite_setup" }
 vite_shared = { path = "crates/vite_shared" }
 vite_static_config = { path = "crates/vite_static_config" }
-vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "8daa9bb72faa89b745cb58c087b416b15d3bddc5" }
-vite_powershell = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "8daa9bb72faa89b745cb58c087b416b15d3bddc5" }
-vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "8daa9bb72faa89b745cb58c087b416b15d3bddc5" }
-vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "8daa9bb72faa89b745cb58c087b416b15d3bddc5" }
-vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "8daa9bb72faa89b745cb58c087b416b15d3bddc5" }
+vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "0c5c6236c9ae3b16c7fd02574d3f87537a938eee" }
+vite_powershell = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "0c5c6236c9ae3b16c7fd02574d3f87537a938eee" }
+vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "0c5c6236c9ae3b16c7fd02574d3f87537a938eee" }
+vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "0c5c6236c9ae3b16c7fd02574d3f87537a938eee" }
+vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "0c5c6236c9ae3b16c7fd02574d3f87537a938eee" }
 walkdir = "2.5.0"
 wax = "0.6.0"
 which = "8.0.0"

--- a/crates/vite_command/src/ps1_shim.rs
+++ b/crates/vite_command/src/ps1_shim.rs
@@ -32,7 +32,7 @@
 use std::ffi::OsString;
 
 use vite_path::{AbsolutePath, AbsolutePathBuf};
-use vite_powershell::{POWERSHELL_PREFIX, find_ps1_sibling, powershell_host};
+use vite_powershell::{POWERSHELL_PREFIX, find_ps1_sibling, is_stdin_terminal, powershell_host};
 
 /// Rewrite a vp-managed `.cmd` invocation to go through `PowerShell`.
 ///
@@ -54,19 +54,11 @@ use vite_powershell::{POWERSHELL_PREFIX, find_ps1_sibling, powershell_host};
 pub fn rewrite_cmd_to_powershell(
     resolved: &AbsolutePath,
 ) -> Option<(AbsolutePathBuf, Vec<OsString>)> {
+    // `build_command` always inherits stdin into spawned children, so a TTY on
+    // our stdin means a TTY in the child too. `is_stdin_terminal` is shared with
+    // `vite_task_plan::ps1_shim` via the `vite_powershell` crate.
     let host = powershell_host()?;
     rewrite_in_scope(resolved, vp_home().map(AsRef::as_ref), host, is_stdin_terminal())
-}
-
-/// Cached `stdin.is_terminal()`. The TTY-ness of the parent's stdin
-/// is fixed for the process lifetime, and `build_command` always
-/// inherits stdin into spawned children — so a TTY here means a TTY
-/// in the child too.
-fn is_stdin_terminal() -> bool {
-    use std::{io::IsTerminal, sync::LazyLock};
-
-    static IS_TTY: LazyLock<bool> = LazyLock::new(|| std::io::stdin().is_terminal());
-    *IS_TTY
 }
 
 /// Cached `$VP_HOME` (`~/.vite-plus` by default; overridable via env var).


### PR DESCRIPTION
## Problem

vite-task's plan-time `.cmd` -> `.ps1` rewrite was ungated and hung Windows CI builds via `vp run <script>` (e.g. `vp run tauri build`): the `.ps1` wrappers block draining a non-TTY stdin pipe, so the process never exits after the build finishes and the runner waits on the open pipe until the job is cancelled hours later.

## Fix

Bump vite-task to `fix/ps1-stdin-tty-gate`, which gates that rewrite on `is_stdin_terminal()` (matching `vite_command`'s ps1_shim). Rev `8daa9bb7` -> `0c5c6236`.

Depends on voidzero-dev/vite-task#491
Closes #1971