### PR TITLE
ci: pack local dirs for the registry bridge instead of pkg.pr.new

### DIFF
--- a/.claude/skills/test-pkg-pr-new-migrate/SKILL.md
+++ b/.claude/skills/test-pkg-pr-new-migrate/SKILL.md
@@ -16,7 +16,7 @@ Required inputs: a `<PR-or-SHA>` (the build to verify) and a `<project-path>`. I
 .github/scripts/test-pkg-pr-new-migrate.sh 1891 /path/to/npmx.dev --no-interactive
 ```
 
-- First arg is a PR number or commit SHA; the script resolves the immutable commit via the bridge `x-commit-key` header and verifies the bridge serves it (the preview publish workflow, triggered by the `pkg.pr.new` label, registers each commit).
+- First arg is a PR number or commit SHA; the script resolves the immutable commit via the bridge `x-commit-key` header and verifies the bridge serves it (the preview publish workflow, triggered by the `preview-build` label, registers each commit).
 - Never touches `~/.vite-plus`; clears only the workspace ROOT lockfile + `node_modules` before migrating; refuses a dirty worktree unless `ALLOW_DIRTY=1`; prints the project's `git status`/`diff` at the end — inspect that to confirm the migration result.
 
 **The build under test must include the "migrate writes the bridge registry" feature** (this session's work / current branch head onward). The harness no longer writes the registry itself — it relies on `vp migrate` doing it. Testing an older build with this harness would leave the project with no bridge registry, so its deps resolve from npmjs (`ERR_PNPM_NO_MATCHING_VERSION` on the `0.0.0-commit.<sha>` version). Always verify a fresh build of the branch, not a stale published commit.

--- a/.claude/skills/test-pkg-pr-new-migrate/SKILL.md
+++ b/.claude/skills/test-pkg-pr-new-migrate/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: test-pkg-pr-new-migrate
-description: Verify a pkg.pr.new build of vite-plus against a real project before release — run `vp migrate` from the pkg.pr.new commit against a local project, deps resolved through the registry bridge. Use when asked to verify/e2e-test a pkg.pr.new build against a project, "test PR #<N> on <project>", or check a prerelease against a repo.
+description: Verify a preview (registry bridge) build of vite-plus against a real project before release — run `vp migrate` from the preview commit against a local project, deps resolved through the registry bridge. Use when asked to verify/e2e-test a preview or pkg-pr-new build against a project, "test PR #<N> on <project>", or check a prerelease against a repo.
 allowed-tools: Bash, Read
 ---
 
-# Verify a pkg.pr.new build against one project
+# Verify a preview build against one project
 
 Installs an isolated global `vp` built from a registry bridge commit build and runs `vp migrate` on a specified local project. The global CLI and the migrated project both pin `vite-plus`/`vite` to the clearly-defined `0.0.0-commit.<sha>` build. `vp migrate` itself writes the bridge registry into the project's `.npmrc` (or `.yarnrc.yml` for Yarn Berry) so the deps resolve, during this run and in the project's own CI; this script only force-stages that file past `.gitignore`.
 
@@ -16,7 +16,7 @@ Required inputs: a `<PR-or-SHA>` (the build to verify) and a `<project-path>`. I
 .github/scripts/test-pkg-pr-new-migrate.sh 1891 /path/to/npmx.dev --no-interactive
 ```
 
