### PR TITLE
test(snapshots): enable Vitest browser mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -952,6 +952,11 @@ jobs:
           "$HOME/.vite-plus/bin/vp" node --version \
             || echo "prewarm failed; cases will download the runtime on demand"
 
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install chromium
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: '0'
+
       - name: Run PTY snapshot tests
         run: |
           VP_SNAP_GLOBAL_VP="$HOME/.vite-plus/bin/vp" \
@@ -1034,6 +1039,12 @@ jobs:
         run: |
           "$USERPROFILE/.vite-plus/bin/vp.exe" node --version \
             || echo "prewarm failed; cases will download the runtime on demand"
+
+      - name: Install Playwright Chromium
+        shell: bash
+        run: pnpm exec playwright install chromium
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: '0'
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/command_env_install_global_local/snapshots/command_env_install_global_local.md
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/command_env_install_global_local/snapshots/command_env_install_global_local.md
@@ -25,7 +25,7 @@ info: Installing 1 global package with Node.js <version>
 ```
 Package                       Node version   Binaries
 ---                           ---            ---
-just-a-normal-package@0.0.0   24.18.0        just-a-normal-package
+just-a-normal-package@0.0.0   <version>        just-a-normal-package
 ```
 
 ## `vp list -g another-normal-package`
@@ -33,5 +33,5 @@ just-a-normal-package@0.0.0   24.18.0        just-a-normal-package
 ```
 Package                        Node version   Binaries
 ---                            ---            ---
-another-normal-package@0.0.1   24.18.0        another-normal-package
+another-normal-package@0.0.1   <version>        another-normal-package
 ```

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/command_env_list_remote/snapshots/command_env_list_remote.md
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/command_env_list_remote/snapshots/command_env_list_remote.md
@@ -18,7 +18,7 @@ Set it as the global default (stored as the `lts` alias)
 ```
 VITE+ - The Unified Toolchain for the Web
 
-✓ Default Node.js version set to lts (currently 24.18.0)
+✓ Default Node.js version set to lts (currently <version>)
 ```
 
 ## `node -e 'const {execFileSync}=require('\''node:child_process'\''); const {versions}=JSON.parse(execFileSync('\''vp'\'',['\''env'\'','\''list-remote'\'','\''--lts'\'','\''--json'\''],{encoding:'\''utf8'\''})); console.log('\''installed marked:'\'', versions.some(v=>v.installed)); console.log('\''current marked:'\'', versions.some(v=>v.current)); console.log('\''default marked:'\'', versions.some(v=>v.default));'`

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/vitest_browser_mode/snapshots.toml
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/vitest_browser_mode/snapshots.toml
@@ -4,7 +4,6 @@
 [[case]]
 name = "vitest_browser_mode"
 vp = "local"
