### PR TITLE
chore: bump vite-task to 417b6aa

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2337,7 +2337,7 @@ dependencies = [
 [[package]]
 name = "fspy"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=417b6aae5fca92b128c586c8ff3421e43911b553#417b6aae5fca92b128c586c8ff3421e43911b553"
 dependencies = [
  "anyhow",
  "bstr",
@@ -2372,7 +2372,7 @@ dependencies = [
 [[package]]
 name = "fspy_detours_sys"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=417b6aae5fca92b128c586c8ff3421e43911b553#417b6aae5fca92b128c586c8ff3421e43911b553"
 dependencies = [
  "cc",
  "winapi",
@@ -2381,7 +2381,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=417b6aae5fca92b128c586c8ff3421e43911b553#417b6aae5fca92b128c586c8ff3421e43911b553"
 dependencies = [
  "anyhow",
  "bstr",
@@ -2396,7 +2396,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_windows"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=417b6aae5fca92b128c586c8ff3421e43911b553#417b6aae5fca92b128c586c8ff3421e43911b553"
 dependencies = [
  "constcat",
  "fspy_detours_sys",
@@ -2412,7 +2412,7 @@ dependencies = [
 [[package]]
 name = "fspy_seccomp_unotify"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=417b6aae5fca92b128c586c8ff3421e43911b553#417b6aae5fca92b128c586c8ff3421e43911b553"
 dependencies = [
  "futures-util",
  "libc",
@@ -2429,7 +2429,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=417b6aae5fca92b128c586c8ff3421e43911b553#417b6aae5fca92b128c586c8ff3421e43911b553"
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
@@ -2448,7 +2448,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=417b6aae5fca92b128c586c8ff3421e43911b553#417b6aae5fca92b128c586c8ff3421e43911b553"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3611,7 +3611,7 @@ dependencies = [
 [[package]]
 name = "materialized_artifact"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=417b6aae5fca92b128c586c8ff3421e43911b553#417b6aae5fca92b128c586c8ff3421e43911b553"
 dependencies = [
  "tempfile",
 ]
@@ -3619,7 +3619,7 @@ dependencies = [
 [[package]]
 name = "materialized_artifact_build"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=417b6aae5fca92b128c586c8ff3421e43911b553#417b6aae5fca92b128c586c8ff3421e43911b553"
 dependencies = [
  "xxhash-rust",
 ]
@@ -3843,7 +3843,7 @@ dependencies = [
 [[package]]
 name = "native_str"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=417b6aae5fca92b128c586c8ff3421e43911b553#417b6aae5fca92b128c586c8ff3421e43911b553"
 dependencies = [
  "bumpalo",
  "bytemuck",
@@ -5596,7 +5596,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=417b6aae5fca92b128c586c8ff3421e43911b553#417b6aae5fca92b128c586c8ff3421e43911b553"
 dependencies = [
  "anyhow",
  "portable-pty",
@@ -5606,7 +5606,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal_test"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=417b6aae5fca92b128c586c8ff3421e43911b553#417b6aae5fca92b128c586c8ff3421e43911b553"
 dependencies = [
  "anyhow",
  "portable-pty",
@@ -5617,7 +5617,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal_test_client"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=417b6aae5fca92b128c586c8ff3421e43911b553#417b6aae5fca92b128c586c8ff3421e43911b553"
 
 [[package]]
 name = "quote"
@@ -7512,7 +7512,7 @@ dependencies = [
 [[package]]
 name = "snapshot_test"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=417b6aae5fca92b128c586c8ff3421e43911b553#417b6aae5fca92b128c586c8ff3421e43911b553"
 dependencies = [
  "serde",
  "serde_json",
@@ -8584,7 +8584,7 @@ dependencies = [
 [[package]]
 name = "vite_glob"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=417b6aae5fca92b128c586c8ff3421e43911b553#417b6aae5fca92b128c586c8ff3421e43911b553"
 dependencies = [
  "globset",
  "thiserror 2.0.18",
@@ -8632,7 +8632,7 @@ dependencies = [
 [[package]]
 name = "vite_graph_ser"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=417b6aae5fca92b128c586c8ff3421e43911b553#417b6aae5fca92b128c586c8ff3421e43911b553"
 dependencies = [
  "petgraph 0.8.3",
  "serde",
@@ -8732,7 +8732,7 @@ dependencies = [
 [[package]]
 name = "vite_path"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=417b6aae5fca92b128c586c8ff3421e43911b553#417b6aae5fca92b128c586c8ff3421e43911b553"
 dependencies = [
  "diff-struct",
  "os_str_bytes",
@@ -8764,7 +8764,7 @@ dependencies = [
 [[package]]
 name = "vite_powershell"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=417b6aae5fca92b128c586c8ff3421e43911b553#417b6aae5fca92b128c586c8ff3421e43911b553"
 dependencies = [
  "vite_path",
  "which",
@@ -8773,7 +8773,7 @@ dependencies = [
 [[package]]
 name = "vite_select"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=417b6aae5fca92b128c586c8ff3421e43911b553#417b6aae5fca92b128c586c8ff3421e43911b553"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -8826,7 +8826,7 @@ dependencies = [
 [[package]]
 name = "vite_shell"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=417b6aae5fca92b128c586c8ff3421e43911b553#417b6aae5fca92b128c586c8ff3421e43911b553"
 dependencies = [
  "brush-parser 0.4.0",
  "diff-struct",
@@ -8853,7 +8853,7 @@ dependencies = [
 [[package]]
 name = "vite_str"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=417b6aae5fca92b128c586c8ff3421e43911b553#417b6aae5fca92b128c586c8ff3421e43911b553"
 dependencies = [
  "compact_str",
  "diff-struct",
@@ -8864,7 +8864,7 @@ dependencies = [
 [[package]]
 name = "vite_task"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=417b6aae5fca92b128c586c8ff3421e43911b553#417b6aae5fca92b128c586c8ff3421e43911b553"
 dependencies = [
  "anstream",
  "anyhow",
@@ -8913,7 +8913,7 @@ dependencies = [
 [[package]]
 name = "vite_task_client"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=417b6aae5fca92b128c586c8ff3421e43911b553#417b6aae5fca92b128c586c8ff3421e43911b553"
 dependencies = [
  "native_str",
  "rustc-hash",
@@ -8926,7 +8926,7 @@ dependencies = [
 [[package]]
 name = "vite_task_client_napi"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=417b6aae5fca92b128c586c8ff3421e43911b553#417b6aae5fca92b128c586c8ff3421e43911b553"
 dependencies = [
  "napi",
  "napi-build",
@@ -8938,7 +8938,7 @@ dependencies = [
 [[package]]
 name = "vite_task_graph"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=417b6aae5fca92b128c586c8ff3421e43911b553#417b6aae5fca92b128c586c8ff3421e43911b553"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8960,7 +8960,7 @@ dependencies = [
 [[package]]
 name = "vite_task_ipc_shared"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=417b6aae5fca92b128c586c8ff3421e43911b553#417b6aae5fca92b128c586c8ff3421e43911b553"
 dependencies = [
  "native_str",
  "rustc-hash",
@@ -8970,7 +8970,7 @@ dependencies = [
 [[package]]
 name = "vite_task_plan"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=417b6aae5fca92b128c586c8ff3421e43911b553#417b6aae5fca92b128c586c8ff3421e43911b553"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8998,7 +8998,7 @@ dependencies = [
 [[package]]
 name = "vite_task_server"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=417b6aae5fca92b128c586c8ff3421e43911b553#417b6aae5fca92b128c586c8ff3421e43911b553"
 dependencies = [
  "futures",
  "native_str",
@@ -9022,7 +9022,7 @@ version = "0.0.0"
 [[package]]
 name = "vite_workspace"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=6cfa6e47a1a5fdadd215e1556766cc753603a539#6cfa6e47a1a5fdadd215e1556766cc753603a539"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=417b6aae5fca92b128c586c8ff3421e43911b553#417b6aae5fca92b128c586c8ff3421e43911b553"
 dependencies = [
  "clap",
  "petgraph 0.8.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ dunce = "1.0.5"
 fast-glob = "1.0.0"
 flate2 = { version = "=1.1.9", features = ["zlib-rs"] }
 form_urlencoded = "1.2.1"
-fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "6cfa6e47a1a5fdadd215e1556766cc753603a539" }
+fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "417b6aae5fca92b128c586c8ff3421e43911b553" }
 futures = "0.3.31"
 futures-util = "0.3.31"
 glob = "0.3.2"
@@ -251,8 +251,8 @@ pretty_assertions = "1.4.1"
 phf = "0.13.0"
 prettyplease = "0.2.32"
 proc-macro2 = "1"
-pty_terminal_test = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "6cfa6e47a1a5fdadd215e1556766cc753603a539" }
-pty_terminal_test_client = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "6cfa6e47a1a5fdadd215e1556766cc753603a539" }
+pty_terminal_test = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "417b6aae5fca92b128c586c8ff3421e43911b553" }
+pty_terminal_test_client = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "417b6aae5fca92b128c586c8ff3421e43911b553" }
 quote = "1"
 rayon = "1.10.0"
 regex = "1.11.1"
@@ -276,7 +276,7 @@ sha2 = "0.10.9"
 shell-escape = "0.1.5"
 simdutf8 = "0.1.5"
 smallvec = { version = "1.15.1", features = ["union"] }
-snapshot_test = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "6cfa6e47a1a5fdadd215e1556766cc753603a539" }
+snapshot_test = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "417b6aae5fca92b128c586c8ff3421e43911b553" }
 string_cache = "0.9.0"
 sugar_path = { version = "2.0.1", features = ["cached_current_dir"] }
 supports-color = "3"
@@ -313,11 +313,11 @@ vite_pm_cli = { path = "crates/vite_pm_cli" }
 vite_setup = { path = "crates/vite_setup" }
 vite_shared = { path = "crates/vite_shared" }
 vite_static_config = { path = "crates/vite_static_config" }
-vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "6cfa6e47a1a5fdadd215e1556766cc753603a539" }
-vite_powershell = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "6cfa6e47a1a5fdadd215e1556766cc753603a539" }
-vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "6cfa6e47a1a5fdadd215e1556766cc753603a539" }
-vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "6cfa6e47a1a5fdadd215e1556766cc753603a539" }
-vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "6cfa6e47a1a5fdadd215e1556766cc753603a539" }
+vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "417b6aae5fca92b128c586c8ff3421e43911b553" }
+vite_powershell = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "417b6aae5fca92b128c586c8ff3421e43911b553" }
+vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "417b6aae5fca92b128c586c8ff3421e43911b553" }
+vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "417b6aae5fca92b128c586c8ff3421e43911b553" }
+vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "417b6aae5fca92b128c586c8ff3421e43911b553" }
 walkdir = "2.5.0"
 wax = "0.6.0"
 which = "8.0.0"


### PR DESCRIPTION
Bumps the vite-task git dependency from `6cfa6e4` to `417b6aa`.

The only functional change is a NAPI fix ([#508](https://github.com/voidzero-dev/vite-task/pull/508)): missing env vars requested through `@voidzero-dev/vite-task-client` now return `undefined` instead of `null`, preserving Vite production `NODE_ENV` semantics when builds run through `vp run`. The remaining commits are dependency/CI/test chores.

Changelog: https://github.com/voidzero-dev/vite-task/compare/6cfa6e47a1a5fdadd215e1556766cc753603a539...417b6aae5fca92b128c586c8ff3421e43911b553#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed