### PR TITLE
ci: remove temporary release dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
     paths:
       - 'packages/cli/package.json'
-  workflow_dispatch:
 
 permissions: {}
 
@@ -15,7 +14,7 @@ env:
 
 jobs:
   check:
-    if: github.repository == 'voidzero-dev/vite-plus' && github.ref == 'refs/heads/main'
+    if: github.repository == 'voidzero-dev/vite-plus'
     name: Check version
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Why

[v0.2.5](https://github.com/voidzero-dev/vite-plus/releases/tag/v0.2.5) has been published successfully by [Release run 29545637687](https://github.com/voidzero-dev/vite-plus/actions/runs/29545637687).

PR #2190 added a temporary manual trigger to retry the unpublished release after fixing the npm/Node compatibility failure. 

## Changes

- remove the temporary `workflow_dispatch` trigger
- remove the now-redundant `main` ref guard; the remaining push trigger already only accepts `main`
