### PR TITLE
fix(tools): fail on Vite branding source drift

### DIFF
--- a/packages/tools/src/brand-vite.ts
+++ b/packages/tools/src/brand-vite.ts
@@ -18,14 +18,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const VITE_DIR = 'vite';
-const VITE_NODE_DIR = join('packages', 'vite', 'src', 'node');
-const VITE_BRAND_FILES = [
-  join(VITE_NODE_DIR, 'constants.ts'),
-  join(VITE_NODE_DIR, 'cli.ts'),
-  join(VITE_NODE_DIR, 'build.ts'),
-  join(VITE_NODE_DIR, 'logger.ts'),
-  join(VITE_NODE_DIR, 'plugins', 'reporter.ts'),
-];
+const VITE_NODE_DIR = join(VITE_DIR, 'packages', 'vite', 'src', 'node');
 
 function log(message: string) {
   console.log(`[brand-vite] ${message}`);
@@ -96,11 +89,12 @@ function logPatch(file: string, desc: string, result: 'patched' | 'already') {
 export function brandVite(rootDir: string = process.cwd()) {
   log('Applying Vite+ branding patches...');
 
-  const viteDir = join(rootDir, VITE_DIR);
   // Always patch raw upstream sources, including when sync-remote already applied branding.
-  execFileSync('git', ['restore', '--source=HEAD', '--', ...VITE_BRAND_FILES], { cwd: viteDir });
+  execFileSync('git', ['restore', '--source=HEAD', '--', '.'], {
+    cwd: join(rootDir, VITE_DIR),
+  });
 
-  const nodeDir = join(viteDir, VITE_NODE_DIR);
+  const nodeDir = join(rootDir, VITE_NODE_DIR);
 
   // 1. constants.ts: Add VITE_PLUS_VERSION constant after VERSION
   const constantsFile = join(nodeDir, 'constants.ts');

--- a/packages/tools/src/brand-vite.ts
+++ b/packages/tools/src/brand-vite.ts
@@ -52,10 +52,7 @@ function replaceInFile(
   );
 }
 
-function removeAnyInFile(
-  filePath: string,
-  searches: Array<string | RegExp>,
-): 'patched' | 'already' {
+function removeAnyInFile(filePath: string, searches: Array<string | RegExp>): 'patched' {
   const content = readFileSync(filePath, 'utf-8');
   for (const search of searches) {
     if (typeof search === 'string') {
@@ -73,7 +70,11 @@ function removeAnyInFile(
       return 'patched';
     }
   }
-  return 'already';
+  throw new Error(
+    `[brand-vite] Patch failed in ${filePath}:\n` +
+      `  Could not find any expected search pattern.\n` +
+      `  The upstream code may have changed. Please update the search patterns in brand-vite.ts.`,
+  );
 }
 
 function logPatch(file: string, desc: string, result: 'patched' | 'already') {

--- a/packages/tools/src/brand-vite.ts
+++ b/packages/tools/src/brand-vite.ts
@@ -13,11 +13,19 @@
  * 5. plugins/reporter.ts: Suppress redundant "vite v<version>" native reporter line
  */
 
+import { execFileSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const VITE_DIR = 'vite';
-const VITE_NODE_DIR = join(VITE_DIR, 'packages', 'vite', 'src', 'node');
+const VITE_NODE_DIR = join('packages', 'vite', 'src', 'node');
+const VITE_BRAND_FILES = [
+  join(VITE_NODE_DIR, 'constants.ts'),
+  join(VITE_NODE_DIR, 'cli.ts'),
+  join(VITE_NODE_DIR, 'build.ts'),
+  join(VITE_NODE_DIR, 'logger.ts'),
+  join(VITE_NODE_DIR, 'plugins', 'reporter.ts'),
+];
 
 function log(message: string) {
   console.log(`[brand-vite] ${message}`);
@@ -88,7 +96,11 @@ function logPatch(file: string, desc: string, result: 'patched' | 'already') {
 export function brandVite(rootDir: string = process.cwd()) {
   log('Applying Vite+ branding patches...');
 
-  const nodeDir = join(rootDir, VITE_NODE_DIR);
+  const viteDir = join(rootDir, VITE_DIR);
+  // Always patch raw upstream sources, including when sync-remote already applied branding.
+  execFileSync('git', ['restore', '--source=HEAD', '--', ...VITE_BRAND_FILES], { cwd: viteDir });
+
+  const nodeDir = join(viteDir, VITE_NODE_DIR);
 
   // 1. constants.ts: Add VITE_PLUS_VERSION constant after VERSION
   const constantsFile = join(nodeDir, 'constants.ts');


### PR DESCRIPTION
The Vite branding patcher currently treats a missing removable build-banner pattern as "Already patched". When upstream changes, sync can continue even though the branding patch no longer applies.

This PR restores the nested Vite checkout from `HEAD` before each patch pass, so repeated calls still start from raw upstream sources. If a restored source no longer matches a known pattern, the patcher raises an actionable upstream-drift error instead.

It leaves the build-banner behavior and CLI snapshots unchanged.

A small follow-up to #2200

🤖 Generated with Codex