### PR TITLE
test(snapshots): redact scaffolded devEngines version pins

### DIFF
--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/create_approve_builds_bun/snapshots/create_approve_builds_bun.md
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/create_approve_builds_bun/snapshots/create_approve_builds_bun.md
@@ -36,7 +36,7 @@ core-js recorded under trustedDependencies
   "devEngines": {
     "packageManager": {
       "name": "bun",
-      "version": "1.3.14",
+      "version": "<version>",
       "onFail": "download"
     }
   },
@@ -86,7 +86,7 @@ no trustedDependencies, the build was not run
   "devEngines": {
     "packageManager": {
       "name": "bun",
-      "version": "1.3.14",
+      "version": "<version>",
       "onFail": "download"
     }
   }
@@ -131,7 +131,7 @@ core-js is now recorded under trustedDependencies
   "devEngines": {
     "packageManager": {
       "name": "bun",
-      "version": "1.3.14",
+      "version": "<version>",
       "onFail": "download"
     }
   },

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/create_approve_builds_yarn/snapshots/create_approve_builds_yarn.md
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/create_approve_builds_yarn/snapshots/create_approve_builds_yarn.md
@@ -40,7 +40,7 @@ core-js recorded under dependenciesMeta.built
   "devEngines": {
     "packageManager": {
       "name": "yarn",
-      "version": "4.17.0",
+      "version": "<version>",
       "onFail": "download"
     }
   }
@@ -86,7 +86,7 @@ no dependenciesMeta, the build was not run
   "devEngines": {
     "packageManager": {
       "name": "yarn",
-      "version": "4.17.0",
+      "version": "<version>",
       "onFail": "download"
     }
   }

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/create_org_bundled/snapshots/create_org_bundled.md
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/create_org_bundled/snapshots/create_org_bundled.md
@@ -29,7 +29,7 @@ verify package.json name was rewritten
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": "11.10.0",
+      "version": "<version>",
       "onFail": "download"
     }
   }

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/new_vite_monorepo/snapshots/new_vite_monorepo.md
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/new_vite_monorepo/snapshots/new_vite_monorepo.md
@@ -42,7 +42,7 @@ check package.json
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": "11.10.0",
+      "version": "<version>",
       "onFail": "download"
     }
   },
@@ -422,7 +422,7 @@ check package.json
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": "11.10.0",
+      "version": "<version>",
       "onFail": "download"
     }
   },

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/new_vite_monorepo_bun/snapshots/new_vite_monorepo_bun.md
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/new_vite_monorepo_bun/snapshots/new_vite_monorepo_bun.md
@@ -49,7 +49,7 @@ check package.json with catalog
   "devEngines": {
     "packageManager": {
       "name": "bun",
-      "version": "1.3.14",
+      "version": "<version>",
       "onFail": "download"
     }
   },

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/redact.rs
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/redact.rs
@@ -47,6 +47,22 @@ static VP_VERSION_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
     )
     .unwrap()
 });
+// `vp create`/`vp migrate` pin the exact resolved runtime and package-manager
+// version into a scaffolded manifest's `devEngines` block (`{ "name": "yarn",
+// "version": "4.17.0", ... }`, likewise pnpm/bun/node). Those track whatever
+// the package manager or Node published most recently, so they churn on every
+// upstream release exactly like the banner's `yarn <version>` line (already
+// masked). Mask by the adjacent `"name"` context so a scaffolded pin is
+// redacted while user-controlled semver in the same manifest (`"core-js":
+// "3.39.0"`, a pre-existing `"packageManager": "bun@1.3.11"` input) stays
+// assertable. The tool-name allowlist keeps ordinary top-level `"name":
+// "my-app"` / `"version": "0.0.0"` pairs verbatim.
+static DEV_ENGINES_VERSION_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(
+        r#"("name":\s*"(?:node|npm|pnpm|yarn|bun|deno)",\s*"version":\s*")\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?"#,
+    )
+    .unwrap()
+});
 // Output bytes differ across OSes (line endings, embedded paths), so byte
 // sizes and content-derived asset hashes can never be part of a shared
 // snapshot. The unit is kept ("<size> kB"): it only changes when content
@@ -176,6 +192,10 @@ pub fn redact_output(
     // Redact the workspace's own vite-plus/core version by package context
     // (see VP_VERSION_RE), which bumps on every release.
     output = VP_VERSION_RE.replace_all(&output, "${1}<version>").into_owned();
+
+    // Redact scaffolded devEngines runtime/package-manager pins by name
+    // context (see DEV_ENGINES_VERSION_RE), which track upstream releases.
+    output = DEV_ENGINES_VERSION_RE.replace_all(&output, "${1}<version>").into_owned();
 
     // Redact thread counts like "16 threads" to "<n> threads"
     output = THREAD_RE.replace_all(&output, "<n> threads").into_owned();

--- a/crates/vite_cli_snapshots/tests/redact_unit.rs
+++ b/crates/vite_cli_snapshots/tests/redact_unit.rs
@@ -83,6 +83,51 @@ fn masks_vite_plus_version_by_context_only() {
 }
 
 #[test]
+fn masks_scaffolded_dev_engines_pins_by_name_context() {
+    // vp create/migrate pin the resolved runtime and package-manager version
+    // into devEngines; both churn on upstream releases and must be masked,
+    // while user-controlled semver in the same manifest stays verbatim.
+    let input = concat!(
+        "  \"devEngines\": {\n",
+        "    \"packageManager\": {\n",
+        "      \"name\": \"yarn\",\n",
+        "      \"version\": \"4.17.0\",\n",
+        "      \"onFail\": \"download\"\n",
+        "    },\n",
+        "    \"runtime\": {\n",
+        "      \"name\": \"node\",\n",
+        "      \"version\": \"24.18.0\"\n",
+        "    }\n",
+        "  },\n",
+        "  \"name\": \"approved-app\",\n",
+        "  \"version\": \"0.0.0\",\n",
+        "  \"packageManager\": \"bun@1.3.11\",\n",
+        "  \"core-js\": \"3.39.0\"\n",
+    )
+    .to_owned();
+    assert_eq!(
+        redact_output(input, &[], true),
+        concat!(
+            "  \"devEngines\": {\n",
+            "    \"packageManager\": {\n",
+            "      \"name\": \"yarn\",\n",
+            "      \"version\": \"<version>\",\n",
+            "      \"onFail\": \"download\"\n",
+            "    },\n",
+            "    \"runtime\": {\n",
+            "      \"name\": \"node\",\n",
+            "      \"version\": \"<version>\"\n",
+            "    }\n",
+            "  },\n",
+            "  \"name\": \"approved-app\",\n",
+            "  \"version\": \"0.0.0\",\n",
+            "  \"packageManager\": \"bun@1.3.11\",\n",
+            "  \"core-js\": \"3.39.0\"\n",
+        )
+    );
+}
+
+#[test]
 fn replaces_paths_with_labels() {
     let input = "built /tmp/stage-1/dist in 3ms\n".to_owned();
     assert_eq!(


### PR DESCRIPTION
vp create/migrate write the resolved runtime and package-manager version
into a scaffolded package.json devEngines block, so recorded snapshots go
stale whenever the package manager or Node publishes a release (yarn
4.17.0 -> 4.17.1 broke the create_approve_builds_yarn case).

Mask the version value adjacent to a devEngines tool-name key
(node/npm/pnpm/yarn/bun/deno), the same way the banner already masks
"yarn <version>", and normalize the 9 existing pins across 5 snapshots.
User-controlled semver in the same manifests (core-js, a pre-existing
packageManager string, top-level version) stays verbatim.