### PR TITLE
fix(docker): passwordless sudo for the non-root vp user

### DIFF
--- a/.github/workflows/test-docker-image.yml
+++ b/.github/workflows/test-docker-image.yml
@@ -1,0 +1,117 @@
+name: Test Docker Image
+
+permissions: {}
+
+on:
+  # Manual runs can pin a specific vp version or verify a PR's registry-bridge
+  # build. Leave both blank to use the Dockerfile defaults (VP_VERSION=latest).
+  workflow_dispatch:
+    inputs:
+      vp_version:
+        description: 'vp version or dist-tag to install (blank = Dockerfile default: latest)'
+        required: false
+        type: string
+      vp_pr_version:
+        description: 'PR number or commit SHA to build a preview image from the registry bridge (overrides vp_version)'
+        required: false
+        type: string
+  pull_request:
+    paths:
+      - 'docker/**'
+      - '.github/workflows/test-docker-image.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build-and-smoke-test:
+    name: Build and smoke-test the toolchain image
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    env:
+      IMAGE: vite-plus:ci-smoke
+    steps:
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      # Only forward build-args that were provided (manual runs), so
+      # empty inputs fall back to the Dockerfile defaults instead of overriding
+      # them with empty strings.
+      - name: Resolve build args
+        id: buildargs
+        env:
+          VP_VERSION: ${{ inputs.vp_version }}
+          VP_PR_VERSION: ${{ inputs.vp_pr_version }}
+        run: |
+          {
+            echo "args<<__EOF__"
+            if [ -n "$VP_VERSION" ]; then echo "VP_VERSION=$VP_VERSION"; fi
+            if [ -n "$VP_PR_VERSION" ]; then echo "VP_PR_VERSION=$VP_PR_VERSION"; fi
+            echo "__EOF__"
+          } >> "$GITHUB_OUTPUT"
+
+      # Build the toolchain image locally and load it into the daemon (no push).
+      # amd64-only keeps it fast; the release build covers arm64.
+      - name: Build image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: docker
+          file: docker/Dockerfile
+          platforms: linux/amd64
+          load: true
+          push: false
+          tags: ${{ env.IMAGE }}
+          build-args: ${{ steps.buildargs.outputs.args }}
+          provenance: false
+
+      # Guard the security/DX balance the image commits to: it stays non-root by
+      # default, yet the vp user can reach root through sudo. The apt-get check is
+      # the exact escalation `playwright install --with-deps` performs, so this
+      # would have caught the missing-sudo failure from issue #2087.
+      - name: Smoke test
+        run: |
+          docker run --rm "$IMAGE" sh -euc '
+            echo "== default user is the non-root vp (uid 1000) =="
+            user=$(whoami); uid=$(id -u)
+            echo "user=$user uid=$uid"
+            [ "$user" = vp ] || { echo "FAIL: expected default user vp, got $user"; exit 1; }
+            [ "$uid" = 1000 ] || { echo "FAIL: expected uid 1000, got $uid"; exit 1; }
+
+            echo "== sudo present so playwright install --with-deps takes the sudo branch =="
+            command -v sudo >/dev/null || { echo "FAIL: sudo not on PATH"; exit 1; }
+
+            echo "== passwordless sudo works (no su-root password fallback) =="
+            sudo -n true || { echo "FAIL: passwordless sudo did not work"; exit 1; }
+
+            echo "== the exact apt-get escalation playwright runs succeeds =="
+            sudo -n -- sh -c "apt-get --version >/dev/null" || { echo "FAIL: elevated apt-get"; exit 1; }
+
+            echo "== vp is installed and runnable =="
+            vp --version
+
+            echo "ALL SMOKE CHECKS PASSED"
+          '
+
+      # End-to-end proof for issue #2087: run a real Vitest browser-mode test
+      # (Playwright, headless Chromium) with `vp test` inside the image. This
+      # exercises the whole path the report needed and the smoke test only
+      # simulates: `playwright install --with-deps` escalating to root via sudo,
+      # then launching Chromium as the non-root vp user. On the old (sudo-less)
+      # image the install step fails with `su: Authentication failure`.
+      # Repro repo: https://github.com/why-reproductions-are-required/vite-plus-vitest-browser-mode
+      - name: Vitest browser mode e2e (vp test)
+        run: |
+          docker run --rm -w /app "$IMAGE" bash -euc '
+            git clone --depth 1 https://github.com/why-reproductions-are-required/vite-plus-vitest-browser-mode .
+            vp install --frozen-lockfile
+            vp exec playwright install --with-deps chromium
+            vp test
+          '

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,8 @@ ARG VP_PR_VERSION=
 
 # Toolchain image: include git (+ openssh-client for git+ssh dependencies) and a
 # C/C++ build toolchain so native addons (for example better-sqlite3 or sharp)
-# can compile during `vp install`.
+# can compile during `vp install`. `sudo` provides the non-root vp user an
+# escape hatch to root (see the sudoers entry below).
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
       ca-certificates \
@@ -37,13 +38,26 @@ RUN apt-get update \
       build-essential \
       python3 \
       pkg-config \
