### PR TITLE
fix(pm): fallback for Yarn Classic dedupe

### DIFF
--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/pm_dedupe/bun/package.json
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/pm_dedupe/bun/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "pm-dedupe-bun",
+  "version": "1.0.0",
+  "private": true,
+  "license": "MIT",
+  "packageManager": "bun@1.3.11"
+}

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/pm_dedupe/npm/package.json
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/pm_dedupe/npm/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "pm-dedupe-npm",
+  "version": "1.0.0",
+  "private": true,
+  "license": "MIT",
+  "packageManager": "npm@11.13.0"
+}

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/pm_dedupe/pnpm/package.json
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/pm_dedupe/pnpm/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "pm-dedupe-pnpm",
+  "version": "1.0.0",
+  "private": true,
+  "license": "MIT",
+  "packageManager": "pnpm@11.11.0"
+}

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/pm_dedupe/snapshots.toml
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/pm_dedupe/snapshots.toml
@@ -1,0 +1,45 @@
+[[case]]
+name = "pm_dedupe_npm"
+vp = "global"
+cwd = "npm"
+steps = [
+  { argv = ["vp", "dedupe", "--", "--json"], comment = "npm deduplicates dependencies" },
+  { argv = ["vpt", "print-file", "package.json"], comment = "verify npm completed" },
+]
+
+[[case]]
+name = "pm_dedupe_pnpm"
+vp = "global"
+cwd = "pnpm"
+steps = [
+  { argv = ["vp", "dedupe"], comment = "pnpm deduplicates dependencies" },
+  { argv = ["vpt", "print-file", "package.json"], comment = "verify pnpm completed" },
+]
+
+[[case]]
+name = "pm_dedupe_yarn"
+vp = "global"
+cwd = "yarn"
+steps = [
+  { argv = ["vp", "dedupe", "--", "--silent"], comment = "Yarn Classic falls back to install because install already deduplicates dependencies" },
+  { argv = ["vpt", "print-file", "package.json"], comment = "verify Yarn Classic completed" },
+]
+
+[[case]]
+name = "pm_dedupe_yarn_berry"
+vp = "global"
+cwd = "yarn_berry"
+env = { YARN_ENABLE_TELEMETRY = "0" }
+steps = [
+  { argv = ["vp", "dedupe", "--", "--json"], comment = "Yarn Berry deduplicates dependencies" },
+  { argv = ["vpt", "print-file", "package.json"], comment = "verify Yarn Berry completed" },
+]
+
+[[case]]
+name = "pm_dedupe_bun"
+vp = "global"
+cwd = "bun"
+steps = [
+  { argv = ["vp", "dedupe", "--", "--silent"], comment = "Bun falls back to install because it does not support dedupe" },
+  { argv = ["vpt", "print-file", "package.json"], comment = "verify Bun completed" },
+]

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/pm_dedupe/snapshots/pm_dedupe_bun.md
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/pm_dedupe/snapshots/pm_dedupe_bun.md
@@ -1,0 +1,23 @@
+# pm_dedupe_bun
+
+## `vp dedupe -- --silent`
+
+Bun falls back to install because it does not support dedupe
+
+```
+warn: bun does not support dedupe, falling back to bun install
+```
+
+## `vpt print-file package.json`
+
+verify Bun completed
+
+```
+{
+  "name": "pm-dedupe-bun",
+  "version": "1.0.0",
+  "private": true,
+  "license": "MIT",
+  "packageManager": "bun@1.3.11"
+}
+```

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/pm_dedupe/snapshots/pm_dedupe_npm.md
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/pm_dedupe/snapshots/pm_dedupe_npm.md
@@ -1,0 +1,50 @@
+# pm_dedupe_npm
+
+## `vp dedupe -- --json`
+
+npm deduplicates dependencies
+
+```
+{
+  "add": [],
+  "added": 0,
+  "audited": 1,
+  "change": [],
+  "changed": 0,
+  "funding": 0,
+  "remove": [],
+  "removed": 0,
+  "audit": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 0,
+      "moderate": 0,
+      "high": 0,
+      "critical": 0,
+      "total": 0
+    },
+    "dependencies": {
+      "prod": 1,
+      "dev": 0,
+      "optional": 0,
+      "peer": 0,
+      "peerOptional": 0,
+      "total": 0
+    }
+  }
+}
+```
+
+## `vpt print-file package.json`
+
+verify npm completed
+
+```
+{
+  "name": "pm-dedupe-npm",
+  "version": "1.0.0",
+  "private": true,
+  "license": "MIT",
+  "packageManager": "npm@11.13.0"
+}
+```

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/pm_dedupe/snapshots/pm_dedupe_pnpm.md
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/pm_dedupe/snapshots/pm_dedupe_pnpm.md
@@ -1,0 +1,23 @@
+# pm_dedupe_pnpm
+
+## `vp dedupe`
+
+pnpm deduplicates dependencies
+
+```
+Already up to date
+```
+
+## `vpt print-file package.json`
+
+verify pnpm completed
+
+```
+{
+  "name": "pm-dedupe-pnpm",
+  "version": "1.0.0",
+  "private": true,
+  "license": "MIT",
+  "packageManager": "pnpm@11.11.0"
+}
+```

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/pm_dedupe/snapshots/pm_dedupe_yarn.md
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/pm_dedupe/snapshots/pm_dedupe_yarn.md
@@ -1,0 +1,23 @@
+# pm_dedupe_yarn
+
+## `vp dedupe -- --silent`
+
+Yarn Classic falls back to install because install already deduplicates dependencies
+
+```
+warn: Yarn Classic dedupes during install, falling back to yarn install
+```
+
+## `vpt print-file package.json`
+
+verify Yarn Classic completed
+
+```
+{
+  "name": "pm-dedupe-yarn",
+  "version": "1.0.0",
+  "private": true,
+  "license": "MIT",
+  "packageManager": "yarn@1.22.22"
+}
+```

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/pm_dedupe/snapshots/pm_dedupe_yarn_berry.md
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/pm_dedupe/snapshots/pm_dedupe_yarn_berry.md
@@ -1,0 +1,22 @@
+# pm_dedupe_yarn_berry
+
+## `vp dedupe -- --json`
+
+Yarn Berry deduplicates dependencies
+
+```
+```
+
+## `vpt print-file package.json`
+
+verify Yarn Berry completed
+
+```
+{
+  "name": "pm-dedupe-yarn-berry",
+  "version": "1.0.0",
+  "private": true,
+  "license": "MIT",
+  "packageManager": "yarn@4.12.0"
+}
+```

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/pm_dedupe/yarn/package.json
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/pm_dedupe/yarn/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "pm-dedupe-yarn",
+  "version": "1.0.0",
+  "private": true,
+  "license": "MIT",
+  "packageManager": "yarn@1.22.22"
+}

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/pm_dedupe/yarn_berry/package.json
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/pm_dedupe/yarn_berry/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "pm-dedupe-yarn-berry",
+  "version": "1.0.0",
+  "private": true,
+  "license": "MIT",
+  "packageManager": "yarn@4.12.0"
+}

