### PR TITLE
docs: Vite Task cache reuse and tool-reported caching

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -17,6 +17,10 @@ const taskRunnerGuideItems = [
     link: '/guide/cache',
   },
   {
+    text: 'GitHub Actions Cache',
+    link: '/guide/github-actions-cache',
+  },
+  {
     text: 'Running Binaries',
     link: '/guide/vpx',
   },

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -17,6 +17,10 @@ const taskRunnerGuideItems = [
     link: '/guide/cache',
   },
   {
+    text: 'Tool-Reported Caching',
+    link: '/guide/tool-reported-caching',
+  },
+  {
     text: 'GitHub Actions Cache',
     link: '/guide/github-actions-cache',
   },

--- a/docs/config/run.md
+++ b/docs/config/run.md
@@ -191,6 +191,8 @@ tasks: {
 
 Wildcard patterns and `!` exclusion patterns are supported: `VITE_*` matches all variables starting with `VITE_`, and `!VITE_SECRET` excludes the `VITE_SECRET` variable from the match.
 
+For `vp build`, Vite reports Vite environment variables through [tool-reported caching](/guide/tool-reported-caching). Do not add `VITE_*` or `NODE_ENV` here for a standard Vite build unless your project has extra build behavior Vite cannot report.
+
 ```bash
 $ NODE_ENV=development vp run build    # first run
 $ NODE_ENV=production vp run build     # cache miss: env 'NODE_ENV' changed
@@ -213,6 +215,8 @@ tasks: {
 ```
 
 `untrackedEnv` accepts the same wildcard and `!` exclusion patterns as [`env`](#env).
+
+Do not put a variable in `untrackedEnv` if its value changes the task result. If a tool reports the variable through [tool-reported caching](/guide/tool-reported-caching), leave it out of both `env` and `untrackedEnv`.
 
 Vite Task passes a set of common environment variables to all tasks:
 

--- a/docs/config/run.md
+++ b/docs/config/run.md
@@ -120,8 +120,10 @@ Commands joined with `&&` (or supplied as an array) are automatically split into
 
 ### `dependsOn`
 
-- **Type:** `string[]`
+- **Type:** `Array<string | { task: string, from: DependsOnFrom }>`
 - **Default:** `[]`
+
+`DependsOnFrom` accepts `"dependencies"`, `"devDependencies"`, `"peerDependencies"`, or an array of those values.
 
 Tasks that must complete successfully before this one starts.
 
@@ -139,6 +141,19 @@ Dependencies can reference tasks in other packages using the `package#task` form
 ```ts [vite.config.ts]
 dependsOn: ['@my/core#build', '@my/utils#lint'];
 ```
+
+Use the object form `{ task: string, from: DependsOnFrom }` to reference tasks from all dependencies:
+
+```ts [vite.config.ts]
+tasks: {
+  test: {
+    command: 'vp test',
+    dependsOn: [{ task: 'build', from: ['dependencies', 'devDependencies'] }],
+  },
+}
+```
+
+For the example above, Vite Task reads the declaring package's direct `dependencies` and `devDependencies`, and runs `build` task in each dependency if it defines one. Packages without `build` are skipped.
 
 See [Task Dependencies](/guide/run#task-dependencies) for details on how explicit and topological dependencies interact.
 
@@ -168,17 +183,17 @@ Environment variables included in the cache fingerprint. When any listed variabl
 ```ts [vite.config.ts]
 tasks: {
   build: {
-    command: 'vp build',
+    command: 'node build.mjs',
     env: ['NODE_ENV'],
   },
 }
 ```
 
-Wildcard patterns are supported: `VITE_*` matches all variables starting with `VITE_`.
+Wildcard patterns and `!` exclusion patterns are supported: `VITE_*` matches all variables starting with `VITE_`, and `!VITE_SECRET` excludes the `VITE_SECRET` variable from the match.
 
 ```bash
 $ NODE_ENV=development vp run build    # first run
-$ NODE_ENV=production vp run build     # cache miss: variable changed
+$ NODE_ENV=production vp run build     # cache miss: env 'NODE_ENV' changed
 ```
 
 ### `untrackedEnv`
@@ -191,13 +206,15 @@ Environment variables passed to the task process but **not** included in the cac
 ```ts [vite.config.ts]
 tasks: {
   build: {
-    command: 'vp build',
+    command: 'node build.mjs',
     untrackedEnv: ['CI', 'GITHUB_ACTIONS'],
   },
 }
 ```
 
-A set of common environment variables are automatically passed through to all tasks:
+`untrackedEnv` accepts the same wildcard and `!` exclusion patterns as [`env`](#env).
+
+Vite Task passes a set of common environment variables to all tasks:
 
 - **System:** `HOME`, `USER`, `PATH`, `SHELL`, `LANG`, `TZ`
 - **Node.js:** `NODE_OPTIONS`, `COREPACK_HOME`, `PNPM_HOME`
@@ -270,16 +287,29 @@ String glob patterns are resolved relative to the package directory by default. 
 
 ### `output`
 
-- **Type:** `Array<string | { pattern: string, base: "workspace" | "package" }>`
-- **Default:** `[]` (nothing is archived)
+- **Type:** `Array<string | { auto: boolean } | { pattern: string, base: "workspace" | "package" }>`
+- **Default:** automatic write tracking
 
-Files the task produces. They get archived after a successful run and restored on a cache hit, so you don't have to rebuild them. Leave it empty (or omit it) and nothing is archived.
+Files Vite Task archives after a successful run and restores on a cache hit.
+
+If you omit `output`, Vite Task tracks files that the task writes and restores those files on cache hits. Use explicit output entries when you need to override the tracked files.
 
 ```ts [vite.config.ts]
 tasks: {
   build: {
-    command: 'vp build',
+    command: 'node build.mjs',
     output: ['dist/**', '!dist/cache/**'],
+  },
+}
+```
+
+Use `{ auto: true }` to keep automatic write tracking while adding explicit output globs:
+
+```ts [vite.config.ts]
+tasks: {
+  build: {
+    command: 'node build.mjs',
+    output: [{ auto: true }, 'storybook-static/**'],
   },
 }
 ```
@@ -289,7 +319,7 @@ If a task writes outside its own package, use the object form with `base: "works
 ```ts [vite.config.ts]
 tasks: {
   build: {
-    command: 'vp build',
+    command: 'node build.mjs',
     output: [
       'dist/**',
       { pattern: 'shared-artifacts/**', base: 'workspace' },
@@ -297,6 +327,19 @@ tasks: {
   },
 }
 ```
+
+Set `output: []` to disable output restoration for a cached task:
+
+```ts [vite.config.ts]
+tasks: {
+  report: {
+    command: 'node scripts/report.mjs',
+    output: [],
+  },
+}
+```
+
+Vite Task still replays terminal output for that task on cache hits.
 
 ### `cwd`
 

--- a/docs/guide/cache.md
+++ b/docs/guide/cache.md
@@ -72,17 +72,9 @@ tasks: {
 
 ### Tool-Reported Caching
 
-Tool-reported caching lets a tool report the cache facts it already knows at runtime, instead of making you copy tool-specific inputs, outputs, or environment variables into task config.
+Tool-reported caching lets a tool report cache metadata to Vite Task while it runs. Vite+ supports this for `vp build` today, so standard Vite builds do not need manual `env: ['VITE_*']` or `output: ['dist/**']` config.
 
-Vite+ currently supports tool-reported caching for `vp build`. When a task runs `vp build`, Vite reports the build cache metadata at runtime, so you do not need to declare `env: ['VITE_*']` or `output: ['dist/**']` for a standard Vite build. With task shorthand, the task can be:
-
-```ts [vite.config.ts]
-tasks: {
-  build: 'vp build',
-}
-```
-
-We plan to extend tool-reported caching to more first-party tools. Third-party tools can report cache metadata with [`@voidzero-dev/vite-task-client`](https://npmx.dev/package/@voidzero-dev/vite-task-client).
+See [Tool-Reported Caching](/guide/tool-reported-caching) for current support, manual config rules, and third-party tool integration.
 
 ## Environment Variables
 
@@ -99,7 +91,7 @@ tasks: {
 }
 ```
 
-To pass a variable to the task **without** affecting cache behavior, use [`untrackedEnv`](/config/run#untracked-env). This is useful for variables like `CI` or `GITHUB_ACTIONS` that should be available in the task, but do not affect caching behavior.
+To pass a variable to the task **without** affecting cache behavior, use [`untrackedEnv`](/config/run#untrackedenv). This is useful for variables like `CI` or `GITHUB_ACTIONS` that should be available in the task, but do not affect caching behavior.
 
 See [Run Config](/config/run#env) for details on wildcard patterns and the full list of automatically passed-through variables.
 

--- a/docs/guide/cache.md
+++ b/docs/guide/cache.md
@@ -4,32 +4,19 @@ Vite Task can automatically track dependencies and cache tasks run through `vp r
 
 ## Overview
 
-When a task runs successfully (exit code 0), its terminal output (stdout/stderr) is saved. On the next run, Vite Task checks if anything changed:
+When a task runs successfully (exit code 0), its terminal output (stdout/stderr) and all files it writes (output files) are saved. On the next run, Vite Task checks if anything changed:
 
 1. **Arguments:** did the [additional arguments](/guide/run#additional-arguments) passed to the task change?
 2. **Environment variables:** did any [fingerprinted env vars](/config/run#env) change?
 3. **Input files:** did any file that the command reads change?
 
-If everything matches, the cached output is replayed instantly, and the command does not run.
-
-::: info
-By default, only terminal output is cached and replayed. To cache files produced by a task, configure [`output`](/config/run#output) globs. Matching files are archived after a successful run and restored on a cache hit.
-:::
-
-```ts [vite.config.ts]
-tasks: {
-  build: {
-    command: 'vp build',
-    output: ['dist/**'],
-  },
-}
-```
+If the entry matches, Vite Task replays the terminal output, restores the written files, and skips the command.
 
 When a cache miss occurs, Vite Task tells you exactly why:
 
 ```
 $ vp lint ✗ cache miss: 'src/utils.ts' modified, executing
-$ vp build ✗ cache miss: env changed, executing
+$ vp build ✗ cache miss: env 'VITE_GREETING' changed, executing
 $ vp test ✗ cache miss: args changed, executing
 ```
 
@@ -45,7 +32,7 @@ A task can set [`cache: false`](/config/run#cache) to opt out. This cannot be ov
 
 ### 2. CLI flags
 
-`--no-cache` disables caching for everything. `--cache` enables caching for both tasks and scripts, which is equivalent to setting [`run.cache: true`](/config/run#run-cache) for that invocation.
+`--no-cache` disables caching for tasks and scripts. `--cache` enables caching for both tasks and scripts, which is equivalent to setting [`run.cache: true`](/config/run#run-cache) for that invocation.
 
 ### 3. Workspace config
 
@@ -83,6 +70,14 @@ tasks: {
 }
 ```
 
+### Tool-Reported Caching
+
+Tool-reported caching lets a tool tell Vite Task which cache inputs, outputs, and environment variables affect its result.
+
+Vite+ only supports tool-reported caching for `vp build` today. Vite reports the build cache metadata it already knows, so you do not need to declare `env: ['VITE_*']` or replace automatic inputs for a standard Vite build. Add manual `input`, `output`, or `env` entries when your project has extra cache behavior the tool cannot know.
+
+We plan to extend tool-reported caching to more first-party tools. Third-party tools can report cache metadata with [`@voidzero-dev/vite-task-client`](https://npmx.dev/package/@voidzero-dev/vite-task-client).
+
 ## Environment Variables
 
 By default, tasks run in a clean environment. Only a small set of common variables, such as `PATH`, `HOME`, and `CI`, are passed through. Other environment variables are neither visible to the task nor included in the cache fingerprint.
@@ -98,7 +93,7 @@ tasks: {
 }
 ```
 
-To pass a variable to the task **without** affecting cache behavior, use [`untrackedEnv`](/config/run#untracked-env). This is useful for variables like `CI` or `GITHUB_ACTIONS` that should be available in the task, but do not generally affect caching behavior.
+To pass a variable to the task **without** affecting cache behavior, use [`untrackedEnv`](/config/run#untracked-env). This is useful for variables like `CI` or `GITHUB_ACTIONS` that should be available in the task, but do not affect caching behavior.
 
 See [Run Config](/config/run#env) for details on wildcard patterns and the full list of automatically passed-through variables.
 

--- a/docs/guide/cache.md
+++ b/docs/guide/cache.md
@@ -72,9 +72,15 @@ tasks: {
 
 ### Tool-Reported Caching
 
-Tool-reported caching lets a tool tell Vite Task which cache inputs, outputs, and environment variables affect its result.
+Tool-reported caching lets a tool report the cache facts it already knows at runtime, instead of making you copy tool-specific inputs, outputs, or environment variables into task config.
 
-Vite+ only supports tool-reported caching for `vp build` today. Vite reports the build cache metadata it already knows, so you do not need to declare `env: ['VITE_*']` or replace automatic inputs for a standard Vite build. Add manual `input`, `output`, or `env` entries when your project has extra cache behavior the tool cannot know.
+Vite+ currently supports tool-reported caching for `vp build`. When a task runs `vp build`, Vite reports the build cache metadata at runtime, so you do not need to declare `env: ['VITE_*']` or `output: ['dist/**']` for a standard Vite build. With task shorthand, the task can be:
+
+```ts [vite.config.ts]
+tasks: {
+  build: 'vp build',
+}
+```
 
 We plan to extend tool-reported caching to more first-party tools. Third-party tools can report cache metadata with [`@voidzero-dev/vite-task-client`](https://npmx.dev/package/@voidzero-dev/vite-task-client).
 

--- a/docs/guide/ci.md
+++ b/docs/guide/ci.md
@@ -23,6 +23,10 @@ That means you usually do not need separate `setup-node`, package-manager setup,
 
 With `cache: true`, `setup-vp` handles dependency caching for you automatically.
 
+::: tip
+`setup-vp` caches package-manager data. To reuse Vite Task results across CI runs, add a separate [GitHub Actions cache for Vite Task](/guide/github-actions-cache).
+:::
+
 ## Simplifying Existing Workflows
 
 If you are migrating an existing GitHub Actions workflow, you can often replace large blocks of Node, package-manager, and cache setup with a single `setup-vp` step.

--- a/docs/guide/github-actions-cache.md
+++ b/docs/guide/github-actions-cache.md
@@ -28,7 +28,7 @@ Fix local misses first. GitHub Actions cache can move Vite Task's local cache di
 
 Only commands run through `vp run` use Vite Task caching. A direct command such as `vp build` does not use the task cache; run `vp run build` or define a CI-specific task.
 
-The example below uses automatic input tracking for `vp build`. Vite reports build cache metadata to Vite Task through [tool-reported caching](/guide/cache#tool-reported-caching), so a short explicit list can miss files such as `public/**`, `.env*`, or framework config. The extra lockfile input ties the task fingerprint to dependency identity.
+The example below uses automatic input tracking for `vp build`. Vite reports build cache metadata to Vite Task through [tool-reported caching](/guide/tool-reported-caching), so a short explicit list can miss files such as `public/**`, `.env*`, or framework config. The extra lockfile input ties the task fingerprint to dependency identity.
 
 The lint task uses explicit inputs because its CI input set is smaller. If you use npm, Yarn, or Bun, replace `pnpm-lock.yaml` with the lockfile your project commits.
 
@@ -137,7 +137,7 @@ Leave source files out of the GitHub Actions key. Vite Task fingerprints task in
 
 ## 3. Verify In The Logs
 
-On the first run, the restore step should say that no cache was found, and the save step should create one.
+On the first run, the restore step should say that no cache was found, and the save step should create one. Pull requests from forks may be restore-only because GitHub can give the cache token read-only access. In that case, the save step warns and exits successfully without writing a cache entry.
 
 On a later run, look for both layers:
 
@@ -219,6 +219,7 @@ You can add a broader restore prefix only if the task inputs include the package
 ## Limitations And Workarounds
 
 - **Cache entries are immutable.** Use a unique primary key per run and restore prefixes. GitHub will not update an existing cache entry in place.
+- **Fork pull requests may be restore-only.** GitHub can allow forked pull request runs to restore existing caches without saving new entries. Populate shared caches from trusted branch or default-branch runs.
 - **GitHub evicts caches.** GitHub removes caches that have not been accessed for over 7 days. It also evicts least-recently-used entries when repository cache storage exceeds its limit, which defaults to 10 GB. If this causes churn, narrow what you cache, delete stale entries, or increase the repository cache limit in GitHub settings.
 - **Cache scope is branch-aware.** Workflow runs can restore caches from the current branch and the default branch. Pull request merge-ref caches have limited scope and help re-runs of the same pull request. See [GitHub's dependency caching reference](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching) for the full branch and tag rules.
 - **Secrets can leak through cache contents.** Vite Task caches terminal output and configured output files. Keep secrets out of task logs and generated files that you cache.

--- a/docs/guide/github-actions-cache.md
+++ b/docs/guide/github-actions-cache.md
@@ -1,0 +1,231 @@
+# GitHub Actions Cache
+
+::: warning Experimental
+Reusing Vite Task cache through GitHub Actions cache is experimental. Validate the workflow in your project before you depend on it for CI time savings.
+:::
+
+Vite Task stores task results in `node_modules/.vite/task-cache` at the workspace root. You can restore that directory in a later GitHub Actions run, then let Vite Task decide whether each task matches the current command, environment, inputs, and outputs.
+
+GitHub Actions cache and Vite Task make separate decisions:
+
+1. `actions/cache` restores and saves the cache directory based on the key in your workflow.
+2. Vite Task checks the restored entries and replays only the tasks whose fingerprints still match.
+
+This cache is separate from dependency caching. Keep using [`setup-vp` cache support](/guide/ci) for package installs, then restore the Vite Task cache after dependencies are installed.
+
+## Before You Start
+
+Use this workflow when all of these are true:
+
+- The command runs through [`vp run`](/guide/run).
+- The task hits on a second local run.
+- The task has a stable input strategy for CI.
+- The workflow installs dependencies before restoring `node_modules/.vite/task-cache`.
+
+Fix local misses first. GitHub Actions cache can move Vite Task's local cache directory between runs, but it cannot make an unstable task cacheable.
+
+## 1. Define Cacheable CI Tasks
+
+Only commands run through `vp run` use Vite Task caching. A direct command such as `vp build` does not use the task cache; run `vp run build` or define a CI-specific task.
+
+The example below uses automatic input tracking for `vp build`. Vite reports build cache metadata to Vite Task through [tool-reported caching](/guide/cache#tool-reported-caching), so a short explicit list can miss files such as `public/**`, `.env*`, or framework config. The extra lockfile input ties the task fingerprint to dependency identity.
+
+The lint task uses explicit inputs because its CI input set is smaller. If you use npm, Yarn, or Bun, replace `pnpm-lock.yaml` with the lockfile your project commits.
+
+```ts [vite.config.ts]
+import { defineConfig } from 'vite-plus';
+
+export default defineConfig({
+  run: {
+    tasks: {
+      'ci-build': {
+        command: 'vp build',
+        input: [{ auto: true }, 'pnpm-lock.yaml', '!dist', '!dist/**'],
+        output: ['dist/**'],
+      },
+      'ci-lint': {
+        command: 'vp lint',
+        input: ['package.json', 'pnpm-lock.yaml', 'src/**', 'tsconfig*.json', 'vite.config.ts'],
+      },
+    },
+  },
+});
+```
+
+The build task sets `output: ['dist/**']` to narrow output restoration to `dist`. The `!dist` input exclusions keep generated output files from invalidating the same cache entry Vite Task can restore. If you omit `output`, Vite Task tracks files that the task writes and restores those files on cache hits. Use [`output`](/config/run#output) when you need to narrow, extend, or disable output restoration.
+
+Run each task twice:
+
+```bash
+vp run ci-build
+vp run ci-build # should print "cache hit"
+vp run ci-lint
+vp run ci-lint # should print "cache hit"
+```
+
+For other auto-tracked tasks that produce files, use the same output pattern:
+
+```ts [vite.config.ts]
+import { defineConfig } from 'vite-plus';
+
+export default defineConfig({
+  run: {
+    tasks: {
+      report: {
+        command: 'node scripts/report.mjs',
+        input: [{ auto: true }, '!reports', '!reports/**'],
+        output: ['reports/**'],
+      },
+    },
+  },
+});
+```
+
+For a standard Vite build, you do not need to add `env: ['VITE_*']` or replace automatic inputs. Add explicit `input` entries only to track extra files such as lockfiles or to exclude generated outputs.
+
+## 2. Restore The Cache After Install
+
+Restore `node_modules/.vite/task-cache` after `vp install`, because package installation can recreate or modify `node_modules`.
+
+```yaml [.github/workflows/ci.yml]
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: '24'
+          cache: true
+
+      - run: vp install
+
+      - name: Restore Vite Task cache
+        id: vite-task-cache
+        uses: actions/cache/restore@v6
+        with:
+          path: node_modules/.vite/task-cache
+          key: vite-task-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml', '**/package-lock.json', '**/yarn.lock', '**/bun.lock', '**/bun.lockb') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            vite-task-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml', '**/package-lock.json', '**/yarn.lock', '**/bun.lock', '**/bun.lockb') }}-
+
+      - run: vp run ci-lint
+      - run: vp run ci-build
+
+      - name: Save Vite Task cache
+        if: success()
+        uses: actions/cache/save@v6
+        with:
+          path: node_modules/.vite/task-cache
+          key: ${{ steps.vite-task-cache.outputs.cache-primary-key }}
+```
+
+The primary key includes `github.run_id` and `github.run_attempt` so each successful run can save a new immutable cache entry. The restore prefix includes the lockfile hash, so a dependency change starts from a cold Vite Task cache instead of restoring entries from a different dependency graph.
+
+Leave source files out of the GitHub Actions key. Vite Task fingerprints task inputs. If a source change updates the Actions key, GitHub can skip useful restores before Vite Task decides which tasks still hit.
+
+## 3. Verify In The Logs
+
+On the first run, the restore step should say that no cache was found, and the save step should create one.
+
+On a later run, look for both layers:
+
+```text
+Cache restored from key: vite-task-Linux-X64-...
+$ vp build ◉ cache hit, replaying
+vp run: cache hit, 1.10s saved.
+```
+
+If GitHub restores a cache but Vite Task prints a cache miss, the Actions cache transport worked, but the task fingerprint changed.
+
+## 4. Workspaces
+
+Cache reuse works with workspace task targets. Define cacheable tasks in the package that owns the target, then run the same `vp run` command in CI:
+
+```bash
+vp run -t @my/app#build
+```
+
+For workspace builds, keep automatic tracking and add the workspace lockfile as a workspace-relative input:
+
+```ts [vite.config.ts]
+import { defineConfig } from 'vite-plus';
+
+export default defineConfig({
+  run: {
+    tasks: {
+      build: {
+        command: 'vp build',
+        dependsOn: [{ task: 'build', from: 'dependencies' }],
+        input: [
+          { auto: true },
+          { pattern: 'pnpm-lock.yaml', base: 'workspace' },
+          '!dist',
+          '!dist/**',
+        ],
+        output: ['dist/**'],
+      },
+    },
+  },
+});
+```
+
+The object-form `dependsOn` runs `build` in direct workspace dependency packages that define that task. Each dependency can pull in more tasks through its own `dependsOn` config.
+
+When the task cache is restored, Vite Task can replay hits for the target package and its workspace dependencies. In a transitive `core -> util -> app` experiment, restoring only `node_modules/.vite/task-cache` in a fresh checkout produced `3/3` cache hits and restored each package's `dist/**` output.
+
+## Keep Inputs Stable Across CI Runs
+
+Vite Task's [automatic input tracking](/guide/cache#automatic-file-tracking) records file reads, missing-file probes, and directory listings. In CI, a command can read files that describe the dependency install or tool state rather than source behavior. Those reads can change between runs and cause misses after a successful GitHub cache restore.
+
+Treat these cases by root cause:
+
+- **Dependency install metadata.** Package managers and build tools can read install metadata to resolve packages, discover workspace layout, or configure file-system access. Track dependency identity with committed package manifests and lockfiles. For `vp build`, keep automatic tracking and add the lockfile as an input. Use explicit `input` globs only for commands with a small input set you can name.
+- **Tool-owned incremental state.** Tools such as TypeScript can write incremental state into a directory they also scan. A fresh checkout may lack that file, so the next run can miss because the directory listing changed. Move that state into a generated cache directory or use explicit task inputs. For TypeScript, set `--tsBuildInfoFile` to a generated cache location instead of writing `*.tsbuildinfo` next to source files.
+- **Task outputs.** If a task output also appears in the input fingerprint, deleting the output causes a miss instead of an output restore. Keep generated files out of `input`, then let Vite Task restore tracked outputs.
+- **Absolute arguments.** Vite Task stores command arguments in the fingerprint. If a command receives a different absolute checkout path between runs, it can miss with `args changed`. GitHub-hosted runners check out a repository under a stable path unless you override the checkout path. On self-hosted runners, keep the working directory stable or avoid absolute arguments.
+
+## Choose A Cache Key
+
+Use a rolling primary key plus a restore prefix:
+
+```yaml [.github/workflows/ci.yml]
+key: vite-task-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ github.run_id }}-${{ github.run_attempt }}
+restore-keys: |
+  vite-task-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}-
+```
+
+The exact key misses on each new run because the key contains `github.run_id` and `github.run_attempt`. GitHub then searches the restore prefix and restores the newest matching cache. Vite Task checks restored entries before replaying a task.
+
+Include:
+
+- `runner.os` and `runner.arch`, because outputs and native tools can be platform-specific.
+- Your lockfile hash, so GitHub restores caches from the same dependency graph.
+- A per-run value such as `github.run_id` and `github.run_attempt`, because GitHub cache entries are immutable.
+
+You can add a broader restore prefix only if the task inputs include the package manifests and lockfiles that define dependency identity. The broader prefix can save a download on some projects, but it can also restore a cache that Vite Task rejects task by task.
+
+## Limitations And Workarounds
+
+- **Cache entries are immutable.** Use a unique primary key per run and restore prefixes. GitHub will not update an existing cache entry in place.
+- **GitHub evicts caches.** GitHub removes caches that have not been accessed for over 7 days. It also evicts least-recently-used entries when repository cache storage exceeds its limit, which defaults to 10 GB. If this causes churn, narrow what you cache, delete stale entries, or increase the repository cache limit in GitHub settings.
+- **Cache scope is branch-aware.** Workflow runs can restore caches from the current branch and the default branch. Pull request merge-ref caches have limited scope and help re-runs of the same pull request. See [GitHub's dependency caching reference](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching) for the full branch and tag rules.
+- **Secrets can leak through cache contents.** Vite Task caches terminal output and configured output files. Keep secrets out of task logs and generated files that you cache.
+- **Output tracking can be too broad or too narrow.** By default, Vite Task restores files that the task writes. Use `output` globs such as `['dist/**']` when you want to narrow restoration. Use `{ auto: true }` with extra globs when you want automatic write tracking plus extra files.
+- **Failed tasks are not cached.** Vite Task saves successful task results. Fix failing lint, test, or build commands before expecting cache reuse.
+- **Toolchain changes can start cold.** Vite Task uses schema-versioned cache directories. If a restored cache was written by an incompatible version, Vite Task ignores those entries and reruns the task.
+
+::: tip
+Restore after dependency install because the default cache path lives under `node_modules`. If your workflow must restore before install, set a stable absolute `VITE_CACHE_PATH` outside `node_modules` for all `vp run` steps and cache that directory instead.
+:::

--- a/docs/guide/run.md
+++ b/docs/guide/run.md
@@ -102,10 +102,40 @@ See [Run Config](/config/run) for the full `run` block reference.
 
 ## Task Dependencies
 
-Use [`dependsOn`](/config/run#dependson) to run tasks in the right order. Running `vp run deploy` with the config above runs `build` and `test` first. Dependencies can also target other packages in the same project with the `package#task` notation:
+Use [`dependsOn`](/config/run#dependson) to run tasks in the right order. Running `vp run deploy` with the config above runs `build` and `test` first.
+
+String task names in `dependsOn` reference tasks in the current or another package:
 
 ```ts [vite.config.ts]
-dependsOn: ['@my/core#build', '@my/utils#lint'];
+dependsOn: [
+  'build', // same package
+  '@my/core#build', // another package
+];
+```
+
+Use the object form when you need to reference all tasks with a given name from the current package's dependencies:
+
+```ts [vite.config.ts]
+import { defineConfig } from 'vite-plus';
+
+export default defineConfig({
+  run: {
+    tasks: {
+      test: {
+        command: 'vp test',
+        dependsOn: [{ task: 'build', from: 'dependencies' }],
+      },
+    },
+  },
+});
+```
+
+In this example, `vp run test` checks the current package's `dependencies`. For each direct workspace dependency that defines `build`, Vite Task runs that dependency's `build` task before `test`.
+
+Use an array when you need more than one dependency field:
+
+```ts [vite.config.ts]
+dependsOn: [{ task: 'build', from: ['dependencies', 'devDependencies'] }];
 ```
 
 ## Running in a Workspace

--- a/docs/guide/tool-reported-caching.md
+++ b/docs/guide/tool-reported-caching.md
@@ -1,0 +1,73 @@
+# Tool-Reported Caching
+
+Tool-reported caching lets a tool report cache metadata to Vite Task while it runs. The tool can report inputs, outputs, and environment variables that affect its result.
+
+Use this page when a tool can report cache behavior that task config should not duplicate.
+
+## Current Support
+
+Vite+ supports tool-reported caching for `vp build` today.
+
+When a task runs `vp build`, Vite reports build cache metadata to Vite Task. For a standard Vite build, you do not need to add these entries yourself:
+
+- `env: ['VITE_*']` or `env: ['NODE_ENV']`
+- `output: ['dist/**']`
+- explicit input globs that replace automatic input tracking
+
+Define the task through `vp run`:
+
+```ts [vite.config.ts]
+import { defineConfig } from 'vite-plus';
+
+export default defineConfig({
+  run: {
+    tasks: {
+      build: 'vp build',
+    },
+  },
+});
+```
+
+Then run it with:
+
+```bash
+vp run build
+```
+
+## When To Add Manual Config
+
+Tool-reported caching does not remove manual config. Add [`input`](/config/run#input), [`output`](/config/run#output), or [`env`](/config/run#env) when your project has behavior the tool cannot know.
+
+Common cases:
+
+- Add lockfiles or generated metadata that should affect [CI cache reuse](/guide/github-actions-cache).
+- Exclude generated output directories from automatic inputs.
+- Add custom environment variables that your own build wrapper reads.
+
+For example, a CI build can keep automatic inputs and add the lockfile:
+
+```ts [vite.config.ts]
+build: {
+  command: 'vp build',
+  input: [{ auto: true }, 'pnpm-lock.yaml', '!dist', '!dist/**'],
+  output: ['dist/**'],
+}
+```
+
+## Environment Variables
+
+For `vp build`, Vite reports the Vite environment variables that affect the build. Do not add `VITE_*` or `NODE_ENV` to [`env`](/config/run#env) or [`untrackedEnv`](/config/run#untrackedenv) for a standard Vite build.
+
+For other commands, use `env` when a variable changes the result, and use `untrackedEnv` only when the task needs the variable but the value does not affect cache behavior.
+
+## Third-Party Tools
+
+Third-party tools can report cache metadata with [`@voidzero-dev/vite-task-client`](https://npmx.dev/package/@voidzero-dev/vite-task-client).
+
+Tool-reported caching works with Vite Task's [automatic file tracking](/guide/cache#automatic-file-tracking). Vite Task still observes file reads and writes, and the tool report adds metadata the tool knows at runtime.
+
+## Future Support
+
+Vite+ will add tool-reported caching to more first-party tools as those integrations are built.
+
+Until a tool supports tool-reported caching, configure cache behavior with [`input`](/config/run#input), [`output`](/config/run#output), and [`env`](/config/run#env).


### PR DESCRIPTION
## Summary

- Add an experimental guide for reusing Vite Task cache with GitHub Actions cache.
- Add a standalone Tool-Reported Caching guide under Execute and link it from task caching, CI caching, and run config docs.
- Clarify `dependsOn`, `env`, `untrackedEnv`, `input`, and `output` reference behavior needed by the cache examples.

## Validation

- `vp fmt docs/.vitepress/config.mts docs/config/run.md docs/guide/cache.md docs/guide/ci.md docs/guide/github-actions-cache.md docs/guide/run.md docs/guide/tool-reported-caching.md --check`
- `git diff --check`
- `pnpm -C docs build`
- Rendered HTML anchor check for `untrackedEnv`
- Implementation checks against `packages/cli/src/run-config.ts` and `packages/cli/binding/src/cli/resolver.rs`
- GitHub cache behavior checked against `actions/cache` v6.1.0 docs

## Stack

Stacked on #1991, which skips full CI for docs-only PRs. This PR should still run docs preview/build checks, but full CI, CLI E2E, and snap-test matrices should skip.

## Notes

The GitHub Actions cache guide is marked experimental. I did not run a live GitHub Actions cache workflow for this branch.