+      sudo \
  && rm -rf /var/lib/apt/lists/* \
  && useradd --create-home --shell /bin/bash vp \
  # Own /app for the vp user so downstream `WORKDIR /app` + `vp install` can write.
  && mkdir -p /app \
- && chown vp:vp /app
+ && chown vp:vp /app \
+ # Grant the non-root vp user passwordless sudo. The image defaults to non-root
+ # (bind-mounted files stay owned by uid 1000, and Chromium keeps its sandbox),
+ # but build/CI/dev work still needs occasional root: installing extra apt
+ # packages, and `playwright install --with-deps` for Vitest browser mode. When
+ # not already root, Playwright runs the apt-get step via `sudo` if present and
+ # otherwise falls back to `su root`, which fails here (the vp user has no
+ # password). Providing NOPASSWD sudo lets that path succeed. This mirrors the
+ # devcontainer base images (non-root user + NOPASSWD sudo).
+ && echo 'vp ALL=(root) NOPASSWD:ALL' > /etc/sudoers.d/vp \
+ && chmod 0440 /etc/sudoers.d/vp
 
-# Run as a non-root user by default (mirrors oven/bun's `bun` and Deno's `deno`).
+# Run as a non-root user by default. Unlike a production runtime image, this is a
+# build/CI/dev image, so the vp user also has passwordless sudo (above) for the
+# root work those phases occasionally need.
 USER vp
 
 ENV VP_HOME=/home/vp/.vite-plus \

--- a/docs/guide/docker.md
+++ b/docs/guide/docker.md
@@ -30,7 +30,9 @@ Tags track the `vp` version:
 
 The examples use `:latest` to track the newest release; pin an exact tag or a
 digest if you need reproducible builds. The image is published for `linux/amd64`
-and `linux/arm64` and runs as a non-root user by default.
+and `linux/arm64` and runs as the non-root `vp` user by default. That user has
+passwordless `sudo`, so build/CI steps that need root (extra apt packages,
+`playwright install --with-deps`) work without changing the image user.
 
 Browse all published versions and digests on the [GitHub package page](https://github.com/voidzero-dev/vite-plus/pkgs/container/vite-plus).
 
@@ -136,6 +138,44 @@ build:
 
 On GitHub Actions, prefer [`setup-vp`](./ci) instead of the image.
 
+## Browser mode tests (Vitest / Playwright)
+
+Running as the non-root `vp` user is what you want for browsers: Chromium keeps
+its sandbox (running a browser as root disables it). Install the browser and its
+system libraries in the job. `playwright install --with-deps` needs root to
+`apt-get install` those libraries. The `vp` user has passwordless `sudo`, so
+Playwright uses it to install them without changing the image user:
+
+```yaml [.gitlab-ci.yml]
+test:
+  image: ghcr.io/voidzero-dev/vite-plus:latest
+  script:
+    - vp install --frozen-lockfile
+    - vp exec playwright install --with-deps chromium
+    - vp test
+```
+
+`vp exec` runs the project's own Playwright (from your lockfile), so it installs
+the browser revision your tests expect. Prefer it over `vpx playwright install`,
+which would download whatever Playwright is latest and can fetch a different
+browser revision.
+
+To bake the browser and its libraries into a derived image instead of installing
+them on every run, install the project dependencies first so the baked browser
+matches your lockfile, then install with the project's Playwright (root is
+available through `sudo`):
+
+```dockerfile [Dockerfile]
+FROM ghcr.io/voidzero-dev/vite-plus:latest
+WORKDIR /app
+COPY --chown=vp:vp package.json pnpm-lock.yaml pnpm-workspace.yaml .node-version* ./
+RUN vp install --frozen-lockfile
+RUN vp exec playwright install --with-deps chromium
+```
+
+If Chromium crashes under load in CI, give the container more shared memory with
+`--ipc=host`; see the [Playwright Docker docs](https://playwright.dev/docs/docker).
+
 ## Devcontainers
 
 Use the image as a ready-to-go development container with the toolchain
@@ -164,7 +204,11 @@ docker run --rm -it -v "$PWD:/app" -w /app ghcr.io/voidzero-dev/vite-plus vp bui
   those that use one have it available in every stage.
 - **Non-root user**: the image runs as the non-root `vp` user, so copy sources
   with `COPY --chown=vp:vp ...` as shown. Without it, `COPY` writes root-owned
-  files that `vp install` cannot update (permission denied).
+  files that `vp install` cannot update (permission denied). The `vp` user has
+  passwordless `sudo` for the occasional root step (installing extra apt packages
+  or `playwright install --with-deps`), so you rarely need to switch the image
+  user. The production runtime stage is a separate, vp-free base image, so this
+  convenience does not reach your deployed image.
 - **Native addons**: the image includes a C/C++ build toolchain (`build-essential`,
   `python3`), so native dependencies such as `better-sqlite3` compile during
   `vp install`.


### PR DESCRIPTION
The toolchain image runs as the non-root `vp` user but shipped no `sudo`, so
`playwright install --with-deps` (Vitest browser mode) and any `apt-get` during
build or CI failed. When not already root, Playwright installs system libraries
via `sudo` if present and otherwise falls back to `su root`, which has no
password in the image, producing `su: Authentication failure` (the error in the
issue).

## Change

Add `sudo` plus a NOPASSWD sudoers entry for `vp`. The image keeps its non-root
default (bind-mounted files stay uid 1000, Chromium keeps its sandbox) while
build, CI, and dev steps can reach root on demand. This matches the devcontainer
base images (non-root user + passwordless sudo) rather than flipping the whole
image to root. Docs get the model plus a Vitest browser-mode CI recipe.

## Validation

Built a container from the changed layer and confirmed in one run: default user
is non-root `vp` (uid 1000); `which sudo` succeeds (so Playwright takes the sudo
branch); `sudo -n true` and the literal `sudo -- sh -c 'apt-get ...'` escalation
both work passwordlessly; and the no-sudo negative control reproduces the issue
error verbatim (`su: Authentication failure`).

Closes #2087