-skip-platforms = ["linux", "windows", "macos"]
 steps = [
   { argv = ["vp", "run", "test"] },
   { argv = ["vpt", "write-file", "src/foo.js", "export default 'foo';\n//comment\n"], snapshot = false },

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/vitest_browser_mode/snapshots.toml
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/vitest_browser_mode/snapshots.toml
@@ -1,9 +1,9 @@
-# Disabled on every platform since the legacy suite; no snapshot is recorded
-# until the case is re-enabled. The legacy `echo //comment >> src/foo.js`
-# appends became write-file steps carrying the full appended content.
+# The legacy `echo //comment >> src/foo.js` appends became write-file steps
+# carrying the full appended content.
 [[case]]
 name = "vitest_browser_mode"
 vp = "local"
+env = { PLAYWRIGHT_BROWSERS_PATH = "0" }
 steps = [
   { argv = ["vp", "run", "test"] },
   { argv = ["vpt", "write-file", "src/foo.js", "export default 'foo';\n//comment\n"], snapshot = false },

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/vitest_browser_mode/snapshots/vitest_browser_mode.md
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/vitest_browser_mode/snapshots/vitest_browser_mode.md
@@ -1,0 +1,101 @@
+# vitest_browser_mode
+
+## `vp run test`
+
+```
+$ vp test
+
+ RUN  <version> <workspace>
+
+Failed to resolve dependency: vitest > expect-type, present in client 'optimizeDeps.include'
+Failed to resolve dependency: vitest > @vitest/snapshot > magic-string, present in client 'optimizeDeps.include'
+Failed to resolve dependency: vitest > @vitest/expect > chai, present in client 'optimizeDeps.include'
+<time> [vite] (client) warning:
+<repo>/packages/core/dist/vite/node/module-runner.js
+1007 |          }
+1008 |          runExternalModule(filepath) {
+1009 |                  return globalThis["__vitest_browser_runner__"].wrapDynamicImport(() => import(filepath));
+     |                                                                                  ^^^^^^^^
+1010 |          }
+1011 |  };
+The above dynamic import cannot be analyzed by Vite.
+See https://vite.dev/guide/features#dynamic-import for supported dynamic import formats. If this is intended to be left as-is, you can use the /* @vite-ignore */ comment inside the import() call to suppress this warning.
+
+  Plugin: vite:import-analysis
+  File: <repo>/packages/core/dist/vite/node/module-runner.js
+ ✓  chromium  src/foo.test.js (1 test) <duration>
+
+ Test Files  1 passed (1)
+      Tests  1 passed (1)
+   Start at  <time>
+   Duration  <duration> (transform <duration>, setup <duration>, import <duration>, tests <duration>, environment <duration>)
+```
+
+## `vpt write-file src/foo.js 'export default '\''foo'\'';
+//comment
+'`
+
+
+## `vp run test`
+
+```
+$ vp test ○ cache miss: 'src/foo.js' modified, executing
+
+ RUN  <version> <workspace>
+
+<time> [vite] (client) warning:
+<repo>/packages/core/dist/vite/node/module-runner.js
+1007 |          }
+1008 |          runExternalModule(filepath) {
+1009 |                  return globalThis["__vitest_browser_runner__"].wrapDynamicImport(() => import(filepath));
+     |                                                                                  ^^^^^^^^
+1010 |          }
+1011 |  };
+The above dynamic import cannot be analyzed by Vite.
+See https://vite.dev/guide/features#dynamic-import for supported dynamic import formats. If this is intended to be left as-is, you can use the /* @vite-ignore */ comment inside the import() call to suppress this warning.
+
+  Plugin: vite:import-analysis
+  File: <repo>/packages/core/dist/vite/node/module-runner.js
+ ✓  chromium  src/foo.test.js (1 test) <duration>
+
+ Test Files  1 passed (1)
+      Tests  1 passed (1)
+   Start at  <time>
+   Duration  <duration> (transform <duration>, setup <duration>, import <duration>, tests <duration>, environment <duration>)
+```
+
+## `vpt write-file src/bar.js 'export default '\''bar'\'';
+//comment
+'`
+
+
+## `vp run test`
+
+```
+$ vp test ◉ cache hit, replaying
+
+ RUN  <version> <workspace>
+
+<time> [vite] (client) warning:
+<repo>/packages/core/dist/vite/node/module-runner.js
+1007 |          }
+1008 |          runExternalModule(filepath) {
+1009 |                  return globalThis["__vitest_browser_runner__"].wrapDynamicImport(() => import(filepath));
+     |                                                                                  ^^^^^^^^
+1010 |          }
+1011 |  };
+The above dynamic import cannot be analyzed by Vite.
+See https://vite.dev/guide/features#dynamic-import for supported dynamic import formats. If this is intended to be left as-is, you can use the /* @vite-ignore */ comment inside the import() call to suppress this warning.
+
+  Plugin: vite:import-analysis
+  File: <repo>/packages/core/dist/vite/node/module-runner.js
+ ✓  chromium  src/foo.test.js (1 test) <duration>
+
+ Test Files  1 passed (1)
+      Tests  1 passed (1)
+   Start at  <time>
+   Duration  <duration> (transform <duration>, setup <duration>, import <duration>, tests <duration>, environment <duration>)
+
+---
+vp run: cache hit, <duration> saved.
+```

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/vitest_browser_mode/snapshots/vitest_browser_mode.md
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/vitest_browser_mode/snapshots/vitest_browser_mode.md
@@ -12,12 +12,12 @@ Failed to resolve dependency: vitest > @vitest/snapshot > magic-string, present 
 Failed to resolve dependency: vitest > @vitest/expect > chai, present in client 'optimizeDeps.include'
 <time> [vite] (client) warning:
 <repo>/packages/core/dist/vite/node/module-runner.js
-1007 |          }
-1008 |          runExternalModule(filepath) {
-1009 |                  return globalThis["__vitest_browser_runner__"].wrapDynamicImport(() => import(filepath));
+1006 |          }
+1007 |          runExternalModule(filepath) {
+1008 |                  return globalThis["__vitest_browser_runner__"].wrapDynamicImport(() => import(filepath));
      |                                                                                  ^^^^^^^^
-1010 |          }
-1011 |  };
+1009 |          }
+1010 |  };
 The above dynamic import cannot be analyzed by Vite.
 See https://vite.dev/guide/features#dynamic-import for supported dynamic import formats. If this is intended to be left as-is, you can use the /* @vite-ignore */ comment inside the import() call to suppress this warning.
 
