### PR TITLE
fix(run): preserve Vite production environment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2299,7 +2299,7 @@ dependencies = [
 [[package]]
 name = "fspy"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e68b62544b1f5853fd70de2e2f9757037eba836e#e68b62544b1f5853fd70de2e2f9757037eba836e"
 dependencies = [
  "anyhow",
  "bstr",
@@ -2334,7 +2334,7 @@ dependencies = [
 [[package]]
 name = "fspy_detours_sys"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e68b62544b1f5853fd70de2e2f9757037eba836e#e68b62544b1f5853fd70de2e2f9757037eba836e"
 dependencies = [
  "cc",
  "winapi",
@@ -2343,7 +2343,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e68b62544b1f5853fd70de2e2f9757037eba836e#e68b62544b1f5853fd70de2e2f9757037eba836e"
 dependencies = [
  "anyhow",
  "bstr",
@@ -2358,7 +2358,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_windows"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e68b62544b1f5853fd70de2e2f9757037eba836e#e68b62544b1f5853fd70de2e2f9757037eba836e"
 dependencies = [
  "constcat",
  "fspy_detours_sys",
@@ -2374,7 +2374,7 @@ dependencies = [
 [[package]]
 name = "fspy_seccomp_unotify"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e68b62544b1f5853fd70de2e2f9757037eba836e#e68b62544b1f5853fd70de2e2f9757037eba836e"
 dependencies = [
  "futures-util",
  "libc",
@@ -2391,7 +2391,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e68b62544b1f5853fd70de2e2f9757037eba836e#e68b62544b1f5853fd70de2e2f9757037eba836e"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -2410,7 +2410,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e68b62544b1f5853fd70de2e2f9757037eba836e#e68b62544b1f5853fd70de2e2f9757037eba836e"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3561,7 +3561,7 @@ dependencies = [
 [[package]]
 name = "materialized_artifact"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e68b62544b1f5853fd70de2e2f9757037eba836e#e68b62544b1f5853fd70de2e2f9757037eba836e"
 dependencies = [
  "tempfile",
 ]
@@ -3569,7 +3569,7 @@ dependencies = [
 [[package]]
 name = "materialized_artifact_build"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e68b62544b1f5853fd70de2e2f9757037eba836e#e68b62544b1f5853fd70de2e2f9757037eba836e"
 dependencies = [
  "xxhash-rust",
 ]
@@ -3793,7 +3793,7 @@ dependencies = [
 [[package]]
 name = "native_str"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e68b62544b1f5853fd70de2e2f9757037eba836e#e68b62544b1f5853fd70de2e2f9757037eba836e"
 dependencies = [
  "bumpalo",
  "bytemuck",
@@ -5513,7 +5513,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal_test_client"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e68b62544b1f5853fd70de2e2f9757037eba836e#e68b62544b1f5853fd70de2e2f9757037eba836e"
 
 [[package]]
 name = "quote"
@@ -8388,7 +8388,7 @@ dependencies = [
 [[package]]
 name = "vite_glob"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e68b62544b1f5853fd70de2e2f9757037eba836e#e68b62544b1f5853fd70de2e2f9757037eba836e"
 dependencies = [
  "globset",
  "thiserror 2.0.18",
@@ -8436,7 +8436,7 @@ dependencies = [
 [[package]]
 name = "vite_graph_ser"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e68b62544b1f5853fd70de2e2f9757037eba836e#e68b62544b1f5853fd70de2e2f9757037eba836e"
 dependencies = [
  "petgraph 0.8.3",
  "serde",
@@ -8536,7 +8536,7 @@ dependencies = [
 [[package]]
 name = "vite_path"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e68b62544b1f5853fd70de2e2f9757037eba836e#e68b62544b1f5853fd70de2e2f9757037eba836e"
 dependencies = [
  "diff-struct",
  "os_str_bytes",
@@ -8568,7 +8568,7 @@ dependencies = [
 [[package]]
 name = "vite_powershell"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e68b62544b1f5853fd70de2e2f9757037eba836e#e68b62544b1f5853fd70de2e2f9757037eba836e"
 dependencies = [
  "vite_path",
  "which",
@@ -8577,7 +8577,7 @@ dependencies = [
 [[package]]
 name = "vite_select"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e68b62544b1f5853fd70de2e2f9757037eba836e#e68b62544b1f5853fd70de2e2f9757037eba836e"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -8631,7 +8631,7 @@ dependencies = [
 [[package]]
 name = "vite_shell"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e68b62544b1f5853fd70de2e2f9757037eba836e#e68b62544b1f5853fd70de2e2f9757037eba836e"
 dependencies = [
  "brush-parser 0.4.0",
  "diff-struct",
@@ -8658,7 +8658,7 @@ dependencies = [
 [[package]]
 name = "vite_str"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e68b62544b1f5853fd70de2e2f9757037eba836e#e68b62544b1f5853fd70de2e2f9757037eba836e"
 dependencies = [
  "compact_str",
  "diff-struct",
@@ -8669,7 +8669,7 @@ dependencies = [
 [[package]]
 name = "vite_task"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e68b62544b1f5853fd70de2e2f9757037eba836e#e68b62544b1f5853fd70de2e2f9757037eba836e"
 dependencies = [
  "anstream",
  "anyhow",
@@ -8718,7 +8718,7 @@ dependencies = [
 [[package]]
 name = "vite_task_client"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e68b62544b1f5853fd70de2e2f9757037eba836e#e68b62544b1f5853fd70de2e2f9757037eba836e"
 dependencies = [
  "native_str",
  "rustc-hash",
@@ -8731,7 +8731,7 @@ dependencies = [
 [[package]]
 name = "vite_task_client_napi"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e68b62544b1f5853fd70de2e2f9757037eba836e#e68b62544b1f5853fd70de2e2f9757037eba836e"
 dependencies = [
  "napi",
  "napi-build",
@@ -8743,7 +8743,7 @@ dependencies = [
 [[package]]
 name = "vite_task_graph"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e68b62544b1f5853fd70de2e2f9757037eba836e#e68b62544b1f5853fd70de2e2f9757037eba836e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8765,7 +8765,7 @@ dependencies = [
 [[package]]
 name = "vite_task_ipc_shared"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e68b62544b1f5853fd70de2e2f9757037eba836e#e68b62544b1f5853fd70de2e2f9757037eba836e"
 dependencies = [
  "native_str",
  "rustc-hash",
@@ -8775,7 +8775,7 @@ dependencies = [
 [[package]]
 name = "vite_task_plan"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e68b62544b1f5853fd70de2e2f9757037eba836e#e68b62544b1f5853fd70de2e2f9757037eba836e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8803,7 +8803,7 @@ dependencies = [
 [[package]]
 name = "vite_task_server"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e68b62544b1f5853fd70de2e2f9757037eba836e#e68b62544b1f5853fd70de2e2f9757037eba836e"
 dependencies = [
  "futures",
  "native_str",
@@ -8827,7 +8827,7 @@ version = "0.0.0"
 [[package]]
 name = "vite_workspace"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=e68b62544b1f5853fd70de2e2f9757037eba836e#e68b62544b1f5853fd70de2e2f9757037eba836e"
 dependencies = [
  "clap",
  "petgraph 0.8.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,7 @@ dunce = "1.0.5"
 fast-glob = "1.0.0"
 flate2 = { version = "=1.1.9", features = ["zlib-rs"] }
 form_urlencoded = "1.2.1"
-fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "6cfa6e47a1a5fdadd215e1556766cc753603a539" }
+fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "e68b62544b1f5853fd70de2e2f9757037eba836e" }
 futures = "0.3.31"
 futures-util = "0.3.31"
 glob = "0.3.2"
@@ -305,11 +305,11 @@ vite_pm_cli = { path = "crates/vite_pm_cli" }
 vite_setup = { path = "crates/vite_setup" }
 vite_shared = { path = "crates/vite_shared" }
 vite_static_config = { path = "crates/vite_static_config" }
-vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "6cfa6e47a1a5fdadd215e1556766cc753603a539" }
-vite_powershell = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "6cfa6e47a1a5fdadd215e1556766cc753603a539" }
-vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "6cfa6e47a1a5fdadd215e1556766cc753603a539" }
-vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "6cfa6e47a1a5fdadd215e1556766cc753603a539" }
-vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "6cfa6e47a1a5fdadd215e1556766cc753603a539" }
+vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "e68b62544b1f5853fd70de2e2f9757037eba836e" }
+vite_powershell = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "e68b62544b1f5853fd70de2e2f9757037eba836e" }
+vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "e68b62544b1f5853fd70de2e2f9757037eba836e" }
+vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "e68b62544b1f5853fd70de2e2f9757037eba836e" }
+vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "e68b62544b1f5853fd70de2e2f9757037eba836e" }
 walkdir = "2.5.0"
 wax = "0.6.0"
 which = "8.0.0"

--- a/packages/cli/snap-tests/vp-run-vite-node-env/index.html
+++ b/packages/cli/snap-tests/vp-run-vite-node-env/index.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html>
+  <body>
+    <script type="module" src="/main.ts"></script>
+  </body>
+</html>

--- a/packages/cli/snap-tests/vp-run-vite-node-env/main.ts
+++ b/packages/cli/snap-tests/vp-run-vite-node-env/main.ts
@@ -1,0 +1,7 @@
+console.log(
+  JSON.stringify({
+    DEV: import.meta.env.DEV,
+    MODE: import.meta.env.MODE,
+    PROD: import.meta.env.PROD,
+  }),
+);

--- a/packages/cli/snap-tests/vp-run-vite-node-env/package.json
+++ b/packages/cli/snap-tests/vp-run-vite-node-env/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "vp-run-vite-node-env-test",
+  "private": true
+}

--- a/packages/cli/snap-tests/vp-run-vite-node-env/snap.txt
+++ b/packages/cli/snap-tests/vp-run-vite-node-env/snap.txt
@@ -1,0 +1,33 @@
+> vp build 2>&1 | grep '^NODE_ENV=' # direct build
+NODE_ENV="production"
+
+> node -e "const fs=require('node:fs');require('./dist/assets/'+fs.readdirSync('dist/assets').find(f=>f.endsWith('.js')))"
+{"DEV":false,"MODE":"production","PROD":true}
+
+> rm -rf dist
+> vp run build 2>&1 | grep '^NODE_ENV=' # task runner build
+NODE_ENV="production"
+
+> node -e "const fs=require('node:fs');require('./dist/assets/'+fs.readdirSync('dist/assets').find(f=>f.endsWith('.js')))"
+{"DEV":false,"MODE":"production","PROD":true}
+
+> rm -rf dist
+> vp run --no-cache deploy 2>&1 | grep '^NODE_ENV=' # build dependency of deploy
+NODE_ENV="production"
+
+> node -e "const fs=require('node:fs');require('./dist/assets/'+fs.readdirSync('dist/assets').find(f=>f.endsWith('.js')))"
+{"DEV":false,"MODE":"production","PROD":true}
+
+> rm -rf dist
+> NODE_ENV=test vp build 2>&1 | grep '^NODE_ENV=' # direct build with explicit NODE_ENV
+NODE_ENV="test"
+
+> node -e "const fs=require('node:fs');require('./dist/assets/'+fs.readdirSync('dist/assets').find(f=>f.endsWith('.js')))"
+{"DEV":true,"MODE":"production","PROD":false}
+
+> rm -rf dist
+> NODE_ENV=test vp run build 2>&1 | grep '^NODE_ENV=' # task runner build with explicit NODE_ENV
+NODE_ENV="test"
+
+> node -e "const fs=require('node:fs');require('./dist/assets/'+fs.readdirSync('dist/assets').find(f=>f.endsWith('.js')))"
+{"DEV":true,"MODE":"production","PROD":false}

--- a/packages/cli/snap-tests/vp-run-vite-node-env/steps.json
+++ b/packages/cli/snap-tests/vp-run-vite-node-env/steps.json
@@ -1,0 +1,19 @@
+{
+  "ignoredPlatforms": ["win32"],
+  "commands": [
+    "vp build 2>&1 | grep '^NODE_ENV=' # direct build",
+    "node -e \"const fs=require('node:fs');require('./dist/assets/'+fs.readdirSync('dist/assets').find(f=>f.endsWith('.js')))\"",
+    "rm -rf dist",
+    "vp run build 2>&1 | grep '^NODE_ENV=' # task runner build",
+    "node -e \"const fs=require('node:fs');require('./dist/assets/'+fs.readdirSync('dist/assets').find(f=>f.endsWith('.js')))\"",
+    "rm -rf dist",
+    "vp run --no-cache deploy 2>&1 | grep '^NODE_ENV=' # build dependency of deploy",
+    "node -e \"const fs=require('node:fs');require('./dist/assets/'+fs.readdirSync('dist/assets').find(f=>f.endsWith('.js')))\"",
+    "rm -rf dist",
+    "NODE_ENV=test vp build 2>&1 | grep '^NODE_ENV=' # direct build with explicit NODE_ENV",
+    "node -e \"const fs=require('node:fs');require('./dist/assets/'+fs.readdirSync('dist/assets').find(f=>f.endsWith('.js')))\"",
+    "rm -rf dist",
+    "NODE_ENV=test vp run build 2>&1 | grep '^NODE_ENV=' # task runner build with explicit NODE_ENV",
+    "node -e \"const fs=require('node:fs');require('./dist/assets/'+fs.readdirSync('dist/assets').find(f=>f.endsWith('.js')))\""
+  ]
+}

--- a/packages/cli/snap-tests/vp-run-vite-node-env/vite.config.ts
+++ b/packages/cli/snap-tests/vp-run-vite-node-env/vite.config.ts
@@ -1,0 +1,24 @@
+export default {
+  build: {
+    modulePreload: false,
+  },
+  run: {
+    tasks: {
+      build: 'vp build',
+      'db:migrate:prod': 'node -e ""',
+      deploy: {
+        command: 'node -e ""',
+        dependsOn: ['build', 'db:migrate:prod'],
+        cache: false,
+      },
+    },
+  },
+  plugins: [
+    {
+      name: 'node-env',
+      config() {
+        console.log(`NODE_ENV=${JSON.stringify(process.env.NODE_ENV)}`);
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Motivation

Running `vp build` directly defaults `NODE_ENV` to `"production"`, but running the same build through `vp run build` or `vpr build` received JavaScript `null` from the Vite Task environment client. Vite assigned that value to `process.env.NODE_ENV`, which Node coerced to `"null"`, producing `import.meta.env.DEV=true` and `PROD=false` in production builds.

Fixes #2047.

## Changes

- Pin Vite Task to the merged fix from voidzero-dev/vite-task#508.
- Add a focused snapshot comparing direct `vp build` with `vp run build`.
- Verify an explicit `NODE_ENV=test` is preserved instead of being replaced with the production default.
- Cover a `deploy` task whose dependencies include `build` and `db:migrate:prod`, matching the follow-up report in #2047.
- Assert production builds expose `NODE_ENV="production"`, `DEV=false`, and `PROD=true`.