### PR TITLE
test(snapshots): stabilize Windows fixtures

### DIFF
--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/env_install_interrupt/long-time-install-package/postinstall.js
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/env_install_interrupt/long-time-install-package/postinstall.js
@@ -1,7 +1,12 @@
 const { promisify } = require('util');
+const fs = require('fs');
+const path = require('path');
 
 const sleep = promisify(setTimeout);
 
 (async () => {
-  await sleep(200);
+  if (process.env.VP_TEST_INTERRUPT_INSTALL === '1') {
+    fs.writeFileSync(path.join(process.env.VP_HOME, 'env-install-interrupt-ready'), '');
+    await sleep(30_000);
+  }
 })();

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/env_install_interrupt/snapshots.toml
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/env_install_interrupt/snapshots.toml
@@ -5,9 +5,9 @@ steps = [
   { argv = ["vp", "install", "-g", "./long-time-install-package"], continue-on-failure = true },
   { argv = ["long-time-install-package"], continue-on-failure = true },
   # snapshot = false: the killed install's partial screen is timing-dependent
-  # (which spinner frame was live at the 100ms SIGKILL) and ConPTY renders a
-  # trailing blank line Unix does not; the meaningful outcome is asserted by
-  # the check-stale-packages step that follows.
+  # (which spinner frame was live when the process tree was terminated). ConPTY
+  # also renders a trailing blank line Unix does not; the meaningful outcome is
+  # asserted by the check-stale-packages step that follows.
   { argv = ["node", "test-reinstall-interrupt.js"], comment = "Reinstall but interrupt", snapshot = false, continue-on-failure = true },
   { argv = ["long-time-install-package"], comment = "Original package should be still runnable", continue-on-failure = true },
   { argv = ["node", "check-stale-packages.js", "--expect-stale"], comment = "Interrupted reinstall should leave stale package", continue-on-failure = true },

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/env_install_interrupt/test-reinstall-interrupt.js
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/env_install_interrupt/test-reinstall-interrupt.js
@@ -1,11 +1,18 @@
-const { spawn } = require('child_process');
+const { spawn, spawnSync } = require('child_process');
 
 const child = spawn('vp', ['install', '-g', './long-time-install-package'], {
   stdio: 'inherit',
 });
 
 setTimeout(() => {
-  if (!child.killed) {
+  if (child.exitCode === null && child.signalCode === null) {
+    if (process.platform === 'win32') {
+      // Killing vp.exe alone leaves its installer child running in the background.
+      spawnSync('taskkill.exe', ['/PID', String(child.pid), '/T', '/F'], {
+        stdio: 'ignore',
+      });
+      return;
+    }
     child.kill('SIGKILL');
   }
 }, 100);

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/env_install_interrupt/test-reinstall-interrupt.js
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/env_install_interrupt/test-reinstall-interrupt.js
@@ -1,22 +1,55 @@
+const fs = require('fs');
+const path = require('path');
 const { spawn, spawnSync } = require('child_process');
+const { promisify } = require('util');
+
+const sleep = promisify(setTimeout);
+const readyPath = path.join(process.env.VP_HOME, 'env-install-interrupt-ready');
+fs.rmSync(readyPath, { force: true });
 
 const child = spawn('vp', ['install', '-g', './long-time-install-package'], {
+  env: { ...process.env, VP_TEST_INTERRUPT_INSTALL: '1' },
   stdio: 'inherit',
 });
 
-setTimeout(() => {
-  if (child.exitCode === null && child.signalCode === null) {
-    if (process.platform === 'win32') {
-      // Killing vp.exe alone leaves its installer child running in the background.
+function killInstall() {
+  if (process.platform === 'win32') {
+    // Killing vp.exe alone leaves its installer child running in the background.
+    return (
       spawnSync('taskkill.exe', ['/PID', String(child.pid), '/T', '/F'], {
         stdio: 'ignore',
-      });
+      }).status === 0
+    );
+  }
+  return child.kill('SIGKILL');
+}
+
+let interrupted = false;
+
+(async () => {
+  for (let attempt = 0; attempt < 500; attempt++) {
+    if (fs.existsSync(readyPath)) {
+      if (!killInstall()) {
+        throw new Error('failed to interrupt reinstall');
+      }
+      interrupted = true;
       return;
     }
-    child.kill('SIGKILL');
+    if (child.exitCode !== null || child.signalCode !== null) {
+      throw new Error('reinstall exited before reaching postinstall');
+    }
+    await sleep(20);
   }
-}, 100);
+  throw new Error('timed out waiting for reinstall postinstall');
+})().catch((error) => {
+  console.error(error.message);
+  killInstall();
+  process.exitCode = 1;
+});
 
 child.on('close', (code) => {
-  process.exit(code);
+  fs.rmSync(readyPath, { force: true });
+  if (!interrupted) {
+    process.exitCode ||= code || 1;
+  }
 });

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/vitest_browser_mode/vitest.config.ts
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/vitest_browser_mode/vitest.config.ts
@@ -4,8 +4,9 @@ import { playwright } from 'vite-plus/test/browser-playwright';
 export default {
   plugins: [
     {
-      name: 'vitest-browser-mode-suppress-warnings',
+      name: 'vitest-browser-mode-suppress-vite-logs',
       configResolved(config) {
+        config.logger.info = () => {};
         config.logger.warn = () => {};
       },
     },

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/vitest_browser_mode/vitest.config.ts
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/vitest_browser_mode/vitest.config.ts
@@ -4,9 +4,14 @@ import { playwright } from 'vite-plus/test/browser-playwright';
 export default {
   plugins: [
     {
-      name: 'vitest-browser-mode-suppress-vite-logs',
+      name: 'vitest-browser-mode-suppress-known-vite-logs',
       configResolved(config) {
-        config.logger.info = () => {};
+        const info = config.logger.info;
+        config.logger.info = (message, options) => {
+          if (!message.includes('is in use, trying another one')) {
+            info(message, options);
+          }
+        };
         config.logger.warn = () => {};
       },
     },


### PR DESCRIPTION
## Summary

- kill the entire Windows installer process tree in the interrupted-install fixture
- suppress fixture-local Vite info logs so automatic browser-port fallback does not change snapshots

## Context

This unblocks the v0.2.7 release PR after repeated Windows snapshot failures in `env_install_interrupt` and `vitest_browser_mode`.

## Testing

- `node --check crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/env_install_interrupt/test-reinstall-interrupt.js`
- `git diff --check`
- targeted behavior will be exercised by the Windows snapshot CI job