### PR TITLE
ci: cache Vite Task output for docs builds

### DIFF
--- a/.github/workflows/deploy-docs-preview.yml
+++ b/.github/workflows/deploy-docs-preview.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           path: docs/node_modules/.vite/task-cache
           key: vite-task-docs-${{ runner.os }}-${{ runner.arch }}-pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+          # Prefer this PR's newest cache, then fall back to main for new PRs.
           restore-keys: |
             vite-task-docs-${{ runner.os }}-${{ runner.arch }}-pr-${{ github.event.pull_request.number }}-
             vite-task-docs-${{ runner.os }}-${{ runner.arch }}-main-

--- a/.github/workflows/deploy-docs-preview.yml
+++ b/.github/workflows/deploy-docs-preview.yml
@@ -40,6 +40,9 @@ jobs:
       - run: vp run build
         working-directory: docs
 
+      - run: vp run build
+        working-directory: docs
+
       - run: vpx void deploy --dir docs/.vitepress/dist
         env:
           VOID_TOKEN: ${{ secrets.VOID_TOKEN }}

--- a/.github/workflows/deploy-docs-preview.yml
+++ b/.github/workflows/deploy-docs-preview.yml
@@ -37,11 +37,28 @@ jobs:
           working-directory: docs
           cache-dependency-path: docs/pnpm-lock.yaml
 
+      - name: Restore Vite Task cache
+        id: vite-task-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: docs/node_modules/.vite/task-cache
+          key: vite-task-docs-${{ runner.os }}-${{ runner.arch }}-pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+          restore-keys: |
+            vite-task-docs-${{ runner.os }}-${{ runner.arch }}-pr-${{ github.event.pull_request.number }}-
+            vite-task-docs-${{ runner.os }}-${{ runner.arch }}-main-
+
       - run: vp run build
         working-directory: docs
 
       - run: vp run build
         working-directory: docs
+
+      - name: Save Vite Task cache
+        if: success() && steps.vite-task-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: docs/node_modules/.vite/task-cache
+          key: ${{ steps.vite-task-cache.outputs.cache-primary-key }}
 
       - run: vpx void deploy --dir docs/.vitepress/dist
         env:

--- a/.github/workflows/deploy-docs-preview.yml
+++ b/.github/workflows/deploy-docs-preview.yml
@@ -32,6 +32,8 @@ jobs:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 
       - uses: voidzero-dev/setup-vp@13e7afb99c66525824db54e107d667216e795d37 # main
+        env:
+          VP_PR_VERSION: 0fecc75a64a39bc5600ff6a1cee8baff378a8cc1
         with:
           cache: true
           working-directory: docs

--- a/.github/workflows/deploy-docs-preview.yml
+++ b/.github/workflows/deploy-docs-preview.yml
@@ -50,9 +50,6 @@ jobs:
       - run: vp run build
         working-directory: docs
 
-      - run: vp run build
-        working-directory: docs
-
       - name: Save Vite Task cache
         if: success() && steps.vite-task-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6

--- a/.github/workflows/deploy-docs-preview.yml
+++ b/.github/workflows/deploy-docs-preview.yml
@@ -37,7 +37,7 @@ jobs:
           working-directory: docs
           cache-dependency-path: docs/pnpm-lock.yaml
 
-      - name: Restore Vite Task cache
+      - name: Restore docs Vite Task cache
         id: vite-task-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
@@ -50,7 +50,7 @@ jobs:
       - run: vp run build
         working-directory: docs
 
-      - name: Save Vite Task cache
+      - name: Save docs Vite Task cache
         if: success() && steps.vite-task-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:

--- a/.github/workflows/deploy-docs-preview.yml
+++ b/.github/workflows/deploy-docs-preview.yml
@@ -32,8 +32,6 @@ jobs:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 
       - uses: voidzero-dev/setup-vp@13e7afb99c66525824db54e107d667216e795d37 # main
-        env:
-          VP_PR_VERSION: 0fecc75a64a39bc5600ff6a1cee8baff378a8cc1
         with:
           cache: true
           working-directory: docs

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -40,6 +40,9 @@ jobs:
       - run: vp run build
         working-directory: docs
 
+      - run: vp run build
+        working-directory: docs
+
       - run: vpx void deploy --dir docs/.vitepress/dist
         env:
           VOID_TOKEN: ${{ secrets.VOID_TOKEN }}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -37,7 +37,7 @@ jobs:
           working-directory: docs
           cache-dependency-path: docs/pnpm-lock.yaml
 
