### PR TITLE
ci: bump registry-bridge action to content-addressed tarball URLs

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Register commit build with the registry bridge
         id: bridge
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: voidzero-dev/pkg-pr-registry-bridge@65c8157a6f44f075c50d3d3faf3a9bd43d2b230a # main
+        uses: voidzero-dev/pkg-pr-registry-bridge@a83d8aaac9f93918f5112eed3ec8e3b16afe401b # content-addressed tarball URLs (#58)
         with:
           sha: ${{ github.event.pull_request.head.sha }}
           admin-token: ${{ secrets.PKG_PR_BRIDGE_ADMIN_TOKEN }}

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Register commit build with the registry bridge
         id: bridge
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: voidzero-dev/pkg-pr-registry-bridge@a83d8aaac9f93918f5112eed3ec8e3b16afe401b # main
+        uses: voidzero-dev/pkg-pr-registry-bridge@4fbc4133d80536c36e4ce25aab3527da3645afc4 # main
         with:
           sha: ${{ github.event.pull_request.head.sha }}
           admin-token: ${{ secrets.PKG_PR_BRIDGE_ADMIN_TOKEN }}

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Register commit build with the registry bridge
         id: bridge
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: voidzero-dev/pkg-pr-registry-bridge@a83d8aaac9f93918f5112eed3ec8e3b16afe401b # content-addressed tarball URLs (#58)
+        uses: voidzero-dev/pkg-pr-registry-bridge@a83d8aaac9f93918f5112eed3ec8e3b16afe401b # main
         with:
           sha: ${{ github.event.pull_request.head.sha }}
           admin-token: ${{ secrets.PKG_PR_BRIDGE_ADMIN_TOKEN }}


### PR DESCRIPTION
Points the `preview-build` action at [pkg-pr-registry-bridge#58](https://github.com/voidzero-dev/pkg-pr-registry-bridge/pull/58) (`a83d8aa`, merged + deployed), which makes preview tarballs content-addressed:

- uploads to `/-/tarball/<name>/<version>/<shasum>.tgz`
- `dist.tarball` = `/tarballs/<name>/<version>/<shasum>.tgz`

This fixes the `ERR_PNPM_TARBALL_INTEGRITY` a non-byte-reproducible rebuild of the same commit could cause: each build gets its own URL, so a republish can never cross bytes and integrity. The bridge is already deployed and back-compat (existing version-addressed previews still install via a revalidatable fallback), so this just activates the new upload path for future preview builds.

Add the `preview-build` label to smoke-test a labeled build against the deployed bridge.