### PR TITLE
chore: bump vite-task to 95e9c6ea

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2235,7 +2235,7 @@ dependencies = [
 [[package]]
 name = "fspy"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=85d4e734c64c96c2ce60e734b3e202b5add53696#85d4e734c64c96c2ce60e734b3e202b5add53696"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=95e9c6ea933e7970847496fd2849b20ce462db47#95e9c6ea933e7970847496fd2849b20ce462db47"
 dependencies = [
  "anyhow",
  "bstr",
@@ -2270,7 +2270,7 @@ dependencies = [
 [[package]]
 name = "fspy_detours_sys"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=85d4e734c64c96c2ce60e734b3e202b5add53696#85d4e734c64c96c2ce60e734b3e202b5add53696"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=95e9c6ea933e7970847496fd2849b20ce462db47#95e9c6ea933e7970847496fd2849b20ce462db47"
 dependencies = [
  "cc",
  "winapi",
@@ -2279,7 +2279,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=85d4e734c64c96c2ce60e734b3e202b5add53696#85d4e734c64c96c2ce60e734b3e202b5add53696"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=95e9c6ea933e7970847496fd2849b20ce462db47#95e9c6ea933e7970847496fd2849b20ce462db47"
 dependencies = [
  "anyhow",
  "bstr",
@@ -2294,7 +2294,7 @@ dependencies = [
 [[package]]
 name = "fspy_preload_windows"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=85d4e734c64c96c2ce60e734b3e202b5add53696#85d4e734c64c96c2ce60e734b3e202b5add53696"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=95e9c6ea933e7970847496fd2849b20ce462db47#95e9c6ea933e7970847496fd2849b20ce462db47"
 dependencies = [
  "constcat",
  "fspy_detours_sys",
@@ -2311,7 +2311,7 @@ dependencies = [
 [[package]]
 name = "fspy_seccomp_unotify"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=85d4e734c64c96c2ce60e734b3e202b5add53696#85d4e734c64c96c2ce60e734b3e202b5add53696"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=95e9c6ea933e7970847496fd2849b20ce462db47#95e9c6ea933e7970847496fd2849b20ce462db47"
 dependencies = [
  "futures-util",
  "libc",
@@ -2328,7 +2328,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=85d4e734c64c96c2ce60e734b3e202b5add53696#85d4e734c64c96c2ce60e734b3e202b5add53696"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=95e9c6ea933e7970847496fd2849b20ce462db47#95e9c6ea933e7970847496fd2849b20ce462db47"
 dependencies = [
  "bitflags 2.13.1",
  "bstr",
@@ -2347,7 +2347,7 @@ dependencies = [
 [[package]]
 name = "fspy_shared_unix"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=85d4e734c64c96c2ce60e734b3e202b5add53696#85d4e734c64c96c2ce60e734b3e202b5add53696"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=95e9c6ea933e7970847496fd2849b20ce462db47#95e9c6ea933e7970847496fd2849b20ce462db47"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2365,7 +2365,7 @@ dependencies = [
 [[package]]
 name = "fspy_shm"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=85d4e734c64c96c2ce60e734b3e202b5add53696#85d4e734c64c96c2ce60e734b3e202b5add53696"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=95e9c6ea933e7970847496fd2849b20ce462db47#95e9c6ea933e7970847496fd2849b20ce462db47"
 dependencies = [
  "base64 0.22.1",
  "memfd",
@@ -3513,7 +3513,7 @@ dependencies = [
 [[package]]
 name = "materialized_artifact"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=85d4e734c64c96c2ce60e734b3e202b5add53696#85d4e734c64c96c2ce60e734b3e202b5add53696"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=95e9c6ea933e7970847496fd2849b20ce462db47#95e9c6ea933e7970847496fd2849b20ce462db47"
 dependencies = [
  "tempfile",
 ]
@@ -3521,7 +3521,7 @@ dependencies = [
 [[package]]
 name = "materialized_artifact_build"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=85d4e734c64c96c2ce60e734b3e202b5add53696#85d4e734c64c96c2ce60e734b3e202b5add53696"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=95e9c6ea933e7970847496fd2849b20ce462db47#95e9c6ea933e7970847496fd2849b20ce462db47"
 dependencies = [
  "xxhash-rust",
 ]
@@ -3754,7 +3754,7 @@ dependencies = [
 [[package]]
 name = "native_str"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=85d4e734c64c96c2ce60e734b3e202b5add53696#85d4e734c64c96c2ce60e734b3e202b5add53696"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=95e9c6ea933e7970847496fd2849b20ce462db47#95e9c6ea933e7970847496fd2849b20ce462db47"
 dependencies = [
  "bumpalo",
  "bytemuck",
@@ -5473,7 +5473,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=85d4e734c64c96c2ce60e734b3e202b5add53696#85d4e734c64c96c2ce60e734b3e202b5add53696"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=95e9c6ea933e7970847496fd2849b20ce462db47#95e9c6ea933e7970847496fd2849b20ce462db47"
 dependencies = [
  "anyhow",
  "portable-pty",
@@ -5483,7 +5483,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal_test"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=85d4e734c64c96c2ce60e734b3e202b5add53696#85d4e734c64c96c2ce60e734b3e202b5add53696"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=95e9c6ea933e7970847496fd2849b20ce462db47#95e9c6ea933e7970847496fd2849b20ce462db47"
 dependencies = [
  "anyhow",
  "portable-pty",
@@ -5494,7 +5494,7 @@ dependencies = [
 [[package]]
 name = "pty_terminal_test_client"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=85d4e734c64c96c2ce60e734b3e202b5add53696#85d4e734c64c96c2ce60e734b3e202b5add53696"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=95e9c6ea933e7970847496fd2849b20ce462db47#95e9c6ea933e7970847496fd2849b20ce462db47"
 dependencies = [
  "base64 0.22.1",
  "getrandom 0.4.3",
@@ -7348,7 +7348,7 @@ dependencies = [
 [[package]]
 name = "snapshot_test"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=85d4e734c64c96c2ce60e734b3e202b5add53696#85d4e734c64c96c2ce60e734b3e202b5add53696"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=95e9c6ea933e7970847496fd2849b20ce462db47#95e9c6ea933e7970847496fd2849b20ce462db47"
 dependencies = [
  "serde",
  "serde_json",
@@ -8407,7 +8407,7 @@ dependencies = [
 [[package]]
 name = "vite_glob"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=85d4e734c64c96c2ce60e734b3e202b5add53696#85d4e734c64c96c2ce60e734b3e202b5add53696"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=95e9c6ea933e7970847496fd2849b20ce462db47#95e9c6ea933e7970847496fd2849b20ce462db47"
 dependencies = [
  "globset",
  "thiserror 2.0.19",
@@ -8455,7 +8455,7 @@ dependencies = [
 [[package]]
 name = "vite_graph_ser"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=85d4e734c64c96c2ce60e734b3e202b5add53696#85d4e734c64c96c2ce60e734b3e202b5add53696"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=95e9c6ea933e7970847496fd2849b20ce462db47#95e9c6ea933e7970847496fd2849b20ce462db47"
 dependencies = [
  "petgraph 0.8.3",
  "serde",
@@ -8555,7 +8555,7 @@ dependencies = [
 [[package]]
 name = "vite_path"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=85d4e734c64c96c2ce60e734b3e202b5add53696#85d4e734c64c96c2ce60e734b3e202b5add53696"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=95e9c6ea933e7970847496fd2849b20ce462db47#95e9c6ea933e7970847496fd2849b20ce462db47"
 dependencies = [
  "diff-struct",
  "os_str_bytes",
@@ -8587,7 +8587,7 @@ dependencies = [
 [[package]]
 name = "vite_powershell"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=85d4e734c64c96c2ce60e734b3e202b5add53696#85d4e734c64c96c2ce60e734b3e202b5add53696"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=95e9c6ea933e7970847496fd2849b20ce462db47#95e9c6ea933e7970847496fd2849b20ce462db47"
 dependencies = [
  "vite_path",
  "which",
@@ -8596,7 +8596,7 @@ dependencies = [
 [[package]]
 name = "vite_select"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=85d4e734c64c96c2ce60e734b3e202b5add53696#85d4e734c64c96c2ce60e734b3e202b5add53696"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=95e9c6ea933e7970847496fd2849b20ce462db47#95e9c6ea933e7970847496fd2849b20ce462db47"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -8649,7 +8649,7 @@ dependencies = [
 [[package]]
 name = "vite_shell"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=85d4e734c64c96c2ce60e734b3e202b5add53696#85d4e734c64c96c2ce60e734b3e202b5add53696"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=95e9c6ea933e7970847496fd2849b20ce462db47#95e9c6ea933e7970847496fd2849b20ce462db47"
 dependencies = [
  "brush-parser 0.4.0",
  "diff-struct",
@@ -8676,7 +8676,7 @@ dependencies = [
 [[package]]
 name = "vite_str"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=85d4e734c64c96c2ce60e734b3e202b5add53696#85d4e734c64c96c2ce60e734b3e202b5add53696"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=95e9c6ea933e7970847496fd2849b20ce462db47#95e9c6ea933e7970847496fd2849b20ce462db47"
 dependencies = [
  "compact_str",
  "diff-struct",
@@ -8687,7 +8687,7 @@ dependencies = [
 [[package]]
 name = "vite_task"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=85d4e734c64c96c2ce60e734b3e202b5add53696#85d4e734c64c96c2ce60e734b3e202b5add53696"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=95e9c6ea933e7970847496fd2849b20ce462db47#95e9c6ea933e7970847496fd2849b20ce462db47"
 dependencies = [
  "anstream",
  "anyhow",
@@ -8736,7 +8736,7 @@ dependencies = [
 [[package]]
 name = "vite_task_client"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=85d4e734c64c96c2ce60e734b3e202b5add53696#85d4e734c64c96c2ce60e734b3e202b5add53696"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=95e9c6ea933e7970847496fd2849b20ce462db47#95e9c6ea933e7970847496fd2849b20ce462db47"
 dependencies = [
  "native_str",
  "rustc-hash",
@@ -8749,7 +8749,7 @@ dependencies = [
 [[package]]
 name = "vite_task_client_napi"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=85d4e734c64c96c2ce60e734b3e202b5add53696#85d4e734c64c96c2ce60e734b3e202b5add53696"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=95e9c6ea933e7970847496fd2849b20ce462db47#95e9c6ea933e7970847496fd2849b20ce462db47"
 dependencies = [
  "napi",
  "napi-build",
@@ -8761,7 +8761,7 @@ dependencies = [
 [[package]]
 name = "vite_task_graph"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=85d4e734c64c96c2ce60e734b3e202b5add53696#85d4e734c64c96c2ce60e734b3e202b5add53696"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=95e9c6ea933e7970847496fd2849b20ce462db47#95e9c6ea933e7970847496fd2849b20ce462db47"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8783,7 +8783,7 @@ dependencies = [
 [[package]]
 name = "vite_task_ipc_shared"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=85d4e734c64c96c2ce60e734b3e202b5add53696#85d4e734c64c96c2ce60e734b3e202b5add53696"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=95e9c6ea933e7970847496fd2849b20ce462db47#95e9c6ea933e7970847496fd2849b20ce462db47"
 dependencies = [
  "native_str",
  "rustc-hash",
@@ -8793,7 +8793,7 @@ dependencies = [
 [[package]]
 name = "vite_task_plan"
 version = "0.1.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=85d4e734c64c96c2ce60e734b3e202b5add53696#85d4e734c64c96c2ce60e734b3e202b5add53696"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=95e9c6ea933e7970847496fd2849b20ce462db47#95e9c6ea933e7970847496fd2849b20ce462db47"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8821,7 +8821,7 @@ dependencies = [
 [[package]]
 name = "vite_task_server"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=85d4e734c64c96c2ce60e734b3e202b5add53696#85d4e734c64c96c2ce60e734b3e202b5add53696"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=95e9c6ea933e7970847496fd2849b20ce462db47#95e9c6ea933e7970847496fd2849b20ce462db47"
 dependencies = [
  "futures",
  "native_str",
@@ -8845,7 +8845,7 @@ version = "0.0.0"
 [[package]]
 name = "vite_workspace"
 version = "0.0.0"
-source = "git+https://github.com/voidzero-dev/vite-task.git?rev=85d4e734c64c96c2ce60e734b3e202b5add53696#85d4e734c64c96c2ce60e734b3e202b5add53696"
+source = "git+https://github.com/voidzero-dev/vite-task.git?rev=95e9c6ea933e7970847496fd2849b20ce462db47#95e9c6ea933e7970847496fd2849b20ce462db47"
 dependencies = [
  "clap",
  "petgraph 0.8.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,7 +193,7 @@ dunce = "1.0.5"
 fast-glob = "1.0.0"
 flate2 = { version = "=1.1.9", features = ["zlib-rs"] }
 form_urlencoded = "1.2.1"
-fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "85d4e734c64c96c2ce60e734b3e202b5add53696" }
+fspy = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "95e9c6ea933e7970847496fd2849b20ce462db47" }
 futures = "0.3.31"
 futures-util = "0.3.31"
 glob = "0.3.2"
@@ -250,8 +250,8 @@ pretty_assertions = "1.4.1"
 phf = "0.14.0"
 prettyplease = "0.2.32"
 proc-macro2 = "1"
-pty_terminal_test = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "85d4e734c64c96c2ce60e734b3e202b5add53696" }
-pty_terminal_test_client = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "85d4e734c64c96c2ce60e734b3e202b5add53696" }
+pty_terminal_test = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "95e9c6ea933e7970847496fd2849b20ce462db47" }
+pty_terminal_test_client = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "95e9c6ea933e7970847496fd2849b20ce462db47" }
 quote = "1"
 rayon = "1.10.0"
 regex = "1.11.1"
@@ -274,7 +274,7 @@ sha2 = "0.10.9"
 shell-escape = "0.1.5"
 simdutf8 = "0.1.5"
 smallvec = { version = "1.15.1", features = ["union"] }
-snapshot_test = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "85d4e734c64c96c2ce60e734b3e202b5add53696" }
+snapshot_test = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "95e9c6ea933e7970847496fd2849b20ce462db47" }
 string_cache = "0.9.0"
 sugar_path = { version = "3", features = ["cached_current_dir"] }
 supports-color = "3"
@@ -305,11 +305,11 @@ vite_pm_cli = { path = "crates/vite_pm_cli" }
 vite_setup = { path = "crates/vite_setup" }
 vite_shared = { path = "crates/vite_shared" }
 vite_static_config = { path = "crates/vite_static_config" }
-vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "85d4e734c64c96c2ce60e734b3e202b5add53696" }
-vite_powershell = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "85d4e734c64c96c2ce60e734b3e202b5add53696" }
-vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "85d4e734c64c96c2ce60e734b3e202b5add53696" }
-vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "85d4e734c64c96c2ce60e734b3e202b5add53696" }
-vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "85d4e734c64c96c2ce60e734b3e202b5add53696" }
+vite_path = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "95e9c6ea933e7970847496fd2849b20ce462db47" }
+vite_powershell = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "95e9c6ea933e7970847496fd2849b20ce462db47" }
+vite_str = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "95e9c6ea933e7970847496fd2849b20ce462db47" }
+vite_task = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "95e9c6ea933e7970847496fd2849b20ce462db47" }
+vite_workspace = { git = "https://github.com/voidzero-dev/vite-task.git", rev = "95e9c6ea933e7970847496fd2849b20ce462db47" }
 walkdir = "2.5.0"
 which = "8.0.0"
 winreg = "0.56.0"


### PR DESCRIPTION
Bumps the vite-task git dependency from `85d4e73` to `95e9c6e`.

Changelog diff: https://github.com/voidzero-dev/vite-task/compare/85d4e734c64c96c2ce60e734b3e202b5add53696...95e9c6ea933e7970847496fd2849b20ce462db47#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed

The only user-facing entry is [vite-task#570](https://github.com/voidzero-dev/vite-task/pull/570): every task-spawned process now gets `VP_RUN=1`, forced after `env`/`untrackedEnv` filtering. Not documented here.

No breaking API changes: `cargo check --workspace --all-targets`, `just lint`, and `just test` pass locally.