### PR TITLE
docs: recommend stacked pull requests for submitting changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,10 @@ UPDATE_SNAPSHOTS=1 just snapshot-test <name-filter>   # record/accept snapshots
 
 Snapshot mismatches fail the run with a unified diff and write `<case>.md.new`; recorded `.md` snapshots are reviewed like code and committed with the fixture. Steps are argv arrays (no shell); use `vpt` subcommands instead of coreutils so cases stay platform-identical. Cases declare `vp = "local" | "global" | ["local", "global"]`; local-flavor cases require a fresh `packages/cli/dist`.
 
+### Submitting changes
+
+Prioritize stacked pull requests: split multi-part work into a stack of small PRs so reviewers can approve and merge each layer on its own. Create stacks with the `gh-stack` CLI extension or on github.com. See the "Submitting Pull Requests" section in `CONTRIBUTING.md`.
+
 ## Code Conventions
 
 ### Rust

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,7 +141,7 @@ Snapshot mismatches fail the run with a unified diff and write `<case>.md.new`; 
 
 ### Submitting changes
 
-Prioritize stacked pull requests: split multi-part work into a stack of small PRs so reviewers can approve and merge each layer on its own. Create stacks with the `gh-stack` CLI extension or on github.com. See the "Submitting Pull Requests" section in `CONTRIBUTING.md`.
+Prioritize stacked pull requests: split multi-part work into a stack of small PRs so reviewers can approve and merge each layer on its own. Create stacks with the `gh-stack` CLI extension or on github.com. Stacks require all branches to be in this repository (GitHub does not support cross-fork stacks), so from a fork submit standalone PRs instead. See the "Submitting Pull Requests" section in `CONTRIBUTING.md`.
 
 ## Code Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,6 +155,16 @@ UPDATE_SNAPSHOTS=1 just snapshot-test create
 
 The full case/step/interaction reference (including the `vpt` helper tool and milestone conventions for interactive tests) lives in `crates/vite_cli_snapshots/tests/cli_snapshots/README.md`; the design rationale is in `rfcs/interactive-snapshot-tests.md`.
 
+## Submitting Pull Requests
+
+Prioritize stacked pull requests when your work splits into reviewable layers, for example a refactor PR with the feature PR that depends on it stacked on top. Reviewers handle a stack of small PRs faster than one large PR, and each layer merges on its own.
+
+GitHub has built-in stacked pull requests ([public preview](https://github.blog/changelog/2026-07-30-stacked-pull-requests-are-now-in-public-preview/), rolling out to all repositories). Create stacks on github.com, or from the terminal:
+
+```bash
+gh extension install github/gh-stack
+```
+
 ## Verified Commits
 
 All commits in PR branches should be GitHub-verified so reviewers can confirm commit authenticity.
@@ -162,7 +172,6 @@ All commits in PR branches should be GitHub-verified so reviewers can confirm co
 Set up local commit signing and GitHub verification first:
 
 - Follow GitHub's guide for GPG commit signature verification: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification
-- If you use Graphite, add the Graphite GPG key to your GitHub account from the Graphite UI as well, otherwise commits updated by Graphite won't show as verified.
 
 After setup, re-sign any existing commits in your branch so the full branch is verified:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,6 +165,8 @@ GitHub has built-in stacked pull requests ([public preview](https://github.blog/
 gh extension install github/gh-stack
 ```
 
+Stacked pull requests require all branches to be in this repository; GitHub does not support cross-fork stacks ([reference](https://docs.github.com/en/pull-requests/reference/stacked-pull-requests)). If you contribute from a fork, split large work into a sequence of standalone PRs instead.
+
 ## Verified Commits
 
 All commits in PR branches should be GitHub-verified so reviewers can confirm commit authenticity.


### PR DESCRIPTION
Add a "Submitting Pull Requests" section to CONTRIBUTING.md and a matching "Submitting changes" note in AGENTS.md: split multi-part work into stacked pull requests, created with GitHub's gh-stack CLI extension or on github.com (now in public preview for all repositories). Also remove the Graphite GPG note from Verified Commits, since the docs no longer reference Graphite.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>