-      - name: Restore Vite Task cache
+      - name: Restore docs Vite Task cache
         id: vite-task-cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
@@ -49,7 +49,7 @@ jobs:
       - run: vp run build
         working-directory: docs
 
-      - name: Save Vite Task cache
+      - name: Save docs Vite Task cache
         if: success() && steps.vite-task-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -49,9 +49,6 @@ jobs:
       - run: vp run build
         working-directory: docs
 
-      - run: vp run build
-        working-directory: docs
-
       - name: Save Vite Task cache
         if: success() && steps.vite-task-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -37,11 +37,27 @@ jobs:
           working-directory: docs
           cache-dependency-path: docs/pnpm-lock.yaml
 
+      - name: Restore Vite Task cache
+        id: vite-task-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: docs/node_modules/.vite/task-cache
+          key: vite-task-docs-${{ runner.os }}-${{ runner.arch }}-main-${{ github.sha }}
+          restore-keys: |
+            vite-task-docs-${{ runner.os }}-${{ runner.arch }}-main-
+
       - run: vp run build
         working-directory: docs
 
       - run: vp run build
         working-directory: docs
+
+      - name: Save Vite Task cache
+        if: success() && steps.vite-task-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: docs/node_modules/.vite/task-cache
+          key: ${{ steps.vite-task-cache.outputs.cache-primary-key }}
 
       - run: vpx void deploy --dir docs/.vitepress/dist
         env:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           path: docs/node_modules/.vite/task-cache
           key: vite-task-docs-${{ runner.os }}-${{ runner.arch }}-main-${{ github.sha }}
+          # Restore the latest main cache; Vite Task fingerprints decide reuse.
           restore-keys: |
             vite-task-docs-${{ runner.os }}-${{ runner.arch }}-main-
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -32,6 +32,8 @@ jobs:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 
       - uses: voidzero-dev/setup-vp@13e7afb99c66525824db54e107d667216e795d37 # main
+        env:
+          VP_PR_VERSION: 0fecc75a64a39bc5600ff6a1cee8baff378a8cc1
         with:
           cache: true
           working-directory: docs

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -32,8 +32,6 @@ jobs:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
 
       - uses: voidzero-dev/setup-vp@13e7afb99c66525824db54e107d667216e795d37 # main
-        env:
-          VP_PR_VERSION: 0fecc75a64a39bc5600ff6a1cee8baff378a8cc1
         with:
           cache: true
           working-directory: docs

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "dev": "vitepress dev",
-    "build": "cp ../packages/cli/install.sh ../packages/cli/install.ps1 public/ && vitepress build",
+    "build": "cp ../packages/cli/install.sh ../packages/cli/install.ps1 public/ && vp run build:site",
+    "build:netlify": "cp ../packages/cli/install.sh ../packages/cli/install.ps1 public/ && vitepress build",
     "preview": "vitepress preview",
     "update-trusted-stack-stats": "node .vitepress/theme/data/fetch-trusted-stack-stats.ts"
   },

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -8,7 +8,6 @@ export default {
           '!.vitepress/.temp/**',
           '!.vitepress/dist/**',
           '!node_modules',
-          '!node_modules/.vite-temp',
           '!node_modules/.vite-temp/**',
         ],
         output: ['.vitepress/dist/**'],

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -1,0 +1,16 @@
+export default {
+  run: {
+    tasks: {
+      'build:site': {
+        command: 'vitepress build',
+        input: [
+          { auto: true },
+          '!.vitepress/.temp/**',
+          '!.vitepress/dist/**',
+          '!node_modules/.vite-temp/**',
+        ],
+        output: ['.vitepress/dist/**'],
+      },
+    },
+  },
+};

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -7,6 +7,8 @@ export default {
           { auto: true },
           '!.vitepress/.temp/**',
           '!.vitepress/dist/**',
+          '!node_modules',
+          '!node_modules/.vite-temp',
           '!node_modules/.vite-temp/**',
         ],
       },

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -3,12 +3,7 @@ export default {
     tasks: {
       'build:site': {
         command: 'vitepress build',
-        input: [
-          { auto: true },
-          '!.vitepress/.temp/**',
-          '!.vitepress/dist/**',
-          '!node_modules/.vite-temp/**',
-        ],
+        input: [{ auto: true }, '!.vitepress/.temp/**', '!.vitepress/dist/**'],
         output: ['.vitepress/dist/**'],
       },
     },

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -9,7 +9,6 @@ export default {
           '!.vitepress/dist/**',
           '!node_modules/.vite-temp/**',
         ],
-        output: ['.vitepress/dist/**'],
       },
     },
   },

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -10,6 +10,7 @@ export default {
           '!node_modules',
           '!node_modules/.vite-temp/**',
         ],
