### PR TITLE
docs: add windows to namespace sponsor credit

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,4 +223,4 @@ Or, if you are using Yarn:
 
 ## Sponsors
 
-Thanks to [namespace.so](https://namespace.so) for powering our CI/CD pipelines with fast, free macOS and Linux runners.
+Thanks to [namespace.so](https://namespace.so) for powering our CI/CD pipelines with fast, free macOS, Linux, and Windows runners.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -217,4 +217,4 @@ Or, if you are using Yarn:
 
 ## Sponsors
 
-Thanks to [namespace.so](https://namespace.so) for powering our CI/CD pipelines with fast, free macOS and Linux runners.
+Thanks to [namespace.so](https://namespace.so) for powering our CI/CD pipelines with fast, free macOS, Linux, and Windows runners.


### PR DESCRIPTION
CI now runs on Namespace-provided Windows runners (namespace-profile-windows-4c-8g)
across ci.yml, e2e-test.yml, reusable-release-build.yml, and
test-standalone-install.yml, so the sponsor line should credit macOS, Linux, and
Windows runners.