### PR TITLE
fix(test): redact release-dependent CLI versions

### DIFF
--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/command_helper/snapshots/command_helper.md
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/command_helper/snapshots/command_helper.md
@@ -254,7 +254,7 @@ Available options:
 build help message
 
 ```
-vp/0.2.4
+vp/<version>
 
 Usage:
   $ vp build [root]
@@ -391,7 +391,7 @@ Options:
 preview help message
 
 ```
-vp/0.2.4
+vp/<version>
 
 Usage:
   $ vp preview [root]
@@ -418,7 +418,7 @@ Options:
 dev help message
 
 ```
-vp/0.2.4
+vp/<version>
 
 Usage:
   $ vp [root]

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/command_upgrade_check/snapshots/command_upgrade_check.md
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/command_upgrade_check/snapshots/command_upgrade_check.md
@@ -6,7 +6,7 @@ alpha tag avoids release-day flake (dev version equals npm latest right after a 
 
 ```
 info: checking for updates...
-info: found vite-plus@0.1.21-alpha.7 (current: 0.2.4)
-Update available: 0.2.4 → 0.1.21-alpha.7
+info: found vite-plus@0.1.21-alpha.7 (current: <version>)
+Update available: <version> → 0.1.21-alpha.7
 Run `vp upgrade` to update.
 ```

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/synthetic_dev_cache_disabled/snapshots/synthetic_dev_cache_disabled.md
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/synthetic_dev_cache_disabled/snapshots/synthetic_dev_cache_disabled.md
@@ -6,7 +6,7 @@ synthetic dev (vp dev) should have cache disabled even with cacheScripts
 
 ```
 $ vp dev --help ⊘ cache disabled
-vp/0.2.4
+vp/<version>
 
 Usage:
   $ vp [root]

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/redact.rs
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/redact.rs
@@ -40,7 +40,7 @@ static RULE_COUNT_RE: LazyLock<regex::Regex> =
 // stays assertable.
 static TOOL_VERSION_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
     regex::Regex::new(
-        r"\b((?i:node(?:\.js)?|npm|pnpm|yarn|bun|deno))([ /]+)\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?\b",
+        r"\b((?i:node(?:\.js)?|npm|pnpm|yarn|bun|deno|vp))([ /]+)\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?\b",
     )
     .unwrap()
 });
@@ -81,6 +81,16 @@ static DEV_ENGINES_VERSION_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
 // Unified Toolchain` header untouched.
 static VP_BANNER_VERSION_RE: LazyLock<regex::Regex> =
     LazyLock::new(|| regex::Regex::new(r"(Vite\+ )\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?").unwrap());
+// The upgrade checker includes the running CLI's bare version in its diagnostic
+// (`found vite-plus@<remote> (current: 0.2.4)`) and action line (`Update
+// available: 0.2.4 → <remote>`). The remote version belongs to the fixture and
+// stays assertable; only the current version changes on every Vite+ release.
+static VP_CURRENT_VERSION_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(
+        r"(found vite-plus@[^\n]+ \(current: |Update available: )\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?",
+    )
+    .unwrap()
+});
 // `vp migrate`'s dependency version-change table prints `<name> <from> →
 // <to>` rows (`vite-plus  0.1.21 → 0.2.4`, `vite  8.0.0 → 8.1.3`, `vitest
 // 3.2.4 → 4.1.10`). The target of every managed-toolchain row (vite-plus,
@@ -379,6 +389,10 @@ pub fn redact_output(
     // Redact the CLI's own version in the `vp migrate` completion banner
     // (see VP_BANNER_VERSION_RE), which bumps on every release.
     output = VP_BANNER_VERSION_RE.replace_all(&output, "${1}<version>").into_owned();
+
+    // Redact the CLI's own current version in upgrade-check output while
+    // preserving the fixture-controlled remote version.
+    output = VP_CURRENT_VERSION_RE.replace_all(&output, "${1}<version>").into_owned();
 
     // Redact the managed-toolchain row targets of `vp migrate`'s version-change
     // table (see VP_UPGRADE_TARGET_RE); the CLI/bundled target bumps on release.

--- a/crates/vite_cli_snapshots/tests/redact_unit.rs
+++ b/crates/vite_cli_snapshots/tests/redact_unit.rs
@@ -60,10 +60,26 @@ fn masks_only_v_prefixed_versions() {
 #[test]
 fn masks_bare_runtime_tool_versions_by_name_context() {
     // vp create prints these without the v prefix.
-    let input = "Node 24.18.0  pnpm 10.34.4 (agent npm/11.4.2)\n".to_owned();
+    let input = "Node 24.18.0  pnpm 10.34.4 (agents npm/11.4.2 vp/0.2.4)\n".to_owned();
     assert_eq!(
         redact_output(input, &[], true),
-        "Node <version>  pnpm <version> (agent npm/<version>)\n"
+        "Node <version>  pnpm <version> (agents npm/<version> vp/<version>)\n"
+    );
+}
+
+#[test]
+fn masks_current_vite_plus_version_in_upgrade_check_output() {
+    let input = concat!(
+        "info: found vite-plus@0.1.21-alpha.7 (current: 0.2.4)\n",
+        "Update available: 0.2.4 → 0.1.21-alpha.7\n",
+    )
+    .to_owned();
+    assert_eq!(
+        redact_output(input, &[], true),
+        concat!(
+            "info: found vite-plus@0.1.21-alpha.7 (current: <version>)\n",
+            "Update available: <version> → 0.1.21-alpha.7\n",
+        )
     );
 }
 


### PR DESCRIPTION
## Summary

- redact `vp/<version>` agent strings in CLI snapshots
- redact only the running version in upgrade-check output while preserving the fixture-controlled remote version
- re-record the three affected PTY snapshots

## Validation

- `cargo test -p vite_cli_snapshots --test redact_unit`
- `just snapshot-test command_helper`
- `just snapshot-test command_upgrade_check`
- `just snapshot-test synthetic_dev_cache_disabled`