### PR TITLE
test(snapshots): kill vp before its children in env_install_interrupt

### DIFF
--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/env_install_interrupt/test-reinstall-interrupt.js
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/env_install_interrupt/test-reinstall-interrupt.js
@@ -12,14 +12,40 @@ const child = spawn('vp', ['install', '-g', './long-time-install-package'], {
   stdio: 'inherit',
 });
 
+function listWindowsChildren(pid) {
+  const result = spawnSync(
+    'powershell.exe',
+    [
+      '-NoProfile',
+      '-Command',
+      `(Get-CimInstance Win32_Process -Filter "ParentProcessId=${pid}").ProcessId`,
+    ],
+    { encoding: 'utf8' },
+  );
+  if (result.status !== 0 || !result.stdout) {
+    return [];
+  }
+  return result.stdout.split(/\s+/).filter(Boolean);
+}
+
 function killInstall() {
   if (process.platform === 'win32') {
-    // Killing vp.exe alone leaves its installer child running in the background.
-    return (
-      spawnSync('taskkill.exe', ['/PID', String(child.pid), '/T', '/F'], {
+    // taskkill /T terminates the tree in unspecified order. When the
+    // postinstall child dies before vp.exe, vp treats the reinstall as
+    // failed and removes the partial install dir, so no stale dir is left
+    // for the check-stale step. Kill vp.exe first so it cannot react, then
+    // sweep the orphaned installer children (killing vp.exe alone would
+    // leave them running in the background). The tree is stable while
+    // postinstall sleeps, so enumerating children before the kill is safe.
+    const children = listWindowsChildren(child.pid);
+    const killed =
+      spawnSync('taskkill.exe', ['/PID', String(child.pid), '/F'], {
         stdio: 'ignore',
-      }).status === 0
-    );
+      }).status === 0;
+    for (const pid of children) {
+      spawnSync('taskkill.exe', ['/PID', pid, '/T', '/F'], { stdio: 'ignore' });
+    }
+    return killed;
   }
   return child.kill('SIGKILL');
 }


### PR DESCRIPTION
The `env_install_interrupt` PTY snapshot fails intermittently on Windows:

```
+**Exit code:** 1
-interrupted stale package exists
+interrupted stale package removed
```

Example failure: https://github.com/voidzero-dev/vite-plus/actions/runs/30777846280/job/91576844864?pr=2297

`taskkill /T /F` terminates the process tree in unspecified order. When the postinstall child dies before `vp.exe`, vp observes the failed npm child and runs `cleanup_failed_install`, removing the partial install dir before taskkill reaches vp itself, so no stale dir is left for the check-stale step. Reproduced the mechanism on macOS by killing the postinstall child first and letting vp react: same diff as the CI failure.

Fix: enumerate vp's direct children while the tree is parked in the postinstall sleep, kill `vp.exe` first so it cannot react, then `taskkill /T` each orphaned child (killing vp alone would leave the installer children running). The Unix path and the recorded snapshot are unchanged.

Stacked on #2297.