### PR TITLE
test(snapshot): reproduce vp run ctrl-c tearing tasks down mid-shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8529,6 +8529,7 @@ dependencies = [
  "dunce",
  "junction",
  "libtest-mimic",
+ "nix 0.30.1",
  "pty_terminal_test",
  "pty_terminal_test_client",
  "regex",

--- a/crates/vite_cli_snapshots/Cargo.toml
+++ b/crates/vite_cli_snapshots/Cargo.toml
@@ -32,6 +32,9 @@ tempfile = { workspace = true }
 toml = { workspace = true }
 which = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+nix = { workspace = true, features = ["fs", "poll", "process"] }
+
 [target.'cfg(windows)'.dev-dependencies]
 junction = { workspace = true }
 

--- a/crates/vite_cli_snapshots/src/bin/vpt/main.rs
+++ b/crates/vite_cli_snapshots/src/bin/vpt/main.rs
@@ -29,9 +29,11 @@ mod print_native_path;
 mod probe;
 mod read_stdin;
 mod replace_file_content;
+mod report_orphan_on_ctrlc;
 mod rm;
 mod stat_file;
 mod touch_file;
+mod wait_file;
 mod write_file;
 
 fn main() {
@@ -39,7 +41,7 @@ fn main() {
     if args.len() < 2 {
         eprintln!("Usage: vpt <subcommand> [args...]");
         eprintln!(
-            "Subcommands: barrier, check-tty, chmod, cp, exit, exit-on-ctrlc, grep-file, json-edit, list-dir, mkdir, pipe-stdin, print, print-color, print-cwd, print-env, print-file, print-native-path, probe, read-stdin, replace-file-content, rm, stat-file, touch-file, write-file"
+            "Subcommands: barrier, check-tty, chmod, cp, exit, exit-on-ctrlc, grep-file, json-edit, list-dir, mkdir, pipe-stdin, print, print-color, print-cwd, print-env, print-file, print-native-path, probe, read-stdin, replace-file-content, report-orphan-on-ctrlc, rm, stat-file, touch-file, wait-file, write-file"
         );
         std::process::exit(1);
     }
@@ -74,9 +76,11 @@ fn main() {
         "probe" => probe::run(),
         "read-stdin" => read_stdin::run(),
         "replace-file-content" => replace_file_content::run(&args[2..]),
+        "report-orphan-on-ctrlc" => report_orphan_on_ctrlc::run(&args[2..]),
         "rm" => rm::run(&args[2..]),
         "stat-file" => stat_file::run(&args[2..]),
         "touch-file" => touch_file::run(&args[2..]),
+        "wait-file" => wait_file::run(&args[2..]),
         "write-file" => write_file::run(&args[2..]),
         other => {
             eprintln!("Unknown subcommand: {other}");

--- a/crates/vite_cli_snapshots/src/bin/vpt/report_orphan_on_ctrlc.rs
+++ b/crates/vite_cli_snapshots/src/bin/vpt/report_orphan_on_ctrlc.rs
@@ -1,0 +1,126 @@
+/// report-orphan-on-ctrlc `<verdict-file>`
+///
+/// Simulates a task with a graceful shutdown phase (a vite dev server
+/// closing on Ctrl+C) and records whether `vp run` let that shutdown finish
+/// (issue #2036): emits a "ready" milestone, waits for Ctrl+C, then spends
+/// 300 ms shutting down before exiting cleanly.
+///
+/// The verdict is written by a watcher process spawned into its own process
+/// group, insulated from whatever signals vp sends the task tree during
+/// teardown (the same way real dev-server grandchildren outlive `vp run`).
+/// The watcher holds the read end of a pipe; the task writes "done" after
+/// its shutdown completes. Pipe EOF without "done" means the task was torn
+/// down mid-shutdown, and the watcher records that in `<verdict-file>`
+/// (atomically, via a temp-file rename) for a follow-up `vpt wait-file`
+/// step. Nothing is printed after the milestone, so the terminal snapshot
+/// stays deterministic no matter how quickly the task tree is killed.
+#[cfg(unix)]
+pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+    if args.first().is_some_and(|arg| arg == "--watch") {
+        return watch(args.get(1).ok_or("--watch needs a verdict file")?);
+    }
+
+    use std::{io::Write as _, os::fd::OwnedFd, sync::Arc, time::Duration};
+
+    let Some(verdict_path) = args.first() else {
+        return Err("Usage: vpt report-orphan-on-ctrlc <verdict-file>".into());
+    };
+
+    let (pipe_read, pipe_write): (OwnedFd, OwnedFd) = nix::unistd::pipe()?;
+    // The write end must not leak into the watcher, or the pipe never
+    // reports EOF (macOS has no pipe2, so CLOEXEC is set separately).
+    nix::fcntl::fcntl(&pipe_write, nix::fcntl::FcntlArg::F_SETFD(nix::fcntl::FdFlag::FD_CLOEXEC))?;
+
+    let mut watcher = std::process::Command::new(std::env::current_exe()?);
+    watcher
+        .arg("report-orphan-on-ctrlc")
+        .arg("--watch")
+        .arg(verdict_path)
+        .stdin(std::process::Stdio::from(pipe_read))
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    // SAFETY: setpgid is async-signal-safe; the watcher moves to its own
+    // process group so group-directed teardown signals cannot reach it.
+    unsafe {
+        std::os::unix::process::CommandExt::pre_exec(&mut watcher, || {
+            let _ =
+                nix::unistd::setpgid(nix::unistd::Pid::from_raw(0), nix::unistd::Pid::from_raw(0));
+            Ok(())
+        });
+    }
+    watcher.spawn()?;
+
+    let ctrlc_once_lock = Arc::new(std::sync::OnceLock::<()>::new());
+    ctrlc::set_handler({
+        let ctrlc_once_lock = Arc::clone(&ctrlc_once_lock);
+        move || {
+            let _ = ctrlc_once_lock.set(());
+        }
+    })?;
+
+    pty_terminal_test_client::mark_milestone("ready");
+
+    ctrlc_once_lock.wait();
+    // The graceful shutdown a real dev server performs after SIGINT. A
+    // buggy vp tears the task down milliseconds into this window, so the
+    // "done" marker below never gets written.
+    std::thread::sleep(Duration::from_millis(300));
+
+    let mut done_pipe = std::fs::File::from(pipe_write);
+    let _ = done_pipe.write_all(b"done\n");
+    Ok(())
+}
+
+/// Watcher mode: reads the pipe on stdin until EOF (or a 10 s safety cap so
+/// an orphaned watcher can never outlive the suite), then records whether
+/// the task's shutdown completed.
+#[cfg(unix)]
+fn watch(verdict_path: &str) -> Result<(), Box<dyn std::error::Error>> {
+    use std::{
+        io::Read as _,
+        os::fd::AsFd as _,
+        time::{Duration, Instant},
+    };
+
+    use nix::poll::{PollFd, PollFlags, PollTimeout, poll};
+
+    let mut received = Vec::new();
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let stdin = std::io::stdin();
+    let mut stdin_lock = stdin.lock();
+    loop {
+        let mut fds = [PollFd::new(stdin_lock.as_fd(), PollFlags::POLLIN)];
+        if poll(&mut fds, PollTimeout::from(100u8)).is_err() {
+            break;
+        }
+        let revents = fds[0].revents().unwrap_or(PollFlags::empty());
+        if revents.intersects(PollFlags::POLLIN) {
+            let mut buf = [0u8; 64];
+            match stdin_lock.read(&mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => received.extend_from_slice(&buf[..n]),
+            }
+        } else if revents.intersects(PollFlags::POLLHUP | PollFlags::POLLERR | PollFlags::POLLNVAL)
+        {
+            break;
+        }
+        if Instant::now() >= deadline {
+            break;
+        }
+    }
+
+    let verdict = if received.windows(4).any(|w| w == b"done") {
+        "task completed its graceful shutdown"
+    } else {
+        "task was torn down before its graceful shutdown finished"
+    };
+    let tmp = format!("{verdict_path}.tmp");
+    std::fs::write(&tmp, format!("{verdict}\n"))?;
+    std::fs::rename(&tmp, verdict_path)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+pub fn run(_args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+    Err("report-orphan-on-ctrlc is unix-only (process-group/PTY semantics)".into())
+}

--- a/crates/vite_cli_snapshots/src/bin/vpt/wait_file.rs
+++ b/crates/vite_cli_snapshots/src/bin/vpt/wait_file.rs
@@ -1,0 +1,31 @@
+/// wait-file `<path>` \[timeout-ms\]
+///
+/// Polls until `<path>` exists, then prints its contents. Fails after the
+/// timeout (default 5000 ms). For asserting on files written asynchronously
+/// by a previous step's process tree (e.g. a task outliving `vp run`).
+pub fn run(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+    let Some(path) = args.first() else {
+        return Err("Usage: vpt wait-file <path> [timeout-ms]".into());
+    };
+    let timeout_ms: u64 = match args.get(1) {
+        Some(raw) => raw.parse()?,
+        None => 5000,
+    };
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
+    loop {
+        match std::fs::read_to_string(path) {
+            Ok(content) => {
+                print!("{content}");
+                return Ok(());
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                if std::time::Instant::now() >= deadline {
+                    return Err(format!("timed out waiting for file: {path}").into());
+                }
+                std::thread::sleep(std::time::Duration::from_millis(25));
+            }
+            Err(err) => return Err(err.into()),
+        }
+    }
+}

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/README.md
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/README.md
@@ -122,7 +122,11 @@ is identical on every platform:
 `vpt print`, `vpt print-color`, `vpt print-env`, `vpt print-cwd`,
 `vpt print-native-path` (prints OS-native separators, for redaction
 self-tests), `vpt check-tty`, `vpt read-stdin`, `vpt exit <code>`,
-`vpt exit-on-ctrlc`, `vpt barrier`.
+`vpt exit-on-ctrlc`, `vpt report-orphan-on-ctrlc` (records via a watcher
+process that survives `vp run` whether the task got to finish its graceful
+shutdown), `vpt barrier`. `vpt wait-file <path> [timeout-ms]` polls until a
+file exists and prints it, for asserting on files written by a previous
+step's surviving process tree.
 
 ## Interactive cases
 

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/run_ctrlc_teardown/package.json
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/run_ctrlc_teardown/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "run-ctrlc-teardown",
+  "private": true,
+  "scripts": {
+    "dev": "vpt report-orphan-on-ctrlc verdict.txt"
+  }
+}

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/run_ctrlc_teardown/snapshots.toml
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/run_ctrlc_teardown/snapshots.toml
@@ -1,0 +1,35 @@
+# Reproduces https://github.com/voidzero-dev/vite-plus/issues/2036: killing a
+# `vp run` task with Ctrl+C leaves stray escape sequences on the next fish
+# prompt. fish probes the terminal (OSC 11, CSI 6n, DA1) every time it draws
+# a prompt; after `vp run` + Ctrl+C, the task's process tree (vite dev server,
+# managed node) is still shutting down when the shell takes the terminal back,
+# and its late terminal writes and mode restores race the shell's probes, so
+# the terminal's replies land as garbage input on the prompt
+# (`^[]11;rgb:...^[\^[[9;1R^[[?62;22;52c`). Plain `vite dev` is clean because
+# the shell waits for vite itself, which finishes its terminal cleanup before
+# exiting.
+#
+# The vp-side defect this case pins: on Ctrl+C, `vp run` tears the terminal
+# and the task down within milliseconds instead of letting the task shut
+# down gracefully. The payload simulates a dev-server-like task whose
+# shutdown takes 300 ms; a watcher process outside vp's reach records to
+# verdict.txt whether that shutdown was allowed to finish.
+
+[[case]]
+name = "run_ctrlc_exits_before_task_shutdown"
+vp = "global"
+skip-platforms = ["windows"]
+comment = """
+Issue #2036: on Ctrl+C, `vp run` tears the task down immediately instead of
+waiting for its graceful shutdown, and whatever the dying task tree still
+does to the terminal races the next shell prompt. verdict.txt records the
+current buggy behavior; a fix should flip it to
+"task completed its graceful shutdown".
+"""
+steps = [
+  { argv = ["vp", "run", "dev"], continue-on-failure = true, interactions = [
+    { "expect-milestone" = "ready" },
+    { "write-key" = "ctrl-c" },
+  ] },
+  { argv = ["vpt", "wait-file", "verdict.txt"], comment = "The verdict the task wrote after `vp run` already exited." },
+]

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/run_ctrlc_teardown/snapshots/run_ctrlc_exits_before_task_shutdown.md
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/run_ctrlc_teardown/snapshots/run_ctrlc_exits_before_task_shutdown.md
@@ -1,0 +1,36 @@
+# run_ctrlc_exits_before_task_shutdown
+
+Issue #2036: on Ctrl+C, `vp run` tears the task down immediately instead of
+waiting for its graceful shutdown, and whatever the dying task tree still
+does to the terminal races the next shell prompt. verdict.txt records the
+current buggy behavior; a fix should flip it to
+"task completed its graceful shutdown".
+
+## `vp run dev`
+
+**Exit code:** 1
+
+**→ expect-milestone:** `ready`
+
+```
+VITE+ - The Unified Toolchain for the Web
+
+$ vpt report-orphan-on-ctrlc verdict.txt ⊘ cache disabled
+```
+
+**← write-key:** `ctrl-c`
+
+```
+VITE+ - The Unified Toolchain for the Web
+
+$ vpt report-orphan-on-ctrlc verdict.txt ⊘ cache disabled
+
+```
+
+## `vpt wait-file verdict.txt`
+
+The verdict the task wrote after `vp run` already exited.
+
+```
+task was torn down before its graceful shutdown finished
+```


### PR DESCRIPTION
Reproduces #2036 with a PTY snapshot test.

The stray characters after killing `vp run` in fish are the terminal's replies to fish's own prompt probes (fish 4.x sends OSC 11, CSI 6n, and DA1 at every prompt draw). The vp-side defect that turns them into garbage: on Ctrl+C, `vp run` tears the task down within a few milliseconds instead of waiting for its graceful shutdown, so the dying task tree (vite dev server, managed node) still touches the terminal while the shell is already drawing its next prompt. Plain `vite dev` is clean because the shell waits for vite itself, which finishes its terminal cleanup before exiting. Verified end to end by driving real fish 4.8 in a scripted PTY: `vp run dev` reproduces the exact junk from the issue, a plain `node` process killed the same way does not.

The new `run_ctrlc_teardown` fixture pins this: a dev-server-like `vpt` payload whose shutdown takes 300 ms records whether that shutdown was allowed to finish. The verdict is written by a watcher process in its own process group (it survives vp's teardown the same way real dev-server grandchildren do) and read by a follow-up `vpt wait-file` step, which keeps the snapshot deterministic under parallel suite load. The recorded snapshot currently says:

```
task was torn down before its graceful shutdown finished
```

A fix should flip this line to `task completed its graceful shutdown`.

Also adds `vpt wait-file <path> [timeout-ms]`, a generic helper that polls until a file exists and prints it.
