### PR TITLE
chore(vscode): disable Oxc nested config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,7 @@
   "[json]": {
     "editor.defaultFormatter": "oxc.oxc-vscode"
   },
+  "oxc.disableNestedConfig": true,
   "typescript.preferences.importModuleSpecifierEnding": "js",
   "typescript.reportStyleChecksAsWarnings": false,
   "typescript.updateImportsOnFileMove.enabled": "always",


### PR DESCRIPTION
This repo dog foods Vite+, Vite+ doesn't support Oxlint and Oxfmt's nested config (https://github.com/voidzero-dev/vite-plus/issues/997). So it makes sense to disable it.

And there is a `vite.config.ts` expected to fail in snap tests, Oxc LSP server (VSCode extension) will load it and crash.

https://github.com/voidzero-dev/vite-plus/blob/3b4829e414d3c95df0d54abb679d94f87384881b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/migration_config_process_crash_isolated/vite.config.ts#L10-L12

<img width="443" height="295" alt="image" src="https://github.com/user-attachments/assets/c9ebb6b7-f4ab-4ce4-90b1-e27e588fad25" />