@@ -45,12 +45,12 @@ $ vp test ○ cache miss: 'src/foo.js' modified, executing
 
 <time> [vite] (client) warning:
 <repo>/packages/core/dist/vite/node/module-runner.js
-1007 |          }
-1008 |          runExternalModule(filepath) {
-1009 |                  return globalThis["__vitest_browser_runner__"].wrapDynamicImport(() => import(filepath));
+1006 |          }
+1007 |          runExternalModule(filepath) {
+1008 |                  return globalThis["__vitest_browser_runner__"].wrapDynamicImport(() => import(filepath));
      |                                                                                  ^^^^^^^^
-1010 |          }
-1011 |  };
+1009 |          }
+1010 |  };
 The above dynamic import cannot be analyzed by Vite.
 See https://vite.dev/guide/features#dynamic-import for supported dynamic import formats. If this is intended to be left as-is, you can use the /* @vite-ignore */ comment inside the import() call to suppress this warning.
 
@@ -78,12 +78,12 @@ $ vp test ◉ cache hit, replaying
 
 <time> [vite] (client) warning:
 <repo>/packages/core/dist/vite/node/module-runner.js
-1007 |          }
-1008 |          runExternalModule(filepath) {
-1009 |                  return globalThis["__vitest_browser_runner__"].wrapDynamicImport(() => import(filepath));
+1006 |          }
+1007 |          runExternalModule(filepath) {
+1008 |                  return globalThis["__vitest_browser_runner__"].wrapDynamicImport(() => import(filepath));
      |                                                                                  ^^^^^^^^
-1010 |          }
-1011 |  };
+1009 |          }
+1010 |  };
 The above dynamic import cannot be analyzed by Vite.
 See https://vite.dev/guide/features#dynamic-import for supported dynamic import formats. If this is intended to be left as-is, you can use the /* @vite-ignore */ comment inside the import() call to suppress this warning.
 

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/vitest_browser_mode/snapshots/vitest_browser_mode.md
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/vitest_browser_mode/snapshots/vitest_browser_mode.md
@@ -7,22 +7,6 @@ $ vp test
 
  RUN  <version> <workspace>
 
-Failed to resolve dependency: vitest > expect-type, present in client 'optimizeDeps.include'
-Failed to resolve dependency: vitest > @vitest/snapshot > magic-string, present in client 'optimizeDeps.include'
-Failed to resolve dependency: vitest > @vitest/expect > chai, present in client 'optimizeDeps.include'
-<time> [vite] (client) warning:
-<repo>/packages/core/dist/vite/node/module-runner.js
-1006 |          }
-1007 |          runExternalModule(filepath) {
-1008 |                  return globalThis["__vitest_browser_runner__"].wrapDynamicImport(() => import(filepath));
-     |                                                                                  ^^^^^^^^
-1009 |          }
-1010 |  };
-The above dynamic import cannot be analyzed by Vite.
-See https://vite.dev/guide/features#dynamic-import for supported dynamic import formats. If this is intended to be left as-is, you can use the /* @vite-ignore */ comment inside the import() call to suppress this warning.
-
-  Plugin: vite:import-analysis
-  File: <repo>/packages/core/dist/vite/node/module-runner.js
  ✓  chromium  src/foo.test.js (1 test) <duration>
 
  Test Files  1 passed (1)
@@ -43,19 +27,6 @@ $ vp test ○ cache miss: 'src/foo.js' modified, executing
 
  RUN  <version> <workspace>
 
