### PR TITLE
fix(snapshots): scope registry teardown signal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1104,13 +1104,13 @@ jobs:
       - download-previous-rolldown-binaries
       - build-windows-cli
       - build-windows-tests
-    # Stays on GitHub-hosted windows-latest, NOT the Namespace Windows runner:
-    # this is a PTY snapshot suite. The runner opens a pseudo-console (ConPTY)
-    # and spawns vp into it, but Namespace's Windows runners execute jobs under a
-    # Session-0 service account with no interactive console, where that ConPTY
-    # spawn blocks — vp is never launched and every case times out at 60s.
-    # windows-latest runs in a session where ConPTY works.
-    runs-on: windows-latest
+    # Runs on the Namespace Windows runner. This is a PTY snapshot suite that
+    # opens a pseudo-console (ConPTY) and spawns vp into it. It previously stayed
+    # on GitHub-hosted windows-latest because Namespace's Windows runners ran
+    # under a Session-0 service account with no interactive console, where the
+    # ConPTY spawn blocked and every case timed out at 60s. #2126 (vite-task
+    # bump) resolved that; revert to windows-latest if it recurs.
+    runs-on: namespace-profile-windows-4c-8g
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
       - uses: ./.github/actions/clone

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/main.rs
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/main.rs
@@ -658,15 +658,13 @@ struct RegistryHandle {
 impl Drop for RegistryHandle {
     fn drop(&mut self) {
         // Graceful first: SIGTERM the server so its handler removes the
-        // throwaway yarn/bun caches. Signal both the process itself and its
-        // group (whether the child ended up a group leader can vary), so the
-        // handler reliably runs regardless.
+        // throwaway yarn/bun caches. Keep this scoped to the direct child:
+        // process-group SIGTERM can leak past the case boundary on
+        // ubuntu-latest PTY runs and interrupt the Actions runner itself.
         #[cfg(unix)]
         {
             let pid = self.child.id();
-            let _ = std::process::Command::new("kill")
-                .args(["-TERM", &pid.to_string(), &format!("-{pid}")])
-                .output();
+            let _ = std::process::Command::new("kill").args(["-TERM", &pid.to_string()]).output();
         }
         #[cfg(windows)]
         {


### PR DESCRIPTION
The local-registry teardown sent SIGTERM to both the server process and
its process group (kill -TERM <pid> -<pid>). On the GitHub-hosted
ubuntu-latest PTY runs that process-group signal leaked past the case
boundary and reached the Actions runner agent, which reported "runner
received a shutdown signal" and cancelled the job. Confirmed via a
bpftrace probe on signal:signal_generate: no suite process ever sends a
SIGINT, so the runner itself was doing the cancelling in response to the
stray group SIGTERM. Scope the SIGTERM to the direct child; the server's
own handler still removes its throwaway caches and the force-kill fallback
still guarantees teardown.