### PR TITLE
test(snapshots): suppress racy optimizer logs in vitest_browser_mode

### DIFF
--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/vitest_browser_mode/vitest.config.ts
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/vitest_browser_mode/vitest.config.ts
@@ -6,9 +6,16 @@ export default {
     {
       name: 'vitest-browser-mode-suppress-known-vite-logs',
       configResolved(config) {
+        // "is in use, trying another one": port fallback depends on other
+        // concurrently running servers. "[optimizer]" progress lines fire on
+        // a 1s timer, so they only appear on slow cold-cache runs.
+        const nonDeterministicLogs = [
+          'is in use, trying another one',
+          '[optimizer]',
+        ];
         const info = config.logger.info;
         config.logger.info = (message, options) => {
-          if (!message.includes('is in use, trying another one')) {
+          if (!nonDeterministicLogs.some((log) => message.includes(log))) {
             info(message, options);
           }
         };


### PR DESCRIPTION
The `vitest_browser_mode` PTY snapshot fails intermittently with an extra line:

```
+2:02:47 PM [vite] (client) [optimizer] bundling dependencies...
```

Example failure: https://github.com/voidzero-dev/vite-plus/actions/runs/30750855536/job/91504582504?pr=2248

Vite's dep optimizer emits `[optimizer] bundling dependencies...` (and its sibling `[optimizer] scanning dependencies...`) on a 1s `setTimeout` (`vite/src/node/optimizer/index.ts`), so the line only appears when a cold-cache bundle takes longer than 1s on a slow runner. The fixture already suppresses known non-deterministic Vite logs through a logger patch; this extends that filter to drop `[optimizer]` progress lines. The environment logger looks up `config.logger.info` at call time, so the patch intercepts these messages. The recorded snapshot is unchanged.