### PR TITLE
test(snapshots): kill the real vp process in env_install_interrupt

### DIFF
--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/env_install_interrupt/long-time-install-package/postinstall.js
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/env_install_interrupt/long-time-install-package/postinstall.js
@@ -6,7 +6,13 @@ const sleep = promisify(setTimeout);
 
 (async () => {
   if (process.env.VP_TEST_INTERRUPT_INSTALL === '1') {
-    fs.writeFileSync(path.join(process.env.VP_HOME, 'env-install-interrupt-ready'), '');
+    // The PID lets the interrupt driver kill this subtree directly instead
+    // of enumerating vp's children through PowerShell/CIM, whose cold start
+    // on a loaded runner can outlast the step timeout. Write-then-rename so
+    // the driver never observes the file without the PID in it.
+    const readyPath = path.join(process.env.VP_HOME, 'env-install-interrupt-ready');
+    fs.writeFileSync(`${readyPath}.tmp`, String(process.pid));
+    fs.renameSync(`${readyPath}.tmp`, readyPath);
     await sleep(30_000);
   }
 })();

--- a/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/env_install_interrupt/test-reinstall-interrupt.js
+++ b/crates/vite_cli_snapshots/tests/cli_snapshots/fixtures/env_install_interrupt/test-reinstall-interrupt.js
@@ -7,58 +7,81 @@ const sleep = promisify(setTimeout);
 const readyPath = path.join(process.env.VP_HOME, 'env-install-interrupt-ready');
 fs.rmSync(readyPath, { force: true });
 
