### PR TITLE
refactor(env): rename remaining Vite+ environment variables

### DIFF
--- a/.github/workflows/test-standalone-install.yml
+++ b/.github/workflows/test-standalone-install.yml
@@ -197,7 +197,7 @@ jobs:
               done
               vp env doctor
 
-              export VITE_LOG=trace
+              export VP_LOG=trace
               vp env run --node 24 -- node -p \"process.versions\"
 
               # Verify upgrade
@@ -307,7 +307,7 @@ jobs:
               done
               vp env doctor
 
-              export VITE_LOG=trace
+              export VP_LOG=trace
               vp env run --node 24 -- node -p \"process.versions\"
 
               # FIXME: QEMU doesn't support all syscalls needed by rolldown/tsdown
@@ -693,7 +693,7 @@ jobs:
           echo "PATH: $env:Path"
           vp --version
           vp --help
-          # $env:VITE_LOG = "trace"
+          # $env:VP_LOG = "trace"
           # test create command
           vp create vite --no-interactive --no-agent -- hello --no-interactive -t vanilla
           cd hello && vp run build && vp --version

--- a/crates/vite_global_cli/src/error.rs
+++ b/crates/vite_global_cli/src/error.rs
@@ -18,7 +18,7 @@ pub enum Error {
     CommandExecution(#[from] io::Error),
 
     #[error(
-        "JS scripts directory not found. Set VITE_GLOBAL_CLI_JS_SCRIPTS_DIR or ensure scripts are bundled."
+        "JS scripts directory not found. Set VP_GLOBAL_CLI_JS_SCRIPTS_DIR or ensure scripts are bundled."
     )]
     JsScriptsDirNotFound,
 

