### PR TITLE
ci: fix codiff ecosystem lint preflight

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -337,9 +337,9 @@ jobs:
           - name: codiff
             node-version: 24
             command: |
-              # vp migrate rewrites package.json without reformatting,
-              # so format first before running the project's `vp check && vp test` task.
-              vp fmt
+              # vp migrate can leave generated project code needing lint fixes,
+              # so apply safe fixes before running the project's `vp check && vp test` task.
+              vp check --fix
               vp run test:all
         exclude:
           # frm-stack uses Docker (testcontainers) which doesn't work the same way on Windows


### PR DESCRIPTION
## Summary
- run `vp check --fix` before codiff's ecosystem `test:all` command
- keep the fix scoped to the codiff ecosystem matrix entry

## Why
The upstream codiff project now trips a Vite+ lint autofix during ecosystem CI. Running the safe fixer before `test:all` lets the existing `vp check && vp test` task validate the migrated project instead of failing on generated lint cleanup.

## Validation
- `git diff --check`