--- a/crates/vite_install/src/commands/dedupe.rs
+++ b/crates/vite_install/src/commands/dedupe.rs
@@ -49,11 +49,18 @@ impl PackageManager {
             }
             PackageManagerType::Yarn => {
                 bin_name = "yarn".into();
-                args.push("dedupe".into());
+                if self.is_yarn_berry() {
+                    args.push("dedupe".into());
 
-                // yarn@2+ supports --check
-                if options.check {
-                    args.push("--check".into());
+                    // yarn@2+ supports --check
+                    if options.check {
+                        args.push("--check".into());
+                    }
+                } else {
+                    output::warn(
+                        "Yarn Classic dedupes during install, falling back to yarn install",
+                    );
+                    args.push("install".into());
                 }
             }
             PackageManagerType::Npm => {
@@ -148,6 +155,14 @@ mod tests {
         let pm = create_mock_package_manager(PackageManagerType::Yarn, "4.0.0");
         let result = pm.resolve_dedupe_command(&DedupeCommandOptions { ..Default::default() });
         assert_eq!(result.args, vec!["dedupe"]);
+        assert_eq!(result.bin_path, "yarn");
+    }
+
+    #[test]
+    fn test_yarn_classic_dedupe_falls_back_to_install() {
+        let pm = create_mock_package_manager(PackageManagerType::Yarn, "1.22.22");
+        let result = pm.resolve_dedupe_command(&DedupeCommandOptions { ..Default::default() });
+        assert_eq!(result.args, vec!["install"]);
         assert_eq!(result.bin_path, "yarn");
     }
 


### PR DESCRIPTION
## Summary

- Fallback to `yarn install` for `vp dedupe` on Yarn Classic, as recommended by the [Yarn Classic `dedupe` documentation](https://classic.yarnpkg.com/en/docs/cli/dedupe), and print a warning.
- Add PTY snapshot coverage for npm, pnpm, Yarn Classic, Yarn Berry, and Bun.