### PR TITLE
ci(create): assert the monorepo library emits declarations

### DIFF
--- a/.github/workflows/test-vp-create.yml
+++ b/.github/workflows/test-vp-create.yml
@@ -134,7 +134,14 @@ jobs:
           - name: monorepo
             create-args: vite:monorepo --directory test-project
             template-args: ''
-            verify-command: vp run ready
+            # The trailing check pins the dts deliverable: the utils library
+            # builds with `vp pack` and TypeScript 7, so a green `vp run ready`
+            # alone could still ship a type-less package if declaration
+            # generation is silently skipped. tsdown emits `index.d.mts` next
+            # to the ESM bundle.
+            verify-command: |
+              vp run ready
+              test -f packages/utils/dist/index.d.mts
             verify-migration: 'false'
           - name: application
             create-args: vite:application --directory test-project


### PR DESCRIPTION
## Summary

Adds a declaration-output assertion to the `vp create monorepo` CI jobs: after `vp run ready`, `packages/utils/dist/index.d.mts` must exist.

## Why

A green `vp run ready` only proves the build exited 0. Declaration generation can degrade silently — generator skipped, output landing in the wrong place — while the exit code stays clean, which would ship type-less libraries from every freshly created monorepo without CI noticing.

Since #2168 the monorepo template scaffolds TypeScript 7, so the utils library's `vp pack` runs dts through tsdown's native-compiler (tsgo) path — the machinery that broke in #2160. This assertion turns the four create jobs into an end-to-end regression gate for that path across pnpm/npm/yarn/bun.

## Notes

- The emitted file is `index.d.mts` (paired with the ESM `index.mjs` bundle), not `index.d.ts` — verified against a local-registry build of main:
  ```
  ℹ Emit types with typescript@7.0.2
  ℹ dist/index.mjs    0.10 kB
  ℹ dist/index.d.mts  0.08 kB
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)