### PR TITLE
docs: update announcement links and callout for the beta release

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -154,7 +154,7 @@ export default extendConfig(
               { text: 'Releases', link: 'https://github.com/voidzero-dev/vite-plus/releases' },
               {
                 text: 'Announcement',
-                link: 'https://voidzero.dev/posts/announcing-vite-plus-alpha',
+                link: 'https://voidzero.dev/posts/announcing-vite-plus-beta',
               },
               {
                 text: 'Contributing',

--- a/docs/.vitepress/theme/components/home/Hero.vue
+++ b/docs/.vitepress/theme/components/home/Hero.vue
@@ -15,12 +15,12 @@
       <div class="flex flex-wrap items-center justify-center gap-5">
         <a href="/guide" target="_self" class="button button--primary"> Get started </a>
         <a
-          href="https://voidzero.dev/posts/announcing-vite-plus-alpha"
+          href="https://voidzero.dev/posts/announcing-vite-plus-beta"
           target="_blank"
           rel="noopener noreferrer"
           class="button"
         >
-          Read the Announcement
+          Read the Beta Announcement
         </a>
         <CopyPrompt />
       </div>

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -2,8 +2,8 @@
 
 Use this page when something in Vite+ is not behaving the way you expect.
 
-::: warning
-Vite+ is still in alpha. We are making frequent changes, adding features quickly, and we want feedback to help make it great.
+::: info
+Vite+ is in beta: stable, but not yet complete. We are adding features on the road to 1.0 and prioritize community feedback, so please [reach out](#asking-for-help) if something does not work as expected.
 :::
 
 ## Supported Tool Versions


### PR DESCRIPTION
The docs still linked the alpha announcement and described Vite+ as alpha. Now that the [beta announcement](https://voidzero.dev/posts/announcing-vite-plus-beta) is live:

- The hero button and the Resources nav link point to the beta announcement post, and the button is labeled "Read the Beta Announcement".
- The troubleshooting callout is reworded to match the beta post framing (stable, but not yet complete) and softened from a warning to an info box, since it now invites feedback instead of cautioning about instability.

The `guide/why.md` link to the alpha post is left as is because its `#performance-scale` anchor only exists there.