### PR TITLE
fix(command): resolve fspy program before spawn

### DIFF
--- a/crates/vite_command/src/lib.rs
+++ b/crates/vite_command/src/lib.rs
@@ -206,16 +206,19 @@ where
     S: AsRef<OsStr>,
 {
     let cwd = cwd.as_ref();
+    let (program, prefix_args) = resolve_program(bin_name, envs, cwd)?;
     let args: Vec<OsString> = args.into_iter().map(|s| s.as_ref().to_owned()).collect();
     tracing::debug!(
         target: "vite_command::spawn",
-        bin_name,
+        program = %program.as_path().display(),
+        prefix_args = ?prefix_args,
         args = ?args,
         cwd = %cwd.as_path().display(),
         "spawn (fspy)",
     );
-    let mut cmd = fspy::Command::new(bin_name);
-    cmd.args(&args)
+    let mut cmd = fspy::Command::new(program.as_path());
+    cmd.args(&prefix_args)
+        .args(&args)
         // set system environment variables first
         .envs(std::env::vars_os())
         // then set custom environment variables
@@ -497,12 +500,9 @@ mod tests {
                 run_command_with_fspy("npm-not-exists", &["--version"], &envs, &temp_dir_path)
                     .await;
             assert!(result.is_err(), "Should not find binary path, but got: {:?}", result);
-            assert!(
-                result
-                    .err()
-                    .unwrap()
-                    .to_string()
-                    .contains("could not resolve the full path of program '\"npm-not-exists\"'")
+            assert_eq!(
+                result.unwrap_err().to_string(),
+                "Cannot find binary path for command 'npm-not-exists'"
             );
         }
     }


### PR DESCRIPTION
## Summary

- Resolve `run_command_with_fspy` binaries through the same `resolve_program` path used by `run_command`.
- Preserve Windows `.cmd` to PowerShell prefix args before user args when fspy is enabled.
- Update the missing-binary test expectation to match the shared resolver error.

## Why

`run_command_with_fspy` passed the bare binary name directly to `fspy::Command::new`, so PATH resolution happened inside fspy instead of using Vite+'s resolver. On Windows this can make fspy pick up environment-sensitive shim paths differently from `run_command`. Reusing `resolve_program` keeps both command paths aligned and follows the fix direction described in #1599.

Fixes #1599.

## Validation

- `rustfmt --edition 2024 crates/vite_command/src/lib.rs`
- `git diff --check`
- Confirmed `fspy::Command::new<P: AsRef<OsStr>>` in `voidzero-dev/vite-task` at the locked fspy rev accepts the resolved path argument.

Cargo tests could not run in this local checkout because the workspace references `rolldown/crates/rolldown_binding/Cargo.toml`, but the `rolldown/` directory is not present here.