### PR TITLE
fix release npm compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'packages/cli/package.json'
+  workflow_dispatch:
 
 permissions: {}
 
@@ -153,7 +154,7 @@ jobs:
           merge-multiple: true
 
       - name: 'Setup npm'
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.18.0
 
       - name: Prepare and publish native addons
         run: node ./packages/cli/publish-native-addons.ts --mode npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version-file: .node-version
+          node-version: '24.18.0'
           package-manager-cache: false
           registry-url: 'https://registry.npmjs.org'
 
@@ -152,9 +152,6 @@ jobs:
           path: binary-release
           pattern: vp-release-archive-*
           merge-multiple: true
-
-      - name: 'Setup npm'
-        run: npm install -g npm@11.18.0
 
       - name: Prepare and publish native addons
         run: node ./packages/cli/publish-native-addons.ts --mode npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   check:
-    if: github.repository == 'voidzero-dev/vite-plus'
+    if: github.repository == 'voidzero-dev/vite-plus' && github.ref == 'refs/heads/main'
     name: Check version
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Why

The [v0.2.5 release run](https://github.com/voidzero-dev/vite-plus/actions/runs/29493170643) failed before publishing because `npm@latest` resolved to npm 12.0.1. npm 12.0.1 requires Node 22.22.2 or newer, while the workflow used Node 22.18.0.

## Changes

- run the publishing job on Node 24.18.0, which bundles npm 11.16.0
- remove the separate global npm installation
- add `workflow_dispatch` so the corrected v0.2.5 release can be started manually