### PR TITLE
fix(core): declare vite-plus as optional peer

### DIFF
--- a/packages/core/__tests__/build-artifacts.spec.ts
+++ b/packages/core/__tests__/build-artifacts.spec.ts
@@ -6,8 +6,16 @@ import { describe, expect, it } from 'vitest';
 
 const coreDir = path.resolve(path.dirname(url.fileURLToPath(import.meta.url)), '..');
 const distDir = path.join(coreDir, 'dist');
+const packageJsonPath = path.join(coreDir, 'package.json');
 
 describe('build artifacts', () => {
+  it('should declare vite-plus as an optional peer for native binding resolution', () => {
+    const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+
+    expect(pkg.peerDependencies['vite-plus']).toBe(pkg.version);
+    expect(pkg.peerDependenciesMeta['vite-plus']).toEqual({ optional: true });
+  });
+
   it('should include esm-shims.js in dist for tsdown shims support', () => {
     const shimsPath = path.join(distDir, 'esm-shims.js');
     expect(fs.existsSync(shimsPath), `${shimsPath} should exist`).toBe(true);

--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -759,12 +759,16 @@ async function mergePackageJson() {
   destPkg.peerDependencies = {
     ...tsdownPkg.peerDependencies,
     ...vitePkg.peerDependencies,
+    'vite-plus': destPkg.version,
   };
 
   // Merge peerDependenciesMeta from tsdown and vite
   destPkg.peerDependenciesMeta = {
     ...tsdownPkg.peerDependenciesMeta,
     ...vitePkg.peerDependenciesMeta,
+    'vite-plus': {
+      optional: true,
+    },
   };
 
   // `@tsdown/exe` and `@tsdown/css` are bundled into core (see bundleTsdown), so

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -150,6 +150,7 @@
     "typescript": "^5.0.0 || ^6.0.0",
     "unplugin-unused": "^0.5.0",
     "unrun": "*",
+    "vite-plus": "0.2.2",
     "yaml": "^2.4.2"
   },
   "peerDependenciesMeta": {
@@ -202,6 +203,9 @@
       "optional": true
     },
     "yaml": {
+      "optional": true
+    },
+    "vite-plus": {
       "optional": true
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -564,6 +564,9 @@ importers:
       unrun:
         specifier: '*'
         version: 0.3.1
+      vite-plus:
+        specifier: workspace:vite-plus@*
+        version: link:../cli
       yaml:
         specifier: ^2.4.2
         version: 2.9.0


### PR DESCRIPTION
## Summary

 Adds `vite-plus` as an optional peer dependency of `@voidzero-dev/vite-plus-core`.

 ## Context

 This is based on the Discord discussion here:
 https://discord.com/channels/1475973262193459293/1523149835950362795

 In the reported Windows + pnpm case, `vite-plus/binding` resolved correctly from the project root and the native
package was installed, but `@voidzero-dev/vite-plus-core` was executed from pnpm’s global virtual store realpath:
 ```
 AppData/Local/pnpm/store/v11/links/...
 ```

 From that location, Node could not resolve `vite-plus/binding`, causing Rolldown’s native binding load to fail.

 ## Changes

 - Declares `vite-plus` as an optional peer of `@voidzero-dev/vite-plus-core`
 - Keeps the peer version in lockstep with the core package version via `destPkg.version`
 - Adds a focused test for the package metadata