### PR TITLE
ci: verify registry-bridge content-addressed-tarball fix (bridge #58)

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Register commit build with the registry bridge
         id: bridge
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: voidzero-dev/pkg-pr-registry-bridge@65c8157a6f44f075c50d3d3faf3a9bd43d2b230a # main
+        uses: voidzero-dev/pkg-pr-registry-bridge@84daf7a69402e34be8800d2cbb422ec9bad6bd1a # fix-republish-integrity-cas (bridge #58)
         with:
           sha: ${{ github.event.pull_request.head.sha }}
           admin-token: ${{ secrets.PKG_PR_BRIDGE_ADMIN_TOKEN }}


### PR DESCRIPTION
Verification-only draft. Pins the `preview-build` action to voidzero-dev/pkg-pr-registry-bridge#58 (content-addressed tarball storage, `x-content-shasum`) and triggers a preview build to confirm the new action publishes and installs.

Do not merge. Close once verified.

Result: the build published `0.0.0-commit.6b76e46e...` (19 packages) to the prod bridge, and the advertised integrity matches the served tarball for `vite-plus`, `@voidzero-dev/vite-plus-core`, and a platform binary.

Bridge #58 is not deployed to prod, so this build hits the current prod bridge and confirms the new action stays backward-compatible (a single build is race-free either way). Bridge #58's unit tests and staging smoke cover the republish race-safety, which turns on once #58 deploys.
