### PR TITLE
ci: add installer (vp-setup.exe) to native binary size report

### DIFF
--- a/.github/workflows/vp-binary-size.yml
+++ b/.github/workflows/vp-binary-size.yml
@@ -153,6 +153,7 @@ jobs:
                   vp: `target/${target}/release/vp.exe`,
                   napi: 'packages/cli/binding/vite-plus.win32-x64-msvc.node',
                   trampoline: `target/${target}/release/vp-shim.exe`,
+                  installer: `target/${target}/release/vp-setup.exe`,
                 };
 
           const artifacts = {};
@@ -300,6 +301,13 @@ jobs:
                 baseGzip: baseWindows.artifacts.trampoline.gzip,
                 headRaw: headWindows.artifacts.trampoline.raw,
                 headGzip: headWindows.artifacts.trampoline.gzip,
+              },
+              {
+                name: 'Installer (Windows x64)',
+                baseRaw: baseWindows.artifacts.installer.raw,
+                baseGzip: baseWindows.artifacts.installer.gzip,
+                headRaw: headWindows.artifacts.installer.raw,
+                headGzip: headWindows.artifacts.installer.gzip,
               },
             ];
 


### PR DESCRIPTION
The vp-binary-size workflow measured vp, NAPI, and the Windows trampoline (vp-shim.exe) but omitted the Windows installer (vp-setup.exe), even though both build-upstream and build-windows-cli build and cache it alongside the other artifacts.

Measure vp-setup.exe on Windows and add an "Installer (Windows x64)" row to the report.