### PR TITLE
fix(ci): assign release PRs to workflow actor

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -78,4 +78,4 @@ jobs:
             Release vite-plus v${{ inputs.version }}.
 
             Merging this PR will trigger the release workflow.
-          assignees: fengmk2
+          assignees: ${{ github.actor }}


### PR DESCRIPTION
## Summary

- Assign release PRs to the account that triggered the Prepare Release workflow via `github.actor`.
- Remove the hard-coded `fengmk2` assignee from `prepare_release.yml`.