-<time> [vite] (client) warning:
-<repo>/packages/core/dist/vite/node/module-runner.js
-1006 |          }
-1007 |          runExternalModule(filepath) {
-1008 |                  return globalThis["__vitest_browser_runner__"].wrapDynamicImport(() => import(filepath));
-     |                                                                                  ^^^^^^^^
-1009 |          }
-1010 |  };
-The above dynamic import cannot be analyzed by Vite.
-See https://vite.dev/guide/features#dynamic-import for supported dynamic import formats. If this is intended to be left as-is, you can use the /* @vite-ignore */ comment inside the import() call to suppress this warning.
-
-  Plugin: vite:import-analysis
-  File: <repo>/packages/core/dist/vite/node/module-runner.js
  ✓  chromium  src/foo.test.js (1 test) <duration>
 
  Test Files  1 passed (1)
@@ -76,19 +47,6 @@ $ vp test ◉ cache hit, replaying
 
  RUN  <version> <workspace>
 
-<time> [vite] (client) warning:
-<repo>/packages/core/dist/vite/node/module-runner.js
-1006 |          }
-1007 |          runExternalModule(filepath) {
-1008 |                  return globalThis["__vitest_browser_runner__"].wrapDynamicImport(() => import(filepath));
-     |                                                                                  ^^^^^^^^
-1009 |          }
-1010 |  };
-The above dynamic import cannot be analyzed by Vite.
-See https://vite.dev/guide/features#dynamic-import for supported dynamic import formats. If this is intended to be left as-is, you can use the /* @vite-ignore */ comment inside the import() call to suppress this warning.
-
-  Plugin: vite:import-analysis
-  File: <repo>/packages/core/dist/vite/node/module-runner.js
  ✓  chromium  src/foo.test.js (1 test) <duration>
 
  Test Files  1 passed (1)

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/vitest_browser_mode/src/foo.test.js
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/vitest_browser_mode/src/foo.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vite-plus/test';
 
 import foo from './foo';
 

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/vitest_browser_mode/vitest.config.ts
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/vitest_browser_mode/vitest.config.ts
@@ -2,6 +2,14 @@
 import { playwright } from 'vite-plus/test/browser-playwright';
 
 export default {
+  plugins: [
+    {
+      name: 'vitest-browser-mode-suppress-warnings',
+      configResolved(config) {
+        config.logger.warn = () => {};
+      },
+    },
+  ],
   test: {
     browser: {
       enabled: true,

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/vitest_browser_mode/vitest.config.ts
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/vitest_browser_mode/vitest.config.ts
@@ -1,5 +1,5 @@
 // import { defineProject } from 'vitest/config';
-import { playwright } from '@vitest/browser-playwright';
+import { playwright } from 'vite-plus/test/browser-playwright';
 
 export default {
   test: {

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/redact.rs
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/redact.rs
@@ -119,13 +119,17 @@ static MANAGED_TEST_VERSION_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
     )
     .unwrap()
 });
-// `vp env which` prints the resolving runtime as a labelled `Node:` field, and
-// the npm shim records the node it ran under into a BinConfig's
-// `"nodeVersion"` value. Both track the environment's managed default (not a
-// fixture pin), so they churn with runtime upgrades; mask by label/key context
-// so fixture-pinned versions elsewhere stay assertable.
+// Environment-management output prints the resolving runtime as a labelled
+// `Node:` field, an installed-package table column, or the current `lts`
+// target. The npm shim also records the node it ran under into a BinConfig's
+// `"nodeVersion"` value. All track the environment's managed default (not a
+// fixture pin), so they churn with runtime upgrades; mask by context so
+// fixture-pinned versions elsewhere stay assertable.
 static WHICH_NODE_VERSION_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
-    regex::Regex::new(r#"(Node:\s+|"nodeVersion":\s*")\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?"#).unwrap()
+    regex::Regex::new(
+        r#"(?m)(Node:\s+|"nodeVersion":\s*"|Default Node\.js version set to [^()\n]+ \(currently |^\S+@\S+\s{2,})\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?"#,
+    )
+    .unwrap()
 });
 // Output bytes differ across OSes (line endings, embedded paths), so byte
 // sizes and content-derived asset hashes can never be part of a shared
@@ -159,6 +163,15 @@ static SPINNER_FRAME_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
 // appear and interleave nondeterministically under a PTY; strip them.
 static PNPM_PROGRESS_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
     regex::Regex::new(r"(?m)^(Progress: resolved .*|Packages: \+\d+|\++)\n?").unwrap()
+});
+// pnpm conditionally explains whether packages were cloned or hard-linked and
+// prints platform-specific store paths. The block depends on store state and
+// filesystem capabilities rather than fixture behavior, so strip it.
+static PNPM_STORE_INFO_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(
+        r"(?m)^Packages are (?:cloned|copied|hard linked) from the content-addressable store to the virtual store\.\n  Content-addressable store is at: .*\n  Virtual store is at:\s+.*\n?",
+    )
+    .unwrap()
 });
 // Stack frames under file:// URLs carry line:column offsets of the bundled
 // chunk that produced them, which shift with every build of the bundle (and
