### PR TITLE
fix(output): print notes to stderr

### DIFF
--- a/crates/vite_global_cli/src/js_executor.rs
+++ b/crates/vite_global_cli/src/js_executor.rs
@@ -605,6 +605,10 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let scripts_dir = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
 
+        // Keep this delegation test independent of the moving latest-LTS alias.
+        // The unofficial musl index can advertise a release before its archive exists.
+        tokio::fs::write(temp_dir.path().join(".node-version"), "22.13.1\n").await.unwrap();
+
         // Create a bin.js that prints process.version
         let script_path = temp_dir.path().join("bin.js");
         let mut file = std::fs::File::create(&script_path).unwrap();

--- a/crates/vite_shared/src/output.rs
+++ b/crates/vite_shared/src/output.rs
@@ -67,14 +67,14 @@ pub fn error(msg: &str) {
     eprintln!("{} {msg}", "error:".red().bold());
 }
 
-/// Print a note message to stdout (supplementary info).
-#[expect(clippy::print_stdout, clippy::print_stderr, clippy::disallowed_macros)]
+/// Print a note message to stderr (supplementary info).
+///
+/// A note explains the situation around a command rather than being part of
+/// its result, so it belongs on the diagnostic stream: piping stdout to a file
+/// or a parser keeps the command's own output intact.
+#[expect(clippy::print_stderr, clippy::disallowed_macros)]
 pub fn note(msg: &str) {
-    if user_output_to_stderr() {
-        eprintln!("{} {msg}", "note:".dimmed().bold());
-    } else {
-        println!("{} {msg}", "note:".dimmed().bold());
-    }
+    eprintln!("{} {msg}", "note:".dimmed().bold());
 }
 
 /// Print a success line with checkmark to stdout.


### PR DESCRIPTION
## Motivation

- #2259, at the top of this stack, adds a note that has to reach an AI agent capturing piped output while leaving machine-readable stdout alone (`oxlint -f json`, `vitest --reporter=json` and `oxfmt --stdin-filepath` all put
their payload on stdout). Gating that note on a TTY would hide it from some ai agents; printing it to stdout would corrupt those payloads. Moving `note` to stderr resolves both.

- This is also what `rfcs/cli-output-polish.md` specified for `note` in both Rust
and TypeScript — the implementation incorrectly used `println!`.

## CI stability

The delegation test now pins its temporary project to Node.js 22.13.1. The unofficial musl index can advertise a newer LTS before the matching archive exists, which made this otherwise unrelated test fail with `HashNotFound`. Runtime behavior is unchanged.
