### PR TITLE
test: skip upstream-flaky snap/runtime cases

### DIFF
--- a/crates/vite_js_runtime/src/runtime.rs
+++ b/crates/vite_js_runtime/src/runtime.rs
@@ -1452,6 +1452,13 @@ mod tests {
     }
 
     #[tokio::test]
+    // The unofficial-builds musl channel lists a release in index.json as soon
+    // as its directory is created, before every architecture's binary has been
+    // built. So "latest" can resolve to a version whose linux-*-musl tarball is
+    // not published yet, and the download then fails with HashNotFound. Skip on
+    // musl to avoid this race; other targets download from the atomic official
+    // nodejs.org index and stay reliable.
+    #[cfg_attr(target_env = "musl", ignore = "latest can outrun the unofficial-builds musl channel")]
     async fn test_download_runtime_for_project_with_latest_alias_in_node_version() {
         let temp_dir = TempDir::new().unwrap();
         let temp_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();

--- a/crates/vite_js_runtime/src/runtime.rs
+++ b/crates/vite_js_runtime/src/runtime.rs
@@ -1458,7 +1458,10 @@ mod tests {
     // not published yet, and the download then fails with HashNotFound. Skip on
     // musl to avoid this race; other targets download from the atomic official
     // nodejs.org index and stay reliable.
-    #[cfg_attr(target_env = "musl", ignore = "latest can outrun the unofficial-builds musl channel")]
+    #[cfg_attr(
+        target_env = "musl",
+        ignore = "latest can outrun the unofficial-builds musl channel"
+    )]
     async fn test_download_runtime_for_project_with_latest_alias_in_node_version() {
         let temp_dir = TempDir::new().unwrap();
         let temp_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();

--- a/packages/cli/snap-tests-global/command-env-install-version-alias/steps.json
+++ b/packages/cli/snap-tests-global/command-env-install-version-alias/steps.json
@@ -1,5 +1,5 @@
 {
-  "ignoredPlatforms": ["win32"],
+  "ignoredPlatforms": ["win32", { "os": "linux", "libc": "musl" }],
   "env": {},
   "commands": [
     "vp install -g --node lts ./command-env-install-version-alias-pkg # Install with LTS alias",

--- a/packages/cli/snap-tests-global/create-framework-shim-astro/steps.json
+++ b/packages/cli/snap-tests-global/create-framework-shim-astro/steps.json
@@ -1,5 +1,5 @@
 {
-  "ignoredPlatforms": ["win32"],
+  "ignoredPlatforms": ["win32", "linux", "darwin"],
   "localVitePlusPackages": true,
   "commands": [
     {


### PR DESCRIPTION
Skips three CI cases that fail on transient upstream conditions, not on code in this repo.

## Node `latest` alias on musl
unofficial-builds.nodejs.org lists a Node release in index.json as soon as its directory is created, before every architecture's binary is built. Resolving the `latest` alias can pick a version whose linux-*-musl tarball is not published yet, so the download fails with HashNotFound (seen with node-v26.5.0-linux-x64-musl.tar.gz). Official nodejs.org releases are atomic, so glibc, darwin, and windows keep full coverage.

- runtime unit test `test_download_runtime_for_project_with_latest_alias_in_node_version`: skipped on musl
- snap-tests-global `command-env-install-version-alias`: skipped on musl

## astro create shim
`vp create astro --template basics` scaffolds an astro dependency pinned to the create-astro template's current reference, which between releases is the next unpublished version (astro@^7.0.7 while 7.0.6 is latest). The following `vp install` then fails with ERR_PNPM_NO_MATCHING_VERSION on every platform.

- snap-tests-global `create-framework-shim-astro`: skipped (the vp migrate astro shim cases still cover the shim itself)