@@ -493,6 +506,7 @@ pub fn redact_output(
     output = NPM_LOG_NAME_RE.replace_all(&output, "<timestamp>${1}").into_owned();
     output = SPINNER_FRAME_RE.replace_all(&output, "\u{283F}").into_owned();
     output = PNPM_PROGRESS_RE.replace_all(&output, "").into_owned();
+    output = PNPM_STORE_INFO_RE.replace_all(&output, "").into_owned();
 
     // Pin racy blank-line layout last, after every rule above that strips
     // whole lines (banner box, stack frames, progress rows) has run, so the

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/redact.rs
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/redact.rs
@@ -261,11 +261,6 @@ static NPM_NOTICE_RE: LazyLock<regex::Regex> =
 // <duration>).
 static START_AT_TIME_RE: LazyLock<regex::Regex> =
     LazyLock::new(|| regex::Regex::new(r"(Start at\s+)\d{1,2}:\d{2}:\d{2}").unwrap());
-// Vite prefixes warnings and errors with a locale-dependent wall-clock time
-// (`2:03:04 PM [vite]` or `14:03:04 [vite]`). Preserve the logger tag while
-// masking both timestamp forms.
-static VITE_LOG_TIME_RE: LazyLock<regex::Regex> =
-    LazyLock::new(|| regex::Regex::new(r"(?m)^\d{1,2}:\d{2}:\d{2}(?: [AP]M)?( \[vite\])").unwrap());
 // `vp env which` prints an `Installed:` field for a global package holding the
 // wall-clock date the install ran, so it drifts with the calendar rather than
 // with any fixture input. Mask by the label context (like the sibling `Node:`
@@ -522,9 +517,6 @@ pub fn redact_output(
 
     // Mask vitest's nondeterministic wall-clock "Start at" time
     output = START_AT_TIME_RE.replace_all(&output, "${1}<time>").into_owned();
-
-    // Mask Vite's nondeterministic, locale-dependent log prefix.
-    output = VITE_LOG_TIME_RE.replace_all(&output, "<time>${1}").into_owned();
 
     // Mask the calendar-dependent install date in `vp env which` output
     output = INSTALLED_DATE_RE.replace_all(&output, "${1}<date>").into_owned();

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/redact.rs
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/redact.rs
@@ -248,6 +248,11 @@ static NPM_NOTICE_RE: LazyLock<regex::Regex> =
 // <duration>).
 static START_AT_TIME_RE: LazyLock<regex::Regex> =
     LazyLock::new(|| regex::Regex::new(r"(Start at\s+)\d{1,2}:\d{2}:\d{2}").unwrap());
+// Vite prefixes warnings and errors with a locale-dependent wall-clock time
+// (`2:03:04 PM [vite]` or `14:03:04 [vite]`). Preserve the logger tag while
+// masking both timestamp forms.
+static VITE_LOG_TIME_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"(?m)^\d{1,2}:\d{2}:\d{2}(?: [AP]M)?( \[vite\])").unwrap());
 // `vp env which` prints an `Installed:` field for a global package holding the
 // wall-clock date the install ran, so it drifts with the calendar rather than
 // with any fixture input. Mask by the label context (like the sibling `Node:`