--- a/crates/vite_global_cli/src/js_executor.rs
+++ b/crates/vite_global_cli/src/js_executor.rs
@@ -26,7 +26,7 @@ pub struct JsExecutor {
     cli_runtime: Option<JsRuntime>,
     /// Cached runtime for project delegation (Category C)
     project_runtime: Option<JsRuntime>,
-    /// Directory containing JS scripts (from `VITE_GLOBAL_CLI_JS_SCRIPTS_DIR`)
+    /// Directory containing JS scripts (from `VP_GLOBAL_CLI_JS_SCRIPTS_DIR`)
     scripts_dir: Option<AbsolutePathBuf>,
     /// Subcommand as the user wrote it, forwarded to the CLI this one runs
     raw_subcommand: Option<String>,
@@ -56,7 +56,7 @@ impl JsExecutor {
     ///
     /// Resolution order:
     /// 1. Explicitly provided `scripts_dir`
-    /// 2. `VITE_GLOBAL_CLI_JS_SCRIPTS_DIR` environment variable
+    /// 2. `VP_GLOBAL_CLI_JS_SCRIPTS_DIR` environment variable
     /// 3. Auto-detect from binary location (../dist relative to binary)
     pub fn get_scripts_dir(&self) -> Result<AbsolutePathBuf, Error> {
         // 1. Use explicitly provided scripts_dir
@@ -65,7 +65,7 @@ impl JsExecutor {
         }
 
         // 2. Check environment variable
-        if let Ok(dir) = std::env::var(env_vars::VITE_GLOBAL_CLI_JS_SCRIPTS_DIR) {
+        if let Ok(dir) = std::env::var(env_vars::VP_GLOBAL_CLI_JS_SCRIPTS_DIR) {
             return AbsolutePathBuf::new(dir.into()).ok_or(Error::JsScriptsDirNotFound);
         }
 

--- a/crates/vite_js_runtime/src/runtime.rs
+++ b/crates/vite_js_runtime/src/runtime.rs
@@ -159,7 +159,7 @@ async fn resolve_shasums_content(
 /// that publishes only `SHASUMS256.txt`).
 ///
 /// This is an expected, non-actionable condition for those sources, so it is a
-/// debug log (visible via `VITE_LOG`) rather than a user-facing warning.
+/// debug log (visible via `VP_LOG`) rather than a user-facing warning.
 fn log_checksum_only(archive_filename: &str) {
     tracing::debug!(
         "no PGP signature available for {archive_filename}; verifying SHA-256 checksum only"

--- a/crates/vite_shared/src/env_config.rs
+++ b/crates/vite_shared/src/env_config.rs
@@ -101,7 +101,7 @@ pub struct EnvConfig {
 
     /// Override directory for global CLI JS scripts.
     ///
-    /// Env: `VITE_GLOBAL_CLI_JS_SCRIPTS_DIR`
+    /// Env: `VP_GLOBAL_CLI_JS_SCRIPTS_DIR`
     pub js_scripts_dir: Option<String>,
 
     /// Filter for update task types.
@@ -145,7 +145,7 @@ impl EnvConfig {
             debug_shim: std::env::var(env_vars::VP_DEBUG_SHIM).is_ok(),
             env_use_eval_enable: std::env::var(env_vars::VP_ENV_USE_EVAL_ENABLE).is_ok(),
             tool_recursion: std::env::var(env_vars::VP_TOOL_RECURSION).ok(),
-            js_scripts_dir: std::env::var(env_vars::VITE_GLOBAL_CLI_JS_SCRIPTS_DIR).ok(),
+            js_scripts_dir: std::env::var(env_vars::VP_GLOBAL_CLI_JS_SCRIPTS_DIR).ok(),
             update_task_types: std::env::var(env_vars::VITE_UPDATE_TASK_TYPES).ok(),
             node_version: std::env::var(env_vars::VP_NODE_VERSION).ok(),
             user_home: std::env::var("HOME")

--- a/crates/vite_shared/src/env_config.rs
+++ b/crates/vite_shared/src/env_config.rs
@@ -106,7 +106,7 @@ pub struct EnvConfig {
 
     /// Filter for update task types.
     ///
-    /// Env: `VITE_UPDATE_TASK_TYPES`
+    /// Env: `VP_UPDATE_TASK_TYPES`
     pub update_task_types: Option<String>,
 
     /// Override Node.js version (takes highest priority in version resolution).
@@ -146,7 +146,7 @@ impl EnvConfig {
             env_use_eval_enable: std::env::var(env_vars::VP_ENV_USE_EVAL_ENABLE).is_ok(),
             tool_recursion: std::env::var(env_vars::VP_TOOL_RECURSION).ok(),
             js_scripts_dir: std::env::var(env_vars::VP_GLOBAL_CLI_JS_SCRIPTS_DIR).ok(),
-            update_task_types: std::env::var(env_vars::VITE_UPDATE_TASK_TYPES).ok(),
+            update_task_types: std::env::var(env_vars::VP_UPDATE_TASK_TYPES).ok(),
             node_version: std::env::var(env_vars::VP_NODE_VERSION).ok(),
             user_home: std::env::var("HOME")
                 .or_else(|_| std::env::var("USERPROFILE"))

--- a/crates/vite_shared/src/env_vars.rs
+++ b/crates/vite_shared/src/env_vars.rs
@@ -47,7 +47,7 @@ pub const VP_SHELL: &str = "VP_SHELL";
 pub const VITE_UPDATE_TASK_TYPES: &str = "VITE_UPDATE_TASK_TYPES";
 
 /// Override directory for global CLI JS scripts.
-pub const VITE_GLOBAL_CLI_JS_SCRIPTS_DIR: &str = "VITE_GLOBAL_CLI_JS_SCRIPTS_DIR";
+pub const VP_GLOBAL_CLI_JS_SCRIPTS_DIR: &str = "VP_GLOBAL_CLI_JS_SCRIPTS_DIR";
 
 // ── Runtime: set/removed during shim dispatch for child processes ────────
 

--- a/crates/vite_shared/src/env_vars.rs
+++ b/crates/vite_shared/src/env_vars.rs
@@ -44,7 +44,7 @@ pub const VP_ENV_USE_EVAL_ENABLE: &str = "VP_ENV_USE_EVAL_ENABLE";
 pub const VP_SHELL: &str = "VP_SHELL";
 
 /// Filter for update task types.
-pub const VITE_UPDATE_TASK_TYPES: &str = "VITE_UPDATE_TASK_TYPES";
+pub const VP_UPDATE_TASK_TYPES: &str = "VP_UPDATE_TASK_TYPES";
 
 /// Override directory for global CLI JS scripts.
 pub const VP_GLOBAL_CLI_JS_SCRIPTS_DIR: &str = "VP_GLOBAL_CLI_JS_SCRIPTS_DIR";

--- a/crates/vite_shared/src/env_vars.rs
+++ b/crates/vite_shared/src/env_vars.rs
@@ -16,7 +16,7 @@
 pub const VP_HOME: &str = "VP_HOME";
 
 /// Log filter string for `tracing_subscriber` (e.g. `"debug"`, `"vite_task=trace"`).
-pub const VITE_LOG: &str = "VITE_LOG";
+pub const VP_LOG: &str = "VP_LOG";
 
 /// NPM registry URL (lowercase form, highest priority).
 pub const NPM_CONFIG_REGISTRY: &str = "npm_config_registry";

--- a/crates/vite_shared/src/tracing.rs
+++ b/crates/vite_shared/src/tracing.rs
@@ -9,21 +9,21 @@ use tracing_subscriber::{
 
 use crate::env_vars;
 
-/// Initialize tracing with `VITE_LOG` environment variable.
+/// Initialize tracing with `VP_LOG` environment variable.
 ///
 /// Uses `OnceLock` to ensure tracing is only initialized once,
 /// even if called multiple times.
 ///
-/// Only sets the global default subscriber when `VITE_LOG` is set.
+/// Only sets the global default subscriber when `VP_LOG` is set.
 /// When unset, the global default slot is left free so that other
 /// subscribers (e.g., rolldown devtools) can claim it without panicking.
 ///
 /// # Environment Variables
-/// - `VITE_LOG`: Controls log filtering (e.g., "debug", "`vite_task=trace`")
+/// - `VP_LOG`: Controls log filtering (e.g., "debug", "`vite_task=trace`")
 pub fn init_tracing() {
     static TRACING: OnceLock<()> = OnceLock::new();
     TRACING.get_or_init(|| {
-        let Ok(env_var) = std::env::var(env_vars::VITE_LOG) else {
+        let Ok(env_var) = std::env::var(env_vars::VP_LOG) else {
             return;
         };
 

--- a/docs/guide/installer-env-vars.md
+++ b/docs/guide/installer-env-vars.md
@@ -147,14 +147,14 @@ Vite+ sets additional `VP_*` variables during shim dispatch and shell integratio
 
 ## Logging and Debugging
 
-### `VITE_LOG`
+### `VP_LOG`
 
 - **Purpose**: Log filter string for `tracing_subscriber`
 - **Default**: None
 - **Example**:
   ```bash
-  VITE_LOG=debug vp dev
-  VITE_LOG=vite_task=trace vp build
+  VP_LOG=debug vp dev
+  VP_LOG=vite_task=trace vp build
   ```
 
 ### `VP_DEBUG_SHIM`

--- a/packages/cli/binding/src/cli/mod.rs
+++ b/packages/cli/binding/src/cli/mod.rs
@@ -464,7 +464,7 @@ mod tests {
         let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
         let run_config_path = PathBuf::from(manifest_dir).join("../src/run-config.ts");
 
-        if std::env::var("VITE_UPDATE_TASK_TYPES").as_deref() == Ok("1") {
+        if std::env::var("VP_UPDATE_TASK_TYPES").as_deref() == Ok("1") {
             std::fs::write(&run_config_path, &ts_type).expect("Failed to write run-config.ts");
         } else {
             let current = std::fs::read_to_string(&run_config_path)
@@ -473,7 +473,7 @@ mod tests {
             pretty_assertions::assert_eq!(
                 current,
                 ts_type,
-                "run-config.ts is out of sync. Run `VITE_UPDATE_TASK_TYPES=1 cargo test -p vite-plus-cli run_config_types_in_sync` to update."
+                "run-config.ts is out of sync. Run `VP_UPDATE_TASK_TYPES=1 cargo test -p vite-plus-cli run_config_types_in_sync` to update."
             );
         }
     }

--- a/rfcs/env-command.md
+++ b/rfcs/env-command.md
@@ -2189,7 +2189,7 @@ $ vp env --current --json
 | ------------------------ | ----------------------------------------------------------------------------------------------- | -------------- |
 | `VP_HOME`                | Base directory for bin and config                                                               | `~/.vite-plus` |
 | `VP_NODE_VERSION`        | Session override for Node.js version (set by `vp env use`)                                      | unset          |
-| `VITE_LOG`               | Log level: debug, info, warn, error                                                             | `warn`         |
+| `VP_LOG`                 | Log level: debug, info, warn, error                                                             | `warn`         |
 | `VP_DEBUG_SHIM`          | Enable extra shim diagnostics                                                                   | unset          |
 | `VP_BYPASS`              | PATH-style list of bin dirs to skip when finding system tools; set `=1` to bypass shim entirely | unset          |
 | `VP_TOOL_RECURSION`      | **Internal**: Prevents shim recursion                                                           | unset          |

--- a/rfcs/global-cli-rust-binary.md
+++ b/rfcs/global-cli-rust-binary.md
@@ -193,7 +193,7 @@ Only these commands can run without any Node.js:
 ├──────────────────────────────────────────────────────────────────────────────┤
 │                                                                              │
 │  ┌──────────────────┐  ┌──────────────────┐  ┌──────────────────────────┐   │
-│  │   CLI Parser     │  │ Workspace Detect │  │   VITE_GLOBAL_CLI_JS_SCRIPTS_DIR│   │
+│  │   CLI Parser     │  │ Workspace Detect │  │   VP_GLOBAL_CLI_JS_SCRIPTS_DIR  │   │
 │  │   (clap)         │  │ (from vite_task) │  │   (bundled scripts path) │   │
 │  └────────┬─────────┘  └────────┬─────────┘  └────────────┬─────────────┘   │
 │           │                     │                         │                 │
@@ -274,7 +274,7 @@ use std::process::Command;
 pub struct JsExecutor {
     cli_runtime: Option<JsRuntime>,      // Cached runtime for CLI commands
     project_runtime: Option<JsRuntime>,  // Cached runtime for project delegation
-    scripts_dir: PathBuf,                // From VITE_GLOBAL_CLI_JS_SCRIPTS_DIR
+    scripts_dir: PathBuf,                // From VP_GLOBAL_CLI_JS_SCRIPTS_DIR
 }
 
 impl JsExecutor {
@@ -687,14 +687,14 @@ function getBinaryPath() {
 }
 
 const binaryPath = getBinaryPath();
-// Set VITE_GLOBAL_CLI_JS_SCRIPTS_DIR to point to dist/index.js location
+// Set VP_GLOBAL_CLI_JS_SCRIPTS_DIR to point to dist/index.js location
 const jsScriptsDir = join(__dirname, '..');
 
 execFileSync(binaryPath, process.argv.slice(2), {
   stdio: 'inherit',
   env: {
     ...process.env,
-    VITE_GLOBAL_CLI_JS_SCRIPTS_DIR: jsScriptsDir,
+    VP_GLOBAL_CLI_JS_SCRIPTS_DIR: jsScriptsDir,
   },
 });
 ```
@@ -702,9 +702,9 @@ execFileSync(binaryPath, process.argv.slice(2), {
 **How it works:**
 
 1. `bin/vite` finds the Rust binary (`vp`) from the platform-specific optional dependency
-2. Sets `VITE_GLOBAL_CLI_JS_SCRIPTS_DIR` pointing to the package root (where `dist/index.js` is)
+2. Sets `VP_GLOBAL_CLI_JS_SCRIPTS_DIR` pointing to the package root (where `dist/index.js` is)
 3. Executes the Rust binary with all arguments
-4. The Rust binary uses the JS entry point at `$VITE_GLOBAL_CLI_JS_SCRIPTS_DIR/dist/index.js`
+4. The Rust binary uses the JS entry point at `$VP_GLOBAL_CLI_JS_SCRIPTS_DIR/dist/index.js`
 
 This ensures npm installation works the same way as standalone installation.
 
@@ -859,7 +859,7 @@ The installer supports multiple versions with symlinks, allowing version switchi
 
 When the Rust binary needs to execute JS (for `new`, `migrate`, `--version`, or PM commands):
 
-1. Check `VITE_GLOBAL_CLI_JS_SCRIPTS_DIR` environment variable (optional)
+1. Check `VP_GLOBAL_CLI_JS_SCRIPTS_DIR` environment variable (optional)
 2. If not set, auto-detect by looking for `dist/index.js` relative to the binary
 3. Download Node.js via `vite_js_runtime` if not cached (version from `package.json` devEngines.runtime)
 4. Execute the JS entry point with managed Node.js, passing command and arguments
@@ -881,7 +881,7 @@ When the Rust binary needs to execute JS (for `new`, `migrate`, `--version`, or 
 // In the Rust binary
 fn get_js_scripts_dir() -> Result<PathBuf, Error> {
     // 1. Check environment variable first
-    if let Ok(dir) = std::env::var("VITE_GLOBAL_CLI_JS_SCRIPTS_DIR") {
+    if let Ok(dir) = std::env::var("VP_GLOBAL_CLI_JS_SCRIPTS_DIR") {
         return Ok(PathBuf::from(dir));
     }
 

--- a/rfcs/interactive-snapshot-tests.md
+++ b/rfcs/interactive-snapshot-tests.md
@@ -212,7 +212,7 @@ The snapshot then contains the rendered picker at cursor position 0, at cursor p
 
 ### Global (`vp = "global"`)
 
-The runner runs the freshly built Rust binary, resolved from the target directory next to the test executable (see Design overview), linked into the per-case bin dir under the names `vp`, `vpr`, and `vpx`. `VITE_GLOBAL_CLI_JS_SCRIPTS_DIR` points at the checkout's `packages/cli/dist`, as today.
+The runner runs the freshly built Rust binary, resolved from the target directory next to the test executable (see Design overview), linked into the per-case bin dir under the names `vp`, `vpr`, and `vpx`. `VP_GLOBAL_CLI_JS_SCRIPTS_DIR` points at the checkout's `packages/cli/dist`, as today.
 
 This removes two standing costs of the current global runner:
 


### PR DESCRIPTION
## Summary

This follows up on #1166, which renamed `VITE_PLUS_*` environment variables to use the `VP_*` prefix. It applies the
 same convention to the remaining Vite+-specific variables: `VITE_LOG`, `VITE_GLOBAL_CLI_JS_SCRIPTS_DIR`, and
 `VITE_UPDATE_TASK_TYPES`, without retaining compatibility aliases.

Resolves #2206