### PR TITLE
ci: probe docs preview main cache fallback

### DIFF
--- a/.github/workflows/deploy-docs-preview.yml
+++ b/.github/workflows/deploy-docs-preview.yml
@@ -19,38 +19,8 @@ defaults:
     shell: bash
 
 jobs:
-  export-vite-task-caches:
-    if: github.event.pull_request.number == 2026
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: 92362796
-            key: vite-task-docs-Linux-X64-pr-2026-92362796f7d05cdaafba0037c5cb0fe0cb16eeef
-          - name: cddbc65b
-            key: vite-task-docs-Linux-X64-pr-2026-cddbc65b2eca6bfa7c9ecd36e99ad23d191037f4
-    steps:
-      - name: Restore ${{ matrix.name }} cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-        with:
-          path: docs/node_modules/.vite/task-cache
-          key: ${{ matrix.key }}
-          fail-on-cache-miss: true
-
-      - name: Export ${{ matrix.name }} cache
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: vite-task-cache-${{ matrix.name }}
-          path: docs/node_modules/.vite/task-cache
-          include-hidden-files: true
-          compression-level: 0
-          retention-days: 1
-
   staging-deploy:
-    if: false
+    if: github.repository == 'voidzero-dev/vite-plus'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/deploy-docs-preview.yml
+++ b/.github/workflows/deploy-docs-preview.yml
@@ -19,8 +19,38 @@ defaults:
     shell: bash
 
 jobs:
+  export-vite-task-caches:
+    if: github.event.pull_request.number == 2026
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: 92362796
+            key: vite-task-docs-Linux-X64-pr-2026-92362796f7d05cdaafba0037c5cb0fe0cb16eeef
+          - name: cddbc65b
+            key: vite-task-docs-Linux-X64-pr-2026-cddbc65b2eca6bfa7c9ecd36e99ad23d191037f4
+    steps:
+      - name: Restore ${{ matrix.name }} cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: docs/node_modules/.vite/task-cache
+          key: ${{ matrix.key }}
+          fail-on-cache-miss: true
+
+      - name: Export ${{ matrix.name }} cache
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vite-task-cache-${{ matrix.name }}
+          path: docs/node_modules/.vite/task-cache
+          include-hidden-files: true
+          compression-level: 0
+          retention-days: 1
+
   staging-deploy:
-    if: github.repository == 'voidzero-dev/vite-plus'
+    if: false
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/deploy-docs-preview.yml
+++ b/.github/workflows/deploy-docs-preview.yml
@@ -44,6 +44,7 @@ jobs:
           path: docs/node_modules/.vite/task-cache
           key: vite-task-docs-${{ runner.os }}-${{ runner.arch }}-pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
           # Prefer this PR's newest cache, then fall back to main for new PRs.
+          # Cache fallback probe: a workflow-only PR should be able to replay main.
           restore-keys: |
             vite-task-docs-${{ runner.os }}-${{ runner.arch }}-pr-${{ github.event.pull_request.number }}-
             vite-task-docs-${{ runner.os }}-${{ runner.arch }}-main-

--- a/docs/guide/cache.md
+++ b/docs/guide/cache.md
@@ -1,5 +1,7 @@
 # Task Caching
 
+<!-- cache miss probe: markdown input changed -->
+
 Vite Task can automatically track dependencies and cache tasks run through `vp run`.
 
 ## Overview


### PR DESCRIPTION
## Summary

- Add a workflow-only comment to `deploy-docs-preview.yml`.
- Add a markdown-only probe comment to `docs/guide/cache.md`.
- This is a cache fallback and invalidation probe for docs preview caching.

## Result: PR can replay main cache

Confirmed in [Deploy Docs Preview run 28633592137, job 84915309878](https://github.com/voidzero-dev/vite-plus/actions/runs/28633592137/job/84915309878):

- PR key requested: `vite-task-docs-Linux-X64-pr-2026-92362796f7d05cdaafba0037c5cb0fe0cb16eeef`
- Restored from main fallback: `vite-task-docs-Linux-X64-main-7575a9532b2f6c45cfdaa459a4c66c054dc53cf9`
- `vitepress build` result: `cache hit, replaying`
- Vite Task summary: `1/2 cache hit (50%), 23.72s saved`
- Saved a new PR-scoped cache key after the run: `vite-task-docs-Linux-X64-pr-2026-92362796f7d05cdaafba0037c5cb0fe0cb16eeef`

## Result: markdown change misses cache

Confirmed in [Deploy Docs Preview run 28633701063, job 84915631020](https://github.com/voidzero-dev/vite-plus/actions/runs/28633701063/job/84915631020):

- PR key requested: `vite-task-docs-Linux-X64-pr-2026-cddbc65b2eca6bfa7c9ecd36e99ad23d191037f4`
- Restored previous PR cache: `vite-task-docs-Linux-X64-pr-2026-92362796f7d05cdaafba0037c5cb0fe0cb16eeef`
- `vitepress build` result: `cache miss: 'guide/cache.md' modified, executing`
- Vite Task summary: `0/2 cache hit (0%)`
- Saved a new PR-scoped cache key after the miss: `vite-task-docs-Linux-X64-pr-2026-cddbc65b2eca6bfa7c9ecd36e99ad23d191037f4`

## Validation

- Latest PR checks completed with 11 passed, 16 skipped, 2 neutral, 0 pending, 0 failed.