-const child = spawn('vp', ['install', '-g', './long-time-install-package'], {
+// Stage markers narrate the driver on the PTY. `snapshot = false` hides them
+// on success; on a failure or timeout they name the stage that hung.
+console.log('interrupt driver: start');
+
+// Spawn the real CLI binary, not the `vp` on PATH. On Windows, PATH resolves
+// to the trampoline in VP_HOME/bin, which runs current/bin/vp.exe as a child
+// and waits. With the trampoline as child.pid, killInstall killed the wrong
+// process first: the real vp.exe stayed alive, watched its npm child die in
+// the tree sweep, and removed the partial install dir that the check-stale
+// step needs ("interrupted stale package removed" flake). Spawning
+// current/bin/vp directly makes child.pid the process that runs the install
+// on every platform (on Unix, bin/vp is a symlink to the same binary).
+const vpBinary = path.join(
+  process.env.VP_HOME,
+  'current',
+  'bin',
+  process.platform === 'win32' ? 'vp.exe' : 'vp',
+);
+const child = spawn(vpBinary, ['install', '-g', './long-time-install-package'], {
   env: { ...process.env, VP_TEST_INTERRUPT_INSTALL: '1' },
   stdio: 'inherit',
 });
-
-function listWindowsChildren(pid) {
-  const result = spawnSync(
-    'powershell.exe',
-    [
-      '-NoProfile',
-      '-Command',
-      `(Get-CimInstance Win32_Process -Filter "ParentProcessId=${pid}").ProcessId`,
-    ],
-    { encoding: 'utf8' },
-  );
-  if (result.status !== 0 || !result.stdout) {
-    return [];
-  }
-  return result.stdout.split(/\s+/).filter(Boolean);
-}
+console.log(`interrupt driver: spawned vp (pid ${child.pid})`);
 
 function killInstall() {
   if (process.platform === 'win32') {
-    // taskkill /T terminates the tree in unspecified order. When the
-    // postinstall child dies before vp.exe, vp treats the reinstall as
-    // failed and removes the partial install dir, so no stale dir is left
-    // for the check-stale step. Kill vp.exe first so it cannot react, then
-    // sweep the orphaned installer children (killing vp.exe alone would
-    // leave them running in the background). The tree is stable while
-    // postinstall sleeps, so enumerating children before the kill is safe.
-    const children = listWindowsChildren(child.pid);
+    // Kill vp.exe first so it cannot react: while vp.exe is alive, a dying
+    // postinstall child makes it treat the reinstall as failed and remove
+    // the partial install dir, leaving no stale dir for the check-stale
+    // step. Then kill the postinstall subtree via the PID from the ready
+    // file, so no process enumeration is needed (PowerShell/CIM cold start
+    // on a loaded runner can outlast the step timeout). The npm layers
+    // between vp.exe and postinstall exit on their own once the postinstall
+    // script dies; with vp.exe already dead, nobody reacts to that.
+    let postinstallPid = '';
+    try {
+      postinstallPid = fs.readFileSync(readyPath, 'utf8').trim();
+    } catch {
+      // Ready file absent: the error paths call this without a handshake.
+    }
     const killed =
       spawnSync('taskkill.exe', ['/PID', String(child.pid), '/F'], {
         stdio: 'ignore',
       }).status === 0;
-    for (const pid of children) {
-      spawnSync('taskkill.exe', ['/PID', pid, '/T', '/F'], { stdio: 'ignore' });
+    if (postinstallPid) {
+      spawnSync('taskkill.exe', ['/PID', postinstallPid, '/T', '/F'], {
+        stdio: 'ignore',
+      });
     }
     return killed;
   }
   return child.kill('SIGKILL');
 }
 
+// The runner's step timeout reports whatever is left on the PTY screen,
+// which can be blank after vp's spinner erased its line. Fail from inside
+// the driver first so the failure always carries the stage markers.
+const watchdog = setTimeout(() => {
+  console.error('interrupt driver: watchdog fired after 45s; forcing exit');
+  killInstall();
+  process.exit(1);
+}, 45_000);
+watchdog.unref();
+
 let interrupted = false;
 
 (async () => {
   for (let attempt = 0; attempt < 500; attempt++) {
     if (fs.existsSync(readyPath)) {
+      console.log('interrupt driver: postinstall reached, killing install');
       if (!killInstall()) {
         throw new Error('failed to interrupt reinstall');
       }
       interrupted = true;
+      console.log('interrupt driver: install killed');
       return;
     }
     if (child.exitCode !== null || child.signalCode !== null) {
@@ -74,6 +97,7 @@ let interrupted = false;
 });
 
 child.on('close', (code) => {
+  console.log(`interrupt driver: vp closed (code ${code})`);
   fs.rmSync(readyPath, { force: true });
   if (!interrupted) {
     process.exitCode ||= code || 1;


### PR DESCRIPTION
The Windows `env_install_interrupt` case kept flaking after #2283 and #2299, in two modes: the check-stale step reported "interrupted stale package removed" instead of "exists", and a 60s zero-output step timeout.

Root cause: on Windows, `vp` on PATH is the trampoline in `VP_HOME/bin`, which runs `current/bin/vp.exe` as a child and waits. The interrupt driver's `child.pid` was the trampoline, so #2299 killed the wrong process first. The real vp.exe was then torn down by `taskkill /T`, which kills the tree in unspecified order; whenever the npm subtree died before vp.exe, the still-alive vp treated the reinstall as failed and removed the partial install dir the test asserts on. When child enumeration returned nothing, only the trampoline died and the real vp survived as an orphan, matching the zero-output mode. Unix never flaked because `bin/vp` is a symlink, so the killed child is the installer.

Fix, all inside the fixture:

- Spawn `VP_HOME/current/bin/vp[.exe]` directly so `child.pid` is the process that runs the install on every platform; killing it first now prevents the cleanup reaction.
- Kill the postinstall subtree via a PID handshake: postinstall writes its PID into the ready file (write-then-rename), so the driver needs no PowerShell/CIM enumeration. The npm layers in between exit on their own once the script dies, and with vp already dead nobody reacts.
- Add stage markers and a 45s watchdog so a future failure names the stage that hung instead of showing a blank PTY screen.

Verified on macOS with `cargo test -p vite_cli_snapshots -- env_install_interrupt`; the Windows race itself can only be exercised by this PR's Windows CLI snapshot leg.