### PR TITLE
refactor(env): remove the task type update flag

### DIFF
--- a/crates/vite_shared/src/env_config.rs
+++ b/crates/vite_shared/src/env_config.rs
@@ -104,11 +104,6 @@ pub struct EnvConfig {
     /// Env: `VITE_GLOBAL_CLI_JS_SCRIPTS_DIR`
     pub js_scripts_dir: Option<String>,
 
-    /// Filter for update task types.
-    ///
-    /// Env: `VITE_UPDATE_TASK_TYPES`
-    pub update_task_types: Option<String>,
-
     /// Override Node.js version (takes highest priority in version resolution).
     ///
     /// Env: `VP_NODE_VERSION`
@@ -146,7 +141,6 @@ impl EnvConfig {
             env_use_eval_enable: std::env::var(env_vars::VP_ENV_USE_EVAL_ENABLE).is_ok(),
             tool_recursion: std::env::var(env_vars::VP_TOOL_RECURSION).ok(),
             js_scripts_dir: std::env::var(env_vars::VITE_GLOBAL_CLI_JS_SCRIPTS_DIR).ok(),
-            update_task_types: std::env::var(env_vars::VITE_UPDATE_TASK_TYPES).ok(),
             node_version: std::env::var(env_vars::VP_NODE_VERSION).ok(),
             user_home: std::env::var("HOME")
                 .or_else(|_| std::env::var("USERPROFILE"))
@@ -233,7 +227,6 @@ impl EnvConfig {
             env_use_eval_enable: false,
             tool_recursion: None,
             js_scripts_dir: None,
-            update_task_types: None,
             node_version: None,
             user_home: None,
             vp_shell: None,

--- a/crates/vite_shared/src/env_vars.rs
+++ b/crates/vite_shared/src/env_vars.rs
@@ -43,9 +43,6 @@ pub const VP_ENV_USE_EVAL_ENABLE: &str = "VP_ENV_USE_EVAL_ENABLE";
 /// Explicitly specify the current shell.
 pub const VP_SHELL: &str = "VP_SHELL";
 
-/// Filter for update task types.
-pub const VITE_UPDATE_TASK_TYPES: &str = "VITE_UPDATE_TASK_TYPES";
-
 /// Override directory for global CLI JS scripts.
 pub const VITE_GLOBAL_CLI_JS_SCRIPTS_DIR: &str = "VITE_GLOBAL_CLI_JS_SCRIPTS_DIR";
 

--- a/packages/cli/binding/src/cli/mod.rs
+++ b/packages/cli/binding/src/cli/mod.rs
@@ -464,17 +464,9 @@ mod tests {
         let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
         let run_config_path = PathBuf::from(manifest_dir).join("../src/run-config.ts");
 
-        if std::env::var("VITE_UPDATE_TASK_TYPES").as_deref() == Ok("1") {
-            std::fs::write(&run_config_path, &ts_type).expect("Failed to write run-config.ts");
-        } else {
-            let current = std::fs::read_to_string(&run_config_path)
-                .expect("Failed to read run-config.ts")
-                .replace('\r', "");
-            pretty_assertions::assert_eq!(
-                current,
-                ts_type,
-                "run-config.ts is out of sync. Run `VITE_UPDATE_TASK_TYPES=1 cargo test -p vite-plus-cli run_config_types_in_sync` to update."
-            );
-        }
+        let current = std::fs::read_to_string(&run_config_path)
+            .expect("Failed to read run-config.ts")
+            .replace('\r', "");
+        pretty_assertions::assert_eq!(current, ts_type, "run-config.ts is out of sync.");
     }
 }


### PR DESCRIPTION
## Summary

Removing the repository-unset `VITE_UPDATE_TASK_TYPES` flag also removes its unused shared configuration entries.

Related: #2206, #2312