### PR TITLE
refactor(cli): generate Zed language settings from a language list

### DIFF
--- a/packages/cli/src/utils/editor.ts
+++ b/packages/cli/src/utils/editor.ts
@@ -60,94 +60,36 @@ const ZED_SETTINGS = {
       },
     },
   },
-  languages: {
-    CSS: {
-      format_on_save: 'on',
-      prettier: { allowed: false },
-      formatter: [{ language_server: { name: 'oxfmt' } }],
-    },
-    GraphQL: {
-      format_on_save: 'on',
-      prettier: { allowed: false },
-      formatter: [{ language_server: { name: 'oxfmt' } }],
-    },
-    Handlebars: {
-      format_on_save: 'on',
-      prettier: { allowed: false },
-      formatter: [{ language_server: { name: 'oxfmt' } }],
-    },
-    HTML: {
-      format_on_save: 'on',
-      prettier: { allowed: false },
-      formatter: [{ language_server: { name: 'oxfmt' } }],
-    },
-    JavaScript: {
-      format_on_save: 'on',
-      prettier: { allowed: false },
-      formatter: [{ language_server: { name: 'oxfmt' } }],
-      code_action: 'source.fixAll.oxc',
-    },
-    JSX: {
-      format_on_save: 'on',
-      prettier: { allowed: false },
-      formatter: [{ language_server: { name: 'oxfmt' } }],
-    },
-    JSON: {
-      format_on_save: 'on',
-      prettier: { allowed: false },
-      formatter: [{ language_server: { name: 'oxfmt' } }],
-    },
-    JSON5: {
-      format_on_save: 'on',
-      prettier: { allowed: false },
-      formatter: [{ language_server: { name: 'oxfmt' } }],
-    },
-    JSONC: {
-      format_on_save: 'on',
-      prettier: { allowed: false },
-      formatter: [{ language_server: { name: 'oxfmt' } }],
-    },
-    Less: {
-      format_on_save: 'on',
-      prettier: { allowed: false },
-      formatter: [{ language_server: { name: 'oxfmt' } }],
-    },
-    Markdown: {
-      format_on_save: 'on',
-      prettier: { allowed: false },
-      formatter: [{ language_server: { name: 'oxfmt' } }],
-    },
-    MDX: {
-      format_on_save: 'on',
-      prettier: { allowed: false },
-      formatter: [{ language_server: { name: 'oxfmt' } }],
-    },
-    SCSS: {
-      format_on_save: 'on',
-      prettier: { allowed: false },
-      formatter: [{ language_server: { name: 'oxfmt' } }],
-    },
-    TypeScript: {
-      format_on_save: 'on',
-      prettier: { allowed: false },
-      formatter: [{ language_server: { name: 'oxfmt' } }],
-    },
-    TSX: {
-      format_on_save: 'on',
-      prettier: { allowed: false },
-      formatter: [{ language_server: { name: 'oxfmt' } }],
-    },
-    'Vue.js': {
-      format_on_save: 'on',
-      prettier: { allowed: false },
-      formatter: [{ language_server: { name: 'oxfmt' } }],
-    },
-    YAML: {
-      format_on_save: 'on',
-      prettier: { allowed: false },
-      formatter: [{ language_server: { name: 'oxfmt' } }],
-    },
-  },
+  languages: Object.fromEntries(
+    [
+      'CSS',
+      'GraphQL',
+      'Handlebars',
+      'HTML',
+      'JavaScript',
+      'JSX',
+      'JSON',
+      'JSON5',
+      'JSONC',
+      'Less',
+      'Markdown',
+      'MDX',
+      'SCSS',
+      'TypeScript',
+      'TSX',
+      'Vue.js',
+      'YAML',
+    ].map((language) => [
+      language,
+      {
+        format_on_save: 'on',
+        prettier: { allowed: false },
+        formatter: [{ language_server: { name: 'oxfmt' } }],
+        // Only the JavaScript entry runs the oxc fix-all code action on save
+        ...(language === 'JavaScript' ? { code_action: 'source.fixAll.oxc' } : {}),
+      },
+    ]),
+  ),
 } as const;
 
 export const EDITORS = [


### PR DESCRIPTION
## Summary

`ZED_SETTINGS.languages` in `packages/cli/src/utils/editor.ts` listed 17 per-language blocks that were verbatim-identical except for one key, so this PR replaces them with a language-name array mapped through `Object.fromEntries` (88 lines down to 30).

- The only per-language difference (`code_action: 'source.fixAll.oxc'` on JavaScript) is now an explicit conditional spread instead of being hidden inside a wall of identical blocks.
- Adding a newly supported language becomes a one-line array entry instead of a copy-pasted block.

## Behavior

No behavior change. `Object.fromEntries` preserves array order, so the generated `.zed/settings.json` is byte-identical, and `ZED_SETTINGS` is consumed as `Record<string, unknown>` so the weaker literal typing has no effect.