### PR TITLE
chore: bump pkg-pr-registry-bridge publish action to latest main (#2106)

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Register commit build with the registry bridge
         id: bridge
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: voidzero-dev/pkg-pr-registry-bridge@4fbc4133d80536c36e4ce25aab3527da3645afc4 # main
+        uses: voidzero-dev/pkg-pr-registry-bridge@f57eaa9063ca6af90ea6471ef881c8b46c64a060 # main
         with:
           sha: ${{ github.event.pull_request.head.sha }}
           admin-token: ${{ secrets.PKG_PR_BRIDGE_ADMIN_TOKEN }}


### PR DESCRIPTION
Bumps the pinned `voidzero-dev/pkg-pr-registry-bridge` publish action in `publish-preview.yml` from `4fbc413` (bridge #60) to `f57eaa9` (bridge #61).

The bridge removed its `PKG_PR_NEW_BASE` var and the Worker's on-demand pkg.pr.new fallback; it now serves preview artifacts only from R2. The action's inputs are unchanged and this step packs locally, so publish behavior here is identical. This just keeps the pin in sync with the deployed bridge.