### PR TITLE
ci: make sure staging deploy doesn't trigger on external PRs

### DIFF
--- a/.github/workflows/deploy-docs-preview.yml
+++ b/.github/workflows/deploy-docs-preview.yml
@@ -20,7 +20,9 @@ defaults:
 
 jobs:
   staging-deploy:
-    if: github.repository == 'voidzero-dev/vite-plus'
+    if: >-
+      github.repository == 'voidzero-dev/vite-plus' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Staging deploys which run on all PRs right now and [fail on external repo prs](https://github.com/voidzero-dev/vite-plus/actions?query=workflow%3A%22Deploy+Docs+Preview%22+is%3Afailure)
added condition to only run when the PR's base is this repo
