### PR TITLE
feat(run): expose replayLogs cache option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2273,7 +2273,7 @@ dependencies = [
 [[package]]
 name = "fspy"
 version = "0.1.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "anyhow",
  "bstr",
@@ -2307,7 +2307,7 @@ dependencies = [
 [[package]]
 name = "fspy_client_unix"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -2325,7 +2325,7 @@ dependencies = [
 [[package]]
 name = "fspy_detours_sys"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "cc",
  "winapi",
@@ -2334,7 +2334,7 @@ dependencies = [
 [[package]]
 name = "fspy_ipc_str"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "allocator-api2",
  "bumpalo",
@@ -2347,7 +2347,7 @@ dependencies = [
 [[package]]
 name = "fspy_nostd"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "atoi",
  "bitflags 2.13.1",
@@ -2361,7 +2361,7 @@ dependencies = [
 [[package]]
 name = "fspy_nostd_alloc"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "allocator-api2",
  "bump-scope",
@@ -2371,7 +2371,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_unix"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "ctor",
  "fspy_client_unix",
@@ -2386,7 +2386,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_windows"
 version = "0.1.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "constcat",
  "fspy_detours_sys",
@@ -2404,7 +2404,7 @@ dependencies = [
 [[package]]
 name = "fspy_seccomp_unotify"
 version = "0.1.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "futures-util",
  "libc",
@@ -2421,7 +2421,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "allocator-api2",
  "bitflags 2.13.1",
@@ -2444,7 +2444,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared_unix"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2463,7 +2463,7 @@ dependencies = [
 [[package]]
 name = "fspy_shm"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "fspy_nostd",
  "windows-sys 0.61.2",
@@ -3603,7 +3603,7 @@ dependencies = [
 [[package]]
 name = "materialized_artifact"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "materialized_artifact_macros",
  "tempfile",
@@ -3612,7 +3612,7 @@ dependencies = [
 [[package]]
 name = "materialized_artifact_macros"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5545,7 +5545,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "anyhow",
  "portable-pty",
@@ -5555,7 +5555,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal_test"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "anyhow",
  "portable-pty",
@@ -5566,7 +5566,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal_test_client"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "base64 0.22.1",
  "getrandom 0.4.3",
@@ -5873,7 +5873,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "append-only-vec",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_common"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6097,7 +6097,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_dev"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_dev_common"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "derive_more",
  "rolldown_common",
@@ -6130,7 +6130,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_devtools"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "blake3",
  "rolldown_devtools_action",
@@ -6143,7 +6143,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_devtools_action"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "serde",
  "ts-rs",
@@ -6151,7 +6151,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_ecmascript"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "arcstr",
  "oxc",
@@ -6163,7 +6163,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_ecmascript_utils"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "memchr",
  "oxc",
@@ -6173,7 +6173,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_error"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6190,7 +6190,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_fs"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "oxc_resolver",
  "vfs",
@@ -6198,7 +6198,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_fs_watcher"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "rolldown-notify",
  "rolldown-notify-debouncer-full",
@@ -6207,7 +6207,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6236,7 +6236,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_asset_module"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "rolldown_common",
@@ -6248,7 +6248,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_bundle_analyzer"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "arcstr",
  "rolldown_common",
@@ -6262,7 +6262,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_chunk_import_map"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "arcstr",
  "rolldown_common",
@@ -6275,7 +6275,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_copy_module"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6288,7 +6288,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_data_url"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "arcstr",
  "base64-simd",
@@ -6301,7 +6301,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_esm_external_require"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "nodejs-built-in-modules",
  "rolldown_common",
@@ -6312,7 +6312,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_hmr"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "rolldown_common",
  "rolldown_plugin",
@@ -6320,7 +6320,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_isolated_declaration"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "arcstr",
  "oxc",
@@ -6334,7 +6334,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_lazy_compilation"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6347,7 +6347,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_oxc_runtime"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "arcstr",
  "phf 0.14.0",
@@ -6358,7 +6358,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_replace"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "oxc",
@@ -6374,7 +6374,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_utils"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6527,7 +6527,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_vite_resolve"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6581,7 +6581,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_resolver"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6596,7 +6596,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_sourcemap"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "criterion2",
  "memchr",
@@ -6606,7 +6606,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_std_utils"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "regex",
  "sugar_path",
@@ -6652,7 +6652,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_tracing"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "tracing",
  "tracing-chrome",
@@ -6661,7 +6661,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_utils"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6699,7 +6699,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_watcher"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6719,7 +6719,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_workspace"
-version = "1.2.2"
+version = "1.2.4"
 
 [[package]]
 name = "ropey"
@@ -7420,7 +7420,7 @@ dependencies = [
 [[package]]
 name = "snapshot_test"
 version = "0.1.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "serde",
  "serde_json",
@@ -7450,7 +7450,7 @@ dependencies = [
 [[package]]
 name = "socket_ipc"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "nix 0.31.3",
  "tempfile",
@@ -7530,7 +7530,7 @@ dependencies = [
 
 [[package]]
 name = "string_wizard"
-version = "1.2.2"
+version = "1.2.4"
 dependencies = [
  "insta",
  "memchr",
@@ -8723,7 +8723,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "vt"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "anstream",
  "anyhow",
@@ -8782,7 +8782,7 @@ dependencies = [
 [[package]]
 name = "vt_client"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "fspy_ipc_str",
  "rustc-hash",
@@ -8795,7 +8795,7 @@ dependencies = [
 [[package]]
 name = "vt_client_napi"
 version = "0.1.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "napi",
  "napi-build",
@@ -8807,7 +8807,7 @@ dependencies = [
 [[package]]
 name = "vt_glob"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "globset",
  "thiserror 2.0.19",
@@ -8817,7 +8817,7 @@ dependencies = [
 [[package]]
 name = "vt_graph"
 version = "0.1.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8839,7 +8839,7 @@ dependencies = [
 [[package]]
 name = "vt_graph_ser"
 version = "0.1.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "petgraph 0.8.3",
  "serde",
@@ -8848,7 +8848,7 @@ dependencies = [
 [[package]]
 name = "vt_ipc_shared"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "fspy_ipc_str",
  "rustc-hash",
@@ -8858,7 +8858,7 @@ dependencies = [
 [[package]]
 name = "vt_path"
 version = "0.1.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "diff-struct",
  "os_str_bytes",
@@ -8873,7 +8873,7 @@ dependencies = [
 [[package]]
 name = "vt_plan"
 version = "0.1.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8901,7 +8901,7 @@ dependencies = [
 [[package]]
 name = "vt_powershell"
 version = "0.1.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "vt_path",
  "which",
@@ -8910,7 +8910,7 @@ dependencies = [
 [[package]]
 name = "vt_select"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -8921,7 +8921,7 @@ dependencies = [
 [[package]]
 name = "vt_server"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "fspy_ipc_str",
  "futures",
@@ -8940,7 +8940,7 @@ dependencies = [
 [[package]]
 name = "vt_shell"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "brush-parser 0.4.0",
  "diff-struct",
@@ -8953,7 +8953,7 @@ dependencies = [
 [[package]]
 name = "vt_str"
 version = "0.1.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "compact_str 0.9.1",
  "diff-struct",
@@ -8964,7 +8964,7 @@ dependencies = [
 [[package]]
 name = "vt_workspace"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
 dependencies = [
  "clap",
  "petgraph 0.8.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2273,7 +2273,7 @@ dependencies = [
 [[package]]
 name = "fspy"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
 dependencies = [
  "anyhow",
  "bstr",
@@ -2307,52 +2307,90 @@ dependencies = [
 [[package]]
 name = "fspy_client_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
 dependencies = [
  "allocator-api2",
  "anyhow",
  "bstr",
+ "fspy_nostd",
+ "fspy_nostd_alloc",
  "fspy_shared",
  "fspy_shared_unix",
  "itoa",
  "libc",
  "nix 0.31.3",
- "sigsafe",
- "sigsafe_alloc",
  "wincode",
 ]
 
 [[package]]
 name = "fspy_detours_sys"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
 dependencies = [
  "cc",
  "winapi",
 ]
 
 [[package]]
+name = "fspy_ipc_str"
+version = "0.0.0"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "bytemuck",
+ "fspy_nostd",
+ "fspy_nostd_alloc",
+ "wincode",
+]
+
+[[package]]
+name = "fspy_nostd"
+version = "0.0.0"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+dependencies = [
+ "atoi",
+ "bitflags 2.13.1",
+ "bstr",
+ "libc",
+ "rustix",
+ "syscalls",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fspy_nostd_alloc"
+version = "0.0.0"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
+dependencies = [
+ "allocator-api2",
+ "bump-scope",
+ "fspy_nostd",
+]
+
+[[package]]
 name = "fspy_preload_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
 dependencies = [
  "ctor",
  "fspy_client_unix",
+ "fspy_nostd",
+ "fspy_nostd_alloc",
  "fspy_shared",
  "fspy_shared_unix",
  "libc",
  "nix 0.31.3",
- "sigsafe",
- "sigsafe_alloc",
 ]
 
 [[package]]
 name = "fspy_preload_windows"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
 dependencies = [
  "constcat",
  "fspy_detours_sys",
+ "fspy_nostd",
  "fspy_shared",
  "ntapi",
  "smallvec 2.0.0-alpha.12",
@@ -2366,7 +2404,7 @@ dependencies = [
 [[package]]
 name = "fspy_seccomp_unotify"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
 dependencies = [
  "futures-util",
  "libc",
@@ -2383,14 +2421,18 @@ dependencies = [
 [[package]]
 name = "fspy_shared"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
 dependencies = [
+ "allocator-api2",
  "bitflags 2.13.1",
  "bstr",
  "bumpalo",
  "bytemuck",
+ "fspy_ipc_str",
+ "fspy_nostd",
+ "fspy_nostd_alloc",
  "fspy_shm",
- "native_str",
+ "omnipath",
  "thiserror 2.0.19",
  "tracing",
  "uuid",
@@ -2402,18 +2444,18 @@ dependencies = [
 [[package]]
 name = "fspy_shared_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
  "bstr",
  "elf",
+ "fspy_nostd",
  "fspy_seccomp_unotify",
  "fspy_shared",
  "memmap2",
  "nix 0.31.3",
  "phf 0.13.1",
- "sigsafe",
  "stackalloc",
  "wincode",
 ]
@@ -2421,10 +2463,9 @@ dependencies = [
 [[package]]
 name = "fspy_shm"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
 dependencies = [
- "memmap2",
- "uuid",
+ "fspy_nostd",
  "windows-sys 0.61.2",
 ]
 
@@ -3562,7 +3603,7 @@ dependencies = [
 [[package]]
 name = "materialized_artifact"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
 dependencies = [
  "materialized_artifact_macros",
  "tempfile",
@@ -3571,7 +3612,7 @@ dependencies = [
 [[package]]
 name = "materialized_artifact_macros"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3793,16 +3834,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "native_str"
-version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
-dependencies = [
- "bumpalo",
- "bytemuck",
- "wincode",
 ]
 
 [[package]]
@@ -4119,6 +4150,12 @@ dependencies = [
  "ctr",
  "subtle",
 ]
+
+[[package]]
+name = "omnipath"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80adb31078122c880307e9cdfd4e3361e6545c319f9b9dcafcb03acd3b51a575"
 
 [[package]]
 name = "once_cell"
@@ -5508,7 +5545,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
 dependencies = [
  "anyhow",
  "portable-pty",
@@ -5518,7 +5555,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal_test"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
 dependencies = [
  "anyhow",
  "portable-pty",
@@ -5529,7 +5566,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal_test_client"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
 dependencies = [
  "base64 0.22.1",
  "getrandom 0.4.3",
@@ -5836,7 +5873,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "append-only-vec",
@@ -6024,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_common"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6060,7 +6097,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_dev"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6081,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_dev_common"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "derive_more",
  "rolldown_common",
@@ -6093,7 +6130,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_devtools"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "blake3",
  "rolldown_devtools_action",
@@ -6106,7 +6143,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_devtools_action"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "serde",
  "ts-rs",
@@ -6114,7 +6151,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_ecmascript"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "arcstr",
  "oxc",
@@ -6126,7 +6163,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_ecmascript_utils"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "memchr",
  "oxc",
@@ -6136,7 +6173,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_error"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6153,7 +6190,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_fs"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "oxc_resolver",
  "vfs",
@@ -6161,7 +6198,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_fs_watcher"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "rolldown-notify",
  "rolldown-notify-debouncer-full",
@@ -6170,7 +6207,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6199,7 +6236,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_asset_module"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "rolldown_common",
@@ -6211,7 +6248,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_bundle_analyzer"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "arcstr",
  "rolldown_common",
@@ -6225,7 +6262,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_chunk_import_map"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "arcstr",
  "rolldown_common",
@@ -6238,7 +6275,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_copy_module"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6251,7 +6288,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_data_url"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "arcstr",
  "base64-simd",
@@ -6264,7 +6301,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_esm_external_require"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "nodejs-built-in-modules",
  "rolldown_common",
@@ -6275,7 +6312,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_hmr"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "rolldown_common",
  "rolldown_plugin",
@@ -6283,7 +6320,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_isolated_declaration"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "arcstr",
  "oxc",
@@ -6297,7 +6334,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_lazy_compilation"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6310,7 +6347,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_oxc_runtime"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "arcstr",
  "phf 0.14.0",
@@ -6321,7 +6358,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_replace"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "oxc",
@@ -6337,7 +6374,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_utils"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6490,7 +6527,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_vite_resolve"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6544,7 +6581,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_resolver"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6559,7 +6596,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_sourcemap"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "criterion2",
  "memchr",
@@ -6569,7 +6606,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_std_utils"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "regex",
  "sugar_path",
@@ -6615,7 +6652,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_tracing"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "tracing",
  "tracing-chrome",
@@ -6624,7 +6661,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_utils"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6662,7 +6699,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_watcher"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6682,7 +6719,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_workspace"
-version = "1.2.4"
+version = "1.2.2"
 
 [[package]]
 name = "ropey"
@@ -7278,28 +7315,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sigsafe"
-version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
-dependencies = [
- "atoi",
- "bstr",
- "libc",
- "rustix",
- "syscalls",
-]
-
-[[package]]
-name = "sigsafe_alloc"
-version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
-dependencies = [
- "allocator-api2",
- "bump-scope",
- "sigsafe",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7405,7 +7420,7 @@ dependencies = [
 [[package]]
 name = "snapshot_test"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
 dependencies = [
  "serde",
  "serde_json",
@@ -7435,7 +7450,7 @@ dependencies = [
 [[package]]
 name = "socket_ipc"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
 dependencies = [
  "nix 0.31.3",
  "tempfile",
@@ -7515,7 +7530,7 @@ dependencies = [
 
 [[package]]
 name = "string_wizard"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "insta",
  "memchr",
@@ -8708,7 +8723,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "vt"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
 dependencies = [
  "anstream",
  "anyhow",
@@ -8767,9 +8782,9 @@ dependencies = [
 [[package]]
 name = "vt_client"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
 dependencies = [
- "native_str",
+ "fspy_ipc_str",
  "rustc-hash",
  "socket_ipc",
  "vt_ipc_shared",
@@ -8780,7 +8795,7 @@ dependencies = [
 [[package]]
 name = "vt_client_napi"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
 dependencies = [
  "napi",
  "napi-build",
@@ -8792,7 +8807,7 @@ dependencies = [
 [[package]]
 name = "vt_glob"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
 dependencies = [
  "globset",
  "thiserror 2.0.19",
@@ -8802,7 +8817,7 @@ dependencies = [
 [[package]]
 name = "vt_graph"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8824,7 +8839,7 @@ dependencies = [
 [[package]]
 name = "vt_graph_ser"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
 dependencies = [
  "petgraph 0.8.3",
  "serde",
@@ -8833,9 +8848,9 @@ dependencies = [
 [[package]]
 name = "vt_ipc_shared"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
 dependencies = [
- "native_str",
+ "fspy_ipc_str",
  "rustc-hash",
  "wincode",
 ]
@@ -8843,7 +8858,7 @@ dependencies = [
 [[package]]
 name = "vt_path"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
 dependencies = [
  "diff-struct",
  "os_str_bytes",
@@ -8858,7 +8873,7 @@ dependencies = [
 [[package]]
 name = "vt_plan"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8886,7 +8901,7 @@ dependencies = [
 [[package]]
 name = "vt_powershell"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
 dependencies = [
  "vt_path",
  "which",
@@ -8895,7 +8910,7 @@ dependencies = [
 [[package]]
 name = "vt_select"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -8906,10 +8921,10 @@ dependencies = [
 [[package]]
 name = "vt_server"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
 dependencies = [
+ "fspy_ipc_str",
  "futures",
- "native_str",
  "rustc-hash",
  "socket_ipc",
  "thiserror 2.0.19",
@@ -8925,7 +8940,7 @@ dependencies = [
 [[package]]
 name = "vt_shell"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
 dependencies = [
  "brush-parser 0.4.0",
  "diff-struct",
@@ -8938,7 +8953,7 @@ dependencies = [
 [[package]]
 name = "vt_str"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
 dependencies = [
  "compact_str 0.9.1",
  "diff-struct",
@@ -8949,7 +8964,7 @@ dependencies = [
 [[package]]
 name = "vt_workspace"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=d05b1dcdbaabaa69643ee0b89cebe3cd390957e9#d05b1dcdbaabaa69643ee0b89cebe3cd390957e9"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=5ca3ca50826406b29a47a3bae6b69dd649facb9e#5ca3ca50826406b29a47a3bae6b69dd649facb9e"
 dependencies = [
  "clap",
  "petgraph 0.8.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2057,7 +2057,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2273,7 +2273,7 @@ dependencies = [
 [[package]]
 name = "fspy"
 version = "0.1.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "anyhow",
  "bstr",
@@ -2307,7 +2307,7 @@ dependencies = [
 [[package]]
 name = "fspy_client_unix"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -2325,7 +2325,7 @@ dependencies = [
 [[package]]
 name = "fspy_detours_sys"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "cc",
  "winapi",
@@ -2334,7 +2334,7 @@ dependencies = [
 [[package]]
 name = "fspy_ipc_str"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "allocator-api2",
  "bumpalo",
@@ -2347,7 +2347,7 @@ dependencies = [
 [[package]]
 name = "fspy_nostd"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "atoi",
  "bitflags 2.13.1",
@@ -2361,7 +2361,7 @@ dependencies = [
 [[package]]
 name = "fspy_nostd_alloc"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "allocator-api2",
  "bump-scope",
@@ -2371,7 +2371,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_unix"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "ctor",
  "fspy_client_unix",
@@ -2386,7 +2386,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_windows"
 version = "0.1.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "constcat",
  "fspy_detours_sys",
@@ -2404,7 +2404,7 @@ dependencies = [
 [[package]]
 name = "fspy_seccomp_unotify"
 version = "0.1.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "futures-util",
  "libc",
@@ -2421,7 +2421,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "allocator-api2",
  "bitflags 2.13.1",
@@ -2444,7 +2444,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared_unix"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2463,7 +2463,7 @@ dependencies = [
 [[package]]
 name = "fspy_shm"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "fspy_nostd",
  "windows-sys 0.61.2",
@@ -2987,7 +2987,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3174,7 +3174,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3603,7 +3603,7 @@ dependencies = [
 [[package]]
 name = "materialized_artifact"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "materialized_artifact_macros",
  "tempfile",
@@ -3612,7 +3612,7 @@ dependencies = [
 [[package]]
 name = "materialized_artifact_macros"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5117,7 +5117,7 @@ dependencies = [
  "aes-gcm",
  "aes-kw",
  "argon2",
- "base64 0.22.1",
+ "base64 0.21.7",
  "bitfields",
  "block-padding",
  "blowfish",
@@ -5545,7 +5545,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "anyhow",
  "portable-pty",
@@ -5555,7 +5555,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal_test"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "anyhow",
  "portable-pty",
@@ -5566,7 +5566,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal_test_client"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "base64 0.22.1",
  "getrandom 0.4.3",
@@ -5873,7 +5873,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "append-only-vec",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_common"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6097,7 +6097,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_dev"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_dev_common"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "derive_more",
  "rolldown_common",
@@ -6130,7 +6130,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_devtools"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "blake3",
  "rolldown_devtools_action",
@@ -6143,7 +6143,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_devtools_action"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "serde",
  "ts-rs",
@@ -6151,7 +6151,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_ecmascript"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "arcstr",
  "oxc",
@@ -6163,7 +6163,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_ecmascript_utils"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "memchr",
  "oxc",
@@ -6173,7 +6173,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_error"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6190,7 +6190,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_fs"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "oxc_resolver",
  "vfs",
@@ -6198,7 +6198,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_fs_watcher"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "rolldown-notify",
  "rolldown-notify-debouncer-full",
@@ -6207,7 +6207,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6236,7 +6236,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_asset_module"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "rolldown_common",
@@ -6248,7 +6248,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_bundle_analyzer"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "arcstr",
  "rolldown_common",
@@ -6262,7 +6262,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_chunk_import_map"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "arcstr",
  "rolldown_common",
@@ -6275,7 +6275,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_copy_module"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6288,7 +6288,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_data_url"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "arcstr",
  "base64-simd",
@@ -6301,7 +6301,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_esm_external_require"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "nodejs-built-in-modules",
  "rolldown_common",
@@ -6312,7 +6312,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_hmr"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "rolldown_common",
  "rolldown_plugin",
@@ -6320,7 +6320,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_isolated_declaration"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "arcstr",
  "oxc",
@@ -6334,7 +6334,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_lazy_compilation"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6347,7 +6347,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_oxc_runtime"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "arcstr",
  "phf 0.14.0",
@@ -6358,7 +6358,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_replace"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "oxc",
@@ -6374,7 +6374,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_utils"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6527,7 +6527,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_vite_resolve"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6581,7 +6581,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_resolver"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6596,7 +6596,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_sourcemap"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "criterion2",
  "memchr",
@@ -6606,7 +6606,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_std_utils"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "regex",
  "sugar_path",
@@ -6652,7 +6652,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_tracing"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "tracing",
  "tracing-chrome",
@@ -6661,7 +6661,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_utils"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6699,7 +6699,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_watcher"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6719,7 +6719,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_workspace"
-version = "1.2.4"
+version = "1.2.2"
 
 [[package]]
 name = "ropey"
@@ -6810,7 +6810,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6866,7 +6866,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7420,7 +7420,7 @@ dependencies = [
 [[package]]
 name = "snapshot_test"
 version = "0.1.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "serde",
  "serde_json",
@@ -7450,7 +7450,7 @@ dependencies = [
 [[package]]
 name = "socket_ipc"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "nix 0.31.3",
  "tempfile",
@@ -7530,7 +7530,7 @@ dependencies = [
 
 [[package]]
 name = "string_wizard"
-version = "1.2.4"
+version = "1.2.2"
 dependencies = [
  "insta",
  "memchr",
@@ -7678,7 +7678,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8723,7 +8723,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 [[package]]
 name = "vt"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "anstream",
  "anyhow",
@@ -8782,7 +8782,7 @@ dependencies = [
 [[package]]
 name = "vt_client"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "fspy_ipc_str",
  "rustc-hash",
@@ -8795,7 +8795,7 @@ dependencies = [
 [[package]]
 name = "vt_client_napi"
 version = "0.1.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "napi",
  "napi-build",
@@ -8807,7 +8807,7 @@ dependencies = [
 [[package]]
 name = "vt_glob"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "globset",
  "thiserror 2.0.19",
@@ -8817,7 +8817,7 @@ dependencies = [
 [[package]]
 name = "vt_graph"
 version = "0.1.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8839,7 +8839,7 @@ dependencies = [
 [[package]]
 name = "vt_graph_ser"
 version = "0.1.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "petgraph 0.8.3",
  "serde",
@@ -8848,7 +8848,7 @@ dependencies = [
 [[package]]
 name = "vt_ipc_shared"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "fspy_ipc_str",
  "rustc-hash",
@@ -8858,7 +8858,7 @@ dependencies = [
 [[package]]
 name = "vt_path"
 version = "0.1.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "diff-struct",
  "os_str_bytes",
@@ -8873,7 +8873,7 @@ dependencies = [
 [[package]]
 name = "vt_plan"
 version = "0.1.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8901,7 +8901,7 @@ dependencies = [
 [[package]]
 name = "vt_powershell"
 version = "0.1.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "vt_path",
  "which",
@@ -8910,7 +8910,7 @@ dependencies = [
 [[package]]
 name = "vt_select"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -8921,7 +8921,7 @@ dependencies = [
 [[package]]
 name = "vt_server"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "fspy_ipc_str",
  "futures",
@@ -8940,7 +8940,7 @@ dependencies = [
 [[package]]
 name = "vt_shell"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "brush-parser 0.4.0",
  "diff-struct",
@@ -8953,7 +8953,7 @@ dependencies = [
 [[package]]
 name = "vt_str"
 version = "0.1.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "compact_str 0.9.1",
  "diff-struct",
@@ -8964,7 +8964,7 @@ dependencies = [
 [[package]]
 name = "vt_workspace"
 version = "0.0.0"
-source = "git+https://github.com/taskylizard/vite-task.git?rev=86ff8541052c2afac3c01553547ecfdd17119c21#86ff8541052c2afac3c01553547ecfdd17119c21"
+source = "git+https://github.com/taskylizard/vite-task.git?rev=eb9f4319ae2252361d08d3863699fc136a4d61fe#eb9f4319ae2252361d08d3863699fc136a4d61fe"
 dependencies = [
  "clap",
  "petgraph 0.8.3",
@@ -9175,7 +9175,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,7 @@ ignored = [
   "css-module-lexer",
   "html5gum",
   "prettyplease",
-  "proc-macro2",
-  "quote",
   "string_cache",
-  "syn",
 ]
 
 [workspace.package]
@@ -186,7 +183,7 @@ dunce = "1.0.5"
 fast-glob = "1.0.0"
 flate2 = { version = "=1.1.9", features = ["zlib-rs"] }
 form_urlencoded = "1.2.1"
-fspy = { git = "https://github.com/taskylizard/vite-task.git", rev = "5ca3ca50826406b29a47a3bae6b69dd649facb9e" }
+fspy = { git = "https://github.com/taskylizard/vite-task.git", rev = "86ff8541052c2afac3c01553547ecfdd17119c21" }
 futures = "0.3.31"
 futures-util = "0.3.31"
 glob = "0.3.2"
@@ -243,8 +240,8 @@ pretty_assertions = "1.4.1"
 phf = "0.14.0"
 prettyplease = "0.2.32"
 proc-macro2 = "1"
-pty_terminal_test = { git = "https://github.com/taskylizard/vite-task.git", rev = "5ca3ca50826406b29a47a3bae6b69dd649facb9e" }
-pty_terminal_test_client = { git = "https://github.com/taskylizard/vite-task.git", rev = "5ca3ca50826406b29a47a3bae6b69dd649facb9e" }
+pty_terminal_test = { git = "https://github.com/taskylizard/vite-task.git", rev = "86ff8541052c2afac3c01553547ecfdd17119c21" }
+pty_terminal_test_client = { git = "https://github.com/taskylizard/vite-task.git", rev = "86ff8541052c2afac3c01553547ecfdd17119c21" }
 quote = "1"
 rayon = "1.10.0"
 regex = "1.11.1"
@@ -267,7 +264,7 @@ sha2 = "0.10.9"
 shell-escape = "0.1.5"
 simdutf8 = "0.1.5"
 smallvec = { version = "1.15.1", features = ["union"] }
-snapshot_test = { git = "https://github.com/taskylizard/vite-task.git", rev = "5ca3ca50826406b29a47a3bae6b69dd649facb9e" }
+snapshot_test = { git = "https://github.com/taskylizard/vite-task.git", rev = "86ff8541052c2afac3c01553547ecfdd17119c21" }
 string_cache = "0.9.0"
 sugar_path = { version = "3", features = ["cached_current_dir"] }
 supports-color = "3"
@@ -299,12 +296,12 @@ vp_setup = { path = "crates/vp_setup" }
 vp_shared = { path = "crates/vp_shared" }
 vp_static_config = { path = "crates/vp_static_config" }
 vp_toolchain = { path = "crates/vp_toolchain" }
-vt = { git = "https://github.com/taskylizard/vite-task.git", rev = "5ca3ca50826406b29a47a3bae6b69dd649facb9e" }
-vt_path = { git = "https://github.com/taskylizard/vite-task.git", rev = "5ca3ca50826406b29a47a3bae6b69dd649facb9e" }
-vt_powershell = { git = "https://github.com/taskylizard/vite-task.git", rev = "5ca3ca50826406b29a47a3bae6b69dd649facb9e" }
-vt_select = { git = "https://github.com/taskylizard/vite-task.git", rev = "5ca3ca50826406b29a47a3bae6b69dd649facb9e" }
-vt_str = { git = "https://github.com/taskylizard/vite-task.git", rev = "5ca3ca50826406b29a47a3bae6b69dd649facb9e" }
-vt_workspace = { git = "https://github.com/taskylizard/vite-task.git", rev = "5ca3ca50826406b29a47a3bae6b69dd649facb9e" }
+vt = { git = "https://github.com/taskylizard/vite-task.git", rev = "86ff8541052c2afac3c01553547ecfdd17119c21" }
+vt_path = { git = "https://github.com/taskylizard/vite-task.git", rev = "86ff8541052c2afac3c01553547ecfdd17119c21" }
+vt_powershell = { git = "https://github.com/taskylizard/vite-task.git", rev = "86ff8541052c2afac3c01553547ecfdd17119c21" }
+vt_select = { git = "https://github.com/taskylizard/vite-task.git", rev = "86ff8541052c2afac3c01553547ecfdd17119c21" }
+vt_str = { git = "https://github.com/taskylizard/vite-task.git", rev = "86ff8541052c2afac3c01553547ecfdd17119c21" }
+vt_workspace = { git = "https://github.com/taskylizard/vite-task.git", rev = "86ff8541052c2afac3c01553547ecfdd17119c21" }
 walkdir = "2.5.0"
 webpki-root-certs = "1.0.9"
 which = "8.0.0"
@@ -313,7 +310,7 @@ xxhash-rust = "0.8.15"
 zip = { version = "7.2", default-features = false, features = ["deflate-flate2-zlib-rs"] }
 
 # oxc crates with the same version
-oxc = { version = "0.142.0", features = [
+oxc = { version = "0.144.0", features = [
   "ast_visit",
   "transformer",
   "minifier",
@@ -325,17 +322,17 @@ oxc = { version = "0.142.0", features = [
   "regular_expression",
   "cfg",
 ] }
-oxc_allocator = { version = "0.142.0", features = ["pool"] }
-oxc_ast = "0.142.0"
-oxc_ecmascript = "0.142.0"
-oxc_parser = "0.142.0"
-oxc_span = "0.142.0"
-oxc_napi = "0.142.0"
-oxc_str = "0.142.0"
-oxc_minify_napi = "0.142.0"
-oxc_parser_napi = "0.142.0"
-oxc_transform_napi = "0.142.0"
-oxc_traverse = "0.142.0"
+oxc_allocator = { version = "0.144.0", features = ["pool"] }
+oxc_ast = "0.144.0"
+oxc_ecmascript = "0.144.0"
+oxc_parser = "0.144.0"
+oxc_span = "0.144.0"
+oxc_napi = "0.144.0"
+oxc_str = "0.144.0"
+oxc_minify_napi = "0.144.0"
+oxc_parser_napi = "0.144.0"
+oxc_transform_napi = "0.144.0"
+oxc_traverse = "0.144.0"
 
 # oxc crates in their own repos
 oxc_index = { version = "5", features = ["rayon", "serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,7 +183,7 @@ dunce = "1.0.5"
 fast-glob = "1.0.0"
 flate2 = { version = "=1.1.9", features = ["zlib-rs"] }
 form_urlencoded = "1.2.1"
-fspy = { git = "https://github.com/taskylizard/vite-task.git", rev = "86ff8541052c2afac3c01553547ecfdd17119c21" }
+fspy = { git = "https://github.com/taskylizard/vite-task.git", rev = "eb9f4319ae2252361d08d3863699fc136a4d61fe" }
 futures = "0.3.31"
 futures-util = "0.3.31"
 glob = "0.3.2"
@@ -240,8 +240,8 @@ pretty_assertions = "1.4.1"
 phf = "0.14.0"
 prettyplease = "0.2.32"
 proc-macro2 = "1"
-pty_terminal_test = { git = "https://github.com/taskylizard/vite-task.git", rev = "86ff8541052c2afac3c01553547ecfdd17119c21" }
-pty_terminal_test_client = { git = "https://github.com/taskylizard/vite-task.git", rev = "86ff8541052c2afac3c01553547ecfdd17119c21" }
+pty_terminal_test = { git = "https://github.com/taskylizard/vite-task.git", rev = "eb9f4319ae2252361d08d3863699fc136a4d61fe" }
+pty_terminal_test_client = { git = "https://github.com/taskylizard/vite-task.git", rev = "eb9f4319ae2252361d08d3863699fc136a4d61fe" }
 quote = "1"
 rayon = "1.10.0"
 regex = "1.11.1"
@@ -264,7 +264,7 @@ sha2 = "0.10.9"
 shell-escape = "0.1.5"
 simdutf8 = "0.1.5"
 smallvec = { version = "1.15.1", features = ["union"] }
-snapshot_test = { git = "https://github.com/taskylizard/vite-task.git", rev = "86ff8541052c2afac3c01553547ecfdd17119c21" }
+snapshot_test = { git = "https://github.com/taskylizard/vite-task.git", rev = "eb9f4319ae2252361d08d3863699fc136a4d61fe" }
 string_cache = "0.9.0"
 sugar_path = { version = "3", features = ["cached_current_dir"] }
 supports-color = "3"
@@ -296,12 +296,12 @@ vp_setup = { path = "crates/vp_setup" }
 vp_shared = { path = "crates/vp_shared" }
 vp_static_config = { path = "crates/vp_static_config" }
 vp_toolchain = { path = "crates/vp_toolchain" }
-vt = { git = "https://github.com/taskylizard/vite-task.git", rev = "86ff8541052c2afac3c01553547ecfdd17119c21" }
-vt_path = { git = "https://github.com/taskylizard/vite-task.git", rev = "86ff8541052c2afac3c01553547ecfdd17119c21" }
-vt_powershell = { git = "https://github.com/taskylizard/vite-task.git", rev = "86ff8541052c2afac3c01553547ecfdd17119c21" }
-vt_select = { git = "https://github.com/taskylizard/vite-task.git", rev = "86ff8541052c2afac3c01553547ecfdd17119c21" }
-vt_str = { git = "https://github.com/taskylizard/vite-task.git", rev = "86ff8541052c2afac3c01553547ecfdd17119c21" }
-vt_workspace = { git = "https://github.com/taskylizard/vite-task.git", rev = "86ff8541052c2afac3c01553547ecfdd17119c21" }
+vt = { git = "https://github.com/taskylizard/vite-task.git", rev = "eb9f4319ae2252361d08d3863699fc136a4d61fe" }
+vt_path = { git = "https://github.com/taskylizard/vite-task.git", rev = "eb9f4319ae2252361d08d3863699fc136a4d61fe" }
+vt_powershell = { git = "https://github.com/taskylizard/vite-task.git", rev = "eb9f4319ae2252361d08d3863699fc136a4d61fe" }
+vt_select = { git = "https://github.com/taskylizard/vite-task.git", rev = "eb9f4319ae2252361d08d3863699fc136a4d61fe" }
+vt_str = { git = "https://github.com/taskylizard/vite-task.git", rev = "eb9f4319ae2252361d08d3863699fc136a4d61fe" }
+vt_workspace = { git = "https://github.com/taskylizard/vite-task.git", rev = "eb9f4319ae2252361d08d3863699fc136a4d61fe" }
 walkdir = "2.5.0"
 webpki-root-certs = "1.0.9"
 which = "8.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,10 @@ ignored = [
   "css-module-lexer",
   "html5gum",
   "prettyplease",
+  "proc-macro2",
+  "quote",
   "string_cache",
+  "syn",
 ]
 
 [workspace.package]
@@ -183,7 +186,7 @@ dunce = "1.0.5"
 fast-glob = "1.0.0"
 flate2 = { version = "=1.1.9", features = ["zlib-rs"] }
 form_urlencoded = "1.2.1"
-fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "d05b1dcdbaabaa69643ee0b89cebe3cd390957e9" }
+fspy = { git = "https://github.com/taskylizard/vite-task.git", rev = "5ca3ca50826406b29a47a3bae6b69dd649facb9e" }
 futures = "0.3.31"
 futures-util = "0.3.31"
 glob = "0.3.2"
@@ -240,8 +243,8 @@ pretty_assertions = "1.4.1"
 phf = "0.14.0"
 prettyplease = "0.2.32"
 proc-macro2 = "1"
-pty_terminal_test = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "d05b1dcdbaabaa69643ee0b89cebe3cd390957e9" }
-pty_terminal_test_client = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "d05b1dcdbaabaa69643ee0b89cebe3cd390957e9" }
+pty_terminal_test = { git = "https://github.com/taskylizard/vite-task.git", rev = "5ca3ca50826406b29a47a3bae6b69dd649facb9e" }
+pty_terminal_test_client = { git = "https://github.com/taskylizard/vite-task.git", rev = "5ca3ca50826406b29a47a3bae6b69dd649facb9e" }
 quote = "1"
 rayon = "1.10.0"
 regex = "1.11.1"
@@ -264,7 +267,7 @@ sha2 = "0.10.9"
 shell-escape = "0.1.5"
 simdutf8 = "0.1.5"
 smallvec = { version = "1.15.1", features = ["union"] }
-snapshot_test = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "d05b1dcdbaabaa69643ee0b89cebe3cd390957e9" }
+snapshot_test = { git = "https://github.com/taskylizard/vite-task.git", rev = "5ca3ca50826406b29a47a3bae6b69dd649facb9e" }
 string_cache = "0.9.0"
 sugar_path = { version = "3", features = ["cached_current_dir"] }
 supports-color = "3"
@@ -296,12 +299,12 @@ vp_setup = { path = "crates/vp_setup" }
 vp_shared = { path = "crates/vp_shared" }
 vp_static_config = { path = "crates/vp_static_config" }
 vp_toolchain = { path = "crates/vp_toolchain" }
-vt = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "d05b1dcdbaabaa69643ee0b89cebe3cd390957e9" }
-vt_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "d05b1dcdbaabaa69643ee0b89cebe3cd390957e9" }
-vt_powershell = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "d05b1dcdbaabaa69643ee0b89cebe3cd390957e9" }
-vt_select = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "d05b1dcdbaabaa69643ee0b89cebe3cd390957e9" }
-vt_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "d05b1dcdbaabaa69643ee0b89cebe3cd390957e9" }
-vt_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "d05b1dcdbaabaa69643ee0b89cebe3cd390957e9" }
+vt = { git = "https://github.com/taskylizard/vite-task.git", rev = "5ca3ca50826406b29a47a3bae6b69dd649facb9e" }
+vt_path = { git = "https://github.com/taskylizard/vite-task.git", rev = "5ca3ca50826406b29a47a3bae6b69dd649facb9e" }
+vt_powershell = { git = "https://github.com/taskylizard/vite-task.git", rev = "5ca3ca50826406b29a47a3bae6b69dd649facb9e" }
+vt_select = { git = "https://github.com/taskylizard/vite-task.git", rev = "5ca3ca50826406b29a47a3bae6b69dd649facb9e" }
+vt_str = { git = "https://github.com/taskylizard/vite-task.git", rev = "5ca3ca50826406b29a47a3bae6b69dd649facb9e" }
+vt_workspace = { git = "https://github.com/taskylizard/vite-task.git", rev = "5ca3ca50826406b29a47a3bae6b69dd649facb9e" }
 walkdir = "2.5.0"
 webpki-root-certs = "1.0.9"
 which = "8.0.0"
@@ -310,7 +313,7 @@ xxhash-rust = "0.8.15"
 zip = { version = "7.2", default-features = false, features = ["deflate-flate2-zlib-rs"] }
 
 # oxc crates with the same version
-oxc = { version = "0.144.0", features = [
+oxc = { version = "0.142.0", features = [
   "ast_visit",
   "transformer",
   "minifier",
@@ -322,17 +325,17 @@ oxc = { version = "0.144.0", features = [
   "regular_expression",
   "cfg",
 ] }
-oxc_allocator = { version = "0.144.0", features = ["pool"] }
-oxc_ast = "0.144.0"
-oxc_ecmascript = "0.144.0"
-oxc_parser = "0.144.0"
-oxc_span = "0.144.0"
-oxc_napi = "0.144.0"
-oxc_str = "0.144.0"
-oxc_minify_napi = "0.144.0"
-oxc_parser_napi = "0.144.0"
-oxc_transform_napi = "0.144.0"
-oxc_traverse = "0.144.0"
+oxc_allocator = { version = "0.142.0", features = ["pool"] }
+oxc_ast = "0.142.0"
+oxc_ecmascript = "0.142.0"
+oxc_parser = "0.142.0"
+oxc_span = "0.142.0"
+oxc_napi = "0.142.0"
+oxc_str = "0.142.0"
+oxc_minify_napi = "0.142.0"
+oxc_parser_napi = "0.142.0"
+oxc_transform_napi = "0.142.0"
+oxc_traverse = "0.142.0"
 
 # oxc crates in their own repos
 oxc_index = { version = "5", features = ["rayon", "serde"] }

--- a/docs/config/run.md
+++ b/docs/config/run.md
@@ -170,6 +170,24 @@ tasks: {
 }
 ```
 
+### `replayLogs`
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Whether to replay the task's cached stdout/stderr on cache hits. Set this to `false` when you want cache hits to restore output files and report saved time without printing the task's previous logs:
+
+```ts [vite.config.ts]
+tasks: {
+  build: {
+    command: 'vp build',
+    replayLogs: false,
+  },
+}
+```
+
+This does not disable caching and does not affect [`output`](#output) restoration. On a cache hit, Vite Task still skips the command and restores cached output files.
+
 ### `env`
 
 - **Type:** `string[]`

--- a/docs/guide/cache.md
+++ b/docs/guide/cache.md
@@ -12,6 +12,8 @@ When a task runs successfully (exit code 0), its terminal output (stdout/stderr)
 
 When all checks match, Vite Task replays the cached terminal output, restores saved output files, and skips the command.
 
+Set [`replayLogs: false`](/config/run#replaylogs) on a task when cache hits should stay quiet. The task still hits the cache, skips execution, and restores cached output files; only cached stdout/stderr replay is suppressed.
+
 When a cache miss occurs, Vite Task tells you exactly why:
 
 ```

--- a/packages/cli/binding/src/cli/handler.rs
+++ b/packages/cli/binding/src/cli/handler.rs
@@ -81,6 +81,7 @@ impl CommandHandler for VitePlusCommandHandler {
                 // Check is a composite command (fmt + lint) — run as a subprocess in task scripts
                 Ok(HandledCommand::Synthesized(command.to_synthetic_plan_request(
                     UserCacheConfig::with_config(EnabledCacheConfig {
+                        replay_logs: None,
                         env: Some(Box::new([Str::from("OXLINT_TSGOLINT_PATH")])),
                         untracked_env: None,
                         input: Some(check_cache_inputs()),

--- a/packages/cli/binding/src/cli/resolver.rs
+++ b/packages/cli/binding/src/cli/resolver.rs
@@ -107,6 +107,7 @@ impl SubcommandResolver {
                         .chain(args.into_iter().map(Str::from))
                         .collect(),
                     cache_config: UserCacheConfig::with_config(EnabledCacheConfig {
+                        replay_logs: None,
                         env: Some(Box::new([Str::from("OXLINT_TSGOLINT_PATH")])),
                         untracked_env: None,
                         input: None,
@@ -143,6 +144,7 @@ impl SubcommandResolver {
                         .chain(args.into_iter().map(Str::from))
                         .collect(),
                     cache_config: UserCacheConfig::with_config(EnabledCacheConfig {
+                        replay_logs: None,
                         env: None,
                         untracked_env: None,
                         input: None,
@@ -172,6 +174,7 @@ impl SubcommandResolver {
                     // vite's `ignoreInput`/`ignoreOutput`/`getEnv`/`getEnvs` refine
                     // the fingerprint at runtime.
                     cache_config: UserCacheConfig::with_config(EnabledCacheConfig {
+                        replay_logs: None,
                         env: None,
                         untracked_env: None,
                         input: None,
@@ -198,6 +201,7 @@ impl SubcommandResolver {
                     program: Arc::from(OsStr::new("node")),
                     args: iter::once(Str::from(js_path_str)).chain(vitest_args).collect(),
                     cache_config: UserCacheConfig::with_config(EnabledCacheConfig {
+                        replay_logs: None,
                         env: None,
                         untracked_env: None,
                         input: Some(vec![
@@ -226,6 +230,7 @@ impl SubcommandResolver {
                         .chain(args.into_iter().map(Str::from))
                         .collect(),
                     cache_config: UserCacheConfig::with_config(EnabledCacheConfig {
+                        replay_logs: None,
                         env: None,
                         untracked_env: None,
                         input: Some(build_pack_cache_inputs()),
@@ -284,6 +289,7 @@ impl SubcommandResolver {
                         .chain(args.into_iter().map(Str::from))
                         .collect(),
                     cache_config: UserCacheConfig::with_config(EnabledCacheConfig {
+                        replay_logs: None,
                         env: None,
                         untracked_env: None,
                         input: None,

--- a/packages/cli/src/run-config.ts
+++ b/packages/cli/src/run-config.ts
@@ -51,6 +51,10 @@ dependsOn?: Array<DependsOnEntry>, } & ({
  */
 cache?: true,
 /**
+ * Whether to replay cached stdout/stderr on cache hits.
+ */
+replayLogs?: boolean,
+/**
  * Environment variable names to be fingerprinted and passed to the task.
  */
 env?: Array<string>,


### PR DESCRIPTION
## Motivation

Vite+ should expose Vite Task's `replayLogs` cache option (when merged) through `vite.config.ts` so users can keep cache hits quiet while preserving cache hits and output restoration.


TODO: update the dependencies commit sha on Vite Task PR merge at https://github.com/voidzero-dev/vite-task/pull/531

## Changes

- Add `replayLogs` to generated run config types and Rust config initializers.
- Document `replayLogs: false` in the run config and cache guide.