+        output: ['.vitepress/dist/**'],
       },
     },
   },

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -10,7 +10,6 @@ export default {
           '!node_modules',
           '!node_modules/.vite-temp/**',
         ],
-        output: ['.vitepress/dist/**'],
       },
     },
   },

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -11,6 +11,7 @@ export default {
           '!node_modules/.vite-temp',
           '!node_modules/.vite-temp/**',
         ],
+        output: ['.vitepress/dist/**'],
       },
     },
   },

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -3,7 +3,12 @@ export default {
     tasks: {
       'build:site': {
         command: 'vitepress build',
-        input: [{ auto: true }, '!.vitepress/.temp/**', '!.vitepress/dist/**'],
+        input: [
+          { auto: true },
+          '!.vitepress/.temp/**',
+          '!.vitepress/dist/**',
+          '!node_modules/.vite-temp/**',
+        ],
         output: ['.vitepress/dist/**'],
       },
     },

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,9 +3,6 @@ base = "docs/"
 command = "pnpm build:netlify"
 publish = ".vitepress/dist"
 
-[build.environment]
-NODE_VERSION = "22.18.0"
-
 # Windows installer redirect
 [[redirects]]
 from = "/vp-setup"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,10 @@
 [build]
 base = "docs/"
-command = "pnpm build"
+command = "pnpm build:netlify"
 publish = ".vitepress/dist"
+
+[build.environment]
+NODE_VERSION = "22.18.0"
 
 # Windows installer redirect
 [[redirects]]


### PR DESCRIPTION
## Summary

- Keep the root `docs:build` script as `pnpm -C docs build`.
- Move the cacheable docs build inside `docs/`: `docs` now runs installer asset copying first, then delegates `vitepress build` to the cacheable Vite Task `build:site`.
- Configure `build:site` in `docs/vite.config.ts` with automatic input tracking, necessary generated-file exclusions, and explicit `.vitepress/dist/**` output tracking.
- Add Vite Task cache restore/save steps to `deploy-docs.yml` and `deploy-docs-preview.yml` using `docs/node_modules/.vite/task-cache`.
- Keep Netlify on `pnpm build:netlify`, which runs `vitepress build` directly without `vp`.
- Use the released Vite+ package through `setup-vp` now that the task-cache behavior is available in v0.2.2.


## Time Saved

**The cache-hit verification run reported `23.14s saved` for replaying `vitepress build`.**

- Cache restored: ~13 MB (`13,374,673 B`).
- Restore/download/extract overhead: ~0.41s.
- Net saving after restore overhead: ~22.73s.
- Save/upload overhead for the new PR-scoped key: ~0.69s.
- **Net saving including download & upload overhead: ~22.04s.**


## Cache Verification

| Scenario | Run | Result |
| --- | --- | --- |
| Relevant docs task config change | [Deploy Docs Preview run 28558655161, job 84671537096](https://github.com/voidzero-dev/vite-plus/actions/runs/28558655161/job/84671537096) | Restored the previous PR cache, then `vitepress build` missed with `cache miss: output configuration changed, executing`; saved a new PR cache key for `96913ac2`. |
| Irrelevant workflow-only change | [Deploy Docs Preview run 28559033970, job 84672667814](https://github.com/voidzero-dev/vite-plus/actions/runs/28559033970/job/84672667814) | Restored the PR cache from `96913ac2`, then `vitepress build` hit with `cache hit, replaying`; saved a new PR cache key for `0bfe9c6e`. This verification commit was later dropped from branch history. |
| Rewritten current PR head | [Deploy Docs Preview run 28559971286, job 84675438841](https://github.com/voidzero-dev/vite-plus/actions/runs/28559971286/job/84675438841) | Restored the prior PR cache, replayed `vitepress build`, and saved the current PR-head cache key for `893293ac`. |

## Validation

- Verified the relevant-change push misses and updates the PR cache.
- Verified an irrelevant change restores the previous PR cache and hits `vitepress build`.
- Verified the post-rewrite PR head still restores the prior PR cache and hits `vitepress build`.
- Latest PR checks are green: 12 passed, 16 skipped, 2 neutral, 0 pending, 0 failed.

## Notes

The generated input exclusions remain necessary because VitePress reads and writes generated `.vitepress` and `node_modules/.vite-temp` files during the cacheable build. Explicit `output` is included so cached builds restore `.vitepress/dist` reliably.