### PR TITLE
docs: document disabling git hooks per environment

### DIFF
--- a/docs/guide/commit-hooks.md
+++ b/docs/guide/commit-hooks.md
@@ -58,3 +58,40 @@ export default defineConfig({
 ```
 
 This is the default Vite+ approach and should replace separate `lint-staged` configuration in most projects. Because `vp staged` reads from `vite.config.ts`, your staged-file checks stay in the same place as your lint, format, test, build, and task-runner config.
+
+## Disabling Hooks in Specific Environments
+
+The installed hooks check the environment on every run, so you can disable them per machine or per process without uninstalling anything. This is useful when commits happen outside development — for example on a production server where a flat-file CMS commits content changes.
+
+### Environment variable
+
+Set `VITE_GIT_HOOKS=0` in the environment of the process that runs `git commit`, and every Vite+ hook exits immediately without running:
+
+```bash
+VITE_GIT_HOOKS=0 git commit -m "content update"
+```
+
+`HUSKY=0` is honored the same way for compatibility. Setting `VITE_GIT_HOOKS=0` in an environment also keeps `vp config` from reinstalling hooks there when a lifecycle script such as `prepare` runs.
+
+### Init script
+
+Before checking the environment variable, each hook sources an init script if one exists:
+
+1. `$XDG_CONFIG_HOME/vite-plus/hooks-init.sh` (defaults to `~/.config/vite-plus/hooks-init.sh`)
+2. `$XDG_CONFIG_HOME/husky/init.sh` as a fallback
+
+To disable hooks for a whole machine, create the init script and export the variable there:
+
+```sh [~/.config/vite-plus/hooks-init.sh]
+export VITE_GIT_HOOKS=0
+```
+
+Because the hook itself reads this file, it works even when the committing process does not inherit your shell environment — a daemon or web server making commits is still covered.
+
+### Skipping a single commit
+
+To bypass hooks for one commit without any environment setup, use Git's built-in flag:
+
+```bash
+git commit --no-verify
+```

--- a/docs/guide/commit-hooks.md
+++ b/docs/guide/commit-hooks.md
@@ -61,7 +61,7 @@ This is the default Vite+ approach and should replace separate `lint-staged` con
 
 ## Disabling Hooks in Specific Environments
 
-The installed hooks check the environment on every run, so you can disable them per machine or per process without uninstalling anything. This is useful when commits happen outside development — for example on a production server where a flat-file CMS commits content changes.
+The installed hooks check the environment on every run, so you can disable them per machine or per process without uninstalling anything. This is useful when commits happen outside development, for example through a flat file CMS or other processes.
 
 ### Environment variable
 
@@ -71,7 +71,7 @@ Set `VITE_GIT_HOOKS=0` in the environment of the process that runs `git commit`,
 VITE_GIT_HOOKS=0 git commit -m "content update"
 ```
 
-`HUSKY=0` is honored the same way for compatibility. Setting `VITE_GIT_HOOKS=0` in an environment also keeps `vp config` from reinstalling hooks there when a lifecycle script such as `prepare` runs.
+`HUSKY=0` is honored the same way for ecosystem tooling compatibility. Setting `VITE_GIT_HOOKS=0` in an environment also keeps `vp config` from reinstalling hooks there when a lifecycle script such as `prepare` runs.
 
 ### Init script
 
@@ -86,4 +86,4 @@ To disable hooks for a whole machine, create the init script and export the vari
 export VITE_GIT_HOOKS=0
 ```
 
-Because the hook itself reads this file, it works even when the committing process does not inherit your shell environment — a daemon or web server making commits is still covered.
+Because the hook itself reads this file, it works even when the committing process does not inherit your shell environment, for example if a daemon or web server is making commits.

--- a/docs/guide/commit-hooks.md
+++ b/docs/guide/commit-hooks.md
@@ -87,11 +87,3 @@ export VITE_GIT_HOOKS=0
 ```
 
 Because the hook itself reads this file, it works even when the committing process does not inherit your shell environment — a daemon or web server making commits is still covered.
-
-### Skipping a single commit
-
-To bypass hooks for one commit without any environment setup, use Git's built-in flag:
-
-```bash
-git commit --no-verify
-```


### PR DESCRIPTION
Documents how to disable the installed Vite+ commit hooks per environment