### PR TITLE
test(snapshots): run cases in parallel on Linux, isolate only signal-sensitive ones

### DIFF
--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/ctrlc_isolation/snapshots.toml
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/ctrlc_isolation/snapshots.toml
@@ -1,0 +1,29 @@
+[[case]]
+name = "ctrlc_interrupt"
+vp = "global"
+comment = """
+Scripts a ctrl-c: `vpt exit-on-ctrlc` emits a `ready` milestone, waits for the
+interrupt, then prints and exits. This is the one scenario the runner isolates:
+ctrl-c cases are auto-detected as signal-sensitive (see `case_needs_isolation`)
+and take the exclusive execution lease, so parallel-PTY signal routing can't
+perturb them while every other case still runs concurrently.
+"""
+steps = [
+  { argv = ["vpt", "exit-on-ctrlc"], interactions = [
+    { "expect-milestone" = "ready" },
+    { "write-key" = "ctrl-c" },
+  ] },
+]
+
+[[case]]
+name = "explicit_serial"
+vp = "global"
+serial = true
+comment = """
+Exercises the explicit `serial = true` isolation opt-in (the non-ctrl-c path):
+the case takes the exclusive execution lease and runs to completion, proving
+the flag parses and the isolated path works.
+"""
+steps = [
+  { argv = ["vpt", "print", "runs in isolation"] },
+]

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/ctrlc_isolation/snapshots/ctrlc_interrupt.md
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/ctrlc_isolation/snapshots/ctrlc_interrupt.md
@@ -1,0 +1,20 @@
+# ctrlc_interrupt
+
+Scripts a ctrl-c: `vpt exit-on-ctrlc` emits a `ready` milestone, waits for the
+interrupt, then prints and exits. This is the one scenario the runner isolates:
+ctrl-c cases are auto-detected as signal-sensitive (see `case_needs_isolation`)
+and take the exclusive execution lease, so parallel-PTY signal routing can't
+perturb them while every other case still runs concurrently.
+
+## `vpt exit-on-ctrlc`
+
+**→ expect-milestone:** `ready`
+
+```
+```
+
+**← write-key:** `ctrl-c`
+
+```
+ctrl-c received
+```

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/ctrlc_isolation/snapshots/explicit_serial.md
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/ctrlc_isolation/snapshots/explicit_serial.md
@@ -1,0 +1,11 @@
+# explicit_serial
+
+Exercises the explicit `serial = true` isolation opt-in (the non-ctrl-c path):
+the case takes the exclusive execution lease and runs to completion, proving
+the flag parses and the isolated path works.
+
+## `vpt print 'runs in isolation'`
+
+```
+runs in isolation
+```

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/main.rs
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/main.rs
@@ -331,6 +331,13 @@ struct Case {
     /// Marks the trial `#[ignore]` (runnable with `cargo test -- --ignored`).
     #[serde(default)]
     ignore: bool,
+    /// Run this case in isolation: nothing else runs while it does (the suite
+    /// otherwise runs cases in parallel). Set for signal-sensitive flows (e.g.
+    /// watch modes) that concurrent PTY activity would perturb; ctrl-c cases
+    /// are detected automatically (see `case_needs_isolation`) and need not
+    /// set this.
+    #[serde(default)]
+    serial: bool,
     /// Serve the packed checkout packages through the local npm registry.
     #[serde(default, rename = "local-registry")]
     local_registry: bool,
@@ -919,6 +926,59 @@ fn run_case(
     snapshots.check_snapshot(snapshot_name, &doc)
 }
 
+/// Global execution gate. Ordinary cases hold a shared (read) lease and run
+/// concurrently; isolated cases hold the exclusive (write) lease, so nothing
+/// else runs while they do. This replaces the old blanket `--test-threads=1`
+/// on Linux: only the few signal-sensitive cases pay for serialization, while
+/// the rest parallelize as they already do on macOS and Windows.
+///
+/// This coordinates threads within a single `cargo test` process, which is the
+/// Linux and macOS snapshot jobs and the only place the parallel-PTY
+/// signal-routing flakiness occurs. The Windows job runs the suite under
+/// `cargo nextest`, which executes each trial in its own process; there the
+/// gate is a no-op, but isolation is stronger for free — a signal-sensitive
+/// case already has its own process, PTY, and process group, which is exactly
+/// what this gate reconstructs for the shared-process case.
+static EXECUTION_GATE: std::sync::RwLock<()> = std::sync::RwLock::new(());
+
+/// Held for a case's whole run: either a shared read lease (parallel) or the
+/// exclusive write lease (isolated). Poisoning is ignored — a case that
+/// panicked already failed, and its neighbours should still run.
+enum GateLease {
+    Shared(
+        #[expect(dead_code, reason = "held for its Drop")] std::sync::RwLockReadGuard<'static, ()>,
+    ),
+    Exclusive(
+        #[expect(dead_code, reason = "held for its Drop")] std::sync::RwLockWriteGuard<'static, ()>,
+    ),
+}
+
+fn acquire_gate(isolated: bool) -> GateLease {
+    use std::sync::PoisonError;
+    if isolated {
+        GateLease::Exclusive(EXECUTION_GATE.write().unwrap_or_else(PoisonError::into_inner))
+    } else {
+        GateLease::Shared(EXECUTION_GATE.read().unwrap_or_else(PoisonError::into_inner))
+    }
+}
+
+/// A case needs isolation if it opts in with `serial` or scripts a ctrl-c
+/// keystroke. Parallel PTYs on Linux misroute signals, which is the one
+/// documented flakiness source the old blanket serialization guarded against;
+/// isolating exactly those cases keeps the guarantee while letting the rest
+/// run in parallel.
+fn case_needs_isolation(case: &Case) -> bool {
+    case.serial
+        || case.steps.iter().chain(&case.after).any(|step| {
+            step.interactions.iter().any(|interaction| {
+                matches!(
+                    interaction,
+                    Interaction::WriteKey(WriteKeyInteraction { write_key: WriteKey::CtrlC })
+                )
+            })
+        })
+}
+
 fn main() {
     let tmp_dir = tempfile::tempdir().unwrap();
     // dunce, not std: std's canonicalize returns a `\\?\` verbatim path on
@@ -955,13 +1015,12 @@ fn main() {
         .collect::<Vec<_>>();
     fixture_paths.sort();
 
-    let mut args = libtest_mimic::Arguments::from_args();
-    // On Linux, parallel PTY + signal-routing contention makes ctrl-c cases
-    // flaky (inherited from vite-task's snapshot suite; scoping this serialization
-    // is an open question in the RFC).
-    if cfg!(target_os = "linux") && args.test_threads.is_none() {
-        args.test_threads = Some(1);
-    }
+    // Cases run in parallel on every platform. Signal-sensitive cases (ctrl-c,
+    // or `serial = true`) instead take the exclusive execution lease so they
+    // run in isolation; see `EXECUTION_GATE`. This replaces the old
+    // Linux-wide `--test-threads=1`, which serialized the entire suite to
+    // protect a handful of ctrl-c cases.
+    let args = libtest_mimic::Arguments::from_args();
 
     // `VP_SNAP_SKIP_FLAVORS=local` (comma-separated) skips registering trials
     // for a flavor entirely; CI legs that don't build the JS CLI use it.
@@ -1026,8 +1085,12 @@ fn main() {
                 let tmp_dir_path = Arc::clone(&tmp_dir_path);
                 let case = Arc::clone(&case);
                 let ignored = case.ignore;
+                let isolated = case_needs_isolation(&case);
                 tests.push(
                     libtest_mimic::Trial::test(trial_name, move || {
+                        // Hold the execution lease for the whole case: shared
+                        // (parallel) unless the case needs isolation.
+                        let _gate = acquire_gate(isolated);
                         let runtime = match runtimes.get(flavor) {
                             Ok(runtime) => runtime,
                             Err(message) => return Err(message.clone().into()),

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/redact.rs
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/redact.rs
@@ -33,6 +33,20 @@ static TOOL_VERSION_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
     )
     .unwrap()
 });
+// The workspace's own vite-plus / @voidzero-dev/vite-plus-core version is
+// written verbatim into scaffolded catalogs and manifests (`vite-plus: 0.2.3`,
+// `"vite-plus": "0.2.3"`, `npm:@voidzero-dev/vite-plus-core@0.2.3`). Unlike
+// third-party deps it bumps on every Vite+ release, so mask it by package
+// context while leaving other dep versions (core-js, typescript, ...)
+// assertable. The `vite-plus` key form requires a line-leading key so package
+// NAME values like `"vite-plus-application"` are untouched, and it needs a
+// digit after the separator so `vite-plus: catalog:` stays verbatim.
+static VP_VERSION_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(
+        r#"(?m)(^\s*"?vite-plus"?\s*:\s*"?|@voidzero-dev/vite-plus-core@)\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?"#,
+    )
+    .unwrap()
+});
 // Output bytes differ across OSes (line endings, embedded paths), so byte
 // sizes and content-derived asset hashes can never be part of a shared
 // snapshot. The unit is kept ("<size> kB"): it only changes when content
@@ -158,6 +172,10 @@ pub fn redact_output(
 
     // Redact bare runtime-tool versions by name context (see TOOL_VERSION_RE)
     output = TOOL_VERSION_RE.replace_all(&output, "$1$2<version>").into_owned();
+
+    // Redact the workspace's own vite-plus/core version by package context
+    // (see VP_VERSION_RE), which bumps on every release.
+    output = VP_VERSION_RE.replace_all(&output, "${1}<version>").into_owned();
 
     // Redact thread counts like "16 threads" to "<n> threads"
     output = THREAD_RE.replace_all(&output, "<n> threads").into_owned();

--- a/crates/vite_cli_snapshots/tests/redact_unit.rs
+++ b/crates/vite_cli_snapshots/tests/redact_unit.rs
@@ -56,6 +56,33 @@ fn masks_bare_runtime_tool_versions_by_name_context() {
 }
 
 #[test]
+fn masks_vite_plus_version_by_context_only() {
+    // The workspace vite-plus/core version bumps every release and is masked by
+    // package context; third-party dep versions, `catalog:` refs, and package
+    // NAME values stay verbatim.
+    let input = concat!(
+        "  vite: npm:@voidzero-dev/vite-plus-core@0.2.3\n",
+        "  vite-plus: 0.2.3\n",
+        "    \"vite-plus\": \"0.2.3\",\n",
+        "    \"vite-plus\": \"catalog:\",\n",
+        "    \"core-js\": \"3.39.0\",\n",
+        "    \"name\": \"vite-plus-application\"\n",
+    )
+    .to_owned();
+    assert_eq!(
+        redact_output(input, &[], true),
+        concat!(
+            "  vite: npm:@voidzero-dev/vite-plus-core@<version>\n",
+            "  vite-plus: <version>\n",
+            "    \"vite-plus\": \"<version>\",\n",
+            "    \"vite-plus\": \"catalog:\",\n",
+            "    \"core-js\": \"3.39.0\",\n",
+            "    \"name\": \"vite-plus-application\"\n",
+        )
+    );
+}
+
+#[test]
 fn replaces_paths_with_labels() {
     let input = "built /tmp/stage-1/dist in 3ms\n".to_owned();
     assert_eq!(


### PR DESCRIPTION
The runner forced --test-threads=1 on Linux to protect ctrl-c cases from
parallel-PTY signal-routing contention, but that serialized the entire
suite: the Linux leg's wall time equals the sum of every case's time
(~146s) while macOS runs the same cases in parallel (~26s).

Replace the blanket serialization with a per-case execution gate: ordinary
cases hold a shared (read) lease and run concurrently on every platform,
while signal-sensitive cases hold the exclusive (write) lease and run in
isolation. A case is isolated when it scripts a ctrl-c keystroke (detected
automatically) or sets the new `serial = true` flag. With no ctrl-c cases
today, the whole suite parallelizes on Linux like it already does on macOS
and Windows.