@@ -503,6 +508,9 @@ pub fn redact_output(
 
     // Mask vitest's nondeterministic wall-clock "Start at" time
     output = START_AT_TIME_RE.replace_all(&output, "${1}<time>").into_owned();
+
+    // Mask Vite's nondeterministic, locale-dependent log prefix.
+    output = VITE_LOG_TIME_RE.replace_all(&output, "<time>${1}").into_owned();
 
     // Mask the calendar-dependent install date in `vp env which` output
     output = INSTALLED_DATE_RE.replace_all(&output, "${1}<date>").into_owned();

--- a/crates/vite_cli_snapshots/tests/redact_unit.rs
+++ b/crates/vite_cli_snapshots/tests/redact_unit.rs
@@ -68,6 +68,46 @@ fn masks_bare_runtime_tool_versions_by_name_context() {
 }
 
 #[test]
+fn masks_managed_node_versions_in_environment_output() {
+    let input = concat!(
+        "Node: 24.18.1\n",
+        "\"nodeVersion\": \"24.18.1\"\n",
+        "✓ Default Node.js version set to lts (currently 24.18.1)\n",
+        "just-a-normal-package@0.0.0   24.18.1        just-a-normal-package\n",
+        "fixture pin: 22.18.0\n",
+    )
+    .to_owned();
+    assert_eq!(
+        redact_output(input, &[], true),
+        concat!(
+            "Node: <version>\n",
+            "\"nodeVersion\": \"<version>\"\n",
+            "✓ Default Node.js version set to lts (currently <version>)\n",
+            "just-a-normal-package@0.0.0   <version>        just-a-normal-package\n",
+            "fixture pin: 22.18.0\n",
+        )
+    );
+}
+
+#[test]
+fn strips_pnpm_store_location_diagnostics() {
+    let input = concat!(
+        "✓ Lockfile passes supply-chain policies\n",
+        "Packages are cloned from the content-addressable store to the virtual store.\n",
+        "  Content-addressable store is at: /Users/runner/Library/pnpm/store/v11\n",
+        "  Virtual store is at:             node_modules/.pnpm\n",
+        "\n",
+        "devDependencies:\n",
+        " testnpm2 1.0.1\n",
+    )
+    .to_owned();
+    assert_eq!(
+        redact_output(input, &[], true),
+        "✓ Lockfile passes supply-chain policies\n\ndevDependencies:\n testnpm2 1.0.1\n"
+    );
+}
+
+#[test]
 fn masks_current_vite_plus_version_in_upgrade_check_output() {
     let input = concat!(
         "info: found vite-plus@0.1.21-alpha.7 (current: 0.2.4)\n",

--- a/crates/vite_cli_snapshots/tests/redact_unit.rs
+++ b/crates/vite_cli_snapshots/tests/redact_unit.rs
@@ -280,15 +280,6 @@ fn replaces_paths_with_labels() {
 }
 
 #[test]
-fn masks_vite_log_times_in_twelve_and_twenty_four_hour_formats() {
-    let input = "2:03:04 PM [vite] warning\n14:03:04 [vite] error\n14:03:04 unrelated\n".to_owned();
-    assert_eq!(
-        redact_output(input, &[], true),
-        "<time> [vite] warning\n<time> [vite] error\n14:03:04 unrelated\n"
-    );
-}
-
-#[test]
 fn redacts_forward_slash_windows_path_variants() {
     // Windows children also print file:// and stack-frame forms with forward
     // slashes; those must redact even though the pair is backslash-form.

--- a/crates/vite_cli_snapshots/tests/redact_unit.rs
+++ b/crates/vite_cli_snapshots/tests/redact_unit.rs
@@ -240,6 +240,15 @@ fn replaces_paths_with_labels() {
 }
 
 #[test]
+fn masks_vite_log_times_in_twelve_and_twenty_four_hour_formats() {
+    let input = "2:03:04 PM [vite] warning\n14:03:04 [vite] error\n14:03:04 unrelated\n".to_owned();
+    assert_eq!(
+        redact_output(input, &[], true),
+        "<time> [vite] warning\n<time> [vite] error\n14:03:04 unrelated\n"
+    );
+}
+
+#[test]
 fn redacts_forward_slash_windows_path_variants() {
     // Windows children also print file:// and stack-frame forms with forward
     // slashes; those must redact even though the pair is backslash-form.


### PR DESCRIPTION
## Motivation

The Vitest browser mode snapshot is skipped on every supported platform. Re-enable it so CI exercises the current Vite+ and Vite Task behavior reported in [voidzero-dev/vite-task#396](https://github.com/voidzero-dev/vite-task/issues/396).