### PR TITLE
ci: skip full CI for docs deploy config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
             code:
               - '!**/*.md'
               - '!docs/**'
+              - '!.github/workflows/deploy-docs-preview.yml'
+              - '!.github/workflows/deploy-docs.yml'
+              - '!netlify.toml'
 
   download-previous-rolldown-binaries:
     needs: detect-changes


### PR DESCRIPTION
## Summary

- Treat docs deployment config as non-code for the main CI change detector.
- Exclude `deploy-docs-preview.yml`, `deploy-docs.yml`, and `netlify.toml` from `CI`'s `code` path filter.

## Why

The docs-cache PR changes docs deployment plumbing. Without these exclusions, those deployment config files make `detect-changes` report code changes and fan out the full CI matrix even though the product/runtime code did not change.

## Validation

- Stacked PR #2006 on top of this branch to verify the docs-cache PR no longer runs the full CI matrix.
