### PR TITLE
test(snapshots): mask the run-day install date in `vp env which` output

### DIFF
--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/command_env_which/snapshots/command_env_which.md
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/command_env_which/snapshots/command_env_which.md
@@ -87,7 +87,7 @@ VITE+ - The Unified Toolchain for the Web
   Package:    cowsay@1.6.0
   Binaries:   cowsay, cowthink
   Node:       <version>
-  Installed:  2026-07-10
+  Installed:  <date>
 ```
 
 ## `vp remove -g cowsay`

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/redact.rs
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/redact.rs
@@ -117,6 +117,12 @@ static MANAGED_TEST_VERSION_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
 static WHICH_NODE_VERSION_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
     regex::Regex::new(r#"(Node:\s+|"nodeVersion":\s*")\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?"#).unwrap()
 });
+// `vp env which` prints the package's install date, which is whatever day the
+// recording (or CI run) happened; mask by the `Installed:` label so
+// fixture-controlled dates elsewhere (registry publish timestamps in
+// `vp view` output) stay assertable.
+static INSTALLED_DATE_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"(Installed:\s+)\d{4}-\d{2}-\d{2}").unwrap());
 // Output bytes differ across OSes (line endings, embedded paths), so byte
 // sizes and content-derived asset hashes can never be part of a shared
 // snapshot. The unit is kept ("<size> kB"): it only changes when content
@@ -385,6 +391,10 @@ pub fn redact_output(
     // Redact the environment's managed default runtime version by label/key
     // context (see WHICH_NODE_VERSION_RE).
     output = WHICH_NODE_VERSION_RE.replace_all(&output, "${1}<version>").into_owned();
+
+    // Mask the run-day install date in `vp env which` output by label context
+    // (see INSTALLED_DATE_RE).
+    output = INSTALLED_DATE_RE.replace_all(&output, "${1}<date>").into_owned();
 
     // Redact thread counts like "16 threads" to "<n> threads"
     output = THREAD_RE.replace_all(&output, "<n> threads").into_owned();

--- a/crates/vite_cli_snapshots/tests/redact_unit.rs
+++ b/crates/vite_cli_snapshots/tests/redact_unit.rs
@@ -261,3 +261,15 @@ fn collapses_debug_escaped_separators_and_preserves_urls() {
         "at \"<workspace>/src\" see https://viteplus.dev/guide/\n"
     );
 }
+
+#[test]
+fn masks_install_date_only_by_label() {
+    // `vp env which` prints the day the package was installed, which is
+    // whatever day the run happened.
+    let which = "  Installed:  2026-07-10\n".to_owned();
+    assert_eq!(redact_output(which, &[], true), "  Installed:  <date>\n");
+    // Registry publish timestamps in `vp view` output are fixture-controlled
+    // history and stay assertable.
+    let view = "Published: 2015-07-18T18:23:59.560Z\n".to_owned();
+    assert_eq!(redact_output(view.clone(), &[], true), view);
+}


### PR DESCRIPTION
The command_env_which baseline recorded `Installed: 2026-07-10`, the day
the snapshot was recorded, so the case started failing the next day.
Mask the date by its `Installed:` label; registry publish timestamps in
`vp view` output are fixture-controlled history and stay assertable.