-- First arg is a PR number or commit SHA; the script resolves the immutable commit via the bridge `x-commit-key` header and verifies the bridge serves it (the pkg.pr.new publish workflow registers each commit).
+- First arg is a PR number or commit SHA; the script resolves the immutable commit via the bridge `x-commit-key` header and verifies the bridge serves it (the preview publish workflow, triggered by the `pkg.pr.new` label, registers each commit).
 - Never touches `~/.vite-plus`; clears only the workspace ROOT lockfile + `node_modules` before migrating; refuses a dirty worktree unless `ALLOW_DIRTY=1`; prints the project's `git status`/`diff` at the end — inspect that to confirm the migration result.
 
 **The build under test must include the "migrate writes the bridge registry" feature** (this session's work / current branch head onward). The harness no longer writes the registry itself — it relies on `vp migrate` doing it. Testing an older build with this harness would leave the project with no bridge registry, so its deps resolve from npmjs (`ERR_PNPM_NO_MATCHING_VERSION` on the `0.0.0-commit.<sha>` version). Always verify a fresh build of the branch, not a stale published commit.

--- a/.github/scripts/test-pkg-pr-new-migrate.sh
+++ b/.github/scripts/test-pkg-pr-new-migrate.sh
@@ -108,16 +108,14 @@ resolved_ref="$available_commit"
 commit_version="0.0.0-commit.$resolved_ref"
 vite_core_spec="npm:@voidzero-dev/vite-plus-core@$commit_version"
 
-# The bridge only serves commit builds it has been told about (registered by the
-# pkg.pr.new publish workflow). Fail early with an actionable message instead of
-# letting the project install hit an opaque registry miss.
+# The bridge only serves commit builds published by the preview publish
+# workflow (triggered by the `pkg.pr.new` label). Fail early with an actionable
+# message instead of letting the project install hit an opaque registry miss.
 if ! curl -fsS "${bridge_registry}@voidzero-dev/vite-plus-core" 2>/dev/null |
   grep -q "0.0.0-commit.$resolved_ref"; then
   echo "error: the registry bridge has no build for commit $resolved_ref" >&2
-  echo "Ensure the pkg.pr.new publish workflow registered it, or register it manually:" >&2
-  echo "  curl -fsS -X POST -H \"authorization: Bearer \$PKG_PR_BRIDGE_ADMIN_TOKEN\" \\" >&2
-  echo "    -H 'content-type: application/json' -d '{\"ref\":\"commit.$resolved_ref\"}' \\" >&2
-  echo "    ${bridge_registry}-/refs" >&2
+  echo "Publish it by re-adding the pkg.pr.new label to the PR (the preview publish" >&2
+  echo "workflow packs, uploads, and registers each labeled commit)." >&2
   exit 1
 fi
 

--- a/.github/scripts/test-pkg-pr-new-migrate.sh
+++ b/.github/scripts/test-pkg-pr-new-migrate.sh
@@ -109,13 +109,14 @@ commit_version="0.0.0-commit.$resolved_ref"
 vite_core_spec="npm:@voidzero-dev/vite-plus-core@$commit_version"
 
 # The bridge only serves commit builds published by the preview publish
-# workflow (triggered by the `pkg.pr.new` label). Fail early with an actionable
-# message instead of letting the project install hit an opaque registry miss.
+# workflow (triggered by the `preview-build` label). Fail early with an
+# actionable message instead of letting the project install hit an opaque
+# registry miss.
 if ! curl -fsS "${bridge_registry}@voidzero-dev/vite-plus-core" 2>/dev/null |
   grep -q "0.0.0-commit.$resolved_ref"; then
   echo "error: the registry bridge has no build for commit $resolved_ref" >&2
-  echo "Publish it by re-adding the pkg.pr.new label to the PR (the preview publish" >&2
-  echo "workflow packs, uploads, and registers each labeled commit)." >&2
+  echo "Publish it by re-adding the preview-build label to the PR (the preview" >&2
+  echo "publish workflow packs, uploads, and registers each labeled commit)." >&2
   exit 1
 fi
 

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -4,9 +4,7 @@ name: Publish preview build
 # (https://github.com/voidzero-dev/pkg-pr-registry-bridge), which serves it as
 # the npm version 0.0.0-commit.<sha>. Registered builds:
 # https://registry-bridge.viteplus.dev/-/refs
-# Triggered by adding the `preview-build` label (renamed from `pkg.pr.new`,
-# which predates the bridge). Renamed from publish-to-pkg.pr.new.yml; older
-# runs live under that workflow entry in the Actions UI.
+# Triggered by adding the `preview-build` label.
 
 permissions: {}
 

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -4,9 +4,9 @@ name: Publish preview build
 # (https://github.com/voidzero-dev/pkg-pr-registry-bridge), which serves it as
 # the npm version 0.0.0-commit.<sha>. Registered builds:
 # https://registry-bridge.viteplus.dev/-/refs
-# The `pkg.pr.new` label name predates the bridge and is kept for muscle
-# memory. Renamed from publish-to-pkg.pr.new.yml; older runs live under that
-# workflow entry in the Actions UI.
+# Triggered by adding the `preview-build` label (renamed from `pkg.pr.new`,
+# which predates the bridge). Renamed from publish-to-pkg.pr.new.yml; older
+# runs live under that workflow entry in the Actions UI.
 
 permissions: {}
 
@@ -22,7 +22,7 @@ jobs:
   prepare:
     if: >-
       github.repository == 'voidzero-dev/vite-plus' &&
-      contains(github.event.pull_request.labels.*.name, 'pkg.pr.new')
+      contains(github.event.pull_request.labels.*.name, 'preview-build')
     name: Compute snapshot version
     runs-on: ubuntu-latest
     permissions:
@@ -43,7 +43,7 @@ jobs:
     name: Build bindings and binaries
     if: >-
       github.repository == 'voidzero-dev/vite-plus' &&
-      contains(github.event.pull_request.labels.*.name, 'pkg.pr.new')
+      contains(github.event.pull_request.labels.*.name, 'preview-build')
     needs: prepare
     permissions:
       contents: read
@@ -55,7 +55,7 @@ jobs:
   publish:
     if: >-
       github.repository == 'voidzero-dev/vite-plus' &&
-      contains(github.event.pull_request.labels.*.name, 'pkg.pr.new')
+      contains(github.event.pull_request.labels.*.name, 'preview-build')
     name: Pkg Preview
     runs-on: ubuntu-latest
     needs:
@@ -265,7 +265,7 @@ jobs:
   publish-docker-preview:
     if: >-
       github.repository == 'voidzero-dev/vite-plus' &&
-      contains(github.event.pull_request.labels.*.name, 'pkg.pr.new')
+      contains(github.event.pull_request.labels.*.name, 'preview-build')
     name: Docker preview image
     runs-on: ubuntu-latest
     needs: publish
@@ -312,7 +312,7 @@ jobs:
   comment-docker-preview:
     if: >-
       github.repository == 'voidzero-dev/vite-plus' &&
-      contains(github.event.pull_request.labels.*.name, 'pkg.pr.new')
+      contains(github.event.pull_request.labels.*.name, 'preview-build')
     name: Comment Docker preview
     runs-on: ubuntu-latest
     needs: publish-docker-preview

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -5,8 +5,8 @@ name: Publish preview build
 # the npm version 0.0.0-commit.<sha>. Registered builds:
 # https://registry-bridge.viteplus.dev/-/refs
 # The `pkg.pr.new` label name predates the bridge and is kept for muscle
-# memory, as is this workflow's file name (renaming it would sever the Actions
-# run history).
+# memory. Renamed from publish-to-pkg.pr.new.yml; older runs live under that
+# workflow entry in the Actions UI.
 
 permissions: {}
 

--- a/.github/workflows/publish-to-pkg.pr.new.yml
+++ b/.github/workflows/publish-to-pkg.pr.new.yml
@@ -1,6 +1,12 @@
-name: Publish to pkg.pr.new
+name: Publish preview build
 
-# https://pkg.pr.new/~/voidzero-dev/vite-plus
+# Publishes a labeled PR's commit build to the registry bridge
+# (https://github.com/voidzero-dev/pkg-pr-registry-bridge), which serves it as
+# the npm version 0.0.0-commit.<sha>. Registered builds:
+# https://registry-bridge.viteplus.dev/-/refs
+# The `pkg.pr.new` label name predates the bridge and is kept for muscle
+# memory, as is this workflow's file name (renaming it would sever the Actions
+# run history).
 
 permissions: {}
 
@@ -56,12 +62,12 @@ jobs:
       - prepare
       - build-rust
     permissions:
-      # pkg-pr-new comments on PRs and posts run statuses with this token.
       contents: read
-      pull-requests: write
       # The "Comment bridge version" step creates/updates a sticky comment via
-      # github.rest.issues.createComment/updateComment; creating an issue comment
-      # is gated on issues:write (the create path runs on PRs without one yet).
+      # github.rest.issues.createComment/updateComment; comment writes on PRs
+      # are gated on pull-requests:write, and creating an issue comment is
+      # gated on issues:write (the create path runs on PRs without one yet).
+      pull-requests: write
       issues: write
     env:
       VERSION: ${{ needs.prepare.outputs.version }}
@@ -127,33 +133,22 @@ jobs:
           pattern: vite-global-cli-*
 
       # Stops short of `npm publish` and leaves packages/cli/{npm,cli-npm}/*
-      # on disk for pkg-pr-new to upload.
+      # on disk for the bridge action to pack.
       - name: Prepare native addon and CLI binary packages
         run: node ./packages/cli/publish-native-addons.ts --mode pkg-pr-new
 
-      - name: Publish to pkg.pr.new
-        run: |
-          pnpm dlx pkg-pr-new publish --compact --pnpm \
-            './packages/cli/npm/*' \
-            './packages/cli/cli-npm/*' \
-            './packages/cli' \
-            './packages/core' \
-            './packages/prompts'
-
-      # Publish this commit build to the pkg.pr.new registry bridge so it can be
-      # installed as the npm version 0.0.0-commit.<sha>
-      # (https://github.com/voidzero-dev/pkg-pr-registry-bridge). The bridge action
-      # packs the locally built package directories prepared above (the two
-      # preview packages and every platform binary), re-packs them under the
-      # commit version with matching integrity, uploads them to the bridge, and
-      # registers the ref. It packs from disk with `pnpm pack`, so it no longer
-      # downloads from pkg.pr.new and is independent of the publish step above
-      # (it just needs the workspace installed, which it is). This build publishes
-      # under the PR head commit, so pass that SHA (not the merge commit
-      # github.sha). Restricted to same-repo PRs because fork PRs do not receive
-      # the admin token secret. A bridge failure fails the job: install.sh and
-      # the Docker preview install PR builds through the bridge, so a silently
-      # missing ref would only surface later as a broken install.
+      # Publish this commit build to the registry bridge so it can be installed
+      # as the npm version 0.0.0-commit.<sha>
+      # (https://github.com/voidzero-dev/pkg-pr-registry-bridge). The bridge
+      # action packs the locally built package directories prepared above (the
+      # two preview packages and every platform binary) with `pnpm pack`,
+      # re-packs them under the commit version with matching integrity, uploads
+      # them to the bridge, and registers the ref. This build publishes under
+      # the PR head commit, so pass that SHA (not the merge commit github.sha).
+      # Restricted to same-repo PRs because fork PRs do not receive the admin
+      # token secret. A bridge failure fails the job: install.sh and the Docker
+      # preview install PR builds through the bridge, so a silently missing ref
+      # would only surface later as a broken install.
       - name: Register commit build with the registry bridge
         id: bridge
         if: github.event.pull_request.head.repo.full_name == github.repository
@@ -161,9 +156,9 @@ jobs:
         with:
           sha: ${{ github.event.pull_request.head.sha }}
           admin-token: ${{ secrets.PKG_PR_BRIDGE_ADMIN_TOKEN }}
-          # The locally built directories to pack and publish, matching the
-          # pkg-pr-new publish list above so the two stay in sync. (This is also
-          # the action's default, passed explicitly for review parity.)
+          # The locally built directories to pack and publish. (This is also
+          # the action's default, passed explicitly so the published set is
+          # reviewable here.)
           packages: |
             packages/cli/npm/*
             packages/cli/cli-npm/*
@@ -200,7 +195,7 @@ jobs:
               '',
               `### Registry bridge build (\`${shortSha}\`)`,
               '',
-              'This commit is published to pkg.pr.new and registered with the [registry bridge](https://github.com/voidzero-dev/pkg-pr-registry-bridge), which serves these as ordinary npm versions (every other package proxies to npmjs):',
+              'This commit build is published to the [registry bridge](https://github.com/voidzero-dev/pkg-pr-registry-bridge), which serves these as ordinary npm versions (every other package proxies to npmjs):',
               '',
               '| Package | Version |',
               '| --- | --- |',
@@ -264,9 +259,9 @@ jobs:
               });
             }
 
-  # Build and push a preview Docker image from the pkg.pr.new build so the image
-  # can be verified before a real release. Tagged `pr-<number>`; never `latest`.
-  # See docker/Dockerfile and docs/guide/docker.md.
+  # Build and push a preview Docker image from the registry bridge build so the
+  # image can be verified before a real release. Tagged `pr-<number>`; never
+  # `latest`. See docker/Dockerfile and docs/guide/docker.md.
   publish-docker-preview:
     if: >-
       github.repository == 'voidzero-dev/vite-plus' &&
@@ -292,8 +287,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Builds from the pkg.pr.new packages for this PR (VP_PR_VERSION). The
-      # platform packages must exist first, hence `needs: publish`.
+      # Builds from this PR's registry bridge build (VP_PR_VERSION resolves it
+      # through the bridge). The bridge must have the commit build first, hence
+      # `needs: publish`.
       # amd64-only: this throwaway preview avoids the slow arm64 QEMU leg; arm64
       # is covered by the release build and the test-install-sh-arm64 job.
       - name: Build and push preview image
@@ -358,7 +354,7 @@ jobs:
               marker,
               '## 🐳 Docker preview image',
               '',
-              "Built from this PR's pkg.pr.new build:",
+              "Built from this PR's registry bridge build:",
               '',
               '| Image | Compressed size |',
               '| --- | --- |',

--- a/.github/workflows/publish-to-pkg.pr.new.yml
+++ b/.github/workflows/publish-to-pkg.pr.new.yml
@@ -157,8 +157,7 @@ jobs:
       - name: Register commit build with the registry bridge
         id: bridge
         if: github.event.pull_request.head.repo.full_name == github.repository
-        # Pinned to the PR #56 branch head for verification; repin to main once it merges.
-        uses: voidzero-dev/pkg-pr-registry-bridge@72ef590d3d6c82ddbd21fc4d029c7e7641300755 # feat/action-local-pack (PR #56)
+        uses: voidzero-dev/pkg-pr-registry-bridge@711e22a2e1ae55d809fc5fab514c1180a41ac91e # main
         with:
           sha: ${{ github.event.pull_request.head.sha }}
           admin-token: ${{ secrets.PKG_PR_BRIDGE_ADMIN_TOKEN }}

--- a/.github/workflows/publish-to-pkg.pr.new.yml
+++ b/.github/workflows/publish-to-pkg.pr.new.yml
@@ -151,12 +151,12 @@ jobs:
       # (it just needs the workspace installed, which it is). This build publishes
       # under the PR head commit, so pass that SHA (not the merge commit
       # github.sha). Restricted to same-repo PRs because fork PRs do not receive
-      # the admin token secret; never fails the publish if the bridge is
-      # unreachable.
+      # the admin token secret. A bridge failure fails the job: install.sh and
+      # the Docker preview install PR builds through the bridge, so a silently
+      # missing ref would only surface later as a broken install.
       - name: Register commit build with the registry bridge
         id: bridge
         if: github.event.pull_request.head.repo.full_name == github.repository
-        continue-on-error: true
         # Pinned to the PR #56 branch head for verification; repin to main once it merges.
         uses: voidzero-dev/pkg-pr-registry-bridge@72ef590d3d6c82ddbd21fc4d029c7e7641300755 # feat/action-local-pack (PR #56)
         with:
@@ -177,8 +177,8 @@ jobs:
 
       # Once the bridge has the commit build, post (or update) a sticky PR comment
       # with the resolved npm versions and per-package-manager registry config, so
-      # reviewers can install the build directly. Gated on the bridge step's real
-      # outcome (it is continue-on-error) and skipped for fork PRs.
+      # reviewers can install the build directly. The outcome gate skips this on
+      # fork PRs, where the bridge step itself is skipped.
       - name: Comment bridge version on the PR
         if: steps.bridge.outcome == 'success'
         continue-on-error: true

--- a/.github/workflows/publish-to-pkg.pr.new.yml
+++ b/.github/workflows/publish-to-pkg.pr.new.yml
@@ -143,22 +143,34 @@ jobs:
       # Publish this commit build to the pkg.pr.new registry bridge so it can be
       # installed as the npm version 0.0.0-commit.<sha>
       # (https://github.com/voidzero-dev/pkg-pr-registry-bridge). The bridge action
-      # downloads each pkg.pr.new package (the two preview packages and every
-      # platform binary), re-packs them under the commit version with matching
-      # integrity, uploads them to the bridge, and registers the ref (the CPU
-      # work that previously ran in the bridge's GitHub webhook). pkg-pr-new
-      # publishes under the PR head commit, so pass that SHA (not the merge
-      # commit github.sha). Restricted to same-repo PRs because fork PRs do not
-      # receive the admin token secret; never fails the publish if the bridge is
+      # packs the locally built package directories prepared above (the two
+      # preview packages and every platform binary), re-packs them under the
+      # commit version with matching integrity, uploads them to the bridge, and
+      # registers the ref. It packs from disk with `pnpm pack`, so it no longer
+      # downloads from pkg.pr.new and is independent of the publish step above
+      # (it just needs the workspace installed, which it is). This build publishes
+      # under the PR head commit, so pass that SHA (not the merge commit
+      # github.sha). Restricted to same-repo PRs because fork PRs do not receive
+      # the admin token secret; never fails the publish if the bridge is
       # unreachable.
       - name: Register commit build with the registry bridge
         id: bridge
         if: github.event.pull_request.head.repo.full_name == github.repository
         continue-on-error: true
-        uses: voidzero-dev/pkg-pr-registry-bridge@4072b814c54de94d12d11b5174d6eb2a74496b7c # main
+        # Pinned to the PR #56 branch head for verification; repin to main once it merges.
+        uses: voidzero-dev/pkg-pr-registry-bridge@72ef590d3d6c82ddbd21fc4d029c7e7641300755 # feat/action-local-pack (PR #56)
         with:
           sha: ${{ github.event.pull_request.head.sha }}
           admin-token: ${{ secrets.PKG_PR_BRIDGE_ADMIN_TOKEN }}
+          # The locally built directories to pack and publish, matching the
+          # pkg-pr-new publish list above so the two stay in sync. (This is also
+          # the action's default, passed explicitly for review parity.)
+          packages: |
+            packages/cli/npm/*
+            packages/cli/cli-npm/*
+            packages/cli
+            packages/core
+            packages/prompts
           # Surfaced by the bridge's /-/refs so a registered ref links back to its
           # PR. Always present here (this workflow only runs on pull_request).
           pr-url: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/reusable-release-build.yml
+++ b/.github/workflows/reusable-release-build.yml
@@ -64,7 +64,7 @@ jobs:
           set -euo pipefail
           # Stamp ${VERSION} as the [package] version so CARGO_PKG_VERSION matches
           # the version that gets published/installed (the release version, or
-          # 0.0.0-commit.<sha> for pkg.pr.new). Anchored to the line-start
+          # 0.0.0-commit.<sha> for preview builds). Anchored to the line-start
           # `version = "..."` so crate dependency versions are never touched.
           for f in crates/vite_global_cli/Cargo.toml packages/cli/binding/Cargo.toml; do
             node -e 'const fs=require("fs"),f=process.argv[1];fs.writeFileSync(f,fs.readFileSync(f,"utf8").replace(/^version = "[^"]*"/m,`version = "${process.env.VERSION}"`))' "$f"

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -2,12 +2,21 @@
 
 ## Publishing Preview Packages
 
-Publish to https://pkg.pr.new/~/voidzero-dev/vite-plus
+Add the `pkg.pr.new` label to the PR (the label name predates the registry
+bridge). Each labeled commit is published to the
+[registry bridge](https://registry-bridge.viteplus.dev/-/refs) as the npm
+version `0.0.0-commit.<sha>`; the PR gets a sticky comment with the exact
+version and install steps.
 
-Add the `pkg.pr.new` label to the PR.
-
-Use the commit sha, e.g.:
+Install a preview build with the install script (PR number or commit sha):
 
 ```sh
-pnpm add https://pkg.pr.new/voidzero-dev/vite-plus@sha
+curl -fsSL https://vite.plus | VP_PR_VERSION=1569 bash
+```
+
+Or pin it in a project through the bridge registry (`.npmrc`:
+`registry=https://registry-bridge.viteplus.dev/`):
+
+```sh
+pnpm add vite-plus@0.0.0-commit.<sha>
 ```

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -2,8 +2,7 @@
 
 ## Publishing Preview Packages
 
-Add the `pkg.pr.new` label to the PR (the label name predates the registry
-bridge). Each labeled commit is published to the
+Add the `preview-build` label to the PR. Each labeled commit is published to the
 [registry bridge](https://registry-bridge.viteplus.dev/-/refs) as the npm
 version `0.0.0-commit.<sha>`; the PR gets a sticky comment with the exact
 version and install steps.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@ LABEL org.opencontainers.image.source="https://github.com/voidzero-dev/vite-plus
 #   docker build --build-arg VP_VERSION=1.4.2 .
 ARG VP_VERSION=latest
 
-# Optional: build a preview image from a pkg.pr.new build instead of npm.
+# Optional: build a preview image from a registry bridge build instead of npm.
 # Set to a PR number or commit SHA; when set it overrides VP_VERSION.
 #   docker build --build-arg VP_PR_VERSION=1569 .
 ARG VP_PR_VERSION=
@@ -50,7 +50,7 @@ ENV VP_HOME=/home/vp/.vite-plus \
     PATH=/home/vp/.vite-plus/bin:$PATH
 
 # Install the vp global CLI. The installer downloads the platform package from
-# npm (or from pkg.pr.new when VP_PR_VERSION is set). Node.js itself is
+# npm (or from the registry bridge when VP_PR_VERSION is set). Node.js itself is
 # provisioned per-project by vp at build time, honoring `.node-version` /
 # `engines.node` / `devEngines.runtime`.
 #

--- a/docs/guide/upgrade.md
+++ b/docs/guide/upgrade.md
@@ -62,7 +62,7 @@ Then set the `vitest` override to that exact version, or rerun `vp migrate` to u
 
 Some Vite+ pull requests publish temporary packages for testing before an npm release. Treat these as nightly or bleeding-edge builds: they are useful when you want to verify a specific fix, test a fresh upstream dependency bump, or confirm a change before the next release. For day-to-day work, prefer the published `latest` release.
 
-Each commit on an eligible pull request is published to [pkg.pr.new](https://pkg.pr.new) and registered with the [registry bridge](https://registry-bridge.viteplus.dev/). The bridge serves these builds as ordinary npm versions of the form `0.0.0-commit.<sha>` and proxies every other package to the npm registry. That means you install a preview with normal version specs instead of mutable URLs, and the same versions resolve in CI.
+Each commit on an eligible pull request is published to the [registry bridge](https://registry-bridge.viteplus.dev/). The bridge serves these builds as ordinary npm versions of the form `0.0.0-commit.<sha>` and proxies every other package to the npm registry. That means you install a preview with normal version specs instead of mutable URLs, and the same versions resolve in CI.
 
 Both `vite-plus` and `@voidzero-dev/vite-plus-core` publish under the same `0.0.0-commit.<sha>` version. Each pull request carries a comment listing the exact version for its latest commit, along with ready-to-copy install steps.
 

--- a/packages/cli/install.ps1
+++ b/packages/cli/install.ps1
@@ -26,7 +26,7 @@ $LocalTgz = $env:VP_LOCAL_TGZ
 $LocalBinary = $env:VP_LOCAL_BINARY
 # PR number or commit SHA to install as a test build (registry bridge mode)
 $PrVersion = $env:VP_PR_VERSION
-# Registry bridge that serves pkg.pr.new builds as clearly-versioned packages.
+# Registry bridge that serves PR preview builds as clearly-versioned packages.
 # The pkg.pr.new-style download URL (BridgeDownloadBase) 302-redirects to a
 # canonical 0.0.0-commit.<sha> tarball; the registry (BridgeRegistry) resolves
 # those commit versions (and proxies everything else to npmjs) so a full install

--- a/packages/cli/install.sh
+++ b/packages/cli/install.sh
@@ -37,7 +37,7 @@ LOCAL_TGZ="${VP_LOCAL_TGZ:-}"
 LOCAL_BINARY="${VP_LOCAL_BINARY:-}"
 # PR number or commit SHA to install as a test build (registry bridge mode)
 PR_VERSION="${VP_PR_VERSION:-}"
-# Registry bridge that serves pkg.pr.new builds as clearly-versioned packages.
+# Registry bridge that serves PR preview builds as clearly-versioned packages.
 # The pkg.pr.new-style download URL (BRIDGE_DOWNLOAD_BASE) 302-redirects to a
 # canonical 0.0.0-commit.<sha> tarball; the registry (BRIDGE_REGISTRY) resolves
 # those commit versions (and proxies everything else to npmjs) so a full install

--- a/packages/cli/src/migration/migrator/package-json.ts
+++ b/packages/cli/src/migration/migrator/package-json.ts
@@ -159,7 +159,7 @@ export function rewritePackageJson(
   if (isForceOverrideMode()) {
     for (const { dependencies } of dependencyGroups) {
       if (dependencies?.[VITE_PLUS_NAME]) {
-        // The referenced catalog entry is rewritten to the pkg.pr.new target
+        // The referenced catalog entry is rewritten to the preview target
         // separately. Preserve named/default catalog references so projects
         // such as Vize do not gain an unnecessary default catalog.
         if (

--- a/packages/cli/src/migration/migrator/vite-plus-bootstrap.ts
+++ b/packages/cli/src/migration/migrator/vite-plus-bootstrap.ts
@@ -807,7 +807,7 @@ function ensureVitePlusDependencySpecs(
     }
     // Catalog writers update every existing managed entry in place. Keep a
     // package's deliberate named/default reference instead of collapsing all
-    // packages onto the workspace's preferred catalog, including pkg.pr.new
+    // packages onto the workspace's preferred catalog, including preview
     // force-override runs.
     if (version.startsWith('catalog:') && spec.startsWith('catalog:')) {
       continue;
@@ -823,7 +823,7 @@ function ensureVitePlusDependencySpecs(
     // Plain (non-protocol-pinned) range like `^0.1.24` → rewrite to the target
     // (`catalog:` for catalog-supporting projects, otherwise the concrete
     // version). Already-`catalog:` / other protocol pins are left untouched,
-    // except in force-override mode where ecosystem/pkg.pr.new validation must
+    // except in force-override mode where ecosystem/preview validation must
     // replace every prior target with the requested artifact.
     if (isForceOverrideMode() || !isProtocolPinnedSpec(spec)) {
       dependencies[VITE_PLUS_NAME] = version;

--- a/packages/cli/src/utils/preview-registry.ts
+++ b/packages/cli/src/utils/preview-registry.ts
@@ -16,7 +16,7 @@ const REGISTRY_MARKER = '# vite-plus preview build registry bridge (auto-added b
 const BRIDGE_HOST = 'registry-bridge.viteplus.dev';
 
 /**
- * Registry bridge that serves pkg.pr.new builds as ordinary `0.0.0-commit.<sha>`
+ * Registry bridge that serves PR preview builds as ordinary `0.0.0-commit.<sha>`
  * versions (and proxies everything else to npmjs). Only ever used for preview
  * builds (see {@link isPreviewVitePlusVersion}); real releases never resolve
  * through it. Overridable via `VP_REGISTRY_BRIDGE` for testing or an alternate

--- a/rfcs/docker-image.md
+++ b/rfcs/docker-image.md
@@ -263,11 +263,11 @@ release. (Exact wiring is an implementation detail for the PR.)
 ### Pre-release validation (preview image)
 
 To verify the image before a real release, the preview publish workflow
-(`publish-preview.yml`, triggered by the `pkg.pr.new` label) also builds the
+(`publish-preview.yml`, triggered by the `preview-build` label) also builds the
 multi-arch image, but from the PR's registry bridge build (`VP_PR_VERSION`),
 and pushes it as `ghcr.io/voidzero-dev/vite-plus:pr-<number>`
 (never `latest`). This reuses the exact same `docker/Dockerfile` as the release,
-so labeling a PR with `pkg.pr.new` produces a pullable preview image that
+so labeling a PR with `preview-build` produces a pullable preview image that
 exercises the real build path.
 
 ### Docs example verification

--- a/rfcs/docker-image.md
+++ b/rfcs/docker-image.md
@@ -262,9 +262,10 @@ release. (Exact wiring is an implementation detail for the PR.)
 
 ### Pre-release validation (preview image)
 
-To verify the image before a real release, the `pkg.pr.new` workflow
-(`publish-to-pkg.pr.new.yml`) also builds the multi-arch image, but from the PR's
-pkg.pr.new build (`VP_PR_VERSION`), and pushes it as `ghcr.io/voidzero-dev/vite-plus:pr-<number>`
+To verify the image before a real release, the preview publish workflow
+(`publish-preview.yml`, triggered by the `pkg.pr.new` label) also builds the
+multi-arch image, but from the PR's registry bridge build (`VP_PR_VERSION`),
+and pushes it as `ghcr.io/voidzero-dev/vite-plus:pr-<number>`
 (never `latest`). This reuses the exact same `docker/Dockerfile` as the release,
 so labeling a PR with `pkg.pr.new` produces a pullable preview image that
 exercises the real build path.


### PR DESCRIPTION
Moves the PR preview publish fully onto the registry bridge and drops pkg.pr.new.

- Bumps the bridge action to its local-pack version (voidzero-dev/pkg-pr-registry-bridge#56, merged as `711e22a2`, pinned here): it packs the built package directories with `pnpm pack` and uploads them, instead of downloading them back from pkg.pr.new.
- Removes the `pkg-pr-new publish` step. Nothing in the PR-build install path uses pkg.pr.new anymore: install.sh, `vp migrate`, and the Docker preview all resolve commit builds through the bridge. Direct `https://pkg.pr.new/...` URL installs stop existing for new builds.
- The bridge step now fails the job on error instead of continue-on-error: a silently missing ref would only surface later as a broken install.
- The published set now also includes `packages/cli/cli-npm/*`, so `@voidzero-dev/vite-plus-cli-*` gets real bridge-served tarballs with integrity (previously they 302'd to pkg.pr.new with empty integrity).
- Renames the workflow file to `publish-preview.yml` (display name "Publish preview build"; older runs stay under the previous workflow entry) and the trigger label to `preview-build` (the repo label was renamed in place, so labeled PRs keep it). The rust cache-key keeps its name to keep warm caches.
- Updates docs/comments that described pkg.pr.new as the publish destination (MAINTENANCE.md, upgrade guide, Dockerfile, install scripts, migrate test harness).

Note: both labels exist during the transition: `pkg.pr.new` still triggers main's current workflow on other PRs until this merges, and `preview-build` triggers this PR's workflow. Delete the `pkg.pr.new` label after the merge.

Verified per head along the way, most recently: publish run green with no pkg.pr.new step, 19 packages packed locally and served from R2 with byte-verified integrity, `VP_PR_VERSION=2038` resolving and installing entirely through the bridge, and the Docker preview building from the bridge build.

