### PR TITLE
ci: skip full CI for docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,11 @@ jobs:
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
+          predicate-quantifier: every
           filters: |
             code:
               - '!**/*.md'
+              - '!docs/**'
 
   download-previous-rolldown-binaries:
     needs: detect-changes


### PR DESCRIPTION
## Summary

- Exclude `docs/**` from the main CI workflow's `code` path filter.
- Set `predicate-quantifier: every` so negative path patterns combine correctly.

## Why

Docs-only PRs can include non-Markdown docs files such as `docs/.vitepress/config.mts`. The old filter treated any non-`.md` file as code, which scheduled full CI, CLI E2E, and snapshot matrices for docs-only changes.