### PR TITLE
chore(deps): allow any vite-plus peer version

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -241,6 +241,7 @@ patchedDependencies:
 peerDependencyRules:
   allowAny:
     - vite
+    - vite-plus
     - vitest
     - rolldown
   allowedVersions:


### PR DESCRIPTION
## Summary

The `vite-plus: workspace:vite-plus@*` override rewrites the optional `vite-plus` peer of oxfmt and oxlint into the alias range `vite-plus@*`, which no version satisfies, so every install prints an unmet peer warning block. This adds `vite-plus` to `peerDependencyRules.allowAny`, matching the existing `vite` and `rolldown` entries for the other workspace overrides. Resolution is unchanged (the peer already resolves to `packages/cli`), so the lockfile stays untouched.

**Before:**

```console
$ vp install
Scope: all 17 workspace projects
Progress: resolved 1528, reused 1172, downloaded 0, added 0, done

Issues with peer dependencies found
packages/cli
├─┬ oxfmt 0.61.0
│ └── ✕ unmet peer vite-plus@vite-plus@*: found 0.2.7
└─┬ oxlint 1.76.0
  └── ✕ unmet peer vite-plus@vite-plus@*: found 0.2.7

vite
└─┬ oxfmt 0.60.0
  └── ✕ unmet peer vite-plus@vite-plus@*: found 0.2.7
Done in 1.3s using pnpm v10.34.4
```

**After:**

```console
$ vp install
Scope: all 17 workspace projects
Progress: resolved 1528, reused 1172, downloaded 0, added 0, done

Done in 1.4s using pnpm v10.34.4
```

## Test plan

- `vp install`: warning block no longer appears
- `vp install --frozen-lockfile`: passes, lockfile up to date
