### PR TITLE
test(snap): pin VP_VERSION to a published version in install fixtures

### DIFF
--- a/packages/cli/snap-tests-global/create-framework-shim-astro/steps.json
+++ b/packages/cli/snap-tests-global/create-framework-shim-astro/steps.json
@@ -1,5 +1,8 @@
 {
   "ignoredPlatforms": ["win32"],
+  "env": {
+    "VP_VERSION": "0.2.1"
+  },
   "commands": [
     {
       "command": "vp create astro --no-interactive -- my-astro-app --yes --skip-houston --template basics # create Astro app",

--- a/packages/cli/snap-tests-global/create-framework-shim-vue/steps.json
+++ b/packages/cli/snap-tests-global/create-framework-shim-vue/steps.json
@@ -1,6 +1,9 @@
 {
   "ignoredPlatforms": ["win32", { "os": "linux", "libc": "musl" }],
   "linkCheckoutPackages": true,
+  "env": {
+    "VP_VERSION": "0.2.1"
+  },
   "commands": [
     {
       "command": "vp create vite:application --no-interactive -- --template vue-ts # create Vue+TS app",

--- a/packages/cli/snap-tests-global/migration-framework-shim-astro-vue/steps.json
+++ b/packages/cli/snap-tests-global/migration-framework-shim-astro-vue/steps.json
@@ -1,6 +1,7 @@
 {
   "ignoredPlatforms": ["win32"],
   "env": {
+    "VP_VERSION": "0.2.1",
     "VITE_DISABLE_AUTO_INSTALL": "1",
     "CI": "",
     "VP_SKIP_INSTALL": ""

--- a/packages/cli/snap-tests-global/migration-framework-shim-astro/steps.json
+++ b/packages/cli/snap-tests-global/migration-framework-shim-astro/steps.json
@@ -1,6 +1,7 @@
 {
   "ignoredPlatforms": ["win32"],
   "env": {
+    "VP_VERSION": "0.2.1",
     "VITE_DISABLE_AUTO_INSTALL": "1",
     "CI": "",
     "VP_SKIP_INSTALL": ""

--- a/packages/cli/snap-tests-global/migration-framework-shim-vue/steps.json
+++ b/packages/cli/snap-tests-global/migration-framework-shim-vue/steps.json
@@ -1,6 +1,7 @@
 {
   "ignoredPlatforms": ["win32"],
   "env": {
+    "VP_VERSION": "0.2.1",
     "VITE_DISABLE_AUTO_INSTALL": "1",
     "CI": "",
     "VP_SKIP_INSTALL": ""

--- a/packages/cli/snap-tests-global/migration-standalone-npm/steps.json
+++ b/packages/cli/snap-tests-global/migration-standalone-npm/steps.json
@@ -1,6 +1,7 @@
 {
   "ignoredPlatforms": ["win32"],
   "env": {
+    "VP_VERSION": "0.2.1",
     "VITE_DISABLE_AUTO_INSTALL": "1",
     "CI": "",
     "VP_SKIP_INSTALL": ""

--- a/packages/cli/snap-tests-global/migration-standalone-pnpm/steps.json
+++ b/packages/cli/snap-tests-global/migration-standalone-pnpm/steps.json
@@ -1,6 +1,7 @@
 {
   "ignoredPlatforms": ["win32"],
   "env": {
+    "VP_VERSION": "0.2.1",
     "VITE_DISABLE_AUTO_INSTALL": "1",
     "CI": "",
     "VP_SKIP_INSTALL": ""

--- a/packages/cli/snap-tests/create-approve-builds-bun/steps.json
+++ b/packages/cli/snap-tests/create-approve-builds-bun/steps.json
@@ -1,6 +1,7 @@
 {
   "ignoredPlatforms": ["win32"],
   "env": {
+    "VP_VERSION": "0.2.1",
     "VP_SKIP_INSTALL": "",
     "CI": "",
     "ADBLOCK": "1"

--- a/packages/cli/snap-tests/create-approve-builds-migrate-pnpm11/steps.json
+++ b/packages/cli/snap-tests/create-approve-builds-migrate-pnpm11/steps.json
@@ -1,5 +1,6 @@
 {
   "env": {
+    "VP_VERSION": "0.2.1",
     "VP_SKIP_INSTALL": "",
     "CI": "",
     "ADBLOCK": "1"

--- a/packages/cli/snap-tests/create-approve-builds-pnpm11/steps.json
+++ b/packages/cli/snap-tests/create-approve-builds-pnpm11/steps.json
@@ -1,5 +1,6 @@
 {
   "env": {
+    "VP_VERSION": "0.2.1",
     "VP_SKIP_INSTALL": "",
     "CI": "",
     "ADBLOCK": "1"

--- a/packages/cli/snap-tests/create-approve-builds-yarn/steps.json
+++ b/packages/cli/snap-tests/create-approve-builds-yarn/steps.json
@@ -1,5 +1,6 @@
 {
   "env": {
+    "VP_VERSION": "0.2.1",
     "VP_SKIP_INSTALL": "",
     "CI": "",
     "ADBLOCK": "1"

--- a/packages/cli/snap-tests/migration-standalone-bun-install/steps.json
+++ b/packages/cli/snap-tests/migration-standalone-bun-install/steps.json
@@ -1,6 +1,7 @@
 {
   "ignoredPlatforms": ["win32"],
   "env": {
+    "VP_VERSION": "0.2.1",
     "VP_SKIP_INSTALL": "",
     "CI": ""
   },


### PR DESCRIPTION
Release PR CI (`release/v0.2.2`) fails 12 snap fixtures: since #1891, `vp create` / `vp migrate` pin the exact CLI version, so fixtures that run a real package-manager install try to resolve `vite-plus@0.2.2` / `@voidzero-dev/vite-plus-core@0.2.2` from the registry before they are published (`ERR_PNPM_NO_MATCHING_VERSION`, bun/yarn `failed to resolve`). Example failure: https://github.com/voidzero-dev/vite-plus/actions/runs/28567193246

Pin `VP_VERSION` to the published `0.2.1` in those fixtures, the same approach the existing `migration-upgrade-version-table-pnpm` fixture uses. Snapshot output is unchanged because the normalizer rewrites any version to `<semver>`, so the fixtures stay deterministic on main and on release branches.

Verified locally:

- Reproduced: setting `VP_VERSION=0.2.99` in `migration-standalone-bun-install` produces the exact release-branch failure (`error: vite-plus@<semver> failed to resolve`, `Dependency installation failed`).
- Fixed: with the `0.2.1` pin, `migration-standalone-bun-install` and all four `create-approve-builds-*` fixtures regenerate byte-identical `snap.txt`.
- The 7 `snap-tests-global` fixtures use the same `steps.json` env plumbing already exercised by `migration-upgrade-version-table-pnpm`.