### PR TITLE
feat(lint): export Oxlint plugin APIs from vite-plus

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -327,6 +327,13 @@ jobs:
               vp check --fix
               vp run check
               vp test run --project unit --shard=1/3
+          - name: videojs-v10
+            node-version: 24
+            command: |
+              node $GITHUB_WORKSPACE/ecosystem-ci/verify-videojs-v10.ts
+              # The upstream preset keeps existing diagnostics at warning level.
+              vp lint --quiet
+              vp test run tools/oxlint/anti-slop/rules/tests
           - name: reactive-resume
             node-version: 24
             command: |

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/lint_oxlint_plugin_api/lint/plugin.js
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/lint_oxlint_plugin_api/lint/plugin.js
@@ -1,0 +1,21 @@
+// Authored against the API vite-plus re-exports, with no `@oxlint/plugins`
+// dependency of its own: the point of the test is that this resolves and loads.
+import { definePlugin, defineRule } from 'vite-plus/lint/plugins';
+
+const noFoo = defineRule({
+  meta: { messages: { noFoo: 'Do not name things "foo".' } },
+  create(context) {
+    return {
+      Identifier(node) {
+        if (node.name === 'foo') {
+          context.report({ node, messageId: 'noFoo' });
+        }
+      },
+    };
+  },
+});
+
+export default definePlugin({
+  meta: { name: 'local' },
+  rules: { 'no-foo': noFoo },
+});

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/lint_oxlint_plugin_api/package.json
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/lint_oxlint_plugin_api/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "lint-oxlint-plugin-api",
+  "version": "0.0.0",
+  "private": true
+}

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/lint_oxlint_plugin_api/snapshots.toml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/lint_oxlint_plugin_api/snapshots.toml
@@ -1,0 +1,37 @@
+[[case]]
+name = "lint_oxlint_plugin_api"
+vp = "local"
+skip-platforms = [{ os = "linux", libc = "musl" }]
+steps = [
+  { argv = [
+    "vp",
+    "lint",
+    "src/uses-foo.ts",
+  ], comment = "the local JS plugin imports its API from vite-plus/lint/plugins. It declares no @oxlint/plugins dependency. A reported diagnostic therefore proves the export resolved and loaded", continue-on-failure = true },
+  { argv = [
+    "vp",
+    "lint",
+    "src/legacy-imports.ts",
+  ], comment = "prefer-vite-plus-imports reports the three legacy authoring specifiers", continue-on-failure = true },
+  { argv = [
+    "vp",
+    "lint",
+    "src/config-surface.ts",
+  ], comment = "oxlint still owns defineConfig and OxlintOverride, so these are clean", continue-on-failure = true },
+  { argv = [
+    "vp",
+    "lint",
+    "--fix",
+    "src/legacy-imports.ts",
+  ], comment = "the autofix matches what vp migrate rewrites", continue-on-failure = true },
+  { argv = [
+    "vpt",
+    "print-file",
+    "src/legacy-imports.ts",
+  ], continue-on-failure = true },
+  { argv = [
+    "vp",
+    "lint",
+    "src/legacy-imports.ts",
+  ], comment = "confirm the rewritten file is clean", continue-on-failure = true },
+]

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/lint_oxlint_plugin_api/snapshots/lint_oxlint_plugin_api.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/lint_oxlint_plugin_api/snapshots/lint_oxlint_plugin_api.md
@@ -1,0 +1,92 @@
+# lint_oxlint_plugin_api
+
+## `vp lint src/uses-foo.ts`
+
+the local JS plugin imports its API from vite-plus/lint/plugins. It declares no @oxlint/plugins dependency. A reported diagnostic therefore proves the export resolved and loaded
+
+**Exit code:** 1
+
+```
+
+  × local(no-foo): Do not name things "foo".
+   ╭─[src/uses-foo.ts:1:14]
+ 1 │ export const foo = 1;
+   ·              ───
+ 2 │ export const bar = 2;
+   ╰────
+
+Found 0 warnings and 1 error.
+Finished in <duration> on 1 file with <n> rules using <n> threads.
+```
+
+## `vp lint src/legacy-imports.ts`
+
+prefer-vite-plus-imports reports the three legacy authoring specifiers
+
+**Exit code:** 1
+
+```
+
+  × vite-plus(prefer-vite-plus-imports): Use 'vite-plus/lint/plugins' instead of 'oxlint' in Vite+ projects.
+   ╭─[src/legacy-imports.ts:1:28]
+ 1 │ import { defineRule } from 'oxlint';
+   ·                            ────────
+ 2 │ import { definePlugin } from '@oxlint/plugins';
+   ╰────
+
+  × vite-plus(prefer-vite-plus-imports): Use 'vite-plus/lint/plugins' instead of '@oxlint/plugins' in Vite+ projects.
+   ╭─[src/legacy-imports.ts:2:30]
+ 1 │ import { defineRule } from 'oxlint';
+ 2 │ import { definePlugin } from '@oxlint/plugins';
+   ·                              ─────────────────
+ 3 │ import { RuleTester } from 'oxlint/plugins-dev';
+   ╰────
+
+  × vite-plus(prefer-vite-plus-imports): Use 'vite-plus/lint/plugins-dev' instead of 'oxlint/plugins-dev' in Vite+ projects.
+   ╭─[src/legacy-imports.ts:3:28]
+ 2 │ import { definePlugin } from '@oxlint/plugins';
+ 3 │ import { RuleTester } from 'oxlint/plugins-dev';
+   ·                            ────────────────────
+ 4 │
+   ╰────
+
+Found 0 warnings and 3 errors.
+Finished in <duration> on 1 file with <n> rules using <n> threads.
+```
+
+## `vp lint src/config-surface.ts`
+
+oxlint still owns defineConfig and OxlintOverride, so these are clean
+
+```
+Found 0 warnings and 0 errors.
+Finished in <duration> on 1 file with <n> rules using <n> threads.
+```
+
+## `vp lint --fix src/legacy-imports.ts`
+
+the autofix matches what vp migrate rewrites
+
+```
+Found 0 warnings and 0 errors.
+Finished in <duration> on 1 file with <n> rules using <n> threads.
+```
+
+## `vpt print-file src/legacy-imports.ts`
+
+```
+import { defineRule } from 'vite-plus/lint/plugins';
+import { definePlugin } from 'vite-plus/lint/plugins';
+import { RuleTester } from 'vite-plus/lint/plugins-dev';
+
+export { defineRule, definePlugin, RuleTester };
+```
+
+## `vp lint src/legacy-imports.ts`
+
+confirm the rewritten file is clean
+
+```
+Found 0 warnings and 0 errors.
+Finished in <duration> on 1 file with <n> rules using <n> threads.
+```

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/lint_oxlint_plugin_api/snapshots/lint_oxlint_plugin_api.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/lint_oxlint_plugin_api/snapshots/lint_oxlint_plugin_api.md
@@ -50,7 +50,22 @@ prefer-vite-plus-imports reports the three legacy authoring specifiers
  4 │
    ╰────
 
-Found 0 warnings and 3 errors.
+  × vite-plus(prefer-vite-plus-imports): Use 'vite-plus/lint/plugins' instead of 'oxlint' in Vite+ projects.
+   ╭─[src/legacy-imports.ts:6:38]
+ 5 │ export { defineRule, definePlugin, RuleTester };
+ 6 │ export { 'defineRule' as rule } from 'oxlint';
+   ·                                      ────────
+ 7 │ export type { 'Context' as RuleContext } from 'oxlint';
+   ╰────
+
+  × vite-plus(prefer-vite-plus-imports): Use 'vite-plus/lint/plugins' instead of 'oxlint' in Vite+ projects.
+   ╭─[src/legacy-imports.ts:7:47]
+ 6 │ export { 'defineRule' as rule } from 'oxlint';
+ 7 │ export type { 'Context' as RuleContext } from 'oxlint';
+   ·                                               ────────
+   ╰────
+
+Found 0 warnings and 5 errors.
 Finished in <duration> on 1 file with <n> rules using <n> threads.
 ```
 
@@ -80,6 +95,8 @@ import { definePlugin } from 'vite-plus/lint/plugins';
 import { RuleTester } from 'vite-plus/lint/plugins-dev';
 
 export { defineRule, definePlugin, RuleTester };
+export { 'defineRule' as rule } from 'vite-plus/lint/plugins';
+export type { 'Context' as RuleContext } from 'vite-plus/lint/plugins';
 ```
 
 ## `vp lint src/legacy-imports.ts`

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/lint_oxlint_plugin_api/src/config-surface.ts
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/lint_oxlint_plugin_api/src/config-surface.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'oxlint';
+import type { OxlintOverride } from 'oxlint';
+
+export const override: OxlintOverride = { files: ['**/*.ts'] };
+
+export default defineConfig({ overrides: [override] });

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/lint_oxlint_plugin_api/src/config-surface.ts
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/lint_oxlint_plugin_api/src/config-surface.ts
@@ -4,3 +4,5 @@ import type { OxlintOverride } from 'oxlint';
 export const override: OxlintOverride = { files: ['**/*.ts'] };
 
 export default defineConfig({ overrides: [override] });
+export { 'defineConfig' as config } from 'oxlint';
+export type { 'OxlintOverride' as Override } from 'oxlint';

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/lint_oxlint_plugin_api/src/legacy-imports.ts
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/lint_oxlint_plugin_api/src/legacy-imports.ts
@@ -1,0 +1,5 @@
+import { defineRule } from 'oxlint';
+import { definePlugin } from '@oxlint/plugins';
+import { RuleTester } from 'oxlint/plugins-dev';
+
+export { defineRule, definePlugin, RuleTester };

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/lint_oxlint_plugin_api/src/legacy-imports.ts
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/lint_oxlint_plugin_api/src/legacy-imports.ts
@@ -3,3 +3,5 @@ import { definePlugin } from '@oxlint/plugins';
 import { RuleTester } from 'oxlint/plugins-dev';
 
 export { defineRule, definePlugin, RuleTester };
+export { 'defineRule' as rule } from 'oxlint';
+export type { 'Context' as RuleContext } from 'oxlint';

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/lint_oxlint_plugin_api/src/uses-foo.ts
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/lint_oxlint_plugin_api/src/uses-foo.ts
@@ -1,0 +1,2 @@
+export const foo = 1;
+export const bar = 2;

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/lint_oxlint_plugin_api/vite.config.ts
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/lint_oxlint_plugin_api/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite-plus';
+
+export default defineConfig({
+  lint: {
+    jsPlugins: [
+      './lint/plugin.js',
+      { name: 'vite-plus', specifier: 'vite-plus/oxlint-plugin' },
+    ],
+    rules: {
+      'local/no-foo': 'error',
+      'vite-plus/prefer-vite-plus-imports': 'error',
+    },
+  },
+});

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_built_plugin/.gitignore
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_built_plugin/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_built_plugin/package.json
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_built_plugin/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "migration-oxlint-built-plugin",
+  "private": true,
+  "type": "module",
+  "packageManager": "pnpm@11.24.0",
+  "scripts": {
+    "lint": "oxlint ."
+  },
+  "devDependencies": {
+    "@oxlint/plugins": "1.79.0",
+    "oxlint": "1.81.0",
+    "vite": "^7.0.0"
+  }
+}

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_built_plugin/plugin.cjs
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_built_plugin/plugin.cjs
@@ -1,0 +1,19 @@
+const { definePlugin, defineRule } = require('@oxlint/plugins');
+
+module.exports = definePlugin({
+  meta: { name: 'built' },
+  rules: {
+    'no-foo': defineRule({
+      meta: { messages: { noFoo: 'Do not name things "foo".' } },
+      create(context) {
+        return {
+          Identifier(node) {
+            if (node.name === 'foo') {
+              context.report({ node, messageId: 'noFoo' });
+            }
+          },
+        };
+      },
+    }),
+  },
+});

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_built_plugin/pnpm-workspace.yaml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_built_plugin/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+hoist: false
+minimumReleaseAge: 0

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_built_plugin/snapshots.toml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_built_plugin/snapshots.toml
@@ -1,0 +1,17 @@
+[[case]]
+name = "migration_oxlint_built_plugin"
+vp = "global"
+local-registry = true
+unset-env = ["VP_SKIP_INSTALL"]
+steps = [
+  { argv = ["git", "init"], snapshot = false },
+  { argv = ["vpt", "mkdir", "dist"], snapshot = false },
+  { argv = ["vpt", "cp", "plugin.cjs", "dist/plugin.cjs"], snapshot = false },
+  { argv = ["vpt", "rm", "plugin.cjs"], snapshot = false },
+  { argv = ["vp", "migrate", "--no-interactive", "--no-hooks", "--no-agent", "--no-editor"], snapshot = false },
+  { argv = ["vpt", "print-file", "package.json"], comment = "The ignored build artifact still needs a direct @oxlint/plugins dependency." },
+  { argv = ["vpt", "print-file", "dist/plugin.cjs"], comment = "Migration does not rewrite or rebuild the ignored CommonJS plugin." },
+  { argv = ["vpt", "rm", "-rf", "node_modules"], snapshot = false },
+  { argv = ["vp", "install", "--ignore-scripts"], snapshot = false },
+  { argv = ["vp", "lint", "src/input.js"], comment = "After a strict pnpm reinstall, the built plugin loads and reports its rule." },
+]

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_built_plugin/snapshots/migration_oxlint_built_plugin.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_built_plugin/snapshots/migration_oxlint_built_plugin.md
@@ -1,0 +1,88 @@
+# migration_oxlint_built_plugin
+
+## `git init`
+
+
+## `vpt mkdir dist`
+
+
+## `vpt cp plugin.cjs dist/plugin.cjs`
+
+
+## `vpt rm plugin.cjs`
+
+
+## `vp migrate --no-interactive --no-hooks --no-agent --no-editor`
+
+
+## `vpt print-file package.json`
+
+The ignored build artifact still needs a direct @oxlint/plugins dependency.
+
+```
+{
+  "name": "migration-oxlint-built-plugin",
+  "private": true,
+  "type": "module",
+  "packageManager": "pnpm@11.24.0",
+  "scripts": {
+    "lint": "vp lint ."
+  },
+  "devDependencies": {
+    "@oxlint/plugins": "1.79.0",
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
+  }
+}
+```
+
+## `vpt print-file dist/plugin.cjs`
+
+Migration does not rewrite or rebuild the ignored CommonJS plugin.
+
+```
+const { definePlugin, defineRule } = require('@oxlint/plugins');
+
+module.exports = definePlugin({
+  meta: { name: 'built' },
+  rules: {
+    'no-foo': defineRule({
+      meta: { messages: { noFoo: 'Do not name things "foo".' } },
+      create(context) {
+        return {
+          Identifier(node) {
+            if (node.name === 'foo') {
+              context.report({ node, messageId: 'noFoo' });
+            }
+          },
+        };
+      },
+    }),
+  },
+});
+```
+
+## `vpt rm -rf node_modules`
+
+
+## `vp install --ignore-scripts`
+
+
+## `vp lint src/input.js`
+
+After a strict pnpm reinstall, the built plugin loads and reports its rule.
+
+```
+VITE+ - The Unified Toolchain for the Web
+
+note: You are running `vp lint` as a Vite+ built-in command. If you meant to run the lint npm script, use `vpr lint` instead.
+
+  ⚠ built(no-foo): Do not name things "foo".
+   ╭─[src/input.js:1:14]
+ 1 │ export const foo = 1;
+   ·              ───
+   ╰────
+
+Found 1 warning and 0 errors.
+Finished in <duration> on 1 file with <n> rules using <n> threads.
+```

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_built_plugin/src/input.js
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_built_plugin/src/input.js
@@ -1,0 +1,1 @@
+export const foo = 1;

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_built_plugin/vite.config.ts
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_built_plugin/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  lint: {
+    jsPlugins: [{ name: 'built', specifier: './dist/plugin.cjs' }],
+    rules: { 'built/no-foo': 'warn' },
+    options: { typeAware: false, typeCheck: false },
+  },
+});

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_inline_script/package.json
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_inline_script/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "migration-oxlint-inline-script",
+  "private": true,
+  "packageManager": "pnpm@11.24.0",
+  "scripts": {
+    "check-plugin": "node -e \"console.log(typeof require('@oxlint/plugins').defineRule)\""
+  },
+  "devDependencies": {
+    "@oxlint/plugins": "1.79.0"
+  }
+}

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_inline_script/pnpm-workspace.yaml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_inline_script/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+hoist: false
+minimumReleaseAge: 0

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_inline_script/snapshots.toml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_inline_script/snapshots.toml
@@ -1,0 +1,12 @@
+[[case]]
+name = "migration_oxlint_inline_script"
+vp = "global"
+local-registry = true
+unset-env = ["VP_SKIP_INSTALL"]
+steps = [
+  { argv = ["vp", "migrate", "--no-interactive", "--no-hooks", "--no-agent", "--no-editor"], snapshot = false },
+  { argv = ["vpt", "print-file", "package.json"], comment = "The unchanged inline script still needs a direct @oxlint/plugins dependency." },
+  { argv = ["vpt", "rm", "-rf", "node_modules"], snapshot = false },
+  { argv = ["vp", "install", "--ignore-scripts"], snapshot = false },
+  { argv = ["vp", "run", "check-plugin"], comment = "The script resolves its plugin API after a strict pnpm reinstall." },
+]

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_inline_script/snapshots/migration_oxlint_inline_script.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_inline_script/snapshots/migration_oxlint_inline_script.md
@@ -1,0 +1,41 @@
+# migration_oxlint_inline_script
+
+## `vp migrate --no-interactive --no-hooks --no-agent --no-editor`
+
+
+## `vpt print-file package.json`
+
+The unchanged inline script still needs a direct @oxlint/plugins dependency.
+
+```
+{
+  "name": "migration-oxlint-inline-script",
+  "private": true,
+  "scripts": {
+    "check-plugin": "node -e \"console.log(typeof require('@oxlint/plugins').defineRule)\""
+  },
+  "devDependencies": {
+    "@oxlint/plugins": "1.79.0",
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
+  },
+  "packageManager": "pnpm@11.24.0"
+}
+```
+
+## `vpt rm -rf node_modules`
+
+
+## `vp install --ignore-scripts`
+
+
+## `vp run check-plugin`
+
+The script resolves its plugin API after a strict pnpm reinstall.
+
+```
+VITE+ - The Unified Toolchain for the Web
+
+$ node -e "console.log(typeof require('@oxlint/plugins').defineRule)" ⊘ cache disabled
+function
+```

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_js_plugin_imports/.oxlintrc.json
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_js_plugin_imports/.oxlintrc.json
@@ -1,0 +1,6 @@
+{
+  "jsPlugins": ["./lint/plugin.js"],
+  "rules": {
+    "local/no-foo": "error"
+  }
+}

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_js_plugin_imports/lint/no-foo.js
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_js_plugin_imports/lint/no-foo.js
@@ -1,0 +1,14 @@
+import { defineRule } from 'oxlint';
+
+export const noFoo = defineRule({
+  meta: { messages: { noFoo: 'Do not name things "foo".' } },
+  create(context) {
+    return {
+      Identifier(node) {
+        if (node.name === 'foo') {
+          context.report({ node, messageId: 'noFoo' });
+        }
+      },
+    };
+  },
+});

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_js_plugin_imports/lint/no-foo.test.ts
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_js_plugin_imports/lint/no-foo.test.ts
@@ -1,0 +1,11 @@
+import type { Context } from 'oxlint';
+import { RuleTester } from 'oxlint/plugins-dev';
+
+import { noFoo } from './no-foo.js';
+
+export type RuleContext = Context;
+
+new RuleTester().run('no-foo', noFoo, {
+  valid: ['const bar = 1;'],
+  invalid: [{ code: 'const foo = 1;', errors: 1 }],
+});

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_js_plugin_imports/lint/plugin.js
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_js_plugin_imports/lint/plugin.js
@@ -1,0 +1,8 @@
+import { definePlugin } from '@oxlint/plugins';
+
+import { noFoo } from './no-foo.js';
+
+export default definePlugin({
+  meta: { name: 'local' },
+  rules: { 'no-foo': noFoo },
+});

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_js_plugin_imports/lint/shared-config.ts
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_js_plugin_imports/lint/shared-config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'oxlint';
+import type { OxlintOverride } from 'oxlint';
+
+export const testOverride: OxlintOverride = {
+  files: ['**/*.test.ts'],
+  rules: { 'local/no-foo': 'off' },
+};
+
+export default defineConfig({ overrides: [testOverride] });

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_js_plugin_imports/package.json
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_js_plugin_imports/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "migration-oxlint-js-plugin-imports",
+  "scripts": {
+    "lint": "oxlint ."
+  },
+  "devDependencies": {
+    "@oxlint/plugins": "^1.0.0",
+    "oxlint": "^1.0.0",
+    "vite": "^7.0.0"
+  }
+}

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_js_plugin_imports/snapshots.toml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_js_plugin_imports/snapshots.toml
@@ -31,7 +31,7 @@ steps = [
     "vpt",
     "print-file",
     "lint/shared-config.ts",
-  ], comment = "the config surface is NOT redirected. vite-plus/lint/plugins has no defineConfig or OxlintOverride", continue-on-failure = true },
+  ], comment = "the config surface is NOT redirected. vite-plus/lint/plugins has no defineConfig or OxlintOverride. KNOWN PRE-EXISTING GAP, wider than this PR: `oxlint` is in REMOVE_PACKAGES, so the migration deletes the dependency while this import survives. Under pnpm strict layout the import then fails to resolve. That predates the plugin-API rewrite, since config-surface imports were never rewritten and `oxlint` was always removed. Recorded so a fix shows up as a snapshot diff", continue-on-failure = true },
   { argv = [
     "vpt",
     "print-file",

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_js_plugin_imports/snapshots.toml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_js_plugin_imports/snapshots.toml
@@ -11,7 +11,7 @@ steps = [
     "vpt",
     "print-file",
     "package.json",
-  ], comment = "oxlint is removed and nothing replaces it. The API now comes from vite-plus. @oxlint/plugins stays on purpose: it is inert once the imports are rewritten, and removing it would also remove the peer dependency of a published Oxlint plugin", continue-on-failure = true },
+  ], comment = "oxlint and @oxlint/plugins are both gone from devDependencies, and nothing replaces them. The API now comes from vite-plus", continue-on-failure = true },
   { argv = [
     "vpt",
     "print-file",

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_js_plugin_imports/snapshots.toml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_js_plugin_imports/snapshots.toml
@@ -1,0 +1,40 @@
+[[case]]
+name = "migration_oxlint_js_plugin_imports"
+vp = "global"
+steps = [
+  { argv = [
+    "vp",
+    "migrate",
+    "--no-interactive",
+  ], comment = "the standalone oxlint dependency goes away, so the JS plugin's authoring imports must move to vite-plus", continue-on-failure = true },
+  { argv = [
+    "vpt",
+    "print-file",
+    "package.json",
+  ], comment = "oxlint is removed and nothing replaces it. The API now comes from vite-plus. @oxlint/plugins stays on purpose: it is inert once the imports are rewritten, and removing it would also remove the peer dependency of a published Oxlint plugin", continue-on-failure = true },
+  { argv = [
+    "vpt",
+    "print-file",
+    "lint/no-foo.js",
+  ], comment = "legacy `defineRule` from 'oxlint' -> 'vite-plus/lint/plugins'", continue-on-failure = true },
+  { argv = [
+    "vpt",
+    "print-file",
+    "lint/plugin.js",
+  ], comment = "'@oxlint/plugins' -> 'vite-plus/lint/plugins'", continue-on-failure = true },
+  { argv = [
+    "vpt",
+    "print-file",
+    "lint/no-foo.test.ts",
+  ], comment = "RuleTester lives in 'oxlint/plugins-dev' upstream and breaks the same way, so it maps to 'vite-plus/lint/plugins-dev'. The plugin type import follows the runtime API", continue-on-failure = true },
+  { argv = [
+    "vpt",
+    "print-file",
+    "lint/shared-config.ts",
+  ], comment = "the config surface is NOT redirected. vite-plus/lint/plugins has no defineConfig or OxlintOverride", continue-on-failure = true },
+  { argv = [
+    "vpt",
+    "print-file",
+    "vite.config.ts",
+  ], comment = "the jsPlugins entry survives the .oxlintrc.json merge. It still points at the plugin file, which is now rewritten. KNOWN PRE-EXISTING GAP, unrelated to the import rewrite: the merge drops `local/no-foo`. sanitizeMigratedOxlintConfig derives a plugin's rule namespace from its package name, and a relative-path plugin has no package name. Its namespace comes from `meta.name` at load time instead. Recorded here so a fix shows up as a snapshot diff", continue-on-failure = true },
+]

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_js_plugin_imports/snapshots/migration_oxlint_js_plugin_imports.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_js_plugin_imports/snapshots/migration_oxlint_js_plugin_imports.md
@@ -1,0 +1,140 @@
+# migration_oxlint_js_plugin_imports
+
+## `vp migrate --no-interactive`
+
+the standalone oxlint dependency goes away, so the JS plugin's authoring imports must move to vite-plus
+
+```
+VITE+ - The Unified Toolchain for the Web
+
+◇ Migrated . to Vite+ <version>
+• Node <version>  pnpm <version>
+• 3 config updates applied, 3 files had imports rewritten
+```
+
+## `vpt print-file package.json`
+
+oxlint is removed and nothing replaces it. The API now comes from vite-plus. @oxlint/plugins stays on purpose: it is inert once the imports are rewritten, and removing it would also remove the peer dependency of a published Oxlint plugin
+
+```
+{
+  "name": "migration-oxlint-js-plugin-imports",
+  "scripts": {
+    "lint": "vp lint .",
+    "prepare": "vp config"
+  },
+  "devDependencies": {
+    "@oxlint/plugins": "^1.0.0",
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": "<version>",
+      "onFail": "download"
+    }
+  }
+}
+```
+
+## `vpt print-file lint/no-foo.js`
+
+legacy `defineRule` from 'oxlint' -> 'vite-plus/lint/plugins'
+
+```
+import { defineRule } from 'vite-plus/lint/plugins';
+
+export const noFoo = defineRule({
+  meta: { messages: { noFoo: 'Do not name things "foo".' } },
+  create(context) {
+    return {
+      Identifier(node) {
+        if (node.name === 'foo') {
+          context.report({ node, messageId: 'noFoo' });
+        }
+      },
+    };
+  },
+});
+```
+
+## `vpt print-file lint/plugin.js`
+
+'@oxlint/plugins' -> 'vite-plus/lint/plugins'
+
+```
+import { definePlugin } from 'vite-plus/lint/plugins';
+
+import { noFoo } from './no-foo.js';
+
+export default definePlugin({
+  meta: { name: 'local' },
+  rules: { 'no-foo': noFoo },
+});
+```
+
+## `vpt print-file lint/no-foo.test.ts`
+
+RuleTester lives in 'oxlint/plugins-dev' upstream and breaks the same way, so it maps to 'vite-plus/lint/plugins-dev'. The plugin type import follows the runtime API
+
+```
+import type { Context } from 'vite-plus/lint/plugins';
+import { RuleTester } from 'vite-plus/lint/plugins-dev';
+
+import { noFoo } from './no-foo.js';
+
+export type RuleContext = Context;
+
+new RuleTester().run('no-foo', noFoo, {
+  valid: ['const bar = 1;'],
+  invalid: [{ code: 'const foo = 1;', errors: 1 }],
+});
+```
+
+## `vpt print-file lint/shared-config.ts`
+
+the config surface is NOT redirected. vite-plus/lint/plugins has no defineConfig or OxlintOverride
+
+```
+import { defineConfig } from 'oxlint';
+import type { OxlintOverride } from 'oxlint';
+
+export const testOverride: OxlintOverride = {
+  files: ['**/*.test.ts'],
+  rules: { 'local/no-foo': 'off' },
+};
+
+export default defineConfig({ overrides: [testOverride] });
+```
+
+## `vpt print-file vite.config.ts`
+
+the jsPlugins entry survives the .oxlintrc.json merge. It still points at the plugin file, which is now rewritten. KNOWN PRE-EXISTING GAP, unrelated to the import rewrite: the merge drops `local/no-foo`. sanitizeMigratedOxlintConfig derives a plugin's rule namespace from its package name, and a relative-path plugin has no package name. Its namespace comes from `meta.name` at load time instead. Recorded here so a fix shows up as a snapshot diff
+
+```
+import { defineConfig } from 'vite-plus';
+
+export default defineConfig({
+  staged: {
+    "*": "vp check --fix"
+  },
+  fmt: {},
+  lint: {
+    "jsPlugins": [
+      "./lint/plugin.js",
+      {
+        "name": "vite-plus",
+        "specifier": "vite-plus/oxlint-plugin"
+      }
+    ],
+    "rules": {
+      "vite-plus/prefer-vite-plus-imports": "error"
+    },
+    "options": {
+      "typeAware": true,
+      "typeCheck": true
+    }
+  },
+});
+```

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_js_plugin_imports/snapshots/migration_oxlint_js_plugin_imports.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_js_plugin_imports/snapshots/migration_oxlint_js_plugin_imports.md
@@ -14,7 +14,7 @@ VITE+ - The Unified Toolchain for the Web
 
 ## `vpt print-file package.json`
 
-oxlint is removed and nothing replaces it. The API now comes from vite-plus. @oxlint/plugins stays on purpose: it is inert once the imports are rewritten, and removing it would also remove the peer dependency of a published Oxlint plugin
+oxlint and @oxlint/plugins are both gone from devDependencies, and nothing replaces them. The API now comes from vite-plus
 
 ```
 {
@@ -24,7 +24,6 @@ oxlint is removed and nothing replaces it. The API now comes from vite-plus. @ox
     "prepare": "vp config"
   },
   "devDependencies": {
-    "@oxlint/plugins": "^1.0.0",
     "vite": "catalog:",
     "vite-plus": "catalog:"
   },

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_js_plugin_imports/snapshots/migration_oxlint_js_plugin_imports.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_js_plugin_imports/snapshots/migration_oxlint_js_plugin_imports.md
@@ -93,7 +93,7 @@ new RuleTester().run('no-foo', noFoo, {
 
 ## `vpt print-file lint/shared-config.ts`
 
-the config surface is NOT redirected. vite-plus/lint/plugins has no defineConfig or OxlintOverride
+the config surface is NOT redirected. vite-plus/lint/plugins has no defineConfig or OxlintOverride. KNOWN PRE-EXISTING GAP, wider than this PR: `oxlint` is in REMOVE_PACKAGES, so the migration deletes the dependency while this import survives. Under pnpm strict layout the import then fails to resolve. That predates the plugin-API rewrite, since config-surface imports were never rewritten and `oxlint` was always removed. Recorded so a fix shows up as a snapshot diff
 
 ```
 import { defineConfig } from 'oxlint';

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_optional_plugin/consumer/check.mjs
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_optional_plugin/consumer/check.mjs
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import { registerHooks } from 'node:module';
+
+// The runner exposes its checkout in an ancestor node_modules directory.
+// Reject that fallback: consumers do not install a plugin's devDependencies.
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    assert(
+      specifier !== 'vite-plus' && !specifier.startsWith('vite-plus/'),
+      'The published plugin must not depend on vite-plus',
+    );
+    return nextResolve(specifier, context);
+  },
+});
+
+const { default: plugin } = await import('oxlint-plugin-optional-example');
+assert.equal(plugin.meta.name, 'optional');
+assert.equal(typeof plugin.rules['no-foo'].create, 'function');
+console.log('The published plugin loads with its optional API and without vite-plus.');

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_optional_plugin/consumer/package.json
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_optional_plugin/consumer/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "plugin-consumer",
+  "private": true,
+  "type": "module",
+  "packageManager": "pnpm@11.24.0",
+  "dependencies": {
+    "oxlint-plugin-optional-example": "file:../artifacts/oxlint-plugin-optional-example-1.0.0.tgz"
+  }
+}

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_optional_plugin/package.json
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_optional_plugin/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "oxlint-plugin-optional-example",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": "./plugin.js",
+  "files": ["plugin.js"],
+  "packageManager": "pnpm@11.24.0",
+  "scripts": {
+    "lint": "oxlint ."
+  },
+  "optionalDependencies": {
+    "@oxlint/plugins": "1.79.0"
+  },
+  "devDependencies": {
+    "oxlint": "1.81.0"
+  }
+}

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_optional_plugin/plugin.js
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_optional_plugin/plugin.js
@@ -1,0 +1,19 @@
+import { definePlugin, defineRule } from '@oxlint/plugins';
+
+export default definePlugin({
+  meta: { name: 'optional' },
+  rules: {
+    'no-foo': defineRule({
+      meta: { messages: { noFoo: 'Do not name things "foo".' } },
+      create(context) {
+        return {
+          Identifier(node) {
+            if (node.name === 'foo') {
+              context.report({ node, messageId: 'noFoo' });
+            }
+          },
+        };
+      },
+    }),
+  },
+});

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_optional_plugin/pnpm-workspace.yaml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_optional_plugin/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+hoist: false
+minimumReleaseAge: 0

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_optional_plugin/snapshots.toml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_optional_plugin/snapshots.toml
@@ -1,0 +1,14 @@
+[[case]]
+name = "migration_oxlint_optional_plugin"
+vp = "global"
+local-registry = true
+unset-env = ["VP_SKIP_INSTALL"]
+steps = [
+  { argv = ["vp", "migrate", "--no-interactive", "--no-hooks", "--no-agent", "--no-editor"], snapshot = false },
+  { argv = ["vp", "lint", "--fix", "plugin.js"], comment = "Lint autofix must preserve the optional runtime API import." },
+  ["vpt", "print-file", "package.json"],
+  ["vpt", "print-file", "plugin.js"],
+  { argv = ["vp", "pm", "pack", "--pack-destination", "artifacts"], snapshot = false },
+  { argv = ["pnpm", "install", "--ignore-workspace", "--ignore-scripts"], cwd = "consumer", snapshot = false },
+  { argv = ["node", "check.mjs"], cwd = "consumer", comment = "Install the packed plugin as a consumer dependency, with no vite-plus dependency." },
+]

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_optional_plugin/snapshots/migration_oxlint_optional_plugin.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_optional_plugin/snapshots/migration_oxlint_optional_plugin.md
@@ -1,0 +1,79 @@
+# migration_oxlint_optional_plugin
+
+## `vp migrate --no-interactive --no-hooks --no-agent --no-editor`
+
+
+## `vp lint --fix plugin.js`
+
+Lint autofix must preserve the optional runtime API import.
+
+```
+VITE+ - The Unified Toolchain for the Web
+
+note: You are running `vp lint` as a Vite+ built-in command. If you meant to run the lint npm script, use `vpr lint` instead.
+Found 0 warnings and 0 errors.
+Finished in <duration> on 1 file with <n> rules using <n> threads.
+```
+
+## `vpt print-file package.json`
+
+```
+{
+  "name": "oxlint-plugin-optional-example",
+  "version": "1.0.0",
+  "files": [
+    "plugin.js"
+  ],
+  "type": "module",
+  "exports": "./plugin.js",
+  "scripts": {
+    "lint": "vp lint ."
+  },
+  "devDependencies": {
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
+  },
+  "optionalDependencies": {
+    "@oxlint/plugins": "1.79.0"
+  },
+  "packageManager": "pnpm@11.24.0"
+}
+```
+
+## `vpt print-file plugin.js`
+
+```
+import { definePlugin, defineRule } from "@oxlint/plugins";
+
+export default definePlugin({
+  meta: { name: "optional" },
+  rules: {
+    "no-foo": defineRule({
+      meta: { messages: { noFoo: 'Do not name things "foo".' } },
+      create(context) {
+        return {
+          Identifier(node) {
+            if (node.name === "foo") {
+              context.report({ node, messageId: "noFoo" });
+            }
+          },
+        };
+      },
+    }),
+  },
+});
+```
+
+## `vp pm pack --pack-destination artifacts`
+
+
+## `cd consumer && pnpm install --ignore-workspace --ignore-scripts`
+
+
+## `cd consumer && node check.mjs`
+
+Install the packed plugin as a consumer dependency, with no vite-plus dependency.
+
+```
+The published plugin loads with its optional API and without vite-plus.
+```

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_published_plugin/lint/index.js
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_published_plugin/lint/index.js
@@ -1,0 +1,14 @@
+import { defineRule } from 'oxlint';
+
+export const noFoo = defineRule({
+  meta: { messages: { noFoo: 'Do not name things "foo".' } },
+  create(context) {
+    return {
+      Identifier(node) {
+        if (node.name === 'foo') {
+          context.report({ node, messageId: 'noFoo' });
+        }
+      },
+    };
+  },
+});

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_published_plugin/package.json
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_published_plugin/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "oxlint-plugin-example",
+  "version": "1.0.0",
+  "scripts": {
+    "lint": "oxlint ."
+  },
+  "peerDependencies": {
+    "oxlint": "^1.0.0"
+  },
+  "devDependencies": {
+    "vite": "^7.0.0"
+  }
+}

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_published_plugin/snapshots.toml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_published_plugin/snapshots.toml
@@ -1,0 +1,20 @@
+[[case]]
+name = "migration_oxlint_published_plugin"
+vp = "global"
+steps = [
+  { argv = [
+    "vp",
+    "migrate",
+    "--no-interactive",
+  ], comment = "this package declares `oxlint` as a peer dependency, which marks it a published Oxlint plugin", continue-on-failure = true },
+  { argv = [
+    "vpt",
+    "print-file",
+    "lint/index.js",
+  ], comment = "the authoring import stays on 'oxlint'. Consumers of a published plugin may run plain Oxlint, so a rewrite to vite-plus would break them. This also covers the ordering trap: rewritePackageJson strips `oxlint` before the import rewriter reads the manifest, so the skip signal is captured up front", continue-on-failure = true },
+  { argv = [
+    "vpt",
+    "print-file",
+    "package.json",
+  ], comment = "the `oxlint` peer entry survives. It is a consumer contract, not a tool this package runs, and stripping it would leave the source importing a package the manifest no longer declares", continue-on-failure = true },
+]

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_published_plugin/snapshots/migration_oxlint_published_plugin.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlint_published_plugin/snapshots/migration_oxlint_published_plugin.md
@@ -1,0 +1,63 @@
+# migration_oxlint_published_plugin
+
+## `vp migrate --no-interactive`
+
+this package declares `oxlint` as a peer dependency, which marks it a published Oxlint plugin
+
+```
+VITE+ - The Unified Toolchain for the Web
+
+◇ Migrated . to Vite+ <version>
+• Node <version>  pnpm <version>
+• 2 config updates applied
+```
+
+## `vpt print-file lint/index.js`
+
+the authoring import stays on 'oxlint'. Consumers of a published plugin may run plain Oxlint, so a rewrite to vite-plus would break them. This also covers the ordering trap: rewritePackageJson strips `oxlint` before the import rewriter reads the manifest, so the skip signal is captured up front
+
+```
+import { defineRule } from 'oxlint';
+
+export const noFoo = defineRule({
+  meta: { messages: { noFoo: 'Do not name things "foo".' } },
+  create(context) {
+    return {
+      Identifier(node) {
+        if (node.name === 'foo') {
+          context.report({ node, messageId: 'noFoo' });
+        }
+      },
+    };
+  },
+});
+```
+
+## `vpt print-file package.json`
+
+the `oxlint` peer entry survives. It is a consumer contract, not a tool this package runs, and stripping it would leave the source importing a package the manifest no longer declares
+
+```
+{
+  "name": "oxlint-plugin-example",
+  "version": "1.0.0",
+  "scripts": {
+    "lint": "vp lint .",
+    "prepare": "vp config"
+  },
+  "peerDependencies": {
+    "oxlint": "^1.0.0"
+  },
+  "devDependencies": {
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": "<version>",
+      "onFail": "download"
+    }
+  }
+}
+```

--- a/crates/vp_migration/src/import_rewriter.rs
+++ b/crates/vp_migration/src/import_rewriter.rs
@@ -4214,6 +4214,20 @@ export * from 'oxlint';"#;
     }
 
     #[test]
+    fn test_rewrite_import_content_oxlint_export_const_literal_is_data() {
+        // `inside:` matches the immediate parent. In `export const x = '...'`
+        // the string sits under a lexical_declaration, not directly under the
+        // export_statement, so the re-export rules never see it. Pinned so a
+        // rule loosened to `stopBy: end` cannot start corrupting data.
+        let data = r#"export const pluginApi = '@oxlint/plugins';
+export const legacy = 'oxlint';"#;
+
+        let result = rewrite_import_content(data, &SkipPackages::default()).unwrap();
+        assert!(!result.updated);
+        assert_eq!(result.content, data);
+    }
+
+    #[test]
     fn test_rewrite_import_content_oxlint_require_is_left_alone() {
         // `vite-plus/lint/plugins` is an ESM-only export, so a rewritten
         // `require()` would fail with ERR_PACKAGE_PATH_NOT_EXPORTED.

--- a/crates/vp_migration/src/import_rewriter.rs
+++ b/crates/vp_migration/src/import_rewriter.rs
@@ -1569,59 +1569,22 @@ fix: $NEW_IMPORT
 
 /// ast-grep rules for rewriting Oxlint JS-plugin authoring imports.
 ///
-/// The mapping:
-/// - `import { defineRule } from '@oxlint/plugins'` → `'vite-plus/lint/plugins'`
-/// - `import { RuleTester } from 'oxlint/plugins-dev'` → `'vite-plus/lint/plugins-dev'`
-/// - `import { defineRule } from 'oxlint'` → `'vite-plus/lint/plugins'`
+/// - `@oxlint/plugins` → `vite-plus/lint/plugins`
+/// - `oxlint/plugins-dev` → `vite-plus/lint/plugins-dev`
+/// - Named plugin API imports/exports from `oxlint` → `vite-plus/lint/plugins`
 ///
-/// `rewriteVitePlusImportSpecifier` in `oxlint-plugin.ts` repeats this mapping
-/// for the lint autofix. Both implementations MUST stay in sync.
+/// Keep the mapping and config-name denylist in sync with `oxlint-plugin.ts`.
+/// The shims use the bundled linter's API and resolve under strict pnpm layouts.
 ///
-/// Why this exists: vite-plus bundles Oxlint, so the migration strips `oxlint`
-/// from the project. A JS plugin that imports the authoring API by either name
-/// then stops resolving, and `vp lint` fails to load the plugin.
+/// Bare `oxlint` also exposes config APIs. Rewrite a statement only when all
+/// bindings are named and outside that config surface. Leave mixed, default,
+/// namespace, side-effect, export-all, and dynamic-import forms unchanged.
 ///
-/// The rewrite points those imports at `vite-plus` rather than re-adding
-/// `@oxlint/plugins` as a direct dependency. This locks the API to the bundled
-/// linter, so the user pins nothing. It also resolves from any package that
-/// already has `vite-plus`. A direct `@oxlint/plugins` import does not:
-/// `@oxlint/plugins` is only a transitive dependency, which pnpm's strict
-/// layout hides from a user's plugin file.
-///
-/// The bare `oxlint` specifier is ambiguous. It still serves the CONFIG surface
-/// (`defineConfig`, `OxlintConfig`, `OxlintOverride`, and so on), which must
-/// keep resolving against the standalone package. So the rewrite applies only
-/// to an `import` statement that names a specifier outside that config surface.
-/// The check is therefore a small, stable denylist, not an ever-growing list of
-/// plugin type names. An unrecognized name falls on the side of fixing the
-/// breakage.
-///
-/// A statement that mixes the two surfaces, such as
-/// `import { defineConfig, defineRule } from 'oxlint'`, is left alone. The
-/// rewrite replaces the whole specifier, so moving it would strip
-/// `defineConfig` of its module. Splitting the statement is the user's call.
-///
-/// A statement carrying a default or namespace binding alongside named ones,
-/// such as `import oxlint, { defineRule } from 'oxlint'`, is left alone for the
-/// same reason: `vite-plus/lint/plugins` has no default export.
-///
-/// A named re-export, `export { defineRule } from 'oxlint'`, names the surface
-/// just as clearly as an import, so it rewrites under the same rules. A bare
-/// `export * from 'oxlint'` names nothing and is left alone.
-///
-/// These forms name no specifier, so the rewrite skips them: namespace imports
-/// (`import * as`), default imports, bare side-effect imports,
-/// `require('oxlint')`, and `import('oxlint')`.
-///
-/// `@oxlint/plugins` and `oxlint/plugins-dev` are unambiguous. They expose only
-/// the plugin API and the dev-time utilities, so import, export, and dynamic
-/// `import()` statements all rewrite. The rules leave `require()` unchanged;
-/// dependency cleanup retains `@oxlint/plugins` when these references remain.
-///
-/// The rewrite skips a package that declares `oxlint` or `@oxlint/plugins` in
-/// `dependencies` or `peerDependencies`, or declares optional `@oxlint/plugins`.
-/// Those are published Oxlint plugins, and their consumers may not have Vite+.
-/// See `SkipPackages::skip_oxlint`.
+/// The other two specifiers expose only plugin APIs, so their import, export,
+/// dynamic-import, and import-type forms all rewrite. Preserve require calls
+/// and module augmentations; cleanup retains any remaining `@oxlint/plugins` use.
+/// Published plugins are exempt because consumers may not have Vite+; see
+/// `SkipPackages::skip_oxlint`.
 const REWRITE_OXLINT_PLUGIN_RULES: &str = r#"---
 id: rewrite-oxlint-plugins-import
 language: TypeScript
@@ -2190,11 +2153,8 @@ struct SkipPackages {
     skip_tsdown: bool,
     /// Skip rewriting Oxlint JS-plugin API imports (`oxlint` or `@oxlint/plugins`
     /// is in peerDependencies or dependencies, or @oxlint/plugins is optional).
-    /// A package that declares either as a runtime/peer edge is a published
-    /// Oxlint plugin: its consumers may be running plain Oxlint, so redirecting
-    /// the authoring API at `vite-plus` would break them.
-    /// A devDependency is not a signal: it is just how a
-    /// project's own in-repo plugin gets its types.
+    /// Published plugin consumers may not have Vite+. DevDependencies alone
+    /// do not mark a published plugin and do not prevent rewriting.
     skip_oxlint: bool,
 }
 
@@ -2212,14 +2172,8 @@ pub struct RewriteImportsOptions {
     pub preserve_vitest_in_nuxt_packages: bool,
     /// Directories of packages that declared `oxlint` or `@oxlint/plugins` in
     /// `dependencies` or `peerDependencies`, or optional `@oxlint/plugins`,
-    /// BEFORE the migration edited their manifests.
-    ///
-    /// `rewritePackageJson` strips `oxlint` (it is in `REMOVE_PACKAGES`) before
-    /// import rewriting reads the manifests, so `get_package_rewrite_context`
-    /// can no longer see that signal on disk. The caller captures it up front
-    /// and passes it here, otherwise a published Oxlint plugin that declared
-    /// the legacy `oxlint` package would lose its exemption and get rewritten
-    /// to depend on Vite+.
+    /// before migration. Capture these before manifest edits so ownership
+    /// does not depend on which dependency declarations survive those edits.
     pub oxlint_owner_dirs: Vec<PathBuf>,
 }
 
@@ -2440,10 +2394,7 @@ pub fn rewrite_imports_in_directory_with_options(
 
     // Pre-compute package context for each file (requires mutable cache, done sequentially).
     let mut package_context_cache: HashMap<PathBuf, PackageRewriteContext> = HashMap::new();
-    // Packages whose manifest declared `oxlint` / `@oxlint/plugins` before the
-    // migration edited it. Matched by the package DIRECTORY because the
-    // manifest itself no longer carries the signal (see `oxlint_owner_dirs`).
-    let oxlint_owner_dirs: HashSet<PathBuf> = options.oxlint_owner_dirs.iter().cloned().collect();
+    let oxlint_owner_dirs: HashSet<PathBuf> = options.oxlint_owner_dirs.into_iter().collect();
 
     let files_with_context: Vec<(PathBuf, PackageRewriteContext)> = walk_result
         .files
@@ -2451,15 +2402,15 @@ pub fn rewrite_imports_in_directory_with_options(
         .map(|file_path| {
             let package_context =
                 if let Some(package_json_path) = find_nearest_package_json(&file_path, root) {
-                    let mut context = *package_context_cache
-                        .entry(package_json_path.clone())
-                        .or_insert_with(|| get_package_rewrite_context(&package_json_path));
-                    if let Some(package_dir) = package_json_path.parent()
-                        && oxlint_owner_dirs.contains(package_dir)
-                    {
-                        context.skip_packages.skip_oxlint = true;
-                    }
-                    context
+                    *package_context_cache.entry(package_json_path.clone()).or_insert_with(|| {
+                        let mut context = get_package_rewrite_context(&package_json_path);
+                        if let Some(package_dir) = package_json_path.parent()
+                            && oxlint_owner_dirs.contains(package_dir)
+                        {
+                            context.skip_packages.skip_oxlint = true;
+                        }
+                        context
+                    })
                 } else {
                     PackageRewriteContext::default()
                 };
@@ -4597,6 +4548,39 @@ export default defineConfig({});"#;
 
         let skip = get_skip_packages_from_package_json(&package_json_path);
         assert!(!skip.skip_oxlint);
+    }
+
+    #[test]
+    fn test_captured_oxlint_ownership_stops_at_nested_package_boundary() {
+        let temp = tempdir().unwrap();
+        std::fs::write(temp.path().join("package.json"), "{}").unwrap();
+        let nested = temp.path().join("nested");
+        std::fs::create_dir(&nested).unwrap();
+        std::fs::write(nested.join("package.json"), "{}").unwrap();
+        let content = "import { defineRule } from '@oxlint/plugins';";
+        let root_files = [temp.path().join("plugin.js"), temp.path().join("rule.js")];
+        let nested_file = nested.join("plugin.js");
+        for file in root_files.iter().chain(std::iter::once(&nested_file)) {
+            std::fs::write(file, content).unwrap();
+        }
+
+        let result = rewrite_imports_in_directory_with_options(
+            temp.path(),
+            RewriteImportsOptions {
+                oxlint_owner_dirs: vec![temp.path().to_path_buf()],
+                ..RewriteImportsOptions::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(result.modified_files, vec![nested_file.clone()]);
+        for file in root_files {
+            assert_eq!(std::fs::read_to_string(file).unwrap(), content);
+        }
+        assert_eq!(
+            std::fs::read_to_string(nested_file).unwrap(),
+            "import { defineRule } from 'vite-plus/lint/plugins';"
+        );
     }
 
     #[test]

--- a/crates/vp_migration/src/import_rewriter.rs
+++ b/crates/vp_migration/src/import_rewriter.rs
@@ -1647,6 +1647,7 @@ rule:
   regex: ^['"]@oxlint/plugins['"]$
   inside:
     kind: export_statement
+    field: source
 transform:
   NEW_IMPORT:
     replace:
@@ -1700,6 +1701,7 @@ rule:
   regex: ^['"]oxlint/plugins-dev['"]$
   inside:
     kind: export_statement
+    field: source
 transform:
   NEW_IMPORT:
     replace:
@@ -1737,6 +1739,7 @@ rule:
   regex: ^['"]oxlint['"]$
   inside:
     kind: export_statement
+    field: source
     all:
       - has:
           kind: export_specifier
@@ -4211,6 +4214,19 @@ export * from 'oxlint';"#;
         let result = rewrite_import_content(ty, &SkipPackages::default()).unwrap();
         assert!(result.updated);
         assert_eq!(result.content, r#"type C = import('vite-plus/lint/plugins').Context;"#);
+    }
+
+    #[test]
+    fn test_rewrite_import_content_oxlint_export_default_literal_is_data() {
+        // `export default '...'` puts the string directly under the
+        // export_statement, so an unconstrained `inside:` rewrote the exported
+        // DATA VALUE. The rules match the `source` field only.
+        let data = r#"export default '@oxlint/plugins';
+export = 'oxlint/plugins-dev';"#;
+
+        let result = rewrite_import_content(data, &SkipPackages::default()).unwrap();
+        assert!(!result.updated);
+        assert_eq!(result.content, data);
     }
 
     #[test]

--- a/crates/vp_migration/src/import_rewriter.rs
+++ b/crates/vp_migration/src/import_rewriter.rs
@@ -1615,9 +1615,8 @@ fix: $NEW_IMPORT
 ///
 /// `@oxlint/plugins` and `oxlint/plugins-dev` are unambiguous. They expose only
 /// the plugin API and the dev-time utilities, so import, export, and dynamic
-/// `import()` statements all rewrite. `require()` does NOT: the
-/// `vite-plus/lint/*` exports are ESM-only, so a rewritten `require()` would
-/// fail to resolve with ERR_PACKAGE_PATH_NOT_EXPORTED.
+/// `import()` statements all rewrite. The rules leave `require()` unchanged;
+/// dependency cleanup retains `@oxlint/plugins` when these references remain.
 ///
 /// The rewrite skips a package that declares `oxlint` or `@oxlint/plugins` in
 /// `dependencies` or `peerDependencies`. Those are published Oxlint plugins,
@@ -1750,7 +1749,7 @@ rule:
             stopBy: end
             has:
               field: name
-              regex: ^(defineConfig|AllowWarnDeny|DummyRule|DummyRuleMap|ExternalPluginEntry|ExternalPluginsConfig|OxlintConfig|OxlintEnv|OxlintGlobals|OxlintOverride|RuleCategories)$
+              regex: ^['"]?(defineConfig|AllowWarnDeny|DummyRule|DummyRuleMap|ExternalPluginEntry|ExternalPluginsConfig|OxlintConfig|OxlintEnv|OxlintGlobals|OxlintOverride|RuleCategories)['"]?$
 transform:
   NEW_IMPORT:
     replace:
@@ -1777,7 +1776,7 @@ rule:
             stopBy: end
             has:
               field: name
-              regex: ^(defineConfig|AllowWarnDeny|DummyRule|DummyRuleMap|ExternalPluginEntry|ExternalPluginsConfig|OxlintConfig|OxlintEnv|OxlintGlobals|OxlintOverride|RuleCategories)$
+              regex: ^['"]?(defineConfig|AllowWarnDeny|DummyRule|DummyRuleMap|ExternalPluginEntry|ExternalPluginsConfig|OxlintConfig|OxlintEnv|OxlintGlobals|OxlintOverride|RuleCategories)['"]?$
       - not:
           has:
             kind: namespace_import
@@ -4117,6 +4116,33 @@ export default defineConfig({});"#;
     }
 
     #[test]
+    fn test_rewrite_import_content_oxlint_quoted_config_names_are_preserved() {
+        let content = r#"import { "defineConfig" as cfg } from 'oxlint';
+import type { 'OxlintConfig' as Config } from 'oxlint';
+import { 'defineConfig' as cfg2, defineRule } from 'oxlint';
+export { "defineConfig" as config } from 'oxlint';
+export type { 'OxlintOverride' as Override } from 'oxlint';"#;
+
+        let result = rewrite_import_content(content, &SkipPackages::default()).unwrap();
+        assert!(!result.updated);
+        assert_eq!(result.content, content);
+    }
+
+    #[test]
+    fn test_rewrite_import_content_oxlint_quoted_plugin_names() {
+        let content = r#"import { "defineRule" as rule } from 'oxlint';
+export { 'definePlugin' as plugin } from 'oxlint';"#;
+
+        let result = rewrite_import_content(content, &SkipPackages::default()).unwrap();
+        assert!(result.updated);
+        assert_eq!(
+            result.content,
+            r#"import { "defineRule" as rule } from 'vite-plus/lint/plugins';
+export { 'definePlugin' as plugin } from 'vite-plus/lint/plugins';"#
+        );
+    }
+
+    #[test]
     fn test_rewrite_import_content_oxlint_ambiguous_forms_are_left_alone() {
         // No named specifier means no way to tell the config surface from the
         // plugin API, so these stay put rather than risk a wrong rewrite.
@@ -4245,8 +4271,8 @@ export const legacy = 'oxlint';"#;
 
     #[test]
     fn test_rewrite_import_content_oxlint_require_is_left_alone() {
-        // `vite-plus/lint/plugins` is an ESM-only export, so a rewritten
-        // `require()` would fail with ERR_PACKAGE_PATH_NOT_EXPORTED.
+        // The rules preserve require calls even though the exports support
+        // CommonJS. Dependency cleanup must retain these referenced packages.
         let cjs = r#"const { defineRule } = require('@oxlint/plugins');
 const { RuleTester } = require('oxlint/plugins-dev');"#;
 
@@ -4257,8 +4283,7 @@ const { RuleTester } = require('oxlint/plugins-dev');"#;
 
     #[test]
     fn test_rewrite_import_content_oxlint_dynamic_import_still_rewrites() {
-        // Dynamic `import()` resolves through the `import` condition, so the
-        // ESM-only export is reachable.
+        // Dynamic import resolves through the shim's ESM entry.
         let dynamic = r#"const plugins = await import('@oxlint/plugins');"#;
 
         let result = rewrite_import_content(dynamic, &SkipPackages::default()).unwrap();

--- a/crates/vp_migration/src/import_rewriter.rs
+++ b/crates/vp_migration/src/import_rewriter.rs
@@ -1619,8 +1619,9 @@ fix: $NEW_IMPORT
 /// dependency cleanup retains `@oxlint/plugins` when these references remain.
 ///
 /// The rewrite skips a package that declares `oxlint` or `@oxlint/plugins` in
-/// `dependencies` or `peerDependencies`. Those are published Oxlint plugins,
-/// and their consumers may not have Vite+. See `SkipPackages::skip_oxlint`.
+/// `dependencies` or `peerDependencies`, or declares optional `@oxlint/plugins`.
+/// Those are published Oxlint plugins, and their consumers may not have Vite+.
+/// See `SkipPackages::skip_oxlint`.
 const REWRITE_OXLINT_PLUGIN_RULES: &str = r#"---
 id: rewrite-oxlint-plugins-import
 language: TypeScript
@@ -2188,10 +2189,11 @@ struct SkipPackages {
     /// Skip rewriting tsdown imports (tsdown is in peerDependencies or dependencies)
     skip_tsdown: bool,
     /// Skip rewriting Oxlint JS-plugin API imports (`oxlint` or `@oxlint/plugins`
-    /// is in peerDependencies or dependencies). A package that declares either
-    /// as a runtime/peer edge is a published Oxlint plugin: its consumers may be
-    /// running plain Oxlint, so redirecting the authoring API at `vite-plus`
-    /// would break them. A devDependency is not a signal: it is just how a
+    /// is in peerDependencies or dependencies, or @oxlint/plugins is optional).
+    /// A package that declares either as a runtime/peer edge is a published
+    /// Oxlint plugin: its consumers may be running plain Oxlint, so redirecting
+    /// the authoring API at `vite-plus` would break them.
+    /// A devDependency is not a signal: it is just how a
     /// project's own in-repo plugin gets its types.
     skip_oxlint: bool,
 }
@@ -2209,8 +2211,8 @@ pub struct RewriteImportsOptions {
     /// whose nearest package.json declares `@nuxt/test-utils`.
     pub preserve_vitest_in_nuxt_packages: bool,
     /// Directories of packages that declared `oxlint` or `@oxlint/plugins` in
-    /// `dependencies` or `peerDependencies` BEFORE the migration edited their
-    /// manifests.
+    /// `dependencies` or `peerDependencies`, or optional `@oxlint/plugins`,
+    /// BEFORE the migration edited their manifests.
     ///
     /// `rewritePackageJson` strips `oxlint` (it is in `REMOVE_PACKAGES`) before
     /// import rewriting reads the manifests, so `get_package_rewrite_context`
@@ -2348,7 +2350,8 @@ fn get_package_rewrite_context(package_json_path: &Path) -> PackageRewriteContex
             skip_oxlint: has_package("peerDependencies", "oxlint")
                 || has_package("dependencies", "oxlint")
                 || has_package("peerDependencies", "@oxlint/plugins")
-                || has_package("dependencies", "@oxlint/plugins"),
+                || has_package("dependencies", "@oxlint/plugins")
+                || has_package("optionalDependencies", "@oxlint/plugins"),
         },
         uses_nuxt_test_utils: ["dependencies", "devDependencies", "optionalDependencies"]
             .into_iter()
@@ -4594,6 +4597,44 @@ export default defineConfig({});"#;
 
         let skip = get_skip_packages_from_package_json(&package_json_path);
         assert!(!skip.skip_oxlint);
+    }
+
+    #[test]
+    fn test_optional_oxlint_plugin_api_is_preserved() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("package.json"),
+            r#"{"optionalDependencies":{"@oxlint/plugins":"^1.79.0"}}"#,
+        )
+        .unwrap();
+        let file = temp.path().join("plugin.js");
+        let content = "import { defineRule } from '@oxlint/plugins';";
+        std::fs::write(&file, content).unwrap();
+
+        let result = rewrite_imports_in_directory(temp.path()).unwrap();
+
+        assert!(result.modified_files.is_empty());
+        assert_eq!(std::fs::read_to_string(file).unwrap(), content);
+    }
+
+    #[test]
+    fn test_optional_oxlint_keeps_existing_rewrite_policy() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("package.json"),
+            r#"{"optionalDependencies":{"oxlint":"^1.79.0"}}"#,
+        )
+        .unwrap();
+        let file = temp.path().join("plugin.js");
+        std::fs::write(&file, "import { defineRule } from 'oxlint';").unwrap();
+
+        let result = rewrite_imports_in_directory(temp.path()).unwrap();
+
+        assert_eq!(result.modified_files, vec![file.clone()]);
+        assert_eq!(
+            std::fs::read_to_string(file).unwrap(),
+            "import { defineRule } from 'vite-plus/lint/plugins';"
+        );
     }
 
     #[test]

--- a/crates/vp_migration/src/import_rewriter.rs
+++ b/crates/vp_migration/src/import_rewriter.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
     sync::LazyLock,
 };
@@ -1596,12 +1596,20 @@ fix: $NEW_IMPORT
 /// plugin type names. An unrecognized name falls on the side of fixing the
 /// breakage.
 ///
+/// A statement that mixes the two surfaces, such as
+/// `import { defineConfig, defineRule } from 'oxlint'`, is left alone. The
+/// rewrite replaces the whole specifier, so moving it would strip
+/// `defineConfig` of its module. Splitting the statement is the user's call.
+///
 /// These forms name no specifier, so the rewrite skips them: namespace imports
 /// (`import * as`), default imports, bare side-effect imports,
 /// `require('oxlint')`, and `import('oxlint')`.
 ///
 /// `@oxlint/plugins` and `oxlint/plugins-dev` are unambiguous. They expose only
-/// the plugin API and the dev-time utilities, so every statement form rewrites.
+/// the plugin API and the dev-time utilities, so import, export, and dynamic
+/// `import()` statements all rewrite. `require()` does NOT: the
+/// `vite-plus/lint/*` exports are ESM-only, so a rewritten `require()` would
+/// fail to resolve with ERR_PACKAGE_PATH_NOT_EXPORTED.
 ///
 /// The rewrite skips a package that declares `oxlint` or `@oxlint/plugins` in
 /// `dependencies` or `peerDependencies`. Those are published Oxlint plugins,
@@ -1631,27 +1639,6 @@ rule:
   regex: ^['"]@oxlint/plugins['"]$
   inside:
     kind: export_statement
-transform:
-  NEW_IMPORT:
-    replace:
-      source: $STR
-      replace: "@oxlint/plugins"
-      by: "vite-plus/lint/plugins"
-fix: $NEW_IMPORT
----
-id: rewrite-oxlint-plugins-require
-language: TypeScript
-rule:
-  pattern: $STR
-  kind: string
-  regex: ^['"]@oxlint/plugins['"]$
-  inside:
-    kind: arguments
-    inside:
-      kind: call_expression
-      has:
-        field: function
-        regex: ^require$
 transform:
   NEW_IMPORT:
     replace:
@@ -1713,27 +1700,6 @@ transform:
       by: "vite-plus/lint/plugins-dev"
 fix: $NEW_IMPORT
 ---
-id: rewrite-oxlint-plugins-dev-require
-language: TypeScript
-rule:
-  pattern: $STR
-  kind: string
-  regex: ^['"]oxlint/plugins-dev['"]$
-  inside:
-    kind: arguments
-    inside:
-      kind: call_expression
-      has:
-        field: function
-        regex: ^require$
-transform:
-  NEW_IMPORT:
-    replace:
-      source: $STR
-      replace: oxlint/plugins-dev
-      by: "vite-plus/lint/plugins-dev"
-fix: $NEW_IMPORT
----
 id: rewrite-oxlint-plugins-dev-dynamic-import
 language: TypeScript
 rule:
@@ -1763,13 +1729,17 @@ rule:
   regex: ^['"]oxlint['"]$
   inside:
     kind: import_statement
-    has:
-      kind: import_specifier
-      stopBy: end
-      not:
-        has:
-          field: name
-          regex: ^(defineConfig|AllowWarnDeny|DummyRule|DummyRuleMap|ExternalPluginEntry|ExternalPluginsConfig|OxlintConfig|OxlintEnv|OxlintGlobals|OxlintOverride|RuleCategories)$
+    all:
+      - has:
+          kind: import_specifier
+          stopBy: end
+      - not:
+          has:
+            kind: import_specifier
+            stopBy: end
+            has:
+              field: name
+              regex: ^(defineConfig|AllowWarnDeny|DummyRule|DummyRuleMap|ExternalPluginEntry|ExternalPluginsConfig|OxlintConfig|OxlintEnv|OxlintGlobals|OxlintOverride|RuleCategories)$
 transform:
   NEW_IMPORT:
     replace:
@@ -2187,11 +2157,22 @@ struct PackageRewriteContext {
 }
 
 /// Options controlling directory-wide import rewriting.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct RewriteImportsOptions {
     /// Preserve `vitest` and `vitest/*` module specifiers throughout packages
     /// whose nearest package.json declares `@nuxt/test-utils`.
     pub preserve_vitest_in_nuxt_packages: bool,
+    /// Directories of packages that declared `oxlint` or `@oxlint/plugins` in
+    /// `dependencies` or `peerDependencies` BEFORE the migration edited their
+    /// manifests.
+    ///
+    /// `rewritePackageJson` strips `oxlint` (it is in `REMOVE_PACKAGES`) before
+    /// import rewriting reads the manifests, so `get_package_rewrite_context`
+    /// can no longer see that signal on disk. The caller captures it up front
+    /// and passes it here, otherwise a published Oxlint plugin that declared
+    /// the legacy `oxlint` package would lose its exemption and get rewritten
+    /// to depend on Vite+.
+    pub oxlint_owner_dirs: Vec<PathBuf>,
 }
 
 impl SkipPackages {
@@ -2410,15 +2391,26 @@ pub fn rewrite_imports_in_directory_with_options(
 
     // Pre-compute package context for each file (requires mutable cache, done sequentially).
     let mut package_context_cache: HashMap<PathBuf, PackageRewriteContext> = HashMap::new();
+    // Packages whose manifest declared `oxlint` / `@oxlint/plugins` before the
+    // migration edited it. Matched by the package DIRECTORY because the
+    // manifest itself no longer carries the signal (see `oxlint_owner_dirs`).
+    let oxlint_owner_dirs: HashSet<PathBuf> = options.oxlint_owner_dirs.iter().cloned().collect();
+
     let files_with_context: Vec<(PathBuf, PackageRewriteContext)> = walk_result
         .files
         .into_iter()
         .map(|file_path| {
             let package_context =
                 if let Some(package_json_path) = find_nearest_package_json(&file_path, root) {
-                    *package_context_cache
+                    let mut context = *package_context_cache
                         .entry(package_json_path.clone())
-                        .or_insert_with(|| get_package_rewrite_context(&package_json_path))
+                        .or_insert_with(|| get_package_rewrite_context(&package_json_path));
+                    if let Some(package_dir) = package_json_path.parent()
+                        && oxlint_owner_dirs.contains(package_dir)
+                    {
+                        context.skip_packages.skip_oxlint = true;
+                    }
+                    context
                 } else {
                     PackageRewriteContext::default()
                 };
@@ -3452,7 +3444,10 @@ import { mockNuxtImport } from '@nuxt/test-utils/runtime';"#,
 
         let result = rewrite_imports_in_directory_with_options(
             temp.path(),
-            RewriteImportsOptions { preserve_vitest_in_nuxt_packages: true },
+            RewriteImportsOptions {
+                preserve_vitest_in_nuxt_packages: true,
+                ..RewriteImportsOptions::default()
+            },
         )
         .unwrap();
 
@@ -3490,7 +3485,10 @@ import { mockNuxtImport } from '@nuxt/test-utils/runtime';"#,
 
         let result = rewrite_imports_in_directory_with_options(
             temp.path(),
-            RewriteImportsOptions { preserve_vitest_in_nuxt_packages: true },
+            RewriteImportsOptions {
+                preserve_vitest_in_nuxt_packages: true,
+                ..RewriteImportsOptions::default()
+            },
         )
         .unwrap();
 
@@ -4099,6 +4097,40 @@ new RuleTester().run('no-foo', noFoo, { valid: [], invalid: [] });"#;
 
 new RuleTester().run('no-foo', noFoo, { valid: [], invalid: [] });"#
         );
+    }
+
+    #[test]
+    fn test_rewrite_import_content_oxlint_mixed_surfaces_are_left_alone() {
+        // Replacing the specifier would move `defineConfig` to an entry that
+        // does not export it. Splitting the statement is the user's call.
+        let mixed = r#"import { defineConfig, defineRule } from 'oxlint';"#;
+
+        let result = rewrite_import_content(mixed, &SkipPackages::default()).unwrap();
+        assert!(!result.updated);
+        assert_eq!(result.content, mixed);
+    }
+
+    #[test]
+    fn test_rewrite_import_content_oxlint_require_is_left_alone() {
+        // `vite-plus/lint/plugins` is an ESM-only export, so a rewritten
+        // `require()` would fail with ERR_PACKAGE_PATH_NOT_EXPORTED.
+        let cjs = r#"const { defineRule } = require('@oxlint/plugins');
+const { RuleTester } = require('oxlint/plugins-dev');"#;
+
+        let result = rewrite_import_content(cjs, &SkipPackages::default()).unwrap();
+        assert!(!result.updated);
+        assert_eq!(result.content, cjs);
+    }
+
+    #[test]
+    fn test_rewrite_import_content_oxlint_dynamic_import_still_rewrites() {
+        // Dynamic `import()` resolves through the `import` condition, so the
+        // ESM-only export is reachable.
+        let dynamic = r#"const plugins = await import('@oxlint/plugins');"#;
+
+        let result = rewrite_import_content(dynamic, &SkipPackages::default()).unwrap();
+        assert!(result.updated);
+        assert_eq!(result.content, r#"const plugins = await import('vite-plus/lint/plugins');"#);
     }
 
     #[test]

--- a/crates/vp_migration/src/import_rewriter.rs
+++ b/crates/vp_migration/src/import_rewriter.rs
@@ -1601,6 +1601,10 @@ fix: $NEW_IMPORT
 /// rewrite replaces the whole specifier, so moving it would strip
 /// `defineConfig` of its module. Splitting the statement is the user's call.
 ///
+/// A statement carrying a default or namespace binding alongside named ones,
+/// such as `import oxlint, { defineRule } from 'oxlint'`, is left alone for the
+/// same reason: `vite-plus/lint/plugins` has no default export.
+///
 /// These forms name no specifier, so the rewrite skips them: namespace imports
 /// (`import * as`), default imports, bare side-effect imports,
 /// `require('oxlint')`, and `import('oxlint')`.
@@ -1740,6 +1744,15 @@ rule:
             has:
               field: name
               regex: ^(defineConfig|AllowWarnDeny|DummyRule|DummyRuleMap|ExternalPluginEntry|ExternalPluginsConfig|OxlintConfig|OxlintEnv|OxlintGlobals|OxlintOverride|RuleCategories)$
+      - not:
+          has:
+            kind: namespace_import
+            stopBy: end
+      - not:
+          has:
+            kind: import_clause
+            has:
+              kind: identifier
 transform:
   NEW_IMPORT:
     replace:
@@ -4104,6 +4117,18 @@ new RuleTester().run('no-foo', noFoo, { valid: [], invalid: [] });"#
         // Replacing the specifier would move `defineConfig` to an entry that
         // does not export it. Splitting the statement is the user's call.
         let mixed = r#"import { defineConfig, defineRule } from 'oxlint';"#;
+
+        let result = rewrite_import_content(mixed, &SkipPackages::default()).unwrap();
+        assert!(!result.updated);
+        assert_eq!(result.content, mixed);
+    }
+
+    #[test]
+    fn test_rewrite_import_content_oxlint_default_binding_is_left_alone() {
+        // `vite-plus/lint/plugins` has no default export, so redirecting a
+        // statement that carries one would leave the file invalid.
+        let mixed = r#"import oxlint, { defineRule } from 'oxlint';
+import * as everything2, { definePlugin } from 'oxlint';"#;
 
         let result = rewrite_import_content(mixed, &SkipPackages::default()).unwrap();
         assert!(!result.updated);

--- a/crates/vp_migration/src/import_rewriter.rs
+++ b/crates/vp_migration/src/import_rewriter.rs
@@ -216,7 +216,7 @@ fix: $NEW_IMPORT
 /// ast-grep rules for rewriting vitest imports.
 ///
 /// This rewrites (the canonical mapping shared with the `oxlint-plugin.ts`
-/// `rewriteVitePlusImportSpecifier` autofix — both implementations MUST stay
+/// `rewriteVitePlusImportSpecifier` autofix; both implementations MUST stay
 /// in sync and only produce targets that exist in the `vite-plus` package
 /// `exports` map, otherwise Node fails with `ERR_PACKAGE_PATH_NOT_EXPORTED`):
 /// - `import { ... } from 'vitest'` → `import { ... } from 'vite-plus/test'`
@@ -1567,6 +1567,218 @@ transform:
 fix: $NEW_IMPORT
 "#;
 
+/// ast-grep rules for rewriting Oxlint JS-plugin authoring imports.
+///
+/// The mapping:
+/// - `import { defineRule } from '@oxlint/plugins'` → `'vite-plus/lint/plugins'`
+/// - `import { RuleTester } from 'oxlint/plugins-dev'` → `'vite-plus/lint/plugins-dev'`
+/// - `import { defineRule } from 'oxlint'` → `'vite-plus/lint/plugins'`
+///
+/// `rewriteVitePlusImportSpecifier` in `oxlint-plugin.ts` repeats this mapping
+/// for the lint autofix. Both implementations MUST stay in sync.
+///
+/// Why this exists: vite-plus bundles Oxlint, so the migration strips `oxlint`
+/// from the project. A JS plugin that imports the authoring API by either name
+/// then stops resolving, and `vp lint` fails to load the plugin.
+///
+/// The rewrite points those imports at `vite-plus` rather than re-adding
+/// `@oxlint/plugins` as a direct dependency. This locks the API to the bundled
+/// linter, so the user pins nothing. It also resolves from any package that
+/// already has `vite-plus`. A direct `@oxlint/plugins` import does not:
+/// `@oxlint/plugins` is only a transitive dependency, which pnpm's strict
+/// layout hides from a user's plugin file.
+///
+/// The bare `oxlint` specifier is ambiguous. It still serves the CONFIG surface
+/// (`defineConfig`, `OxlintConfig`, `OxlintOverride`, and so on), which must
+/// keep resolving against the standalone package. So the rewrite applies only
+/// to an `import` statement that names a specifier outside that config surface.
+/// The check is therefore a small, stable denylist, not an ever-growing list of
+/// plugin type names. An unrecognized name falls on the side of fixing the
+/// breakage.
+///
+/// These forms name no specifier, so the rewrite skips them: namespace imports
+/// (`import * as`), default imports, bare side-effect imports,
+/// `require('oxlint')`, and `import('oxlint')`.
+///
+/// `@oxlint/plugins` and `oxlint/plugins-dev` are unambiguous. They expose only
+/// the plugin API and the dev-time utilities, so every statement form rewrites.
+///
+/// The rewrite skips a package that declares `oxlint` or `@oxlint/plugins` in
+/// `dependencies` or `peerDependencies`. Those are published Oxlint plugins,
+/// and their consumers may not have Vite+. See `SkipPackages::skip_oxlint`.
+const REWRITE_OXLINT_PLUGIN_RULES: &str = r#"---
+id: rewrite-oxlint-plugins-import
+language: TypeScript
+rule:
+  pattern: $STR
+  kind: string
+  regex: ^['"]@oxlint/plugins['"]$
+  inside:
+    kind: import_statement
+transform:
+  NEW_IMPORT:
+    replace:
+      source: $STR
+      replace: "@oxlint/plugins"
+      by: "vite-plus/lint/plugins"
+fix: $NEW_IMPORT
+---
+id: rewrite-oxlint-plugins-export
+language: TypeScript
+rule:
+  pattern: $STR
+  kind: string
+  regex: ^['"]@oxlint/plugins['"]$
+  inside:
+    kind: export_statement
+transform:
+  NEW_IMPORT:
+    replace:
+      source: $STR
+      replace: "@oxlint/plugins"
+      by: "vite-plus/lint/plugins"
+fix: $NEW_IMPORT
+---
+id: rewrite-oxlint-plugins-require
+language: TypeScript
+rule:
+  pattern: $STR
+  kind: string
+  regex: ^['"]@oxlint/plugins['"]$
+  inside:
+    kind: arguments
+    inside:
+      kind: call_expression
+      has:
+        field: function
+        regex: ^require$
+transform:
+  NEW_IMPORT:
+    replace:
+      source: $STR
+      replace: "@oxlint/plugins"
+      by: "vite-plus/lint/plugins"
+fix: $NEW_IMPORT
+---
+id: rewrite-oxlint-plugins-dynamic-import
+language: TypeScript
+rule:
+  pattern: $STR
+  kind: string
+  regex: ^['"]@oxlint/plugins['"]$
+  inside:
+    kind: arguments
+    inside:
+      kind: call_expression
+      has:
+        field: function
+        kind: import
+transform:
+  NEW_IMPORT:
+    replace:
+      source: $STR
+      replace: "@oxlint/plugins"
+      by: "vite-plus/lint/plugins"
+fix: $NEW_IMPORT
+---
+id: rewrite-oxlint-plugins-dev-import
+language: TypeScript
+rule:
+  pattern: $STR
+  kind: string
+  regex: ^['"]oxlint/plugins-dev['"]$
+  inside:
+    kind: import_statement
+transform:
+  NEW_IMPORT:
+    replace:
+      source: $STR
+      replace: oxlint/plugins-dev
+      by: "vite-plus/lint/plugins-dev"
+fix: $NEW_IMPORT
+---
+id: rewrite-oxlint-plugins-dev-export
+language: TypeScript
+rule:
+  pattern: $STR
+  kind: string
+  regex: ^['"]oxlint/plugins-dev['"]$
+  inside:
+    kind: export_statement
+transform:
+  NEW_IMPORT:
+    replace:
+      source: $STR
+      replace: oxlint/plugins-dev
+      by: "vite-plus/lint/plugins-dev"
+fix: $NEW_IMPORT
+---
+id: rewrite-oxlint-plugins-dev-require
+language: TypeScript
+rule:
+  pattern: $STR
+  kind: string
+  regex: ^['"]oxlint/plugins-dev['"]$
+  inside:
+    kind: arguments
+    inside:
+      kind: call_expression
+      has:
+        field: function
+        regex: ^require$
+transform:
+  NEW_IMPORT:
+    replace:
+      source: $STR
+      replace: oxlint/plugins-dev
+      by: "vite-plus/lint/plugins-dev"
+fix: $NEW_IMPORT
+---
+id: rewrite-oxlint-plugins-dev-dynamic-import
+language: TypeScript
+rule:
+  pattern: $STR
+  kind: string
+  regex: ^['"]oxlint/plugins-dev['"]$
+  inside:
+    kind: arguments
+    inside:
+      kind: call_expression
+      has:
+        field: function
+        kind: import
+transform:
+  NEW_IMPORT:
+    replace:
+      source: $STR
+      replace: oxlint/plugins-dev
+      by: "vite-plus/lint/plugins-dev"
+fix: $NEW_IMPORT
+---
+id: rewrite-oxlint-plugin-api-import
+language: TypeScript
+rule:
+  pattern: $STR
+  kind: string
+  regex: ^['"]oxlint['"]$
+  inside:
+    kind: import_statement
+    has:
+      kind: import_specifier
+      stopBy: end
+      not:
+        has:
+          field: name
+          regex: ^(defineConfig|AllowWarnDeny|DummyRule|DummyRuleMap|ExternalPluginEntry|ExternalPluginsConfig|OxlintConfig|OxlintEnv|OxlintGlobals|OxlintOverride|RuleCategories)$
+transform:
+  NEW_IMPORT:
+    replace:
+      source: $STR
+      replace: oxlint
+      by: "vite-plus/lint/plugins"
+fix: $NEW_IMPORT
+"#;
+
 static PARSED_VITE_RULES: LazyLock<Vec<RuleConfig<SupportLang>>> = LazyLock::new(|| {
     ast_grep::load_rules(REWRITE_VITE_RULES).expect("failed to parse vite rewrite rules")
 });
@@ -1611,6 +1823,11 @@ static PARSED_VITEST_RULES_WITHOUT_UNSCOPED: LazyLock<Vec<RuleConfig<SupportLang
 
 static PARSED_TSDOWN_RULES: LazyLock<Vec<RuleConfig<SupportLang>>> = LazyLock::new(|| {
     ast_grep::load_rules(REWRITE_TSDOWN_RULES).expect("failed to parse tsdown rewrite rules")
+});
+
+static PARSED_OXLINT_PLUGIN_RULES: LazyLock<Vec<RuleConfig<SupportLang>>> = LazyLock::new(|| {
+    ast_grep::load_rules(REWRITE_OXLINT_PLUGIN_RULES)
+        .expect("failed to parse oxlint plugin rewrite rules")
 });
 
 // Regex patterns for rewriting `/// <reference types="..." />` directives.
@@ -1954,6 +2171,13 @@ struct SkipPackages {
     skip_vitest: bool,
     /// Skip rewriting tsdown imports (tsdown is in peerDependencies or dependencies)
     skip_tsdown: bool,
+    /// Skip rewriting Oxlint JS-plugin API imports (`oxlint` or `@oxlint/plugins`
+    /// is in peerDependencies or dependencies). A package that declares either
+    /// as a runtime/peer edge is a published Oxlint plugin: its consumers may be
+    /// running plain Oxlint, so redirecting the authoring API at `vite-plus`
+    /// would break them. A devDependency is not a signal: it is just how a
+    /// project's own in-repo plugin gets its types.
+    skip_oxlint: bool,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -1973,7 +2197,7 @@ pub struct RewriteImportsOptions {
 impl SkipPackages {
     /// Check if all packages should be skipped (file can be skipped entirely)
     const fn all_skipped(&self) -> bool {
-        self.skip_vite && self.skip_vitest && self.skip_tsdown
+        self.skip_vite && self.skip_vitest && self.skip_tsdown && self.skip_oxlint
     }
 }
 
@@ -2094,6 +2318,10 @@ fn get_package_rewrite_context(package_json_path: &Path) -> PackageRewriteContex
                 || has_package("dependencies", "vitest"),
             skip_tsdown: has_package("peerDependencies", "tsdown")
                 || has_package("dependencies", "tsdown"),
+            skip_oxlint: has_package("peerDependencies", "oxlint")
+                || has_package("dependencies", "oxlint")
+                || has_package("peerDependencies", "@oxlint/plugins")
+                || has_package("dependencies", "@oxlint/plugins"),
         },
         uses_nuxt_test_utils: ["dependencies", "devDependencies", "optionalDependencies"]
             .into_iter()
@@ -2325,6 +2553,11 @@ fn content_may_need_rewriting(content: &str, skip_packages: &SkipPackages) -> bo
     if !skip_packages.skip_tsdown && content.contains("tsdown") {
         return true;
     }
+    // Covers the bare `oxlint` specifier plus `@oxlint/plugins` and
+    // `oxlint/plugins-dev`, which all contain it as a substring.
+    if !skip_packages.skip_oxlint && content.contains("oxlint") {
+        return true;
+    }
     false
 }
 
@@ -2403,6 +2636,18 @@ fn rewrite_import_content_full(
         let tsdown_content = ast_grep::apply_loaded_rules(&new_content, &PARSED_TSDOWN_RULES);
         if tsdown_content != new_content {
             new_content = tsdown_content;
+            updated = true;
+        }
+    }
+
+    // Apply Oxlint JS-plugin API rules if not skipped (using pre-parsed rules).
+    // Unlike `vite`, these are NOT scoped to config entry files: the imports
+    // that break live in the plugin and rule sources themselves.
+    if !skip_packages.skip_oxlint {
+        let oxlint_content =
+            ast_grep::apply_loaded_rules(&new_content, &PARSED_OXLINT_PLUGIN_RULES);
+        if oxlint_content != new_content {
+            new_content = oxlint_content;
             updated = true;
         }
     }
@@ -3767,6 +4012,109 @@ export default defineConfig({
     }
 
     #[test]
+    fn test_rewrite_import_content_oxlint_plugins_scoped() {
+        let plugin = r#"import { definePlugin, defineRule } from "@oxlint/plugins";
+import type { Context, ESTree } from '@oxlint/plugins';"#;
+
+        let result = rewrite_import_content(plugin, &SkipPackages::default()).unwrap();
+        assert!(result.updated);
+        assert_eq!(
+            result.content,
+            r#"import { definePlugin, defineRule } from "vite-plus/lint/plugins";
+import type { Context, ESTree } from 'vite-plus/lint/plugins';"#
+        );
+    }
+
+    #[test]
+    fn test_rewrite_import_content_oxlint_plugin_api_bare_specifier() {
+        // The pre-`@oxlint/plugins` authoring API, which is what projects
+        // migrating off a standalone `oxlint` dependency actually have.
+        let rule = r#"import { defineRule } from 'oxlint';
+
+export const noFoo = defineRule({ create: () => ({}) });"#;
+
+        let result = rewrite_import_content(rule, &SkipPackages::default()).unwrap();
+        assert!(result.updated);
+        assert_eq!(
+            result.content,
+            r#"import { defineRule } from 'vite-plus/lint/plugins';
+
+export const noFoo = defineRule({ create: () => ({}) });"#
+        );
+    }
+
+    #[test]
+    fn test_rewrite_import_content_oxlint_plugin_api_type_only_and_aliased() {
+        let rule = r#"import type { Context } from 'oxlint';
+import { defineRule as rule } from "oxlint";"#;
+
+        let result = rewrite_import_content(rule, &SkipPackages::default()).unwrap();
+        assert!(result.updated);
+        assert_eq!(
+            result.content,
+            r#"import type { Context } from 'vite-plus/lint/plugins';
+import { defineRule as rule } from "vite-plus/lint/plugins";"#
+        );
+    }
+
+    #[test]
+    fn test_rewrite_import_content_oxlint_config_surface_is_preserved() {
+        // `oxlint` still owns the config surface; only the plugin authoring API
+        // moved. Redirecting these at `vite-plus/lint/plugins` would break them.
+        let config = r#"import { defineConfig } from 'oxlint';
+import type { OxlintConfig, OxlintOverride } from 'oxlint';
+
+export default defineConfig({});"#;
+
+        let result = rewrite_import_content(config, &SkipPackages::default()).unwrap();
+        assert!(!result.updated);
+        assert_eq!(result.content, config);
+    }
+
+    #[test]
+    fn test_rewrite_import_content_oxlint_ambiguous_forms_are_left_alone() {
+        // No named specifier means no way to tell the config surface from the
+        // plugin API, so these stay put rather than risk a wrong rewrite.
+        let content = r#"import oxlint from 'oxlint';
+import * as everything from 'oxlint';
+import 'oxlint';
+const lazy = require('oxlint');"#;
+
+        let result = rewrite_import_content(content, &SkipPackages::default()).unwrap();
+        assert!(!result.updated);
+        assert_eq!(result.content, content);
+    }
+
+    #[test]
+    fn test_rewrite_import_content_oxlint_plugins_dev_rule_tester() {
+        let test_file = r#"import { RuleTester } from 'oxlint/plugins-dev';
+
+new RuleTester().run('no-foo', noFoo, { valid: [], invalid: [] });"#;
+
+        let result = rewrite_import_content(test_file, &SkipPackages::default()).unwrap();
+        assert!(result.updated);
+        assert_eq!(
+            result.content,
+            r#"import { RuleTester } from 'vite-plus/lint/plugins-dev';
+
+new RuleTester().run('no-foo', noFoo, { valid: [], invalid: [] });"#
+        );
+    }
+
+    #[test]
+    fn test_rewrite_import_content_oxlint_skipped_for_published_plugins() {
+        let plugin = r#"import { defineRule } from '@oxlint/plugins';"#;
+
+        let result = rewrite_import_content(
+            plugin,
+            &SkipPackages { skip_oxlint: true, ..SkipPackages::default() },
+        )
+        .unwrap();
+        assert!(!result.updated);
+        assert_eq!(result.content, plugin);
+    }
+
+    #[test]
     fn test_rewrite_declare_module_tsdown() {
         let content = r#"declare module 'tsdown' {
   interface BuildConfig {
@@ -3876,8 +4224,12 @@ import { describe } from 'vitest';
 
 export default defineConfig({});"#;
 
-        let skip_packages =
-            SkipPackages { skip_vite: true, skip_vitest: false, skip_tsdown: false };
+        let skip_packages = SkipPackages {
+            skip_vite: true,
+            skip_vitest: false,
+            skip_tsdown: false,
+            skip_oxlint: false,
+        };
 
         let result = rewrite_import_content(content, &skip_packages).unwrap();
         assert!(result.updated);
@@ -3899,8 +4251,12 @@ import { describe } from 'vitest';
 
 export default defineConfig({});"#;
 
-        let skip_packages =
-            SkipPackages { skip_vite: false, skip_vitest: true, skip_tsdown: false };
+        let skip_packages = SkipPackages {
+            skip_vite: false,
+            skip_vitest: true,
+            skip_tsdown: false,
+            skip_oxlint: false,
+        };
 
         let result = rewrite_import_content(content, &skip_packages).unwrap();
         assert!(result.updated);
@@ -3923,7 +4279,12 @@ import { build } from 'tsdown';
 
 export default defineConfig({});"#;
 
-        let skip_packages = SkipPackages { skip_vite: true, skip_vitest: true, skip_tsdown: true };
+        let skip_packages = SkipPackages {
+            skip_vite: true,
+            skip_vitest: true,
+            skip_tsdown: true,
+            skip_oxlint: true,
+        };
 
         let result = rewrite_import_content(content, &skip_packages).unwrap();
         assert!(!result.updated);
@@ -3932,10 +4293,20 @@ export default defineConfig({});"#;
 
     #[test]
     fn test_skip_packages_all_skipped() {
-        let skip_all = SkipPackages { skip_vite: true, skip_vitest: true, skip_tsdown: true };
+        let skip_all = SkipPackages {
+            skip_vite: true,
+            skip_vitest: true,
+            skip_tsdown: true,
+            skip_oxlint: true,
+        };
         assert!(skip_all.all_skipped());
 
-        let skip_some = SkipPackages { skip_vite: true, skip_vitest: false, skip_tsdown: true };
+        let skip_some = SkipPackages {
+            skip_vite: true,
+            skip_vitest: false,
+            skip_tsdown: true,
+            skip_oxlint: false,
+        };
         assert!(!skip_some.all_skipped());
 
         let skip_none = SkipPackages::default();
@@ -3975,7 +4346,8 @@ export default defineConfig({});"#;
   "peerDependencies": {
     "vite": "^5.0.0",
     "vitest": "^1.0.0",
-    "tsdown": "^1.0.0"
+    "tsdown": "^1.0.0",
+    "oxlint": "^1.0.0"
   }
 }"#;
         let package_json_path = temp.path().join("package.json");
@@ -3985,7 +4357,53 @@ export default defineConfig({});"#;
         assert!(skip.skip_vite);
         assert!(skip.skip_vitest);
         assert!(skip.skip_tsdown);
+        assert!(skip.skip_oxlint);
         assert!(skip.all_skipped());
+    }
+
+    #[test]
+    fn test_get_skip_packages_from_package_json_with_oxlint_plugins_peer_dependency() {
+        use std::fs;
+
+        let temp = tempdir().unwrap();
+
+        // A published Oxlint plugin declares the authoring API as a peer so its
+        // consumers supply it. Redirecting those imports at `vite-plus` would
+        // break consumers running plain Oxlint.
+        let pkg_json = r#"{
+  "name": "oxlint-plugin-example",
+  "peerDependencies": {
+    "@oxlint/plugins": "^1.0.0"
+  }
+}"#;
+        let package_json_path = temp.path().join("package.json");
+        fs::write(&package_json_path, pkg_json).unwrap();
+
+        let skip = get_skip_packages_from_package_json(&package_json_path);
+        assert!(skip.skip_oxlint);
+        assert!(!skip.skip_vite);
+    }
+
+    #[test]
+    fn test_get_skip_packages_from_package_json_oxlint_dev_dependency_is_not_a_skip_signal() {
+        use std::fs;
+
+        let temp = tempdir().unwrap();
+
+        // A devDependency is how a project's own in-repo plugin gets its types;
+        // it does not make the package a published Oxlint plugin.
+        let pkg_json = r#"{
+  "name": "my-app",
+  "devDependencies": {
+    "@oxlint/plugins": "^1.0.0",
+    "oxlint": "^1.0.0"
+  }
+}"#;
+        let package_json_path = temp.path().join("package.json");
+        fs::write(&package_json_path, pkg_json).unwrap();
+
+        let skip = get_skip_packages_from_package_json(&package_json_path);
+        assert!(!skip.skip_oxlint);
     }
 
     #[test]
@@ -4768,8 +5186,12 @@ module.exports = defineConfig({});"#
         // also be skipped (parity with the import-shape rule).
         let content = r#"const vi = require('vitest');
 const { defineConfig } = require('vite');"#;
-        let skip_packages =
-            SkipPackages { skip_vite: false, skip_vitest: true, skip_tsdown: false };
+        let skip_packages = SkipPackages {
+            skip_vite: false,
+            skip_vitest: true,
+            skip_tsdown: false,
+            skip_oxlint: false,
+        };
         let result = rewrite_import_content(content, &skip_packages).unwrap();
         assert!(result.updated);
         // vitest require is NOT rewritten; vite require IS rewritten.
@@ -5235,8 +5657,12 @@ export default defineConfig({});"#
         let content = r#"/// <reference types="vite/client" />
 /// <reference types="vitest" />"#;
 
-        let skip_packages =
-            SkipPackages { skip_vite: true, skip_vitest: false, skip_tsdown: false };
+        let skip_packages = SkipPackages {
+            skip_vite: true,
+            skip_vitest: false,
+            skip_tsdown: false,
+            skip_oxlint: false,
+        };
         let result = rewrite_import_content(content, &skip_packages).unwrap();
         assert!(result.updated);
         assert_eq!(
@@ -5252,8 +5678,12 @@ export default defineConfig({});"#
 /// <reference types="vitest" />
 /// <reference types="@vitest/browser/matchers" />"#;
 
-        let skip_packages =
-            SkipPackages { skip_vite: false, skip_vitest: true, skip_tsdown: false };
+        let skip_packages = SkipPackages {
+            skip_vite: false,
+            skip_vitest: true,
+            skip_tsdown: false,
+            skip_oxlint: false,
+        };
         let result = rewrite_import_content(content, &skip_packages).unwrap();
         assert!(result.updated);
         assert_eq!(
@@ -5269,8 +5699,12 @@ export default defineConfig({});"#
         let content = r#"/// <reference types="tsdown/client" />
 /// <reference types="vite/client" />"#;
 
-        let skip_packages =
-            SkipPackages { skip_vite: false, skip_vitest: false, skip_tsdown: true };
+        let skip_packages = SkipPackages {
+            skip_vite: false,
+            skip_vitest: false,
+            skip_tsdown: true,
+            skip_oxlint: false,
+        };
         let result = rewrite_import_content(content, &skip_packages).unwrap();
         assert!(result.updated);
         assert_eq!(
@@ -5286,7 +5720,12 @@ export default defineConfig({});"#
 /// <reference types="vitest" />
 /// <reference types="tsdown/client" />"#;
 
-        let skip_packages = SkipPackages { skip_vite: true, skip_vitest: true, skip_tsdown: true };
+        let skip_packages = SkipPackages {
+            skip_vite: true,
+            skip_vitest: true,
+            skip_tsdown: true,
+            skip_oxlint: true,
+        };
         let result = rewrite_import_content(content, &skip_packages).unwrap();
         assert!(!result.updated);
         assert_eq!(result.content, content);

--- a/crates/vp_migration/src/import_rewriter.rs
+++ b/crates/vp_migration/src/import_rewriter.rs
@@ -1605,6 +1605,10 @@ fix: $NEW_IMPORT
 /// such as `import oxlint, { defineRule } from 'oxlint'`, is left alone for the
 /// same reason: `vite-plus/lint/plugins` has no default export.
 ///
+/// A named re-export, `export { defineRule } from 'oxlint'`, names the surface
+/// just as clearly as an import, so it rewrites under the same rules. A bare
+/// `export * from 'oxlint'` names nothing and is left alone.
+///
 /// These forms name no specifier, so the rewrite skips them: namespace imports
 /// (`import * as`), default imports, bare side-effect imports,
 /// `require('oxlint')`, and `import('oxlint')`.
@@ -1723,6 +1727,33 @@ transform:
       source: $STR
       replace: oxlint/plugins-dev
       by: "vite-plus/lint/plugins-dev"
+fix: $NEW_IMPORT
+---
+id: rewrite-oxlint-plugin-api-export
+language: TypeScript
+rule:
+  pattern: $STR
+  kind: string
+  regex: ^['"]oxlint['"]$
+  inside:
+    kind: export_statement
+    all:
+      - has:
+          kind: export_specifier
+          stopBy: end
+      - not:
+          has:
+            kind: export_specifier
+            stopBy: end
+            has:
+              field: name
+              regex: ^(defineConfig|AllowWarnDeny|DummyRule|DummyRuleMap|ExternalPluginEntry|ExternalPluginsConfig|OxlintConfig|OxlintEnv|OxlintGlobals|OxlintOverride|RuleCategories)$
+transform:
+  NEW_IMPORT:
+    replace:
+      source: $STR
+      replace: oxlint
+      by: "vite-plus/lint/plugins"
 fix: $NEW_IMPORT
 ---
 id: rewrite-oxlint-plugin-api-import
@@ -4133,6 +4164,53 @@ import * as everything2, { definePlugin } from 'oxlint';"#;
         let result = rewrite_import_content(mixed, &SkipPackages::default()).unwrap();
         assert!(!result.updated);
         assert_eq!(result.content, mixed);
+    }
+
+    #[test]
+    fn test_rewrite_import_content_oxlint_named_reexport() {
+        let barrel = r#"export { defineRule } from 'oxlint';
+export type { Context } from 'oxlint';"#;
+
+        let result = rewrite_import_content(barrel, &SkipPackages::default()).unwrap();
+        assert!(result.updated);
+        assert_eq!(
+            result.content,
+            r#"export { defineRule } from 'vite-plus/lint/plugins';
+export type { Context } from 'vite-plus/lint/plugins';"#
+        );
+    }
+
+    #[test]
+    fn test_rewrite_import_content_oxlint_config_reexport_is_left_alone() {
+        let barrel = r#"export { defineConfig } from 'oxlint';
+export * from 'oxlint';"#;
+
+        let result = rewrite_import_content(barrel, &SkipPackages::default()).unwrap();
+        assert!(!result.updated);
+        assert_eq!(result.content, barrel);
+    }
+
+    #[test]
+    fn test_rewrite_import_content_oxlint_import_equals_is_left_alone() {
+        // Verified against the parser, not assumed: tree-sitter does not treat
+        // `import x = require(...)` as a plain `import_statement` string, so
+        // the ESM rules never see it. Pinned so that stays true.
+        let cjs = r#"import plugins = require('@oxlint/plugins');"#;
+
+        let result = rewrite_import_content(cjs, &SkipPackages::default()).unwrap();
+        assert!(!result.updated);
+        assert_eq!(result.content, cjs);
+    }
+
+    #[test]
+    fn test_rewrite_import_content_oxlint_import_type_rewrites() {
+        // A type-position `import(...)` resolves through the shim's re-exported
+        // types, so rewriting it is correct.
+        let ty = r#"type C = import('@oxlint/plugins').Context;"#;
+
+        let result = rewrite_import_content(ty, &SkipPackages::default()).unwrap();
+        assert!(result.updated);
+        assert_eq!(result.content, r#"type C = import('vite-plus/lint/plugins').Context;"#);
     }
 
     #[test]

--- a/docs/guide/lint.md
+++ b/docs/guide/lint.md
@@ -50,3 +50,58 @@ This path is powered by [tsgolint](https://github.com/oxc-project/tsgolint) on t
 If you are migrating from ESLint and still depend on a few critical JavaScript-based ESLint plugins, Oxlint has [JS plugin support](https://oxc.rs/docs/guide/usage/linter/js-plugins) that can help you keep those plugins running while you complete the migration.
 
 JS Plugins also enable [writing your own custom rules](https://oxc.rs/docs/guide/usage/linter/writing-js-plugins.html) for Oxlint.
+
+### Writing Your Own Rules
+
+Import the plugin authoring API from `vite-plus/lint/plugins`:
+
+```js [lint/my-plugin.js]
+import { definePlugin, defineRule } from 'vite-plus/lint/plugins';
+
+const noFoo = defineRule({
+  meta: { messages: { noFoo: 'Do not name things "foo".' } },
+  create(context) {
+    return {
+      Identifier(node) {
+        if (node.name === 'foo') {
+          context.report({ node, messageId: 'noFoo' });
+        }
+      },
+    };
+  },
+});
+
+export default definePlugin({
+  meta: { name: 'my' },
+  rules: { 'no-foo': noFoo },
+});
+```
+
+Register it under `lint.jsPlugins` and enable its rules:
+
+```ts [vite.config.ts]
+import { defineConfig } from 'vite-plus';
+
+export default defineConfig({
+  lint: {
+    jsPlugins: ['./lint/my-plugin.js'],
+    rules: {
+      'my/no-foo': 'error',
+    },
+  },
+});
+```
+
+For rule tests, `RuleTester` is available from `vite-plus/lint/plugins-dev`.
+
+Both entrypoints re-export the copy that ships with Vite+. The API therefore
+always matches the bundled Oxlint.
+
+Use them instead of adding `@oxlint/plugins` or `oxlint` as a direct
+dependency. A separately pinned copy can drift from the linter that loads your
+plugin. It also does not resolve from a plugin file under pnpm's strict layout,
+unless every package that holds a plugin declares it.
+
+`vp migrate` rewrites existing `oxlint` and `@oxlint/plugins` imports for you.
+See [Oxlint JS Plugin Imports](/guide/migrate-rules#oxlint-js-plugin-imports).
+The `vite-plus/prefer-vite-plus-imports` rule reports any that come back.

--- a/docs/guide/migrate-rules.md
+++ b/docs/guide/migrate-rules.md
@@ -280,8 +280,13 @@ The migration leaves three forms alone:
 - Bare side-effect `oxlint` imports, for the same reason.
 
 The migration also skips a package that declares `oxlint` or `@oxlint/plugins`
-in `dependencies` or `peerDependencies`. That shape marks a published Oxlint
-plugin. Its consumers may not run Vite+.
+in `dependencies` or `peerDependencies`, or `@oxlint/plugins` in
+`optionalDependencies`. These dependencies can supply a published Oxlint plugin.
+Its consumers may not run Vite+.
+
+The cleanup retains a development dependency on `@oxlint/plugins` when source,
+package import aliases, or built plugins still reference it. This includes
+ignored output in directories such as `dist`, `build`, and `out`.
 
 ### What Is Never Rewritten
 

--- a/docs/guide/migrate-rules.md
+++ b/docs/guide/migrate-rules.md
@@ -250,6 +250,39 @@ surface are written against `vite-plus` by hand.
   needed.
 - Existing `vite-plus/test*` imports are left unchanged.
 
+### Oxlint JS Plugin Imports
+
+Vite+ bundles Oxlint, so the migration removes a standalone `oxlint`
+dependency. Your own Oxlint JS plugins import the authoring API by name. That
+import stops resolving when the dependency goes away. `vp lint` then fails to
+load the plugin.
+
+The migration repoints those imports at Vite+:
+
+- It rewrites `@oxlint/plugins` to `vite-plus/lint/plugins`.
+- It rewrites `oxlint/plugins-dev` to `vite-plus/lint/plugins-dev`.
+- It rewrites `oxlint` to `vite-plus/lint/plugins` when the import names a
+  binding from the authoring API, such as `defineRule`, `definePlugin`, or
+  `Context`. Older Oxlint releases exposed that API from the main entry. It now
+  lives in `@oxlint/plugins`.
+
+An import through Vite+ always matches the version of Oxlint that Vite+
+bundles. You pin no second package. The import also resolves from any package
+that already depends on `vite-plus`.
+
+The migration leaves three forms alone:
+
+- `oxlint` imports that name only the config surface, such as `defineConfig`,
+  `OxlintConfig`, or `OxlintOverride`. These still resolve against the
+  standalone package.
+- Default and namespace `oxlint` imports. They name no binding, so the
+  migration cannot tell the two surfaces apart.
+- Bare side-effect `oxlint` imports, for the same reason.
+
+The migration also skips a package that declares `oxlint` or `@oxlint/plugins`
+in `dependencies` or `peerDependencies`. That shape marks a published Oxlint
+plugin. Its consumers may not run Vite+.
+
 ### What Is Never Rewritten
 
 - `declare module 'vitest'` and `declare module '@vitest/browser*'`: module

--- a/ecosystem-ci/repo.json
+++ b/ecosystem-ci/repo.json
@@ -83,6 +83,12 @@
     "hash": "2a2ce31ecc286ae38ab1f0bce13d94418da8a513",
     "forceFreshMigration": true
   },
+  "videojs-v10": {
+    "repository": "https://github.com/videojs/v10.git",
+    "branch": "main",
+    "hash": "a86f3d735973e47669d529f3edba178585c9cfa9",
+    "forceFreshMigration": true
+  },
   "reactive-resume": {
     "repository": "https://github.com/amruthpillai/reactive-resume.git",
     "branch": "main",

--- a/ecosystem-ci/verify-videojs-v10.ts
+++ b/ecosystem-ci/verify-videojs-v10.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(`${process.cwd()}/`);
+const pkg = JSON.parse(readFileSync('package.json', 'utf-8')) as Record<
+  string,
+  Record<string, string> | undefined
+>;
+
+// A fresh pnpm install must load the migrated plugin without direct Oxlint dependencies.
+for (const name of ['@oxlint/plugins', 'oxlint']) {
+  for (const field of [
+    'dependencies',
+    'devDependencies',
+    'peerDependencies',
+    'optionalDependencies',
+  ]) {
+    assert.equal(pkg[field]?.[name], undefined, `${field} still contains ${name}`);
+  }
+  assert.throws(() => require.resolve(`${name}/package.json`), { code: 'MODULE_NOT_FOUND' });
+}
+
+const pluginDir = 'tools/oxlint/anti-slop';
+for (const [file, specifier] of [
+  ['index.ts', 'vite-plus/lint/plugins'],
+  ['rules/padding-line-between-statements.ts', 'vite-plus/lint/plugins'],
+  ['rules/tests/padding-line-between-statements.test.ts', 'vite-plus/lint/plugins-dev'],
+]) {
+  const source = readFileSync(`${pluginDir}/${file}`, 'utf-8');
+  assert.ok(
+    source.includes(`from "${specifier}"`) || source.includes(`from '${specifier}'`),
+    `${file} must import from ${specifier}`,
+  );
+}
+
+console.log('ok Video.js custom rules and RuleTester use the Vite+ plugin APIs');

--- a/packages/cli/binding/index.d.cts
+++ b/packages/cli/binding/index.d.cts
@@ -3802,6 +3802,7 @@ export declare function rewriteEslint(scriptsJson: string): string | null;
 export declare function rewriteImportsInDirectory(
   root: string,
   preserveVitestInNuxtPackages?: boolean | undefined | null,
+  oxlintOwnerDirs?: Array<string> | undefined | null,
 ): BatchRewriteResult;
 
 /**

--- a/packages/cli/binding/src/migration.rs
+++ b/packages/cli/binding/src/migration.rs
@@ -292,11 +292,17 @@ pub fn wrap_lazy_plugins(vite_config_path: String) -> Result<MergeJsonConfigResu
 pub fn rewrite_imports_in_directory(
     root: String,
     preserve_vitest_in_nuxt_packages: Option<bool>,
+    oxlint_owner_dirs: Option<Vec<String>>,
 ) -> Result<BatchRewriteResult> {
     let result = vp_migration::rewrite_imports_in_directory_with_options(
         Path::new(&root),
         vp_migration::RewriteImportsOptions {
             preserve_vitest_in_nuxt_packages: preserve_vitest_in_nuxt_packages.unwrap_or(false),
+            oxlint_owner_dirs: oxlint_owner_dirs
+                .unwrap_or_default()
+                .into_iter()
+                .map(std::path::PathBuf::from)
+                .collect(),
         },
     )
     .map_err(anyhow::Error::from)?;

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -71,7 +71,8 @@
     },
     "./lint/plugins": {
       "types": "./dist/lint-plugins.d.ts",
-      "import": "./dist/lint-plugins.js"
+      "import": "./dist/lint-plugins.js",
+      "require": "./dist/lint-plugins.cjs"
     },
     "./lint/plugins-dev": {
       "types": "./dist/lint-plugins-dev.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -69,6 +69,14 @@
       "types": "./dist/lint.d.ts",
       "import": "./dist/lint.js"
     },
+    "./lint/plugins": {
+      "types": "./dist/lint-plugins.d.ts",
+      "import": "./dist/lint-plugins.js"
+    },
+    "./lint/plugins-dev": {
+      "types": "./dist/lint-plugins-dev.d.ts",
+      "import": "./dist/lint-plugins-dev.js"
+    },
     "./oxlint-plugin": {
       "module-sync": "./dist/oxlint-plugin.js",
       "node": "./dist/oxlint-plugin.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -76,7 +76,7 @@
     },
     "./lint/plugins-dev": {
       "types": "./dist/lint-plugins-dev.d.ts",
-      "import": "./dist/lint-plugins-dev.js"
+      "default": "./dist/lint-plugins-dev.js"
     },
     "./oxlint-plugin": {
       "module-sync": "./dist/oxlint-plugin.js",

--- a/packages/cli/src/__tests__/exports-map.spec.ts
+++ b/packages/cli/src/__tests__/exports-map.spec.ts
@@ -147,6 +147,15 @@ describe('Oxlint JS-plugin authoring entrypoints', () => {
     );
   });
 
+  it('serves the authoring API to CommonJS too', () => {
+    // A `.cts` plugin, or a `.ts` one compiled with `module: commonjs`, emits
+    // its import as `require()`. `@oxlint/plugins` ships CJS, so the shim does
+    // too. `plugins-dev` deliberately does not: it is ESM-only upstream.
+    const plugins = requireFromHere('vite-plus/lint/plugins') as Record<string, unknown>;
+    expect(plugins.defineRule).toBeTypeOf('function');
+    expect(plugins.definePlugin).toBeTypeOf('function');
+  });
+
   it('exposes RuleTester from vite-plus/lint/plugins-dev', async () => {
     const ruleTester = await import('vite-plus/lint/plugins-dev');
     expect(ruleTester.RuleTester).toBeTypeOf('function');

--- a/packages/cli/src/__tests__/exports-map.spec.ts
+++ b/packages/cli/src/__tests__/exports-map.spec.ts
@@ -118,6 +118,42 @@ describe('package.json exports map', () => {
 });
 
 /**
+ * Migration rewrites Oxlint JS-plugin authoring imports to
+ * `vite-plus/lint/plugins` and `vite-plus/lint/plugins-dev`. See the
+ * `rewrite-oxlint-plugin-*` rules in `import_rewriter.rs` and
+ * `rewriteVitePlusImportSpecifier` in `oxlint-plugin.ts`.
+ *
+ * That rewrite exists so a user's plugin file reaches the API through
+ * `vite-plus` instead of pinning its own `@oxlint/plugins`. These entrypoints
+ * MUST therefore stay resolvable, and they MUST keep re-exporting the upstream
+ * surface. If either breaks, every migrated plugin fails when `vp lint` loads
+ * it.
+ */
+describe('Oxlint JS-plugin authoring entrypoints', () => {
+  it('re-exports the full @oxlint/plugins value surface', async () => {
+    const [lintPlugins, oxlintPlugins] = await Promise.all([
+      import('vite-plus/lint/plugins'),
+      import('@oxlint/plugins'),
+    ]);
+    const expected = namedValueExports(oxlintPlugins);
+    expect(expected.length, 'sanity: @oxlint/plugins should expose value exports').toBeGreaterThan(
+      0,
+    );
+    const missing = expected.filter(
+      (key) => !(key in lintPlugins) || (lintPlugins as Record<string, unknown>)[key] === undefined,
+    );
+    expect(missing, '@oxlint/plugins value exports missing from vite-plus/lint/plugins').toEqual(
+      [],
+    );
+  });
+
+  it('exposes RuleTester from vite-plus/lint/plugins-dev', async () => {
+    const ruleTester = await import('vite-plus/lint/plugins-dev');
+    expect(ruleTester.RuleTester).toBeTypeOf('function');
+  });
+});
+
+/**
  * Migration rewrites the `vitest/config` specifier to bare `vite-plus` (see the
  * Rust `import_rewriter.rs` rule and the `prefer-vite-plus-imports` oxlint rule
  * in `oxlint-plugin.ts`). After that rewrite a user's

--- a/packages/cli/src/__tests__/exports-map.spec.ts
+++ b/packages/cli/src/__tests__/exports-map.spec.ts
@@ -117,18 +117,7 @@ describe('package.json exports map', () => {
   });
 });
 
-/**
- * Migration rewrites Oxlint JS-plugin authoring imports to
- * `vite-plus/lint/plugins` and `vite-plus/lint/plugins-dev`. See the
- * `rewrite-oxlint-plugin-*` rules in `import_rewriter.rs` and
- * `rewriteVitePlusImportSpecifier` in `oxlint-plugin.ts`.
- *
- * That rewrite exists so a user's plugin file reaches the API through
- * `vite-plus` instead of pinning its own `@oxlint/plugins`. These entrypoints
- * MUST therefore stay resolvable, and they MUST keep re-exporting the upstream
- * surface. If either breaks, every migrated plugin fails when `vp lint` loads
- * it.
- */
+// Migrated plugins depend on these entry points resolving the upstream APIs.
 describe('Oxlint JS-plugin authoring entrypoints', () => {
   it('re-exports the full @oxlint/plugins value surface', async () => {
     const [lintPlugins, oxlintPlugins] = await Promise.all([

--- a/packages/cli/src/__tests__/exports-map.spec.ts
+++ b/packages/cli/src/__tests__/exports-map.spec.ts
@@ -150,7 +150,7 @@ describe('Oxlint JS-plugin authoring entrypoints', () => {
   it('serves the authoring API to CommonJS too', () => {
     // A `.cts` plugin, or a `.ts` one compiled with `module: commonjs`, emits
     // its import as `require()`. `@oxlint/plugins` ships CJS, so the shim does
-    // too. `plugins-dev` deliberately does not: it is ESM-only upstream.
+    // too. `plugins-dev` instead exposes its ESM entry to both module systems.
     const plugins = requireFromHere('vite-plus/lint/plugins') as Record<string, unknown>;
     expect(plugins.defineRule).toBeTypeOf('function');
     expect(plugins.definePlugin).toBeTypeOf('function');
@@ -159,6 +159,16 @@ describe('Oxlint JS-plugin authoring entrypoints', () => {
   it('exposes RuleTester from vite-plus/lint/plugins-dev', async () => {
     const ruleTester = await import('vite-plus/lint/plugins-dev');
     expect(ruleTester.RuleTester).toBeTypeOf('function');
+  });
+
+  it('serves the same RuleTester to CommonJS', async () => {
+    // Static imports in .cts files compile to require() after migration.
+    const ruleTester = requireFromHere('vite-plus/lint/plugins-dev') as Record<string, unknown>;
+    const upstream = requireFromHere('oxlint/plugins-dev') as Record<string, unknown>;
+    const esm = await import('vite-plus/lint/plugins-dev');
+    expect(ruleTester.RuleTester).toBeTypeOf('function');
+    expect(ruleTester.RuleTester).toBe(upstream.RuleTester);
+    expect(ruleTester.RuleTester).toBe(esm.RuleTester);
   });
 });
 

--- a/packages/cli/src/__tests__/fixtures/oxlint-optional-plugin-package/package.json
+++ b/packages/cli/src/__tests__/fixtures/oxlint-optional-plugin-package/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "oxlint-plugin-optional-example",
+  "version": "1.0.0",
+  "optionalDependencies": {
+    "@oxlint/plugins": "^1.79.0"
+  }
+}

--- a/packages/cli/src/__tests__/fixtures/oxlint-optional-tool-package/package.json
+++ b/packages/cli/src/__tests__/fixtures/oxlint-optional-tool-package/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "oxlint-optional-tool-example",
+  "optionalDependencies": {
+    "oxlint": "^1.79.0"
+  }
+}

--- a/packages/cli/src/__tests__/fixtures/oxlint-plugin-package/package.json
+++ b/packages/cli/src/__tests__/fixtures/oxlint-plugin-package/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "oxlint-plugin-example",
+  "private": true,
+  "peerDependencies": {
+    "@oxlint/plugins": "^1.0.0"
+  }
+}

--- a/packages/cli/src/__tests__/fixtures/oxlint-plugin-package/rule.ts
+++ b/packages/cli/src/__tests__/fixtures/oxlint-plugin-package/rule.ts
@@ -1,1 +1,0 @@
-// fixture: a published Oxlint plugin source file

--- a/packages/cli/src/__tests__/fixtures/oxlint-plugin-package/rule.ts
+++ b/packages/cli/src/__tests__/fixtures/oxlint-plugin-package/rule.ts
@@ -1,0 +1,1 @@
+// fixture: a published Oxlint plugin source file

--- a/packages/cli/src/__tests__/oxlint-plugin.spec.ts
+++ b/packages/cli/src/__tests__/oxlint-plugin.spec.ts
@@ -159,6 +159,9 @@ new RuleTester({
       code: `import tester = require('oxlint/plugins-dev')`,
       filename: 'plugin.cts',
     },
+    // `export *` names nothing, and a config-surface re-export is correct.
+    `export * from 'oxlint'`,
+    `export { defineConfig } from 'oxlint'`,
     // A published Oxlint plugin keeps resolving the API from its own peer.
     {
       code: `import { defineRule } from '@oxlint/plugins'`,
@@ -292,6 +295,12 @@ new RuleTester({
       code: `import { defineRule as rule } from "oxlint"`,
       errors: 1,
       output: `import { defineRule as rule } from "vite-plus/lint/plugins"`,
+    },
+    {
+      // A named re-export identifies the surface just as an import does.
+      code: `export { defineRule } from 'oxlint'`,
+      errors: 1,
+      output: `export { defineRule } from 'vite-plus/lint/plugins'`,
     },
     {
       code: `import { page } from '@vitest/browser/context'`,

--- a/packages/cli/src/__tests__/oxlint-plugin.spec.ts
+++ b/packages/cli/src/__tests__/oxlint-plugin.spec.ts
@@ -20,6 +20,13 @@ const nuxtUnitTestFilename = path.join(
   import.meta.dirname,
   'fixtures/nuxt-test-utils/unit.spec.ts',
 );
+// A package that declares `@oxlint/plugins` as a peer is a published Oxlint
+// plugin. Its consumers may run plain Oxlint, so the autofix must not move its
+// authoring imports to `vite-plus`.
+const oxlintPluginPackageFilename = path.join(
+  import.meta.dirname,
+  'fixtures/oxlint-plugin-package/rule.ts',
+);
 
 describe('oxlint plugin config defaults', () => {
   it('adds vite-plus js plugin and lint rule defaults', () => {
@@ -136,6 +143,36 @@ new RuleTester({
     `import 'oxlint'`,
     `import { defineRule } from 'vite-plus/lint/plugins'`,
     `import { RuleTester } from 'vite-plus/lint/plugins-dev'`,
+    // A statement that mixes the two surfaces stays put: the autofix replaces
+    // the whole specifier, and vite-plus/lint/plugins exports no defineConfig.
+    `import { defineConfig, defineRule } from 'oxlint'`,
+    // A published Oxlint plugin keeps resolving the API from its own peer.
+    {
+      code: `import { defineRule } from '@oxlint/plugins'`,
+      filename: oxlintPluginPackageFilename,
+    },
+    {
+      code: `import { defineRule } from 'oxlint'`,
+      filename: oxlintPluginPackageFilename,
+    },
+    {
+      code: `import { RuleTester } from 'oxlint/plugins-dev'`,
+      filename: oxlintPluginPackageFilename,
+    },
+    // `declare module` keeps the upstream module identity, so augmentations
+    // still merge with the upstream declarations.
+    {
+      code: `declare module '@oxlint/plugins' {}`,
+      filename: 'types.ts',
+    },
+    {
+      code: `declare module 'oxlint' {}`,
+      filename: 'types.ts',
+    },
+    {
+      code: `declare module 'oxlint/plugins-dev' {}`,
+      filename: 'types.ts',
+    },
     // `vitest/package.json` must NOT be autofixed — `vite-plus` has no
     // `./test/package.json` export, so a rewrite would break resolution.
     `import pkg from 'vitest/package.json'`,

--- a/packages/cli/src/__tests__/oxlint-plugin.spec.ts
+++ b/packages/cli/src/__tests__/oxlint-plugin.spec.ts
@@ -146,6 +146,19 @@ new RuleTester({
     // A statement that mixes the two surfaces stays put: the autofix replaces
     // the whole specifier, and vite-plus/lint/plugins exports no defineConfig.
     `import { defineConfig, defineRule } from 'oxlint'`,
+    // A default or namespace binding disqualifies the statement too:
+    // vite-plus/lint/plugins has no default export.
+    `import oxlint, { defineRule } from 'oxlint'`,
+    // `import x = require(...)` has require semantics, and the vite-plus lint
+    // subpaths are ESM-only.
+    {
+      code: `import plugins = require('@oxlint/plugins')`,
+      filename: 'plugin.cts',
+    },
+    {
+      code: `import tester = require('oxlint/plugins-dev')`,
+      filename: 'plugin.cts',
+    },
     // A published Oxlint plugin keeps resolving the API from its own peer.
     {
       code: `import { defineRule } from '@oxlint/plugins'`,

--- a/packages/cli/src/__tests__/oxlint-plugin.spec.ts
+++ b/packages/cli/src/__tests__/oxlint-plugin.spec.ts
@@ -102,6 +102,15 @@ describe('rewriteVitePlusImportSpecifier', () => {
     expect(rewriteVitePlusImportSpecifier('vitest/node')).toBe('vite-plus/test/node');
     expect(rewriteVitePlusImportSpecifier('tsx')).toBeNull();
   });
+
+  it('maps the Oxlint plugin authoring API to vite-plus', () => {
+    expect(rewriteVitePlusImportSpecifier('@oxlint/plugins')).toBe('vite-plus/lint/plugins');
+    expect(rewriteVitePlusImportSpecifier('oxlint/plugins-dev')).toBe('vite-plus/lint/plugins-dev');
+    // The bare `oxlint` specifier still serves the config surface. The
+    // specifier alone cannot decide it, so the rule checks each import
+    // statement.
+    expect(rewriteVitePlusImportSpecifier('oxlint')).toBeNull();
+  });
 });
 
 new RuleTester({
@@ -112,6 +121,21 @@ new RuleTester({
   valid: [
     `import { defineConfig } from 'vite-plus'`,
     `export { expect } from 'vite-plus/test'`,
+    // Oxlint's config surface still lives in the `oxlint` package. Only the
+    // plugin authoring API moved. A redirect would break these imports.
+    `import { defineConfig } from 'oxlint'`,
+    {
+      code: `import type { OxlintConfig, OxlintOverride } from 'oxlint'`,
+      filename: 'types.ts',
+    },
+    // These name no binding, so nothing tells the config surface from the
+    // plugin API. The rule leaves them alone instead of risking a wrong
+    // autofix.
+    `import oxlint from 'oxlint'`,
+    `import * as oxlint from 'oxlint'`,
+    `import 'oxlint'`,
+    `import { defineRule } from 'vite-plus/lint/plugins'`,
+    `import { RuleTester } from 'vite-plus/lint/plugins-dev'`,
     // `vitest/package.json` must NOT be autofixed — `vite-plus` has no
     // `./test/package.json` export, so a rewrite would break resolution.
     `import pkg from 'vitest/package.json'`,
@@ -191,6 +215,34 @@ new RuleTester({
     },
   ],
   invalid: [
+    {
+      code: `import { definePlugin, defineRule } from '@oxlint/plugins'`,
+      errors: 1,
+      output: `import { definePlugin, defineRule } from 'vite-plus/lint/plugins'`,
+    },
+    {
+      code: `import { RuleTester } from "oxlint/plugins-dev"`,
+      errors: 1,
+      output: `import { RuleTester } from "vite-plus/lint/plugins-dev"`,
+    },
+    {
+      // The pre-`@oxlint/plugins` authoring API. `oxlint` no longer exports
+      // it, and the migration strips the dependency it came from.
+      code: `import { defineRule } from 'oxlint'`,
+      errors: 1,
+      output: `import { defineRule } from 'vite-plus/lint/plugins'`,
+    },
+    {
+      code: `import type { Context, ESTree } from 'oxlint'`,
+      errors: 1,
+      filename: 'types.ts',
+      output: `import type { Context, ESTree } from 'vite-plus/lint/plugins'`,
+    },
+    {
+      code: `import { defineRule as rule } from "oxlint"`,
+      errors: 1,
+      output: `import { defineRule as rule } from "vite-plus/lint/plugins"`,
+    },
     {
       code: `import { page } from '@vitest/browser/context'`,
       errors: 1,

--- a/packages/cli/src/__tests__/oxlint-plugin.spec.ts
+++ b/packages/cli/src/__tests__/oxlint-plugin.spec.ts
@@ -27,6 +27,14 @@ const oxlintPluginPackageFilename = path.join(
   import.meta.dirname,
   'fixtures/oxlint-plugin-package/rule.ts',
 );
+const oxlintOptionalPluginPackageFilename = path.join(
+  import.meta.dirname,
+  'fixtures/oxlint-optional-plugin-package/rule.ts',
+);
+const oxlintOptionalToolPackageFilename = path.join(
+  import.meta.dirname,
+  'fixtures/oxlint-optional-tool-package/rule.ts',
+);
 
 describe('oxlint plugin config defaults', () => {
   it('adds vite-plus js plugin and lint rule defaults', () => {
@@ -180,6 +188,14 @@ new RuleTester({
       code: `import { RuleTester } from 'oxlint/plugins-dev'`,
       filename: oxlintPluginPackageFilename,
     },
+    // An optional runtime API is also part of a published plugin's contract.
+    ...[
+      `import { defineRule } from '@oxlint/plugins'`,
+      `export { definePlugin } from '@oxlint/plugins'`,
+      `const plugins = await import('@oxlint/plugins')`,
+      `import { defineRule } from 'oxlint'`,
+      `import { RuleTester } from 'oxlint/plugins-dev'`,
+    ].map((code) => ({ code, filename: oxlintOptionalPluginPackageFilename })),
     // `declare module` keeps the upstream module identity, so augmentations
     // still merge with the upstream declarations.
     {
@@ -273,6 +289,13 @@ new RuleTester({
     },
   ],
   invalid: [
+    {
+      // Optional oxlint retains the existing tool-migration policy.
+      code: `import { defineRule } from 'oxlint'`,
+      filename: oxlintOptionalToolPackageFilename,
+      errors: 1,
+      output: `import { defineRule } from 'vite-plus/lint/plugins'`,
+    },
     {
       code: `import { definePlugin, defineRule } from '@oxlint/plugins'`,
       errors: 1,

--- a/packages/cli/src/__tests__/oxlint-plugin.spec.ts
+++ b/packages/cli/src/__tests__/oxlint-plugin.spec.ts
@@ -207,6 +207,11 @@ new RuleTester({
     `import { defineConfig } from 'oxlint'`,
     `import { "defineConfig" as cfg } from 'oxlint'`,
     `export { 'defineConfig' as cfg } from 'oxlint'`,
+    `export { 'defineRule' as rule, 'defineConfig' as cfg } from 'oxlint'`,
+    {
+      code: `export type { 'OxlintConfig' as Config } from 'oxlint'`,
+      filename: 'types.ts',
+    },
     {
       code: `import type { 'OxlintConfig' as Config } from 'oxlint'`,
       filename: 'types.ts',
@@ -243,6 +248,10 @@ new RuleTester({
     `export { defineConfig } from 'oxlint'`,
     // A published Oxlint plugin keeps resolving the API from its own peer.
     {
+      code: `export { 'defineRule' as rule } from 'oxlint'`,
+      filename: oxlintPluginPackageFilename,
+    },
+    {
       code: `import { defineRule } from '@oxlint/plugins'`,
       filename: oxlintPluginPackageFilename,
     },
@@ -260,6 +269,7 @@ new RuleTester({
       `export { definePlugin } from '@oxlint/plugins'`,
       `const plugins = await import('@oxlint/plugins')`,
       `import { defineRule } from 'oxlint'`,
+      `export { 'defineRule' as rule } from 'oxlint'`,
       `import { RuleTester } from 'oxlint/plugins-dev'`,
     ].map((code) => ({ code, filename: oxlintOptionalPluginPackageFilename })),
     // `declare module` keeps the upstream module identity, so augmentations
@@ -395,6 +405,22 @@ new RuleTester({
       code: `export { defineRule } from 'oxlint'`,
       errors: 1,
       output: `export { defineRule } from 'vite-plus/lint/plugins'`,
+    },
+    {
+      code: `export { 'defineRule' as rule } from 'oxlint'`,
+      errors: 1,
+      output: `export { 'defineRule' as rule } from 'vite-plus/lint/plugins'`,
+    },
+    {
+      code: `export { "definePlugin" as plugin, defineRule as rule } from "oxlint"`,
+      errors: 1,
+      output: `export { "definePlugin" as plugin, defineRule as rule } from "vite-plus/lint/plugins"`,
+    },
+    {
+      code: `export type { 'Context' as RuleContext } from 'oxlint'`,
+      errors: 1,
+      filename: 'types.ts',
+      output: `export type { 'Context' as RuleContext } from 'vite-plus/lint/plugins'`,
     },
     {
       code: `import { page } from '@vitest/browser/context'`,

--- a/packages/cli/src/__tests__/oxlint-plugin.spec.ts
+++ b/packages/cli/src/__tests__/oxlint-plugin.spec.ts
@@ -131,6 +131,12 @@ new RuleTester({
     // Oxlint's config surface still lives in the `oxlint` package. Only the
     // plugin authoring API moved. A redirect would break these imports.
     `import { defineConfig } from 'oxlint'`,
+    `import { "defineConfig" as cfg } from 'oxlint'`,
+    `export { 'defineConfig' as cfg } from 'oxlint'`,
+    {
+      code: `import type { 'OxlintConfig' as Config } from 'oxlint'`,
+      filename: 'types.ts',
+    },
     {
       code: `import type { OxlintConfig, OxlintOverride } from 'oxlint'`,
       filename: 'types.ts',
@@ -149,8 +155,7 @@ new RuleTester({
     // A default or namespace binding disqualifies the statement too:
     // vite-plus/lint/plugins has no default export.
     `import oxlint, { defineRule } from 'oxlint'`,
-    // `import x = require(...)` has require semantics, and the vite-plus lint
-    // subpaths are ESM-only.
+    // Import-equals declarations stay unchanged, matching the migrator.
     {
       code: `import plugins = require('@oxlint/plugins')`,
       filename: 'plugin.cts',

--- a/packages/cli/src/__tests__/oxlint-plugin.spec.ts
+++ b/packages/cli/src/__tests__/oxlint-plugin.spec.ts
@@ -1,7 +1,9 @@
+import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 
 import { RuleTester } from 'oxlint/plugins-dev';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
   createDefaultVitePlusLintConfig,
@@ -125,6 +127,70 @@ describe('rewriteVitePlusImportSpecifier', () => {
     // specifier alone cannot decide it, so the rule checks each import
     // statement.
     expect(rewriteVitePlusImportSpecifier('oxlint')).toBeNull();
+  });
+});
+
+function checkImports(filename: string, preservedSpecifiers: readonly string[]): void {
+  const tests: RuleTester.TestCases = { valid: [], invalid: [] };
+  for (const [specifier, binding, replacement] of [
+    ['vitest', 'expect', 'vite-plus/test'],
+    ['@oxlint/plugins', 'defineRule', 'vite-plus/lint/plugins'],
+  ]) {
+    const code = `import { ${binding} } from '${specifier}'`;
+    if (preservedSpecifiers.includes(specifier)) {
+      tests.valid.push({ filename, code });
+    } else {
+      tests.invalid.push({
+        filename,
+        code,
+        output: `import { ${binding} } from '${replacement}'`,
+        errors: [{ messageId: 'preferVitePlusImports' }],
+      });
+    }
+  }
+  new RuleTester().run(PREFER_VITE_PLUS_IMPORTS_RULE_NAME, preferVitePlusImportsRule, tests);
+}
+
+describe('package import exceptions', () => {
+  let projectPath: string;
+
+  beforeEach(() => {
+    projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'vp-lint-package-exceptions-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectPath, { recursive: true, force: true });
+  });
+
+  it('refreshes independent exceptions when the manifest changes', () => {
+    const packageJsonPath = path.join(projectPath, 'package.json');
+    const states = [
+      { pkg: { devDependencies: { '@nuxt/test-utils': '*' } }, preserved: ['vitest'] },
+      { pkg: { peerDependencies: { '@oxlint/plugins': '*' } }, preserved: ['@oxlint/plugins'] },
+      { pkg: { optionalDependencies: { '@oxlint/plugins': '*' } }, preserved: ['@oxlint/plugins'] },
+      { pkg: { devDependencies: { '@oxlint/plugins': '*' } }, preserved: [] },
+    ];
+    for (const [index, { pkg, preserved }] of states.entries()) {
+      fs.writeFileSync(packageJsonPath, JSON.stringify(pkg));
+      // Explicit timestamps avoid filesystem precision affecting invalidation.
+      fs.utimesSync(packageJsonPath, 100 + index, 100 + index);
+      checkImports(path.join(projectPath, 'rule.ts'), preserved);
+      checkImports(path.join(projectPath, 'other.ts'), preserved);
+    }
+  });
+
+  it('does not inherit exceptions across nested package boundaries', () => {
+    fs.writeFileSync(
+      path.join(projectPath, 'package.json'),
+      JSON.stringify({ dependencies: { '@nuxt/test-utils': '*', '@oxlint/plugins': '*' } }),
+    );
+    const nestedPath = path.join(projectPath, 'nested');
+    fs.mkdirSync(nestedPath);
+    fs.writeFileSync(path.join(nestedPath, 'package.json'), '{}');
+
+    checkImports(path.join(projectPath, 'rule.ts'), ['vitest', '@oxlint/plugins']);
+    checkImports(path.join(nestedPath, 'rule.ts'), []);
+    checkImports(path.join(projectPath, 'other.ts'), ['vitest', '@oxlint/plugins']);
   });
 });
 

--- a/packages/cli/src/lint-plugins-dev.ts
+++ b/packages/cli/src/lint-plugins-dev.ts
@@ -1,0 +1,15 @@
+// Oxlint's dev-time plugin utilities (`RuleTester`), re-exported from the copy
+// of Oxlint that ships with Vite+. Companion to `vite-plus/lint/plugins`: rule
+// *tests* break the same way plugin *sources* do, just at a different specifier
+// (these utilities live in `oxlint/plugins-dev`, not `@oxlint/plugins`).
+//
+// The subpath mirrors upstream's rather than naming today's single export, so
+// the mapping stays a mechanical `oxlint/plugins-dev` ->
+// `vite-plus/lint/plugins-dev`, and whatever upstream adds to that entry later
+// still arrives under a name that fits.
+//
+// Kept out of `vite-plus/lint/plugins` on purpose: these are test-only, and
+// importing the authoring API should not pull them in.
+
+export { RuleTester } from 'oxlint/plugins-dev';
+export type * from 'oxlint/plugins-dev';

--- a/packages/cli/src/lint-plugins-dev.ts
+++ b/packages/cli/src/lint-plugins-dev.ts
@@ -1,15 +1,5 @@
-// Oxlint's dev-time plugin utilities (`RuleTester`), re-exported from the copy
-// of Oxlint that ships with Vite+. Companion to `vite-plus/lint/plugins`: rule
-// *tests* break the same way plugin *sources* do, just at a different specifier
-// (these utilities live in `oxlint/plugins-dev`, not `@oxlint/plugins`).
-//
-// The subpath mirrors upstream's rather than naming today's single export, so
-// the mapping stays a mechanical `oxlint/plugins-dev` ->
-// `vite-plus/lint/plugins-dev`, and whatever upstream adds to that entry later
-// still arrives under a name that fits.
-//
-// Kept out of `vite-plus/lint/plugins` on purpose: these are test-only, and
-// importing the authoring API should not pull them in.
+// Keep test utilities separate so plugin imports do not load them at runtime.
+// The subpath mirrors oxlint/plugins-dev and uses the bundled Oxlint version.
 
 export { RuleTester } from 'oxlint/plugins-dev';
 export type * from 'oxlint/plugins-dev';

--- a/packages/cli/src/lint-plugins.ts
+++ b/packages/cli/src/lint-plugins.ts
@@ -1,0 +1,22 @@
+// The Oxlint JS-plugin authoring API, re-exported from the copy of
+// `@oxlint/plugins` that ships with Vite+.
+//
+// Oxlint used to expose `defineRule` and `definePlugin` from its main entry.
+// They now live in `@oxlint/plugins`. The plugin API is versioned against the
+// linter that loads the plugin, and `vp lint` runs the bundled Oxlint. So a
+// project that declares its own `@oxlint/plugins` must keep that pin in step
+// with whatever Vite+ bundles.
+//
+// An import from here removes that pin. The API is always the one the bundled
+// linter understands. It also resolves from any package that already has
+// `vite-plus` installed. A direct `@oxlint/plugins` import does not:
+// `@oxlint/plugins` is a transitive dependency, which pnpm's strict layout
+// hides from a user's plugin file.
+//
+// `vp migrate` rewrites legacy `oxlint` and `@oxlint/plugins` authoring imports
+// to this specifier. The `vite-plus/prefer-vite-plus-imports` lint rule
+// enforces it. See `crates/vp_migration/src/import_rewriter.rs` and
+// `packages/cli/src/oxlint-plugin.ts`. The two mappings must stay in sync.
+
+export { definePlugin, defineRule, eslintCompatPlugin } from '@oxlint/plugins';
+export type * from '@oxlint/plugins';

--- a/packages/cli/src/lint-plugins.ts
+++ b/packages/cli/src/lint-plugins.ts
@@ -1,22 +1,6 @@
-// The Oxlint JS-plugin authoring API, re-exported from the copy of
-// `@oxlint/plugins` that ships with Vite+.
-//
-// Oxlint used to expose `defineRule` and `definePlugin` from its main entry.
-// They now live in `@oxlint/plugins`. The plugin API is versioned against the
-// linter that loads the plugin, and `vp lint` runs the bundled Oxlint. So a
-// project that declares its own `@oxlint/plugins` must keep that pin in step
-// with whatever Vite+ bundles.
-//
-// An import from here removes that pin. The API is always the one the bundled
-// linter understands. It also resolves from any package that already has
-// `vite-plus` installed. A direct `@oxlint/plugins` import does not:
-// `@oxlint/plugins` is a transitive dependency, which pnpm's strict layout
-// hides from a user's plugin file.
-//
-// `vp migrate` rewrites legacy `oxlint` and `@oxlint/plugins` authoring imports
-// to this specifier. The `vite-plus/prefer-vite-plus-imports` lint rule
-// enforces it. See `crates/vp_migration/src/import_rewriter.rs` and
-// `packages/cli/src/oxlint-plugin.ts`. The two mappings must stay in sync.
+// Use the plugin API that matches the bundled linter. This entry also makes
+// the API accessible through a direct vite-plus dependency under strict pnpm.
+// The migrator and prefer-vite-plus-imports rule both target this entry.
 
 export { definePlugin, defineRule, eslintCompatPlugin } from '@oxlint/plugins';
 export type * from '@oxlint/plugins';

--- a/packages/cli/src/migration/__tests__/oxlint-plugin-dependency.spec.ts
+++ b/packages/cli/src/migration/__tests__/oxlint-plugin-dependency.spec.ts
@@ -4,7 +4,15 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { dropDeadOxlintPluginsDependency } from '../migrator.ts';
+import { PackageManager } from '../../types/index.ts';
+import {
+  collectOxlintOwnerDirs,
+  dropDeadOxlintPluginsDependency,
+  packageOwnsOxlintApi,
+  rewritePackageJson,
+  sourceTreeReferencesOxlintPluginsPackage,
+  usesVitestBrowserMode,
+} from '../migrator.ts';
 
 describe('Oxlint plugin dependency cleanup', () => {
   let projectPath: string;
@@ -72,7 +80,6 @@ describe('Oxlint plugin dependency cleanup', () => {
       JSON.stringify({
         imports,
         devDependencies: { '@oxlint/plugins': '^1.79.0', 'vite-plus': 'latest' },
-        optionalDependencies: { '@oxlint/plugins': '^1.79.0' },
       }),
     );
     fs.writeFileSync(
@@ -85,7 +92,90 @@ describe('Oxlint plugin dependency cleanup', () => {
     expect(JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))).toEqual({
       imports,
       devDependencies: { 'vite-plus': 'latest' },
-      optionalDependencies: {},
     });
+  });
+
+  it.each(['dist', 'build', 'out', '.cache'])(
+    'retains dependencies used by an ignored %s plugin',
+    (directory) => {
+      const pkg = { devDependencies: { '@oxlint/plugins': '^1.79.0' } };
+      const packageJsonPath = path.join(projectPath, 'package.json');
+      fs.writeFileSync(packageJsonPath, JSON.stringify(pkg));
+      fs.writeFileSync(path.join(projectPath, '.gitignore'), `${directory}/\n`);
+      fs.mkdirSync(path.join(projectPath, directory));
+      fs.writeFileSync(
+        path.join(projectPath, directory, 'plugin.cjs'),
+        `const { defineRule } = require('@oxlint/plugins');`,
+      );
+      fs.writeFileSync(
+        path.join(projectPath, directory, 'test.js'),
+        `import { chromium } from '@vitest/browser-playwright';`,
+      );
+
+      expect(sourceTreeReferencesOxlintPluginsPackage(projectPath)).toBe(true);
+      expect(usesVitestBrowserMode(projectPath)).toBe(false);
+      dropDeadOxlintPluginsDependency(projectPath);
+
+      expect(JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))).toEqual(pkg);
+    },
+  );
+
+  it.each(['node_modules', '.git'])(
+    'does not retain a dependency referenced only in %s',
+    (directory) => {
+      const packageJsonPath = path.join(projectPath, 'package.json');
+      fs.writeFileSync(
+        packageJsonPath,
+        JSON.stringify({ devDependencies: { '@oxlint/plugins': '^1.79.0' } }),
+      );
+      fs.mkdirSync(path.join(projectPath, directory));
+      fs.writeFileSync(
+        path.join(projectPath, directory, 'plugin.cjs'),
+        `require('@oxlint/plugins');`,
+      );
+
+      dropDeadOxlintPluginsDependency(projectPath);
+
+      expect(JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')).devDependencies).toEqual({});
+    },
+  );
+
+  it('preserves an optional runtime API without introducing a development-only replacement', () => {
+    const pkg = {
+      name: 'oxlint-plugin-optional-example',
+      optionalDependencies: { '@oxlint/plugins': '^1.79.0' },
+      devDependencies: {},
+    };
+    const packageJsonPath = path.join(projectPath, 'package.json');
+    fs.writeFileSync(packageJsonPath, JSON.stringify(pkg));
+
+    expect(collectOxlintOwnerDirs(projectPath)).toEqual([projectPath]);
+    rewritePackageJson(pkg, PackageManager.pnpm);
+    expect(pkg.optionalDependencies).toEqual({ '@oxlint/plugins': '^1.79.0' });
+    expect(pkg.devDependencies).not.toHaveProperty('vite-plus');
+    fs.writeFileSync(packageJsonPath, JSON.stringify(pkg));
+    dropDeadOxlintPluginsDependency(projectPath);
+
+    expect(JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))).toEqual(pkg);
+  });
+
+  it('retains a development copy alongside an optional runtime API', () => {
+    const pkg = {
+      optionalDependencies: { '@oxlint/plugins': '^1.79.0' },
+      devDependencies: { '@oxlint/plugins': '^1.79.0' },
+    };
+    const packageJsonPath = path.join(projectPath, 'package.json');
+    fs.writeFileSync(packageJsonPath, JSON.stringify(pkg));
+
+    dropDeadOxlintPluginsDependency(projectPath);
+
+    expect(JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))).toEqual(pkg);
+  });
+
+  it('keeps optional oxlint on the existing tool-migration path', () => {
+    const pkg = { optionalDependencies: { oxlint: '^1.79.0' } };
+    expect(packageOwnsOxlintApi(pkg)).toBe(false);
+    rewritePackageJson(pkg, PackageManager.pnpm);
+    expect(pkg.optionalDependencies).toEqual({});
   });
 });

--- a/packages/cli/src/migration/__tests__/oxlint-plugin-dependency.spec.ts
+++ b/packages/cli/src/migration/__tests__/oxlint-plugin-dependency.spec.ts
@@ -1,0 +1,91 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { dropDeadOxlintPluginsDependency } from '../migrator.ts';
+
+describe('Oxlint plugin dependency cleanup', () => {
+  let projectPath: string;
+
+  beforeEach(() => {
+    projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'vp-oxlint-plugin-dependency-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectPath, { recursive: true, force: true });
+  });
+
+  it.each(['devDependencies', 'optionalDependencies'] as const)(
+    'retains an import alias target in %s',
+    (field) => {
+      const pkg = {
+        imports: { '#plugin-api': '@oxlint/plugins' },
+        [field]: { '@oxlint/plugins': '^1.79.0' },
+      };
+      const packageJsonPath = path.join(projectPath, 'package.json');
+      fs.writeFileSync(packageJsonPath, JSON.stringify(pkg));
+      fs.writeFileSync(
+        path.join(projectPath, 'plugin.js'),
+        `import { defineRule } from '#plugin-api';`,
+      );
+
+      dropDeadOxlintPluginsDependency(projectPath);
+
+      expect(JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))).toEqual(pkg);
+    },
+  );
+
+  it('retains conditional aliases in nested non-workspace packages', () => {
+    const pkg = { devDependencies: { '@oxlint/plugins': '^1.79.0' } };
+    const packageJsonPath = path.join(projectPath, 'package.json');
+    fs.writeFileSync(packageJsonPath, JSON.stringify(pkg));
+    const examplePath = path.join(projectPath, 'example');
+    fs.mkdirSync(examplePath);
+    fs.writeFileSync(
+      path.join(examplePath, 'package.json'),
+      JSON.stringify({
+        imports: {
+          '#plugin-api': {
+            node: { import: '@oxlint/plugins', require: '@oxlint/plugins' },
+            default: './fallback.js',
+          },
+        },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(examplePath, 'plugin.js'),
+      `import { defineRule } from '#plugin-api';`,
+    );
+
+    dropDeadOxlintPluginsDependency(projectPath);
+
+    expect(JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))).toEqual(pkg);
+  });
+
+  it('removes unused dependencies when aliases already target vite-plus', () => {
+    const packageJsonPath = path.join(projectPath, 'package.json');
+    const imports = { '#plugin-api': 'vite-plus/lint/plugins' };
+    fs.writeFileSync(
+      packageJsonPath,
+      JSON.stringify({
+        imports,
+        devDependencies: { '@oxlint/plugins': '^1.79.0', 'vite-plus': 'latest' },
+        optionalDependencies: { '@oxlint/plugins': '^1.79.0' },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(projectPath, 'plugin.js'),
+      `import { defineRule } from '#plugin-api';`,
+    );
+
+    dropDeadOxlintPluginsDependency(projectPath);
+
+    expect(JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))).toEqual({
+      imports,
+      devDependencies: { 'vite-plus': 'latest' },
+      optionalDependencies: {},
+    });
+  });
+});

--- a/packages/cli/src/migration/__tests__/oxlint-plugin-dependency.spec.ts
+++ b/packages/cli/src/migration/__tests__/oxlint-plugin-dependency.spec.ts
@@ -25,6 +25,61 @@ describe('Oxlint plugin dependency cleanup', () => {
     fs.rmSync(projectPath, { recursive: true, force: true });
   });
 
+  it.each([`node -e "require('@oxlint/plugins')"`, `node -e "import('@oxlint/plugins')"`])(
+    'retains a dependency used by the inline script %s',
+    (script) => {
+      const pkg = {
+        scripts: { 'check-plugin': script },
+        devDependencies: { '@oxlint/plugins': '^1.79.0' },
+      };
+      rewritePackageJson(pkg, PackageManager.pnpm);
+      const packageJsonPath = path.join(projectPath, 'package.json');
+      fs.writeFileSync(packageJsonPath, JSON.stringify(pkg));
+
+      expect(pkg.scripts['check-plugin']).toBe(script);
+      expect(sourceTreeReferencesOxlintPluginsPackage(projectPath)).toBe(true);
+      dropDeadOxlintPluginsDependency(projectPath);
+
+      expect(JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))).toEqual(pkg);
+    },
+  );
+
+  it('retains a dependency used by a nested non-workspace package script', () => {
+    const pkg = { devDependencies: { '@oxlint/plugins': '^1.79.0' } };
+    const packageJsonPath = path.join(projectPath, 'package.json');
+    fs.writeFileSync(packageJsonPath, JSON.stringify(pkg));
+    const examplePath = path.join(projectPath, 'example');
+    fs.mkdirSync(examplePath);
+    fs.writeFileSync(
+      path.join(examplePath, 'package.json'),
+      JSON.stringify({ scripts: { 'check-plugin': `node -e "require('@oxlint/plugins')"` } }),
+    );
+
+    dropDeadOxlintPluginsDependency(projectPath);
+
+    expect(JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))).toEqual(pkg);
+  });
+
+  it('ignores dependency declarations and descriptive metadata when scripts use vite-plus', () => {
+    const packageJsonPath = path.join(projectPath, 'package.json');
+    const metadata = {
+      description: 'Previously used @oxlint/plugins',
+      scripts: { 'check-plugin': `node -e "require('vite-plus/lint/plugins')"` },
+    };
+    fs.writeFileSync(
+      packageJsonPath,
+      JSON.stringify({ ...metadata, devDependencies: { '@oxlint/plugins': '^1.79.0' } }),
+    );
+
+    expect(sourceTreeReferencesOxlintPluginsPackage(projectPath)).toBe(false);
+    dropDeadOxlintPluginsDependency(projectPath);
+
+    expect(JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))).toEqual({
+      ...metadata,
+      devDependencies: {},
+    });
+  });
+
   it.each(['devDependencies', 'optionalDependencies'] as const)(
     'retains an import alias target in %s',
     (field) => {

--- a/packages/cli/src/migration/migrator/orchestrators.ts
+++ b/packages/cli/src/migration/migrator/orchestrators.ts
@@ -10,7 +10,7 @@ import {
   cleanupDeprecatedTsconfigOptions,
   collectInjectedProviderNames,
   collectOxlintOwnerDirs,
-  sourceTreeRequiresOxlintPluginApi,
+  dropDeadOxlintPluginsDependency,
   collectProviderSourceModes,
   collectVitestEcosystemInstallDependencyNames,
   createCatalogDependencyResolver,
@@ -81,7 +81,6 @@ export function rewriteStandaloneProject(
   // Captured before `rewritePackageJson` strips `oxlint`; the import rewriter
   // reads the manifests afterwards and would no longer see the signal.
   const oxlintOwnerDirs = collectOxlintOwnerDirs(projectPath, workspaceInfo.packages);
-  const requiresOxlintPluginApiCjs = sourceTreeRequiresOxlintPluginApi(projectPath);
   // Source-tree scan signals are computed once here and reused below (and inside
   // projectUsesVitestDirectly / collectInjectedProviderNames) so the source tree
   // is traversed once each instead of repeatedly. They do not depend on
@@ -255,7 +254,6 @@ export function rewriteStandaloneProject(
       retainedVitestModule,
       requiredVitestPeer,
       providerCatalogAdditions,
-      requiresOxlintPluginApiCjs,
     );
 
     // ensure vite-plus is in devDependencies — but only when it isn't already a
@@ -341,6 +339,7 @@ export function rewriteStandaloneProject(
   mergeTsdownConfigFile(projectPath, silent, report);
   // rewrite imports in all TypeScript/JavaScript files before lazy plugin import merging
   rewriteAllImports(projectPath, silent, report, true, oxlintOwnerDirs);
+  dropDeadOxlintPluginsDependency(projectPath, workspaceInfo.packages);
   wrapLazyPluginsInViteConfig(projectPath, silent, report);
   // set package manager
   setPackageManager(projectPath, workspaceInfo.downloadPackageManager);
@@ -474,6 +473,7 @@ export function rewriteMonorepo(
   mergeTsdownConfigFile(workspaceInfo.rootDir, silent, report);
   // rewrite imports in all TypeScript/JavaScript files before lazy plugin import merging
   rewriteAllImports(workspaceInfo.rootDir, silent, report, true, oxlintOwnerDirs);
+  dropDeadOxlintPluginsDependency(workspaceInfo.rootDir, workspaceInfo.packages);
   wrapLazyPluginsInViteConfig(workspaceInfo.rootDir, silent, report);
   for (const pkg of workspaceInfo.packages) {
     wrapLazyPluginsInViteConfig(path.join(workspaceInfo.rootDir, pkg.path), silent, report);
@@ -567,7 +567,6 @@ export function rewriteMonorepoProject(
       retainedVitestModule,
       requiredVitestPeer,
       providerCatalogAdditions,
-      sourceTreeRequiresOxlintPluginApi(projectPath),
     );
     // If this SUB-workspace now depends on `vite-plus` and Yarn isolates its
     // hoisting (via the root `nmHoistingLimits` OR the workspace's own

--- a/packages/cli/src/migration/migrator/orchestrators.ts
+++ b/packages/cli/src/migration/migrator/orchestrators.ts
@@ -10,6 +10,7 @@ import {
   cleanupDeprecatedTsconfigOptions,
   collectInjectedProviderNames,
   collectOxlintOwnerDirs,
+  sourceTreeRequiresOxlintPluginApi,
   collectProviderSourceModes,
   collectVitestEcosystemInstallDependencyNames,
   createCatalogDependencyResolver,
@@ -80,6 +81,7 @@ export function rewriteStandaloneProject(
   // Captured before `rewritePackageJson` strips `oxlint`; the import rewriter
   // reads the manifests afterwards and would no longer see the signal.
   const oxlintOwnerDirs = collectOxlintOwnerDirs(projectPath, workspaceInfo.packages);
+  const requiresOxlintPluginApiCjs = sourceTreeRequiresOxlintPluginApi(projectPath);
   // Source-tree scan signals are computed once here and reused below (and inside
   // projectUsesVitestDirectly / collectInjectedProviderNames) so the source tree
   // is traversed once each instead of repeatedly. They do not depend on
@@ -253,6 +255,7 @@ export function rewriteStandaloneProject(
       retainedVitestModule,
       requiredVitestPeer,
       providerCatalogAdditions,
+      requiresOxlintPluginApiCjs,
     );
 
     // ensure vite-plus is in devDependencies — but only when it isn't already a
@@ -564,6 +567,7 @@ export function rewriteMonorepoProject(
       retainedVitestModule,
       requiredVitestPeer,
       providerCatalogAdditions,
+      sourceTreeRequiresOxlintPluginApi(projectPath),
     );
     // If this SUB-workspace now depends on `vite-plus` and Yarn isolates its
     // hoisting (via the root `nmHoistingLimits` OR the workspace's own

--- a/packages/cli/src/migration/migrator/orchestrators.ts
+++ b/packages/cli/src/migration/migrator/orchestrators.ts
@@ -9,6 +9,7 @@ import {
   applyYarnWorkspaceHoistingFix,
   cleanupDeprecatedTsconfigOptions,
   collectInjectedProviderNames,
+  collectOxlintOwnerDirs,
   collectProviderSourceModes,
   collectVitestEcosystemInstallDependencyNames,
   createCatalogDependencyResolver,
@@ -76,6 +77,9 @@ export function rewriteStandaloneProject(
   const packageManager = workspaceInfo.packageManager;
   const catalogDependencyResolver = createCatalogDependencyResolver(projectPath, packageManager);
   const vitestEcosystemPackages = collectVitestEcosystemInstallDependencyNames(projectPath);
+  // Captured before `rewritePackageJson` strips `oxlint`; the import rewriter
+  // reads the manifests afterwards and would no longer see the signal.
+  const oxlintOwnerDirs = collectOxlintOwnerDirs(projectPath, workspaceInfo.packages);
   // Source-tree scan signals are computed once here and reused below (and inside
   // projectUsesVitestDirectly / collectInjectedProviderNames) so the source tree
   // is traversed once each instead of repeatedly. They do not depend on
@@ -333,7 +337,7 @@ export function rewriteStandaloneProject(
   injectFmtDefaults(projectPath, silent, report);
   mergeTsdownConfigFile(projectPath, silent, report);
   // rewrite imports in all TypeScript/JavaScript files before lazy plugin import merging
-  rewriteAllImports(projectPath, silent, report, true);
+  rewriteAllImports(projectPath, silent, report, true, oxlintOwnerDirs);
   wrapLazyPluginsInViteConfig(projectPath, silent, report);
   // set package manager
   setPackageManager(projectPath, workspaceInfo.downloadPackageManager);
@@ -353,6 +357,9 @@ export function rewriteMonorepo(
     workspaceInfo.rootDir,
     workspaceInfo.packageManager,
   );
+  // Captured before `rewritePackageJson` strips `oxlint`; the import rewriter
+  // reads the manifests afterwards and would no longer see the signal.
+  const oxlintOwnerDirs = collectOxlintOwnerDirs(workspaceInfo.rootDir, workspaceInfo.packages);
   const pnpmMajorVersion = pnpmMajor(workspaceInfo.downloadPackageManager.version);
   const usePnpmWorkspaceSettings = pnpmSupportsWorkspaceSettings(
     workspaceInfo.downloadPackageManager.version,
@@ -463,7 +470,7 @@ export function rewriteMonorepo(
   injectFmtDefaults(workspaceInfo.rootDir, silent, report);
   mergeTsdownConfigFile(workspaceInfo.rootDir, silent, report);
   // rewrite imports in all TypeScript/JavaScript files before lazy plugin import merging
-  rewriteAllImports(workspaceInfo.rootDir, silent, report, true);
+  rewriteAllImports(workspaceInfo.rootDir, silent, report, true, oxlintOwnerDirs);
   wrapLazyPluginsInViteConfig(workspaceInfo.rootDir, silent, report);
   for (const pkg of workspaceInfo.packages) {
     wrapLazyPluginsInViteConfig(path.join(workspaceInfo.rootDir, pkg.path), silent, report);

--- a/packages/cli/src/migration/migrator/package-json.ts
+++ b/packages/cli/src/migration/migrator/package-json.ts
@@ -27,6 +27,7 @@ import {
   findDeclaredSpec,
   resolveProviderPeerSpec,
   OPT_IN_BROWSER_PROVIDERS,
+  OXLINT_PLUGINS_PACKAGE,
   OXLINT_PLUGIN_API_PACKAGES,
   REMOVE_PACKAGES,
   VITEST_BROWSER_DEP_NAMES,
@@ -201,6 +202,14 @@ export function rewritePackageJson(
   // preserves several forms. The deletion therefore happens AFTER the rewrite,
   // in `dropDeadOxlintPluginsDependency`, where the question is simply whether
   // anything still names the package.
+  //
+  // The `vite-plus` edge is still decided here, though. A leaf whose only
+  // migration signal is this dependency will have its imports repointed at
+  // `vite-plus/lint/plugins`, so it needs a direct `vite-plus` edge to resolve
+  // them under an isolated layout such as Yarn PnP.
+  if (pkg.devDependencies?.[OXLINT_PLUGINS_PACKAGE] && !ownsOxlintApi) {
+    needVitePlus = true;
+  }
   // remove packages that are replaced with vite-plus
   for (const name of REMOVE_PACKAGES) {
     let wasRemoved = false;

--- a/packages/cli/src/migration/migrator/package-json.ts
+++ b/packages/cli/src/migration/migrator/package-json.ts
@@ -71,6 +71,11 @@ export function rewritePackageJson(
   // one only through source/a shim). An already-installed copy of such a provider
   // must REFERENCE that catalog entry, not pin a concrete version. See #2005.
   providerCatalogAdditions: ReadonlySet<string> = new Set(),
+  // Whether the source tree still reaches the Oxlint plugin API through a
+  // CommonJS `require()`. Those forms survive the import rewrite untouched, so
+  // the direct `@oxlint/plugins` dependency stays load-bearing. Computed by the
+  // caller, which owns the project path (see `sourceTreeRequiresOxlintPluginApi`).
+  requiresOxlintPluginApiCjs = false,
 ): Record<string, string | string[]> | null {
   if (pkg.scripts) {
     const updated = rewriteScripts(
@@ -185,33 +190,50 @@ export function rewritePackageJson(
   const hasBrowserDepSignal = VITEST_BROWSER_DEP_NAMES.some((name) =>
     dependencyGroups.some(({ dependencies }) => dependencies?.[name] !== undefined),
   );
+  // A `dependencies` / `peerDependencies` edge on the Oxlint plugin API marks a
+  // published Oxlint plugin: the API is part of what it ships against, not a
+  // tool it runs. The import rewrite leaves such a package's source on `oxlint`
+  // (`skip_oxlint`), so its manifest edge is preserved too. Stripping it would
+  // leave the source importing a package the manifest no longer declares.
+  //
+  // Both groups are checked, matching `collectOxlintOwnerDirs`. A peer-only
+  // check would preserve the source of a plugin that declares `oxlint` under
+  // `dependencies` while deleting the edge that provides it.
+  const ownsOxlintApi = OXLINT_PLUGIN_API_PACKAGES.some(
+    (name) => pkg.dependencies?.[name] !== undefined || pkg.peerDependencies?.[name] !== undefined,
+  );
   // `@oxlint/plugins` becomes dead weight once the import rewrite points the
-  // authoring API at `vite-plus/lint/plugins`, so drop it. Only from
-  // devDependencies: a `dependencies` / `peerDependencies` edge marks a
-  // published Oxlint plugin, whose consumers supply the API themselves and
-  // whose source the rewrite deliberately leaves alone (`skip_oxlint`).
-  if (pkg.devDependencies?.[OXLINT_PLUGINS_PACKAGE]) {
+  // authoring API at `vite-plus/lint/plugins`, so drop it from devDependencies.
+  // Two exceptions: a published plugin owns the API (above), and a CommonJS
+  // `require()` of it survives the rewrite untouched, so the direct dependency
+  // is still the only resolvable copy under pnpm's strict layout.
+  if (
+    pkg.devDependencies?.[OXLINT_PLUGINS_PACKAGE] &&
+    !ownsOxlintApi &&
+    !requiresOxlintPluginApiCjs
+  ) {
     delete pkg.devDependencies[OXLINT_PLUGINS_PACKAGE];
     needVitePlus = true;
   }
-  // A `peerDependencies` entry on the Oxlint plugin API is a consumer contract,
-  // not a tool this package runs: it says "whoever installs me supplies the
-  // linter". That stays true for a published Oxlint plugin, whose source the
-  // import rewrite deliberately leaves on `oxlint` (`skip_oxlint`). Stripping
-  // the peer would leave the source importing a package the manifest no longer
-  // declares, so the peer entry is preserved.
-  const ownsOxlintApi = OXLINT_PLUGIN_API_PACKAGES.some(
-    (name) => pkg.peerDependencies?.[name] !== undefined,
-  );
   // remove packages that are replaced with vite-plus
   for (const name of REMOVE_PACKAGES) {
     let wasRemoved = false;
     for (const { dependencyField, dependencies } of dependencyGroups) {
       if (
         ownsOxlintApi &&
-        dependencyField === 'peerDependencies' &&
+        (dependencyField === 'peerDependencies' || dependencyField === 'dependencies') &&
         (OXLINT_PLUGIN_API_PACKAGES as readonly string[]).includes(name)
       ) {
+        // A `catalog:` reference would dangle once the catalog entry for a
+        // REMOVE_PACKAGES name is dropped, and the next install fails. Resolve
+        // it to the concrete range the catalog currently points at.
+        const current = dependencies?.[name];
+        if (current?.startsWith('catalog:') && dependencies) {
+          const resolved = catalogDependencyResolver?.(current, name);
+          if (resolved) {
+            dependencies[name] = resolved;
+          }
+        }
         continue;
       }
       if (dependencies?.[name]) {

--- a/packages/cli/src/migration/migrator/package-json.ts
+++ b/packages/cli/src/migration/migrator/package-json.ts
@@ -207,7 +207,13 @@ export function rewritePackageJson(
   // migration signal is this dependency will have its imports repointed at
   // `vite-plus/lint/plugins`, so it needs a direct `vite-plus` edge to resolve
   // them under an isolated layout such as Yarn PnP.
-  if (pkg.devDependencies?.[OXLINT_PLUGINS_PACKAGE] && !ownsOxlintApi) {
+  // An optional install edge provisions the API the same way a dev one does,
+  // so it is the same signal.
+  if (
+    (pkg.devDependencies?.[OXLINT_PLUGINS_PACKAGE] !== undefined ||
+      pkg.optionalDependencies?.[OXLINT_PLUGINS_PACKAGE] !== undefined) &&
+    !ownsOxlintApi
+  ) {
     needVitePlus = true;
   }
   // remove packages that are replaced with vite-plus

--- a/packages/cli/src/migration/migrator/package-json.ts
+++ b/packages/cli/src/migration/migrator/package-json.ts
@@ -27,6 +27,8 @@ import {
   findDeclaredSpec,
   resolveProviderPeerSpec,
   OPT_IN_BROWSER_PROVIDERS,
+  OXLINT_PLUGIN_API_PACKAGES,
+  OXLINT_PLUGINS_PACKAGE,
   REMOVE_PACKAGES,
   VITEST_BROWSER_DEP_NAMES,
   VITEST_IS_MANAGED_OVERRIDE,
@@ -183,10 +185,35 @@ export function rewritePackageJson(
   const hasBrowserDepSignal = VITEST_BROWSER_DEP_NAMES.some((name) =>
     dependencyGroups.some(({ dependencies }) => dependencies?.[name] !== undefined),
   );
+  // `@oxlint/plugins` becomes dead weight once the import rewrite points the
+  // authoring API at `vite-plus/lint/plugins`, so drop it. Only from
+  // devDependencies: a `dependencies` / `peerDependencies` edge marks a
+  // published Oxlint plugin, whose consumers supply the API themselves and
+  // whose source the rewrite deliberately leaves alone (`skip_oxlint`).
+  if (pkg.devDependencies?.[OXLINT_PLUGINS_PACKAGE]) {
+    delete pkg.devDependencies[OXLINT_PLUGINS_PACKAGE];
+    needVitePlus = true;
+  }
+  // A `peerDependencies` entry on the Oxlint plugin API is a consumer contract,
+  // not a tool this package runs: it says "whoever installs me supplies the
+  // linter". That stays true for a published Oxlint plugin, whose source the
+  // import rewrite deliberately leaves on `oxlint` (`skip_oxlint`). Stripping
+  // the peer would leave the source importing a package the manifest no longer
+  // declares, so the peer entry is preserved.
+  const ownsOxlintApi = OXLINT_PLUGIN_API_PACKAGES.some(
+    (name) => pkg.peerDependencies?.[name] !== undefined,
+  );
   // remove packages that are replaced with vite-plus
   for (const name of REMOVE_PACKAGES) {
     let wasRemoved = false;
-    for (const { dependencies } of dependencyGroups) {
+    for (const { dependencyField, dependencies } of dependencyGroups) {
+      if (
+        ownsOxlintApi &&
+        dependencyField === 'peerDependencies' &&
+        (OXLINT_PLUGIN_API_PACKAGES as readonly string[]).includes(name)
+      ) {
+        continue;
+      }
       if (dependencies?.[name]) {
         delete dependencies[name];
         wasRemoved = true;

--- a/packages/cli/src/migration/migrator/package-json.ts
+++ b/packages/cli/src/migration/migrator/package-json.ts
@@ -28,7 +28,6 @@ import {
   resolveProviderPeerSpec,
   OPT_IN_BROWSER_PROVIDERS,
   OXLINT_PLUGIN_API_PACKAGES,
-  OXLINT_PLUGINS_PACKAGE,
   REMOVE_PACKAGES,
   VITEST_BROWSER_DEP_NAMES,
   VITEST_IS_MANAGED_OVERRIDE,
@@ -71,11 +70,6 @@ export function rewritePackageJson(
   // one only through source/a shim). An already-installed copy of such a provider
   // must REFERENCE that catalog entry, not pin a concrete version. See #2005.
   providerCatalogAdditions: ReadonlySet<string> = new Set(),
-  // Whether the source tree still reaches the Oxlint plugin API through a
-  // CommonJS `require()`. Those forms survive the import rewrite untouched, so
-  // the direct `@oxlint/plugins` dependency stays load-bearing. Computed by the
-  // caller, which owns the project path (see `sourceTreeRequiresOxlintPluginApi`).
-  requiresOxlintPluginApiCjs = false,
 ): Record<string, string | string[]> | null {
   if (pkg.scripts) {
     const updated = rewriteScripts(
@@ -202,19 +196,11 @@ export function rewritePackageJson(
   const ownsOxlintApi = OXLINT_PLUGIN_API_PACKAGES.some(
     (name) => pkg.dependencies?.[name] !== undefined || pkg.peerDependencies?.[name] !== undefined,
   );
-  // `@oxlint/plugins` becomes dead weight once the import rewrite points the
-  // authoring API at `vite-plus/lint/plugins`, so drop it from devDependencies.
-  // Two exceptions: a published plugin owns the API (above), and a CommonJS
-  // `require()` of it survives the rewrite untouched, so the direct dependency
-  // is still the only resolvable copy under pnpm's strict layout.
-  if (
-    pkg.devDependencies?.[OXLINT_PLUGINS_PACKAGE] &&
-    !ownsOxlintApi &&
-    !requiresOxlintPluginApiCjs
-  ) {
-    delete pkg.devDependencies[OXLINT_PLUGINS_PACKAGE];
-    needVitePlus = true;
-  }
+  // `@oxlint/plugins` often becomes dead weight once the import rewrite points
+  // the authoring API at `vite-plus/lint/plugins`, but not always: the rewrite
+  // preserves several forms. The deletion therefore happens AFTER the rewrite,
+  // in `dropDeadOxlintPluginsDependency`, where the question is simply whether
+  // anything still names the package.
   // remove packages that are replaced with vite-plus
   for (const name of REMOVE_PACKAGES) {
     let wasRemoved = false;

--- a/packages/cli/src/migration/migrator/package-json.ts
+++ b/packages/cli/src/migration/migrator/package-json.ts
@@ -29,6 +29,7 @@ import {
   OPT_IN_BROWSER_PROVIDERS,
   OXLINT_PLUGINS_PACKAGE,
   OXLINT_PLUGIN_API_PACKAGES,
+  packageOwnsOxlintApi,
   REMOVE_PACKAGES,
   VITEST_BROWSER_DEP_NAMES,
   VITEST_IS_MANAGED_OVERRIDE,
@@ -191,12 +192,8 @@ export function rewritePackageJson(
   // (`skip_oxlint`), so its manifest edge is preserved too. Stripping it would
   // leave the source importing a package the manifest no longer declares.
   //
-  // Both groups are checked, matching `collectOxlintOwnerDirs`. A peer-only
-  // check would preserve the source of a plugin that declares `oxlint` under
-  // `dependencies` while deleting the edge that provides it.
-  const ownsOxlintApi = OXLINT_PLUGIN_API_PACKAGES.some(
-    (name) => pkg.dependencies?.[name] !== undefined || pkg.peerDependencies?.[name] !== undefined,
-  );
+  // Optional `@oxlint/plugins` also supplies a published runtime integration.
+  const ownsOxlintApi = packageOwnsOxlintApi(pkg);
   // `@oxlint/plugins` often becomes dead weight once the import rewrite points
   // the authoring API at `vite-plus/lint/plugins`, but not always: the rewrite
   // preserves several forms. The deletion therefore happens AFTER the rewrite,
@@ -207,13 +204,7 @@ export function rewritePackageJson(
   // migration signal is this dependency will have its imports repointed at
   // `vite-plus/lint/plugins`, so it needs a direct `vite-plus` edge to resolve
   // them under an isolated layout such as Yarn PnP.
-  // An optional install edge provisions the API the same way a dev one does,
-  // so it is the same signal.
-  if (
-    (pkg.devDependencies?.[OXLINT_PLUGINS_PACKAGE] !== undefined ||
-      pkg.optionalDependencies?.[OXLINT_PLUGINS_PACKAGE] !== undefined) &&
-    !ownsOxlintApi
-  ) {
+  if (pkg.devDependencies?.[OXLINT_PLUGINS_PACKAGE] !== undefined && !ownsOxlintApi) {
     needVitePlus = true;
   }
   // remove packages that are replaced with vite-plus

--- a/packages/cli/src/migration/migrator/package-json.ts
+++ b/packages/cli/src/migration/migrator/package-json.ts
@@ -186,24 +186,11 @@ export function rewritePackageJson(
   const hasBrowserDepSignal = VITEST_BROWSER_DEP_NAMES.some((name) =>
     dependencyGroups.some(({ dependencies }) => dependencies?.[name] !== undefined),
   );
-  // A `dependencies` / `peerDependencies` edge on the Oxlint plugin API marks a
-  // published Oxlint plugin: the API is part of what it ships against, not a
-  // tool it runs. The import rewrite leaves such a package's source on `oxlint`
-  // (`skip_oxlint`), so its manifest edge is preserved too. Stripping it would
-  // leave the source importing a package the manifest no longer declares.
-  //
-  // Optional `@oxlint/plugins` also supplies a published runtime integration.
+  // Published plugins keep their upstream imports and the dependencies that
+  // supply them, including optional @oxlint/plugins integrations.
   const ownsOxlintApi = packageOwnsOxlintApi(pkg);
-  // `@oxlint/plugins` often becomes dead weight once the import rewrite points
-  // the authoring API at `vite-plus/lint/plugins`, but not always: the rewrite
-  // preserves several forms. The deletion therefore happens AFTER the rewrite,
-  // in `dropDeadOxlintPluginsDependency`, where the question is simply whether
-  // anything still names the package.
-  //
-  // The `vite-plus` edge is still decided here, though. A leaf whose only
-  // migration signal is this dependency will have its imports repointed at
-  // `vite-plus/lint/plugins`, so it needs a direct `vite-plus` edge to resolve
-  // them under an isolated layout such as Yarn PnP.
+  // Rewritten imports need a direct vite-plus dependency. Defer removal of
+  // @oxlint/plugins until dropDeadOxlintPluginsDependency checks the final source.
   if (pkg.devDependencies?.[OXLINT_PLUGINS_PACKAGE] !== undefined && !ownsOxlintApi) {
     needVitePlus = true;
   }

--- a/packages/cli/src/migration/migrator/shared.ts
+++ b/packages/cli/src/migration/migrator/shared.ts
@@ -321,3 +321,41 @@ export function pnpmMajor(version: string | undefined): number | undefined {
   const coerced = version ? semver.coerce(version)?.version : undefined;
   return coerced ? semver.major(coerced) : undefined;
 }
+
+// Packages that own the Oxlint JS-plugin authoring API as a published contract.
+// A package that declares either in `dependencies` or `peerDependencies` is a
+// published Oxlint plugin, so its source must keep resolving the API from that
+// package rather than from `vite-plus`.
+export const OXLINT_PLUGINS_PACKAGE = '@oxlint/plugins';
+
+export const OXLINT_PLUGIN_API_PACKAGES = ['oxlint', OXLINT_PLUGINS_PACKAGE] as const;
+
+/**
+ * Collect the directories of packages that own the Oxlint plugin API, so the
+ * import rewriter can exempt them.
+ *
+ * Must run BEFORE `rewritePackageJson`. That function strips `oxlint` (it is in
+ * {@link REMOVE_PACKAGES}), and the import rewriter reads the manifests only
+ * afterwards, by which point the signal is gone from disk.
+ */
+export function collectOxlintOwnerDirs(
+  rootDir: string,
+  packages?: readonly { path: string }[],
+): string[] {
+  const owners: string[] = [];
+  const candidates = [rootDir, ...(packages ?? []).map((pkg) => path.join(rootDir, pkg.path))];
+  for (const dir of candidates) {
+    const pkg = readPackageJsonIfExists(path.join(dir, 'package.json'));
+    if (!pkg) {
+      continue;
+    }
+    const owns = OXLINT_PLUGIN_API_PACKAGES.some(
+      (name) =>
+        pkg.dependencies?.[name] !== undefined || pkg.peerDependencies?.[name] !== undefined,
+    );
+    if (owns) {
+      owners.push(dir);
+    }
+  }
+  return owners;
+}

--- a/packages/cli/src/migration/migrator/shared.ts
+++ b/packages/cli/src/migration/migrator/shared.ts
@@ -323,12 +323,21 @@ export function pnpmMajor(version: string | undefined): number | undefined {
 }
 
 // Packages that own the Oxlint JS-plugin authoring API as a published contract.
-// A package that declares either in `dependencies` or `peerDependencies` is a
-// published Oxlint plugin, so its source must keep resolving the API from that
-// package rather than from `vite-plus`.
+// Optional `@oxlint/plugins` is also a runtime contract for consumers of a
+// published integration. Optional `oxlint` keeps the existing tool policy.
 export const OXLINT_PLUGINS_PACKAGE = '@oxlint/plugins';
 
 export const OXLINT_PLUGIN_API_PACKAGES = ['oxlint', OXLINT_PLUGINS_PACKAGE] as const;
+
+export function packageOwnsOxlintApi(pkg: DependencyBag): boolean {
+  return (
+    pkg.optionalDependencies?.[OXLINT_PLUGINS_PACKAGE] !== undefined ||
+    OXLINT_PLUGIN_API_PACKAGES.some(
+      (name) =>
+        pkg.dependencies?.[name] !== undefined || pkg.peerDependencies?.[name] !== undefined,
+    )
+  );
+}
 
 /**
  * Collect the directories of packages that own the Oxlint plugin API, so the
@@ -349,11 +358,7 @@ export function collectOxlintOwnerDirs(
     if (!pkg) {
       continue;
     }
-    const owns = OXLINT_PLUGIN_API_PACKAGES.some(
-      (name) =>
-        pkg.dependencies?.[name] !== undefined || pkg.peerDependencies?.[name] !== undefined,
-    );
-    if (owns) {
+    if (packageOwnsOxlintApi(pkg)) {
       owners.push(dir);
     }
   }

--- a/packages/cli/src/migration/migrator/shared.ts
+++ b/packages/cli/src/migration/migrator/shared.ts
@@ -340,12 +340,8 @@ export function packageOwnsOxlintApi(pkg: DependencyBag): boolean {
 }
 
 /**
- * Collect the directories of packages that own the Oxlint plugin API, so the
- * import rewriter can exempt them.
- *
- * Must run BEFORE `rewritePackageJson`. That function strips `oxlint` (it is in
- * {@link REMOVE_PACKAGES}), and the import rewriter reads the manifests only
- * afterwards, by which point the signal is gone from disk.
+ * Capture plugin owners before manifest edits, so the import rewriter can
+ * preserve their upstream API imports after those edits.
  */
 export function collectOxlintOwnerDirs(
   rootDir: string,
@@ -355,10 +351,7 @@ export function collectOxlintOwnerDirs(
   const candidates = [rootDir, ...(packages ?? []).map((pkg) => path.join(rootDir, pkg.path))];
   for (const dir of candidates) {
     const pkg = readPackageJsonIfExists(path.join(dir, 'package.json'));
-    if (!pkg) {
-      continue;
-    }
-    if (packageOwnsOxlintApi(pkg)) {
+    if (pkg && packageOwnsOxlintApi(pkg)) {
       owners.push(dir);
     }
   }

--- a/packages/cli/src/migration/migrator/source-scan.ts
+++ b/packages/cli/src/migration/migrator/source-scan.ts
@@ -343,12 +343,17 @@ export function collectProviderSourceModes(projectPath: string): Record<string, 
 // project that still has one therefore needs its direct `@oxlint/plugins`
 // dependency: under pnpm's strict layout the transitive copy inside
 // `vite-plus` is not resolvable from the plugin file.
-const OXLINT_PLUGIN_API_CJS_HINTS = [
-  "require('@oxlint/plugins')",
-  'require("@oxlint/plugins")',
-  "require('oxlint/plugins-dev')",
-  'require("oxlint/plugins-dev")',
-] as const;
+// Matched with a tolerant regex rather than fixed substrings: `require (
+// '@oxlint/plugins' )`, a line break before the argument, and
+// `createRequire(...)('@oxlint/plugins')` are all valid and all survive the
+// rewrite. Whitespace (including newlines) is allowed around the callee and
+// the argument, and any callee ending in `require` counts, which covers
+// `createRequire(import.meta.url)` results assigned to a local name.
+//
+// This errs toward retaining the dependency. A false positive leaves one
+// unused devDependency; a false negative breaks a plugin at load time.
+const OXLINT_PLUGIN_API_CJS_RE =
+  /\brequire\s*\(\s*['"](?:@oxlint\/plugins|oxlint\/plugins-dev)['"]\s*\)/;
 
 /**
  * True when the source tree still reaches the Oxlint plugin API through a
@@ -358,5 +363,5 @@ const OXLINT_PLUGIN_API_CJS_HINTS = [
  * fact still load-bearing.
  */
 export function sourceTreeRequiresOxlintPluginApi(projectPath: string): boolean {
-  return sourceTreeReferencesAny(projectPath, OXLINT_PLUGIN_API_CJS_HINTS);
+  return sourceTreeMatches(projectPath, (content) => OXLINT_PLUGIN_API_CJS_RE.test(content));
 }

--- a/packages/cli/src/migration/migrator/source-scan.ts
+++ b/packages/cli/src/migration/migrator/source-scan.ts
@@ -343,17 +343,22 @@ export function collectProviderSourceModes(projectPath: string): Record<string, 
 // project that still has one therefore needs its direct `@oxlint/plugins`
 // dependency: under pnpm's strict layout the transitive copy inside
 // `vite-plus` is not resolvable from the plugin file.
-// Matched with a tolerant regex rather than fixed substrings: `require (
-// '@oxlint/plugins' )`, a line break before the argument, and
-// `createRequire(...)('@oxlint/plugins')` are all valid and all survive the
-// rewrite. Whitespace (including newlines) is allowed around the callee and
-// the argument, and any callee ending in `require` counts, which covers
-// `createRequire(import.meta.url)` results assigned to a local name.
+// A CommonJS reach for the plugin API, matched loosely on purpose. `SEP` is
+// whitespace or a block comment, so `require /* compat */ ( '...' )` and a line
+// break before the argument both match.
 //
-// This errs toward retaining the dependency. A false positive leaves one
-// unused devDependency; a false negative breaks a plugin at load time.
-const OXLINT_PLUGIN_API_CJS_RE =
-  /\brequire\s*\(\s*['"](?:@oxlint\/plugins|oxlint\/plugins-dev)['"]\s*\)/;
+// This errs toward retaining the dependency: a false positive leaves one unused
+// devDependency, a false negative breaks a plugin at load time. The
+// `createRequire` indirection below is caught the same way, by looking for the
+// specifier in a file that also builds its own `require`.
+const SEP = String.raw`(?:\s|\/\*[\s\S]*?\*\/)*`;
+const OXLINT_PLUGIN_API_SPECIFIER = String.raw`['"](?:@oxlint\/plugins|oxlint\/plugins-dev)['"]`;
+const OXLINT_PLUGIN_API_CJS_RE = new RegExp(
+  String.raw`\brequire${SEP}\(${SEP}${OXLINT_PLUGIN_API_SPECIFIER}${SEP}\)`,
+);
+const OXLINT_PLUGIN_API_CREATE_REQUIRE_RE = new RegExp(
+  String.raw`createRequire[\s\S]*?${OXLINT_PLUGIN_API_SPECIFIER}`,
+);
 
 /**
  * True when the source tree still reaches the Oxlint plugin API through a
@@ -363,5 +368,9 @@ const OXLINT_PLUGIN_API_CJS_RE =
  * fact still load-bearing.
  */
 export function sourceTreeRequiresOxlintPluginApi(projectPath: string): boolean {
-  return sourceTreeMatches(projectPath, (content) => OXLINT_PLUGIN_API_CJS_RE.test(content));
+  return sourceTreeMatches(
+    projectPath,
+    (content) =>
+      OXLINT_PLUGIN_API_CJS_RE.test(content) || OXLINT_PLUGIN_API_CREATE_REQUIRE_RE.test(content),
+  );
 }

--- a/packages/cli/src/migration/migrator/source-scan.ts
+++ b/packages/cli/src/migration/migrator/source-scan.ts
@@ -2,10 +2,13 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { type WorkspacePackage } from '../../types/index.ts';
+import { editJsonFile } from '../../utils/json.ts';
 import { hasVitestTypesInTsconfig } from '../../utils/tsconfig.ts';
 import { projectUsesVitestDirectly } from '../migrator.ts';
 import {
   OPT_IN_BROWSER_PROVIDERS,
+  OXLINT_PLUGINS_PACKAGE,
+  OXLINT_PLUGIN_API_PACKAGES,
   PLAYWRIGHT_PROVIDER,
   WEBDRIVERIO_PROVIDER,
   readPackageJsonIfExists,
@@ -343,34 +346,56 @@ export function collectProviderSourceModes(projectPath: string): Record<string, 
 // project that still has one therefore needs its direct `@oxlint/plugins`
 // dependency: under pnpm's strict layout the transitive copy inside
 // `vite-plus` is not resolvable from the plugin file.
-// A CommonJS reach for the plugin API, matched loosely on purpose. `SEP` is
-// whitespace or a block comment, so `require /* compat */ ( '...' )` and a line
-// break before the argument both match.
-//
-// This errs toward retaining the dependency: a false positive leaves one unused
-// devDependency, a false negative breaks a plugin at load time. The
-// `createRequire` indirection below is caught the same way, by looking for the
-// specifier in a file that also builds its own `require`.
-const SEP = String.raw`(?:\s|\/\*[\s\S]*?\*\/)*`;
-const OXLINT_PLUGIN_API_SPECIFIER = String.raw`['"](?:@oxlint\/plugins|oxlint\/plugins-dev)['"]`;
-const OXLINT_PLUGIN_API_CJS_RE = new RegExp(
-  String.raw`\brequire${SEP}\(${SEP}${OXLINT_PLUGIN_API_SPECIFIER}${SEP}\)`,
-);
-const OXLINT_PLUGIN_API_CREATE_REQUIRE_RE = new RegExp(
-  String.raw`createRequire[\s\S]*?${OXLINT_PLUGIN_API_SPECIFIER}`,
-);
+/**
+ * True when the source tree still names `@oxlint/plugins` anywhere.
+ *
+ * Deliberately a plain substring scan over the FINAL source, run after the
+ * import rewrite. By then every form the rewrite handles has already become a
+ * `vite-plus/lint/*` specifier, so anything left is a form it preserves: a
+ * `require()`, an `import x = require()`, a JSDoc `@typedef {import(...)}`, a
+ * template-literal call, or a plain string.
+ *
+ * Enumerating those syntaxes ahead of the rewrite was the wrong shape. It meant
+ * predicting the rewriter with regexes, and each missed spelling silently
+ * deleted a dependency that was still load-bearing. Scanning afterwards asks
+ * the only question that matters: does anything still need this package?
+ */
+export function sourceTreeReferencesOxlintPluginsPackage(projectPath: string): boolean {
+  return sourceTreeReferencesAny(projectPath, ['@oxlint/plugins']);
+}
 
 /**
- * True when the source tree still reaches the Oxlint plugin API through a
- * CommonJS form that the import rewrite does not touch.
+ * Drop `@oxlint/plugins` from devDependencies once nothing names it any more.
  *
- * Used to decide whether the dead-weight `@oxlint/plugins` devDependency is in
- * fact still load-bearing.
+ * Runs AFTER the import rewrite, so the scan sees final source. Skips a package
+ * that owns the API as a published contract (`dependencies` or
+ * `peerDependencies`), and skips any package whose source still names it
+ * through a form the rewrite preserves.
  */
-export function sourceTreeRequiresOxlintPluginApi(projectPath: string): boolean {
-  return sourceTreeMatches(
-    projectPath,
-    (content) =>
-      OXLINT_PLUGIN_API_CJS_RE.test(content) || OXLINT_PLUGIN_API_CREATE_REQUIRE_RE.test(content),
-  );
+export function dropDeadOxlintPluginsDependency(
+  rootDir: string,
+  packages?: readonly { path: string }[],
+): void {
+  const dirs = [rootDir, ...(packages ?? []).map((pkg) => path.join(rootDir, pkg.path))];
+  for (const dir of dirs) {
+    const packageJsonPath = path.join(dir, 'package.json');
+    const pkg = readPackageJsonIfExists(packageJsonPath);
+    if (!pkg?.devDependencies?.[OXLINT_PLUGINS_PACKAGE]) {
+      continue;
+    }
+    const ownsApi = OXLINT_PLUGIN_API_PACKAGES.some(
+      (name) =>
+        pkg.dependencies?.[name] !== undefined || pkg.peerDependencies?.[name] !== undefined,
+    );
+    if (ownsApi || sourceTreeReferencesOxlintPluginsPackage(dir)) {
+      continue;
+    }
+    editJsonFile<{ devDependencies?: Record<string, string> }>(packageJsonPath, (json) => {
+      if (!json.devDependencies?.[OXLINT_PLUGINS_PACKAGE]) {
+        return undefined;
+      }
+      delete json.devDependencies[OXLINT_PLUGINS_PACKAGE];
+      return json;
+    });
+  }
 }

--- a/packages/cli/src/migration/migrator/source-scan.ts
+++ b/packages/cli/src/migration/migrator/source-scan.ts
@@ -396,7 +396,13 @@ export function dropDeadOxlintPluginsDependency(
   for (const dir of dirs) {
     const packageJsonPath = path.join(dir, 'package.json');
     const pkg = readPackageJsonIfExists(packageJsonPath);
-    if (!pkg?.devDependencies?.[OXLINT_PLUGINS_PACKAGE]) {
+    if (!pkg) {
+      continue;
+    }
+    const declaredIn = (['devDependencies', 'optionalDependencies'] as const).filter(
+      (field) => pkg?.[field]?.[OXLINT_PLUGINS_PACKAGE] !== undefined,
+    );
+    if (declaredIn.length === 0) {
       continue;
     }
     const ownsApi = OXLINT_PLUGIN_API_PACKAGES.some(
@@ -406,12 +412,18 @@ export function dropDeadOxlintPluginsDependency(
     if (ownsApi || sourceTreeReferencesOxlintPluginsPackage(dir)) {
       continue;
     }
-    editJsonFile<{ devDependencies?: Record<string, string> }>(packageJsonPath, (json) => {
-      if (!json.devDependencies?.[OXLINT_PLUGINS_PACKAGE]) {
-        return undefined;
+    editJsonFile<{
+      devDependencies?: Record<string, string>;
+      optionalDependencies?: Record<string, string>;
+    }>(packageJsonPath, (json) => {
+      let changed = false;
+      for (const field of declaredIn) {
+        if (json[field]?.[OXLINT_PLUGINS_PACKAGE]) {
+          delete json[field][OXLINT_PLUGINS_PACKAGE];
+          changed = true;
+        }
       }
-      delete json.devDependencies[OXLINT_PLUGINS_PACKAGE];
-      return json;
+      return changed ? json : undefined;
     });
   }
 }

--- a/packages/cli/src/migration/migrator/source-scan.ts
+++ b/packages/cli/src/migration/migrator/source-scan.ts
@@ -218,6 +218,12 @@ const VITEST_SCAN_SKIP_DIRS = new Set([
 function sourceTreeMatches(
   projectPath: string,
   matchesContent: (content: string) => boolean,
+  // Cross nested package.json boundaries. Off by default, because most signals
+  // are per-package and a sub-package is scanned on its own pass. On for the
+  // dependency-retention check, where a nested example or fixture directory
+  // that is not a workspace member would otherwise go unscanned while still
+  // resolving the root's dependency.
+  crossPackageBoundaries = false,
 ): boolean {
   const scanDir = (dir: string, isRoot: boolean): boolean => {
     let entries: fs.Dirent[];
@@ -228,7 +234,11 @@ function sourceTreeMatches(
     }
     // A nested package.json marks a separate workspace package — it is migrated
     // (and scanned) on its own pass, so don't let its files leak into this one.
-    if (!isRoot && entries.some((e) => e.isFile() && e.name === 'package.json')) {
+    if (
+      !crossPackageBoundaries &&
+      !isRoot &&
+      entries.some((e) => e.isFile() && e.name === 'package.json')
+    ) {
       return false;
     }
     for (const entry of entries) {
@@ -361,7 +371,13 @@ export function collectProviderSourceModes(projectPath: string): Record<string, 
  * the only question that matters: does anything still need this package?
  */
 export function sourceTreeReferencesOxlintPluginsPackage(projectPath: string): boolean {
-  return sourceTreeReferencesAny(projectPath, ['@oxlint/plugins']);
+  return sourceTreeMatches(
+    projectPath,
+    (content) => content.includes('@oxlint/plugins'),
+    // Nested non-workspace packages (examples, fixtures) resolve the root's
+    // dependency by walking up, so they must be scanned before it is deleted.
+    true,
+  );
 }
 
 /**

--- a/packages/cli/src/migration/migrator/source-scan.ts
+++ b/packages/cli/src/migration/migrator/source-scan.ts
@@ -336,3 +336,27 @@ export function collectProviderSourceModes(projectPath: string): Record<string, 
   }
   return modes;
 }
+
+// CommonJS forms that reach the Oxlint plugin API. The rewrite deliberately
+// leaves these alone, because `vite-plus/lint/plugins*` is ESM-only and a
+// rewritten `require()` would fail with ERR_PACKAGE_PATH_NOT_EXPORTED. A
+// project that still has one therefore needs its direct `@oxlint/plugins`
+// dependency: under pnpm's strict layout the transitive copy inside
+// `vite-plus` is not resolvable from the plugin file.
+const OXLINT_PLUGIN_API_CJS_HINTS = [
+  "require('@oxlint/plugins')",
+  'require("@oxlint/plugins")',
+  "require('oxlint/plugins-dev')",
+  'require("oxlint/plugins-dev")',
+] as const;
+
+/**
+ * True when the source tree still reaches the Oxlint plugin API through a
+ * CommonJS form that the import rewrite does not touch.
+ *
+ * Used to decide whether the dead-weight `@oxlint/plugins` devDependency is in
+ * fact still load-bearing.
+ */
+export function sourceTreeRequiresOxlintPluginApi(projectPath: string): boolean {
+  return sourceTreeReferencesAny(projectPath, OXLINT_PLUGIN_API_CJS_HINTS);
+}

--- a/packages/cli/src/migration/migrator/source-scan.ts
+++ b/packages/cli/src/migration/migrator/source-scan.ts
@@ -8,7 +8,7 @@ import { projectUsesVitestDirectly } from '../migrator.ts';
 import {
   OPT_IN_BROWSER_PROVIDERS,
   OXLINT_PLUGINS_PACKAGE,
-  OXLINT_PLUGIN_API_PACKAGES,
+  packageOwnsOxlintApi,
   PLAYWRIGHT_PROVIDER,
   WEBDRIVERIO_PROVIDER,
   readPackageJsonIfExists,
@@ -191,6 +191,10 @@ const VITEST_SCAN_SKIP_DIRS = new Set([
   '.cache',
 ]);
 
+// Built plugins can still load the original API after migration. Only installed
+// dependencies and version-control metadata are irrelevant to retention.
+const OXLINT_RETENTION_SKIP_DIRS = new Set(['node_modules', '.git', '.hg', '.svn']);
+
 /**
  * Detect whether a package uses vitest's browser mode.
  *
@@ -223,8 +227,10 @@ function sourceTreeMatches(
     // package imports, even when they are not workspace members.
     crossPackageBoundaries?: boolean;
     includePackageImports?: boolean;
+    skipDirs?: ReadonlySet<string>;
   } = {},
 ): boolean {
+  const skipDirs = options.skipDirs ?? VITEST_SCAN_SKIP_DIRS;
   const scanDir = (dir: string, isRoot: boolean): boolean => {
     let entries: fs.Dirent[];
     try {
@@ -244,7 +250,7 @@ function sourceTreeMatches(
     for (const entry of entries) {
       const entryPath = path.join(dir, entry.name);
       if (entry.isDirectory()) {
-        if (VITEST_SCAN_SKIP_DIRS.has(entry.name)) {
+        if (skipDirs.has(entry.name)) {
           continue;
         }
         if (scanDir(entryPath, false)) {
@@ -379,6 +385,7 @@ export function sourceTreeReferencesOxlintPluginsPackage(projectPath: string): b
   return sourceTreeMatches(projectPath, (content) => content.includes('@oxlint/plugins'), {
     crossPackageBoundaries: true,
     includePackageImports: true,
+    skipDirs: OXLINT_RETENTION_SKIP_DIRS,
   });
 }
 
@@ -386,9 +393,8 @@ export function sourceTreeReferencesOxlintPluginsPackage(projectPath: string): b
  * Drop `@oxlint/plugins` from devDependencies once nothing names it any more.
  *
  * Runs AFTER the import rewrite, so the scan sees final source. Skips a package
- * that owns the API as a published contract (`dependencies` or
- * `peerDependencies`), and skips any package whose source still names it
- * through a form the rewrite preserves.
+ * that owns the API as a runtime or peer dependency, and skips any package
+ * whose source or build output still names it.
  */
 export function dropDeadOxlintPluginsDependency(
   rootDir: string,
@@ -401,31 +407,20 @@ export function dropDeadOxlintPluginsDependency(
     if (!pkg) {
       continue;
     }
-    const declaredIn = (['devDependencies', 'optionalDependencies'] as const).filter(
-      (field) => pkg?.[field]?.[OXLINT_PLUGINS_PACKAGE] !== undefined,
-    );
-    if (declaredIn.length === 0) {
+    if (pkg.devDependencies?.[OXLINT_PLUGINS_PACKAGE] === undefined) {
       continue;
     }
-    const ownsApi = OXLINT_PLUGIN_API_PACKAGES.some(
-      (name) =>
-        pkg.dependencies?.[name] !== undefined || pkg.peerDependencies?.[name] !== undefined,
-    );
-    if (ownsApi || sourceTreeReferencesOxlintPluginsPackage(dir)) {
+    if (packageOwnsOxlintApi(pkg) || sourceTreeReferencesOxlintPluginsPackage(dir)) {
       continue;
     }
     editJsonFile<{
       devDependencies?: Record<string, string>;
-      optionalDependencies?: Record<string, string>;
     }>(packageJsonPath, (json) => {
-      let changed = false;
-      for (const field of declaredIn) {
-        if (json[field]?.[OXLINT_PLUGINS_PACKAGE]) {
-          delete json[field][OXLINT_PLUGINS_PACKAGE];
-          changed = true;
-        }
+      if (json.devDependencies?.[OXLINT_PLUGINS_PACKAGE] === undefined) {
+        return undefined;
       }
-      return changed ? json : undefined;
+      delete json.devDependencies[OXLINT_PLUGINS_PACKAGE];
+      return json;
     });
   }
 }

--- a/packages/cli/src/migration/migrator/source-scan.ts
+++ b/packages/cli/src/migration/migrator/source-scan.ts
@@ -218,12 +218,12 @@ const VITEST_SCAN_SKIP_DIRS = new Set([
 function sourceTreeMatches(
   projectPath: string,
   matchesContent: (content: string) => boolean,
-  // Cross nested package.json boundaries. Off by default, because most signals
-  // are per-package and a sub-package is scanned on its own pass. On for the
-  // dependency-retention check, where a nested example or fixture directory
-  // that is not a workspace member would otherwise go unscanned while still
-  // resolving the root's dependency.
-  crossPackageBoundaries = false,
+  options: {
+    // Nested examples can resolve the root's dependency through source or
+    // package imports, even when they are not workspace members.
+    crossPackageBoundaries?: boolean;
+    includePackageImports?: boolean;
+  } = {},
 ): boolean {
   const scanDir = (dir: string, isRoot: boolean): boolean => {
     let entries: fs.Dirent[];
@@ -235,7 +235,7 @@ function sourceTreeMatches(
     // A nested package.json marks a separate workspace package — it is migrated
     // (and scanned) on its own pass, so don't let its files leak into this one.
     if (
-      !crossPackageBoundaries &&
+      !options.crossPackageBoundaries &&
       !isRoot &&
       entries.some((e) => e.isFile() && e.name === 'package.json')
     ) {
@@ -250,9 +250,20 @@ function sourceTreeMatches(
         if (scanDir(entryPath, false)) {
           return true;
         }
-      } else if (entry.isFile() && VITEST_SCAN_EXTENSIONS.has(path.extname(entry.name))) {
+      } else if (
+        entry.isFile() &&
+        (VITEST_SCAN_EXTENSIONS.has(path.extname(entry.name)) ||
+          (options.includePackageImports && entry.name === 'package.json'))
+      ) {
         try {
-          if (matchesContent(fs.readFileSync(entryPath, 'utf8'))) {
+          let content = fs.readFileSync(entryPath, 'utf8');
+          if (entry.name === 'package.json') {
+            // Check alias targets without counting the dependency declaration
+            // itself as a use. JSON serialization includes conditional targets.
+            const pkg = JSON.parse(content) as { imports?: unknown };
+            content = JSON.stringify(pkg.imports ?? {});
+          }
+          if (matchesContent(content)) {
             return true;
           }
         } catch {
@@ -350,14 +361,8 @@ export function collectProviderSourceModes(projectPath: string): Record<string, 
   return modes;
 }
 
-// CommonJS forms that reach the Oxlint plugin API. The rewrite deliberately
-// leaves these alone, because `vite-plus/lint/plugins*` is ESM-only and a
-// rewritten `require()` would fail with ERR_PACKAGE_PATH_NOT_EXPORTED. A
-// project that still has one therefore needs its direct `@oxlint/plugins`
-// dependency: under pnpm's strict layout the transitive copy inside
-// `vite-plus` is not resolvable from the plugin file.
 /**
- * True when the source tree still names `@oxlint/plugins` anywhere.
+ * True when source or package import aliases still name `@oxlint/plugins`.
  *
  * Deliberately a plain substring scan over the FINAL source, run after the
  * import rewrite. By then every form the rewrite handles has already become a
@@ -371,13 +376,10 @@ export function collectProviderSourceModes(projectPath: string): Record<string, 
  * the only question that matters: does anything still need this package?
  */
 export function sourceTreeReferencesOxlintPluginsPackage(projectPath: string): boolean {
-  return sourceTreeMatches(
-    projectPath,
-    (content) => content.includes('@oxlint/plugins'),
-    // Nested non-workspace packages (examples, fixtures) resolve the root's
-    // dependency by walking up, so they must be scanned before it is deleted.
-    true,
-  );
+  return sourceTreeMatches(projectPath, (content) => content.includes('@oxlint/plugins'), {
+    crossPackageBoundaries: true,
+    includePackageImports: true,
+  });
 }
 
 /**

--- a/packages/cli/src/migration/migrator/source-scan.ts
+++ b/packages/cli/src/migration/migrator/source-scan.ts
@@ -231,7 +231,7 @@ function sourceTreeMatches(
   } = {},
 ): boolean {
   const skipDirs = options.skipDirs ?? VITEST_SCAN_SKIP_DIRS;
-  const scanDir = (dir: string, isRoot: boolean): boolean => {
+  function scanDir(dir: string, isRoot: boolean): boolean {
     let entries: fs.Dirent[];
     try {
       entries = fs.readdirSync(dir, { withFileTypes: true });
@@ -278,7 +278,7 @@ function sourceTreeMatches(
       }
     }
     return false;
-  };
+  }
 
   return scanDir(projectPath, true);
 }
@@ -368,21 +368,12 @@ export function collectProviderSourceModes(projectPath: string): Record<string, 
 }
 
 /**
- * True when source or package import aliases still name `@oxlint/plugins`.
- *
- * Deliberately a plain substring scan over the FINAL source, run after the
- * import rewrite. By then every form the rewrite handles has already become a
- * `vite-plus/lint/*` specifier, so anything left is a form it preserves: a
- * `require()`, an `import x = require()`, a JSDoc `@typedef {import(...)}`, a
- * template-literal call, or a plain string.
- *
- * Enumerating those syntaxes ahead of the rewrite was the wrong shape. It meant
- * predicting the rewriter with regexes, and each missed spelling silently
- * deleted a dependency that was still load-bearing. Scanning afterwards asks
- * the only question that matters: does anything still need this package?
+ * Check final source, build output, and package import aliases after rewriting.
+ * A substring scan conservatively retains references the rewriter leaves alone,
+ * including require calls, type references, and strings.
  */
 export function sourceTreeReferencesOxlintPluginsPackage(projectPath: string): boolean {
-  return sourceTreeMatches(projectPath, (content) => content.includes('@oxlint/plugins'), {
+  return sourceTreeMatches(projectPath, (content) => content.includes(OXLINT_PLUGINS_PACKAGE), {
     crossPackageBoundaries: true,
     includePackageImports: true,
     skipDirs: OXLINT_RETENTION_SKIP_DIRS,
@@ -404,10 +395,7 @@ export function dropDeadOxlintPluginsDependency(
   for (const dir of dirs) {
     const packageJsonPath = path.join(dir, 'package.json');
     const pkg = readPackageJsonIfExists(packageJsonPath);
-    if (!pkg) {
-      continue;
-    }
-    if (pkg.devDependencies?.[OXLINT_PLUGINS_PACKAGE] === undefined) {
+    if (pkg?.devDependencies?.[OXLINT_PLUGINS_PACKAGE] === undefined) {
       continue;
     }
     if (packageOwnsOxlintApi(pkg) || sourceTreeReferencesOxlintPluginsPackage(dir)) {

--- a/packages/cli/src/migration/migrator/source-scan.ts
+++ b/packages/cli/src/migration/migrator/source-scan.ts
@@ -224,9 +224,9 @@ function sourceTreeMatches(
   matchesContent: (content: string) => boolean,
   options: {
     // Nested examples can resolve the root's dependency through source or
-    // package imports, even when they are not workspace members.
+    // package imports/scripts, even when they are not workspace members.
     crossPackageBoundaries?: boolean;
-    includePackageImports?: boolean;
+    includePackageReferences?: boolean;
     skipDirs?: ReadonlySet<string>;
   } = {},
 ): boolean {
@@ -259,15 +259,15 @@ function sourceTreeMatches(
       } else if (
         entry.isFile() &&
         (VITEST_SCAN_EXTENSIONS.has(path.extname(entry.name)) ||
-          (options.includePackageImports && entry.name === 'package.json'))
+          (options.includePackageReferences && entry.name === 'package.json'))
       ) {
         try {
           let content = fs.readFileSync(entryPath, 'utf8');
           if (entry.name === 'package.json') {
-            // Check alias targets without counting the dependency declaration
-            // itself as a use. JSON serialization includes conditional targets.
-            const pkg = JSON.parse(content) as { imports?: unknown };
-            content = JSON.stringify(pkg.imports ?? {});
+            // Check alias targets and inline scripts without counting dependency
+            // declarations as uses. Serialization includes conditional targets.
+            const pkg = JSON.parse(content) as { imports?: unknown; scripts?: unknown };
+            content = JSON.stringify({ imports: pkg.imports, scripts: pkg.scripts });
           }
           if (matchesContent(content)) {
             return true;
@@ -368,14 +368,14 @@ export function collectProviderSourceModes(projectPath: string): Record<string, 
 }
 
 /**
- * Check final source, build output, and package import aliases after rewriting.
+ * Check final source, build output, package import aliases, and package scripts.
  * A substring scan conservatively retains references the rewriter leaves alone,
  * including require calls, type references, and strings.
  */
 export function sourceTreeReferencesOxlintPluginsPackage(projectPath: string): boolean {
   return sourceTreeMatches(projectPath, (content) => content.includes(OXLINT_PLUGINS_PACKAGE), {
     crossPackageBoundaries: true,
-    includePackageImports: true,
+    includePackageReferences: true,
     skipDirs: OXLINT_RETENTION_SKIP_DIRS,
   });
 }

--- a/packages/cli/src/migration/migrator/vite-config.ts
+++ b/packages/cli/src/migration/migrator/vite-config.ts
@@ -522,8 +522,12 @@ export function rewriteAllImports(
   silent = false,
   report?: MigrationReport,
   preserveNuxtVitestImports = true,
+  // Directories of packages that own the Oxlint plugin API, captured before
+  // `rewritePackageJson` stripped `oxlint` from their manifests. See
+  // `collectOxlintOwnerDirs`.
+  oxlintOwnerDirs: string[] = [],
 ): boolean {
-  const result = rewriteImportsInDirectory(projectPath, preserveNuxtVitestImports);
+  const result = rewriteImportsInDirectory(projectPath, preserveNuxtVitestImports, oxlintOwnerDirs);
   const modified = result.modifiedFiles.length;
   const preserved = result.preservedVitestFiles.length;
   const errors = result.errors.length;

--- a/packages/cli/src/oxlint-plugin.ts
+++ b/packages/cli/src/oxlint-plugin.ts
@@ -44,6 +44,37 @@ function isViteConfigFile(filename: string): boolean {
   return VITE_CONFIG_FILE_BASENAMES.has(path.basename(filename));
 }
 
+const OXLINT_PACKAGE = 'oxlint';
+const OXLINT_PLUGINS_PACKAGE = '@oxlint/plugins';
+const OXLINT_PLUGINS_DEV_SUBPATH = 'oxlint/plugins-dev';
+const VITE_PLUS_LINT_PLUGINS = 'vite-plus/lint/plugins';
+const VITE_PLUS_LINT_PLUGINS_DEV = 'vite-plus/lint/plugins-dev';
+
+// Everything the `oxlint` package still exports from its main entry: the config
+// surface. Those imports are correct as they are, so the rule must not redirect
+// them. Any other name in an `import ... from 'oxlint'` belongs to the
+// pre-`@oxlint/plugins` authoring API, such as `defineRule`, `Context`, or
+// `ESTree`. That API no longer resolves once the migration strips the
+// standalone `oxlint` dependency.
+//
+// This is a denylist, not an allowlist of about 60 plugin type names. The
+// denylist is small and stable, and an unrecognized name falls on the side of
+// fixing the breakage. It mirrors the `rewrite-oxlint-plugin-api-import` rule
+// in `crates/vp_migration/src/import_rewriter.rs`. The two MUST stay in sync.
+const OXLINT_CONFIG_SURFACE_EXPORTS = new Set([
+  'defineConfig',
+  'AllowWarnDeny',
+  'DummyRule',
+  'DummyRuleMap',
+  'ExternalPluginEntry',
+  'ExternalPluginsConfig',
+  'OxlintConfig',
+  'OxlintEnv',
+  'OxlintGlobals',
+  'OxlintOverride',
+  'RuleCategories',
+]);
+
 function rewriteVitePlusImportSpecifier(specifier: string): string | null {
   if (specifier === 'vite') {
     return 'vite-plus';
@@ -112,7 +143,45 @@ function rewriteVitePlusImportSpecifier(specifier: string): string | null {
     }
   }
 
+  // The Oxlint JS-plugin authoring API. Vite+ bundles Oxlint, so a project's
+  // own plugin should reach the API through `vite-plus`. Otherwise it pins
+  // `@oxlint/plugins` against whatever Oxlint the bundled linter runs. These
+  // two specifiers serve nothing but the plugin API, so they always rewrite.
+  // `reportLegacyOxlintPluginApiImport` handles the ambiguous bare `oxlint`
+  // specifier.
+  if (specifier === OXLINT_PLUGINS_PACKAGE) {
+    return VITE_PLUS_LINT_PLUGINS;
+  }
+
+  if (specifier === OXLINT_PLUGINS_DEV_SUBPATH) {
+    return VITE_PLUS_LINT_PLUGINS_DEV;
+  }
+
   return null;
+}
+
+function importedName(specifier: ESTree.ImportSpecifier): string | undefined {
+  const imported = specifier.imported;
+  if (imported.type === 'Identifier') {
+    return imported.name;
+  }
+  return typeof imported.value === 'string' ? imported.value : undefined;
+}
+
+/**
+ * True when an `import ... from 'oxlint'` names at least one binding outside
+ * Oxlint's config surface. Such an import reaches for the plugin authoring API.
+ *
+ * Default, namespace, and bare side-effect imports name no binding. They
+ * return `false`, so the rule leaves them alone instead of risking a wrong
+ * rewrite.
+ */
+function importsOxlintPluginApi(node: ESTree.ImportDeclaration): boolean {
+  return node.specifiers.some(
+    (specifier) =>
+      specifier.type === 'ImportSpecifier' &&
+      !OXLINT_CONFIG_SURFACE_EXPORTS.has(importedName(specifier) ?? ''),
+  );
 }
 
 function quoteSpecifier(literal: ESTree.StringLiteral, replacement: string): string {
@@ -179,6 +248,20 @@ function nearestPackageUsesNuxtTestUtils(filename: string): boolean {
   }
 }
 
+function reportSpecifier(context: Context, literal: ESTree.StringLiteral, replacement: string) {
+  context.report({
+    node: literal,
+    messageId: 'preferVitePlusImports',
+    data: {
+      from: literal.value,
+      to: replacement,
+    },
+    fix(fixer) {
+      return fixer.replaceText(literal, quoteSpecifier(literal, replacement));
+    },
+  });
+}
+
 function maybeReportLiteral(
   context: Context,
   literal: ESTree.Expression | ESTree.TSModuleDeclaration['id'] | null | undefined,
@@ -201,17 +284,24 @@ function maybeReportLiteral(
     return;
   }
 
-  context.report({
-    node: literal,
-    messageId: 'preferVitePlusImports',
-    data: {
-      from: literal.value,
-      to: replacement,
-    },
-    fix(fixer) {
-      return fixer.replaceText(literal, quoteSpecifier(literal, replacement));
-    },
-  });
+  reportSpecifier(context, literal, replacement);
+}
+
+/**
+ * `import { defineRule } from 'oxlint'` → `'vite-plus/lint/plugins'`.
+ *
+ * This is separate from {@link maybeReportLiteral} because the specifier string
+ * alone cannot decide the bare `oxlint` case. That specifier still serves the
+ * config surface. Only an `ImportDeclaration` shows the named bindings that
+ * tell the two surfaces apart. Re-export, `require`, and dynamic `import`
+ * statements therefore do not get this rewrite.
+ */
+function reportLegacyOxlintPluginApiImport(context: Context, node: ESTree.ImportDeclaration) {
+  const literal = node.source;
+  if (literal.value !== OXLINT_PACKAGE || !importsOxlintPluginApi(node)) {
+    return;
+  }
+  reportSpecifier(context, literal, VITE_PLUS_LINT_PLUGINS);
 }
 
 export const preferVitePlusImportsRule = defineRule({
@@ -237,6 +327,7 @@ export const preferVitePlusImportsRule = defineRule({
       },
       ImportDeclaration(node) {
         maybeReportLiteral(context, node.source, preserveUpstreamVitest, fileIsViteConfig);
+        reportLegacyOxlintPluginApiImport(context, node);
       },
       ExportAllDeclaration(node) {
         maybeReportLiteral(context, node.source, preserveUpstreamVitest, fileIsViteConfig);

--- a/packages/cli/src/oxlint-plugin.ts
+++ b/packages/cli/src/oxlint-plugin.ts
@@ -399,6 +399,37 @@ function maybeReportLiteral(
  * tell the two surfaces apart. Re-export, `require`, and dynamic `import`
  * statements therefore do not get this rewrite.
  */
+/**
+ * `export { defineRule } from 'oxlint'` → `'vite-plus/lint/plugins'`.
+ *
+ * A named re-export identifies the surface exactly as an import does, so it
+ * follows the same rules. A bare `export * from 'oxlint'` names nothing and is
+ * left alone.
+ */
+function reportLegacyOxlintPluginApiExport(
+  context: Context,
+  node: ESTree.ExportNamedDeclaration,
+  ownsOxlintApi: boolean,
+) {
+  const literal = node.source;
+  if (!literal || literal.value !== OXLINT_PACKAGE || ownsOxlintApi) {
+    return;
+  }
+  const named = node.specifiers;
+  if (named.length === 0) {
+    return;
+  }
+  const allPluginApi = named.every((specifier) => {
+    const local = specifier.local;
+    const name = local.type === 'Identifier' ? local.name : undefined;
+    return name !== undefined && !OXLINT_CONFIG_SURFACE_EXPORTS.has(name);
+  });
+  if (!allPluginApi) {
+    return;
+  }
+  reportSpecifier(context, literal, VITE_PLUS_LINT_PLUGINS);
+}
+
 function reportLegacyOxlintPluginApiImport(
   context: Context,
   node: ESTree.ImportDeclaration,
@@ -464,6 +495,7 @@ export const preferVitePlusImportsRule = defineRule({
           fileIsViteConfig,
           ownsOxlintApi,
         );
+        reportLegacyOxlintPluginApiExport(context, node, ownsOxlintApi);
       },
       ImportExpression(node) {
         maybeReportLiteral(

--- a/packages/cli/src/oxlint-plugin.ts
+++ b/packages/cli/src/oxlint-plugin.ts
@@ -195,6 +195,12 @@ function importedName(specifier: ESTree.ImportSpecifier): string | undefined {
  * rewrite.
  */
 function importsOxlintPluginApi(node: ESTree.ImportDeclaration): boolean {
+  // A default or namespace binding disqualifies the statement outright.
+  // `vite-plus/lint/plugins` has no default export, so redirecting
+  // `import oxlint, { defineRule } from 'oxlint'` would leave the file invalid.
+  if (node.specifiers.some((specifier) => specifier.type !== 'ImportSpecifier')) {
+    return false;
+  }
   const named = node.specifiers.filter(
     (specifier): specifier is ESTree.ImportSpecifier => specifier.type === 'ImportSpecifier',
   );
@@ -478,6 +484,16 @@ export const preferVitePlusImportsRule = defineRule({
         );
       },
       TSExternalModuleReference(node) {
+        // `import plugins = require('...')` has require semantics, and the
+        // `vite-plus/lint/*` subpaths are ESM-only, so they are skipped here
+        // for the same reason the migrate rewriter skips `require()`.
+        if (
+          node.expression.type === 'Literal' &&
+          typeof node.expression.value === 'string' &&
+          isOxlintApiSpecifier(node.expression.value)
+        ) {
+          return;
+        }
         maybeReportLiteral(
           context,
           node.expression,

--- a/packages/cli/src/oxlint-plugin.ts
+++ b/packages/cli/src/oxlint-plugin.ts
@@ -36,6 +36,19 @@ function isVitestFamilyDeclareModuleSpecifier(specifier: string): boolean {
 // (no migrate-resolved custom path). vitest/tsdown/@vitest are unaffected.
 const VITE_CONFIG_FILE_BASENAMES = new Set(viteConfigEntryBasenames);
 
+// `declare module '@oxlint/plugins'` (and the `oxlint` / `oxlint/plugins-dev`
+// forms) are preserved for the same reason as the vitest family above:
+// `vite-plus/lint/plugins*` re-exports the upstream types, so the module
+// identity a user augments stays `@oxlint/plugins`. Retargeting the
+// augmentation would stop it merging with the upstream declarations.
+function isOxlintFamilyDeclareModuleSpecifier(specifier: string): boolean {
+  return (
+    specifier === OXLINT_PACKAGE ||
+    specifier.startsWith(`${OXLINT_PACKAGE}/`) ||
+    specifier === OXLINT_PLUGINS_PACKAGE
+  );
+}
+
 function isViteSpecifier(specifier: string): boolean {
   return specifier === 'vite' || specifier.startsWith('vite/');
 }
@@ -169,18 +182,29 @@ function importedName(specifier: ESTree.ImportSpecifier): string | undefined {
 }
 
 /**
- * True when an `import ... from 'oxlint'` names at least one binding outside
- * Oxlint's config surface. Such an import reaches for the plugin authoring API.
+ * True when EVERY named binding of an `import ... from 'oxlint'` sits outside
+ * Oxlint's config surface. Such an import reaches only for the plugin
+ * authoring API.
  *
- * Default, namespace, and bare side-effect imports name no binding. They
+ * A statement that mixes the two surfaces returns `false`. The autofix replaces
+ * the whole specifier, and `vite-plus/lint/plugins` exports no `defineConfig`,
+ * so moving a mixed statement would leave the file invalid.
+ *
+ * Default, namespace, and bare side-effect imports name no binding. They also
  * return `false`, so the rule leaves them alone instead of risking a wrong
  * rewrite.
  */
 function importsOxlintPluginApi(node: ESTree.ImportDeclaration): boolean {
-  return node.specifiers.some(
-    (specifier) =>
-      specifier.type === 'ImportSpecifier' &&
-      !OXLINT_CONFIG_SURFACE_EXPORTS.has(importedName(specifier) ?? ''),
+  const named = node.specifiers.filter(
+    (specifier): specifier is ESTree.ImportSpecifier => specifier.type === 'ImportSpecifier',
+  );
+  if (named.length === 0) {
+    return false;
+  }
+  // A statement that mixes the two surfaces is left alone. The autofix replaces
+  // the whole specifier, so moving it would strip `defineConfig` of its module.
+  return named.every(
+    (specifier) => !OXLINT_CONFIG_SURFACE_EXPORTS.has(importedName(specifier) ?? ''),
   );
 }
 
@@ -248,6 +272,69 @@ function nearestPackageUsesNuxtTestUtils(filename: string): boolean {
   }
 }
 
+// Same mtime-keyed shape as `nuxtTestUtilsPackageCache`, for the same reason: a
+// long-lived lint process must re-read the manifest after the user edits it.
+const oxlintOwnerPackageCache = new Map<string, { mtimeMs: number; ownsOxlintApi: boolean }>();
+
+/**
+ * True when the nearest package.json declares `oxlint` or `@oxlint/plugins` in
+ * `dependencies` or `peerDependencies`.
+ *
+ * That shape marks a published Oxlint plugin, whose consumers may run plain
+ * Oxlint. Rewriting its source to import from `vite-plus` would break them, so
+ * the autofix must leave it alone. `vp migrate` skips the same package shape
+ * (`SkipPackages::skip_oxlint`); without this check `vp lint --fix` would
+ * immediately undo that exemption.
+ *
+ * A devDependency is deliberately NOT a signal: that is how a project's own
+ * in-repo plugin gets its types, and those imports SHOULD move to `vite-plus`.
+ */
+function nearestPackageOwnsOxlintApi(filename: string): boolean {
+  if (!path.isAbsolute(filename)) {
+    return false;
+  }
+  let directory = path.dirname(filename);
+  while (true) {
+    const packageJsonPath = path.join(directory, 'package.json');
+    if (fs.existsSync(packageJsonPath)) {
+      let mtimeMs: number | undefined;
+      try {
+        mtimeMs = fs.statSync(packageJsonPath).mtimeMs;
+      } catch {
+        // Unreadable manifest: bypass the cache, as above.
+      }
+      const cached =
+        mtimeMs === undefined ? undefined : oxlintOwnerPackageCache.get(packageJsonPath);
+      if (cached !== undefined && cached.mtimeMs === mtimeMs) {
+        return cached.ownsOxlintApi;
+      }
+      let ownsOxlintApi = false;
+      try {
+        const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as {
+          dependencies?: Record<string, string>;
+          peerDependencies?: Record<string, string>;
+        };
+        ownsOxlintApi = [pkg.dependencies, pkg.peerDependencies].some(
+          (dependencies) =>
+            dependencies?.[OXLINT_PACKAGE] !== undefined ||
+            dependencies?.[OXLINT_PLUGINS_PACKAGE] !== undefined,
+        );
+      } catch {
+        // Invalid or unreadable package metadata cannot opt into the exception.
+      }
+      if (mtimeMs !== undefined) {
+        oxlintOwnerPackageCache.set(packageJsonPath, { mtimeMs, ownsOxlintApi });
+      }
+      return ownsOxlintApi;
+    }
+    const parent = path.dirname(directory);
+    if (parent === directory) {
+      return false;
+    }
+    directory = parent;
+  }
+}
+
 function reportSpecifier(context: Context, literal: ESTree.StringLiteral, replacement: string) {
   context.report({
     node: literal,
@@ -262,11 +349,16 @@ function reportSpecifier(context: Context, literal: ESTree.StringLiteral, replac
   });
 }
 
+function isOxlintApiSpecifier(specifier: string): boolean {
+  return specifier === OXLINT_PLUGINS_PACKAGE || specifier === OXLINT_PLUGINS_DEV_SUBPATH;
+}
+
 function maybeReportLiteral(
   context: Context,
   literal: ESTree.Expression | ESTree.TSModuleDeclaration['id'] | null | undefined,
   preserveUpstreamVitest = false,
   fileIsViteConfig = false,
+  ownsOxlintApi = false,
 ) {
   if (!literal || literal.type !== 'Literal' || typeof literal.value !== 'string') {
     return;
@@ -283,6 +375,11 @@ function maybeReportLiteral(
   if (!replacement) {
     return;
   }
+  // A published Oxlint plugin keeps resolving the authoring API from the
+  // package it declares. See `nearestPackageOwnsOxlintApi`.
+  if (ownsOxlintApi && isOxlintApiSpecifier(literal.value)) {
+    return;
+  }
 
   reportSpecifier(context, literal, replacement);
 }
@@ -296,9 +393,16 @@ function maybeReportLiteral(
  * tell the two surfaces apart. Re-export, `require`, and dynamic `import`
  * statements therefore do not get this rewrite.
  */
-function reportLegacyOxlintPluginApiImport(context: Context, node: ESTree.ImportDeclaration) {
+function reportLegacyOxlintPluginApiImport(
+  context: Context,
+  node: ESTree.ImportDeclaration,
+  ownsOxlintApi: boolean,
+) {
   const literal = node.source;
   if (literal.value !== OXLINT_PACKAGE || !importsOxlintPluginApi(node)) {
+    return;
+  }
+  if (ownsOxlintApi) {
     return;
   }
   reportSpecifier(context, literal, VITE_PLUS_LINT_PLUGINS);
@@ -320,29 +424,67 @@ export const preferVitePlusImportsRule = defineRule({
   createOnce(context: Context) {
     let preserveUpstreamVitest = false;
     let fileIsViteConfig = false;
+    let ownsOxlintApi = false;
     return {
       Program() {
         preserveUpstreamVitest = nearestPackageUsesNuxtTestUtils(context.filename);
         fileIsViteConfig = isViteConfigFile(context.filename);
+        ownsOxlintApi = nearestPackageOwnsOxlintApi(context.filename);
       },
       ImportDeclaration(node) {
-        maybeReportLiteral(context, node.source, preserveUpstreamVitest, fileIsViteConfig);
-        reportLegacyOxlintPluginApiImport(context, node);
+        maybeReportLiteral(
+          context,
+          node.source,
+          preserveUpstreamVitest,
+          fileIsViteConfig,
+          ownsOxlintApi,
+        );
+        reportLegacyOxlintPluginApiImport(context, node, ownsOxlintApi);
       },
       ExportAllDeclaration(node) {
-        maybeReportLiteral(context, node.source, preserveUpstreamVitest, fileIsViteConfig);
+        maybeReportLiteral(
+          context,
+          node.source,
+          preserveUpstreamVitest,
+          fileIsViteConfig,
+          ownsOxlintApi,
+        );
       },
       ExportNamedDeclaration(node) {
-        maybeReportLiteral(context, node.source, preserveUpstreamVitest, fileIsViteConfig);
+        maybeReportLiteral(
+          context,
+          node.source,
+          preserveUpstreamVitest,
+          fileIsViteConfig,
+          ownsOxlintApi,
+        );
       },
       ImportExpression(node) {
-        maybeReportLiteral(context, node.source, preserveUpstreamVitest, fileIsViteConfig);
+        maybeReportLiteral(
+          context,
+          node.source,
+          preserveUpstreamVitest,
+          fileIsViteConfig,
+          ownsOxlintApi,
+        );
       },
       TSImportType(node) {
-        maybeReportLiteral(context, node.source, preserveUpstreamVitest, fileIsViteConfig);
+        maybeReportLiteral(
+          context,
+          node.source,
+          preserveUpstreamVitest,
+          fileIsViteConfig,
+          ownsOxlintApi,
+        );
       },
       TSExternalModuleReference(node) {
-        maybeReportLiteral(context, node.expression, preserveUpstreamVitest, fileIsViteConfig);
+        maybeReportLiteral(
+          context,
+          node.expression,
+          preserveUpstreamVitest,
+          fileIsViteConfig,
+          ownsOxlintApi,
+        );
       },
       TSModuleDeclaration(node) {
         if (node.global) {
@@ -352,11 +494,12 @@ export const preferVitePlusImportsRule = defineRule({
         if (
           id?.type === 'Literal' &&
           typeof id.value === 'string' &&
-          isVitestFamilyDeclareModuleSpecifier(id.value)
+          (isVitestFamilyDeclareModuleSpecifier(id.value) ||
+            isOxlintFamilyDeclareModuleSpecifier(id.value))
         ) {
           return;
         }
-        maybeReportLiteral(context, id, preserveUpstreamVitest, fileIsViteConfig);
+        maybeReportLiteral(context, id, preserveUpstreamVitest, fileIsViteConfig, ownsOxlintApi);
       },
     };
   },

--- a/packages/cli/src/oxlint-plugin.ts
+++ b/packages/cli/src/oxlint-plugin.ts
@@ -36,11 +36,7 @@ function isVitestFamilyDeclareModuleSpecifier(specifier: string): boolean {
 // (no migrate-resolved custom path). vitest/tsdown/@vitest are unaffected.
 const VITE_CONFIG_FILE_BASENAMES = new Set(viteConfigEntryBasenames);
 
-// `declare module '@oxlint/plugins'` (and the `oxlint` / `oxlint/plugins-dev`
-// forms) are preserved for the same reason as the vitest family above:
-// `vite-plus/lint/plugins*` re-exports the upstream types, so the module
-// identity a user augments stays `@oxlint/plugins`. Retargeting the
-// augmentation would stop it merging with the upstream declarations.
+// Keep augmentations on the upstream module whose types the shims re-export.
 function isOxlintFamilyDeclareModuleSpecifier(specifier: string): boolean {
   return (
     specifier === OXLINT_PACKAGE ||
@@ -63,17 +59,8 @@ const OXLINT_PLUGINS_DEV_SUBPATH = 'oxlint/plugins-dev';
 const VITE_PLUS_LINT_PLUGINS = 'vite-plus/lint/plugins';
 const VITE_PLUS_LINT_PLUGINS_DEV = 'vite-plus/lint/plugins-dev';
 
-// Everything the `oxlint` package still exports from its main entry: the config
-// surface. Those imports are correct as they are, so the rule must not redirect
-// them. Any other name in an `import ... from 'oxlint'` belongs to the
-// pre-`@oxlint/plugins` authoring API, such as `defineRule`, `Context`, or
-// `ESTree`. That API no longer resolves once the migration strips the
-// standalone `oxlint` dependency.
-//
-// This is a denylist, not an allowlist of about 60 plugin type names. The
-// denylist is small and stable, and an unrecognized name falls on the side of
-// fixing the breakage. It mirrors the `rewrite-oxlint-plugin-api-import` rule
-// in `crates/vp_migration/src/import_rewriter.rs`. The two MUST stay in sync.
+// Names outside this config surface use the legacy plugin API. Keep this list
+// in sync with the Oxlint rules in crates/vp_migration/src/import_rewriter.rs.
 const OXLINT_CONFIG_SURFACE_EXPORTS = new Set([
   'defineConfig',
   'AllowWarnDeny',
@@ -156,12 +143,8 @@ function rewriteVitePlusImportSpecifier(specifier: string): string | null {
     }
   }
 
-  // The Oxlint JS-plugin authoring API. Vite+ bundles Oxlint, so a project's
-  // own plugin should reach the API through `vite-plus`. Otherwise it pins
-  // `@oxlint/plugins` against whatever Oxlint the bundled linter runs. These
-  // two specifiers serve nothing but the plugin API, so they always rewrite.
-  // `reportLegacyOxlintPluginApiImport` handles the ambiguous bare `oxlint`
-  // specifier.
+  // These entry points expose only plugin APIs. Bare `oxlint` also exposes
+  // config APIs, so it needs the named-binding checks below.
   if (specifier === OXLINT_PLUGINS_PACKAGE) {
     return VITE_PLUS_LINT_PLUGINS;
   }
@@ -181,36 +164,16 @@ function importedName(specifier: ESTree.ImportSpecifier): string | undefined {
   return typeof imported.value === 'string' ? imported.value : undefined;
 }
 
-/**
- * True when EVERY named binding of an `import ... from 'oxlint'` sits outside
- * Oxlint's config surface. Such an import reaches only for the plugin
- * authoring API.
- *
- * A statement that mixes the two surfaces returns `false`. The autofix replaces
- * the whole specifier, and `vite-plus/lint/plugins` exports no `defineConfig`,
- * so moving a mixed statement would leave the file invalid.
- *
- * Default, namespace, and bare side-effect imports name no binding. They also
- * return `false`, so the rule leaves them alone instead of risking a wrong
- * rewrite.
- */
+// Replacing the source affects the whole import. Require named plugin bindings
+// only: the shim has neither config exports nor a default export.
 function importsOxlintPluginApi(node: ESTree.ImportDeclaration): boolean {
-  // A default or namespace binding disqualifies the statement outright.
-  // `vite-plus/lint/plugins` has no default export, so redirecting
-  // `import oxlint, { defineRule } from 'oxlint'` would leave the file invalid.
-  if (node.specifiers.some((specifier) => specifier.type !== 'ImportSpecifier')) {
-    return false;
-  }
-  const named = node.specifiers.filter(
-    (specifier): specifier is ESTree.ImportSpecifier => specifier.type === 'ImportSpecifier',
-  );
-  if (named.length === 0) {
-    return false;
-  }
-  // A statement that mixes the two surfaces is left alone. The autofix replaces
-  // the whole specifier, so moving it would strip `defineConfig` of its module.
-  return named.every(
-    (specifier) => !OXLINT_CONFIG_SURFACE_EXPORTS.has(importedName(specifier) ?? ''),
+  return (
+    node.specifiers.length > 0 &&
+    node.specifiers.every(
+      (specifier) =>
+        specifier.type === 'ImportSpecifier' &&
+        !OXLINT_CONFIG_SURFACE_EXPORTS.has(importedName(specifier) ?? ''),
+    )
   );
 }
 
@@ -219,132 +182,94 @@ function quoteSpecifier(literal: ESTree.StringLiteral, replacement: string): str
   return `${quote}${replacement}${quote}`;
 }
 
-// Keyed by package.json path and invalidated by its mtime so a long-lived lint
-// process (editor/LSP session) re-reads the manifest after the user adds or
-// removes `@nuxt/test-utils`, instead of reusing the pre-edit decision forever.
-const nuxtTestUtilsPackageCache = new Map<
-  string,
-  { mtimeMs: number; usesNuxtTestUtils: boolean }
->();
+type PackageDependencies = {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+};
+
+type PackageMatchCache = Map<string, { mtimeMs: number; matches: boolean }>;
+
+// Separate decisions share the same mtime-based invalidation in editor sessions.
+const nuxtTestUtilsPackageCache: PackageMatchCache = new Map();
+const oxlintOwnerPackageCache: PackageMatchCache = new Map();
 
 function isUpstreamVitestSpecifier(specifier: string): boolean {
   return specifier === 'vitest' || specifier.startsWith('vitest/');
 }
 
+function nearestPackageMatches(
+  filename: string,
+  cache: PackageMatchCache,
+  matchesPackage: (pkg: PackageDependencies) => boolean,
+): boolean {
+  if (!path.isAbsolute(filename)) {
+    return false;
+  }
+  let directory = path.dirname(filename);
+  while (true) {
+    const packageJsonPath = path.join(directory, 'package.json');
+    if (fs.existsSync(packageJsonPath)) {
+      let mtimeMs: number | undefined;
+      try {
+        mtimeMs = fs.statSync(packageJsonPath).mtimeMs;
+      } catch {
+        // Bypass the cache when stat fails; a sentinel could reuse stale data.
+      }
+      const cached = mtimeMs === undefined ? undefined : cache.get(packageJsonPath);
+      if (cached !== undefined && cached.mtimeMs === mtimeMs) {
+        return cached.matches;
+      }
+      let matches = false;
+      try {
+        const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as PackageDependencies;
+        matches = matchesPackage(pkg);
+      } catch {
+        // Invalid or unreadable package metadata cannot opt into the exception.
+      }
+      if (mtimeMs !== undefined) {
+        cache.set(packageJsonPath, { mtimeMs, matches });
+      }
+      return matches;
+    }
+    const parent = path.dirname(directory);
+    if (parent === directory) {
+      return false;
+    }
+    directory = parent;
+  }
+}
+
 function nearestPackageUsesNuxtTestUtils(filename: string): boolean {
-  if (!path.isAbsolute(filename)) {
-    return false;
-  }
-  let directory = path.dirname(filename);
-  while (true) {
-    const packageJsonPath = path.join(directory, 'package.json');
-    if (fs.existsSync(packageJsonPath)) {
-      let mtimeMs: number | undefined;
-      try {
-        mtimeMs = fs.statSync(packageJsonPath).mtimeMs;
-      } catch {
-        // Unreadable manifest: bypass the cache entirely below. A sentinel
-        // value would collide with an entry cached during an earlier failure
-        // and pin the pre-edit decision.
-      }
-      const cached =
-        mtimeMs === undefined ? undefined : nuxtTestUtilsPackageCache.get(packageJsonPath);
-      if (cached !== undefined && cached.mtimeMs === mtimeMs) {
-        return cached.usesNuxtTestUtils;
-      }
-      let usesNuxtTestUtils = false;
-      try {
-        const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as {
-          dependencies?: Record<string, string>;
-          devDependencies?: Record<string, string>;
-          optionalDependencies?: Record<string, string>;
-        };
-        usesNuxtTestUtils = [pkg.dependencies, pkg.devDependencies, pkg.optionalDependencies].some(
-          (dependencies) => dependencies?.['@nuxt/test-utils'] !== undefined,
-        );
-      } catch {
-        // Invalid or unreadable package metadata cannot opt into the exception.
-      }
-      if (mtimeMs !== undefined) {
-        nuxtTestUtilsPackageCache.set(packageJsonPath, { mtimeMs, usesNuxtTestUtils });
-      }
-      return usesNuxtTestUtils;
-    }
-    const parent = path.dirname(directory);
-    if (parent === directory) {
-      return false;
-    }
-    directory = parent;
-  }
+  return nearestPackageMatches(filename, nuxtTestUtilsPackageCache, (pkg) =>
+    [pkg.dependencies, pkg.devDependencies, pkg.optionalDependencies].some(
+      (dependencies) => dependencies?.['@nuxt/test-utils'] !== undefined,
+    ),
+  );
 }
 
-// Same mtime-keyed shape as `nuxtTestUtilsPackageCache`, for the same reason: a
-// long-lived lint process must re-read the manifest after the user edits it.
-const oxlintOwnerPackageCache = new Map<string, { mtimeMs: number; ownsOxlintApi: boolean }>();
-
-/**
- * True when the nearest package.json declares `oxlint` or `@oxlint/plugins` in
- * `dependencies` or `peerDependencies`, or has optional `@oxlint/plugins`.
- *
- * That shape marks a published Oxlint plugin, whose consumers may run plain
- * Oxlint. Rewriting its source to import from `vite-plus` would break them, so
- * the autofix must leave it alone. `vp migrate` skips the same package shape
- * (`SkipPackages::skip_oxlint`); without this check `vp lint --fix` would
- * immediately undo that exemption.
- *
- * A devDependency is deliberately NOT a signal: that is how a project's own
- * in-repo plugin gets its types, and those imports SHOULD move to `vite-plus`.
- */
+// Match the migrator's published-plugin exemption. Development-only APIs do not
+// exempt a package; optional @oxlint/plugins is a consumer runtime dependency.
 function nearestPackageOwnsOxlintApi(filename: string): boolean {
-  if (!path.isAbsolute(filename)) {
-    return false;
-  }
-  let directory = path.dirname(filename);
-  while (true) {
-    const packageJsonPath = path.join(directory, 'package.json');
-    if (fs.existsSync(packageJsonPath)) {
-      let mtimeMs: number | undefined;
-      try {
-        mtimeMs = fs.statSync(packageJsonPath).mtimeMs;
-      } catch {
-        // Unreadable manifest: bypass the cache, as above.
-      }
-      const cached =
-        mtimeMs === undefined ? undefined : oxlintOwnerPackageCache.get(packageJsonPath);
-      if (cached !== undefined && cached.mtimeMs === mtimeMs) {
-        return cached.ownsOxlintApi;
-      }
-      let ownsOxlintApi = false;
-      try {
-        const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as {
-          dependencies?: Record<string, string>;
-          peerDependencies?: Record<string, string>;
-          optionalDependencies?: Record<string, string>;
-        };
-        ownsOxlintApi =
-          pkg.optionalDependencies?.[OXLINT_PLUGINS_PACKAGE] !== undefined ||
-          [pkg.dependencies, pkg.peerDependencies].some(
-            (dependencies) =>
-              dependencies?.[OXLINT_PACKAGE] !== undefined ||
-              dependencies?.[OXLINT_PLUGINS_PACKAGE] !== undefined,
-          );
-      } catch {
-        // Invalid or unreadable package metadata cannot opt into the exception.
-      }
-      if (mtimeMs !== undefined) {
-        oxlintOwnerPackageCache.set(packageJsonPath, { mtimeMs, ownsOxlintApi });
-      }
-      return ownsOxlintApi;
-    }
-    const parent = path.dirname(directory);
-    if (parent === directory) {
-      return false;
-    }
-    directory = parent;
-  }
+  return nearestPackageMatches(
+    filename,
+    oxlintOwnerPackageCache,
+    (pkg) =>
+      pkg.optionalDependencies?.[OXLINT_PLUGINS_PACKAGE] !== undefined ||
+      [pkg.dependencies, pkg.peerDependencies].some(
+        (dependencies) =>
+          dependencies?.[OXLINT_PACKAGE] !== undefined ||
+          dependencies?.[OXLINT_PLUGINS_PACKAGE] !== undefined,
+      ),
+  );
 }
 
-function reportSpecifier(context: Context, literal: ESTree.StringLiteral, replacement: string) {
+function reportSpecifier(
+  context: Context,
+  literal: ESTree.StringLiteral,
+  replacement: string,
+): void {
   context.report({
     node: literal,
     messageId: 'preferVitePlusImports',
@@ -362,13 +287,17 @@ function isOxlintApiSpecifier(specifier: string): boolean {
   return specifier === OXLINT_PLUGINS_PACKAGE || specifier === OXLINT_PLUGINS_DEV_SUBPATH;
 }
 
+interface ImportRewriteOptions {
+  preserveUpstreamVitest: boolean;
+  fileIsViteConfig: boolean;
+  ownsOxlintApi: boolean;
+}
+
 function maybeReportLiteral(
   context: Context,
   literal: ESTree.Expression | ESTree.TSModuleDeclaration['id'] | null | undefined,
-  preserveUpstreamVitest = false,
-  fileIsViteConfig = false,
-  ownsOxlintApi = false,
-) {
+  { preserveUpstreamVitest, fileIsViteConfig, ownsOxlintApi }: ImportRewriteOptions,
+): void {
   if (!literal || literal.type !== 'Literal' || typeof literal.value !== 'string') {
     return;
   }
@@ -384,8 +313,6 @@ function maybeReportLiteral(
   if (!replacement) {
     return;
   }
-  // A published Oxlint plugin keeps resolving the authoring API from the
-  // package it declares. See `nearestPackageOwnsOxlintApi`.
   if (ownsOxlintApi && isOxlintApiSpecifier(literal.value)) {
     return;
   }
@@ -393,39 +320,22 @@ function maybeReportLiteral(
   reportSpecifier(context, literal, replacement);
 }
 
-/**
- * `import { defineRule } from 'oxlint'` → `'vite-plus/lint/plugins'`.
- *
- * This is separate from {@link maybeReportLiteral} because the specifier string
- * alone cannot decide the bare `oxlint` case. That specifier still serves the
- * config surface. Only an `ImportDeclaration` shows the named bindings that
- * tell the two surfaces apart. Re-export, `require`, and dynamic `import`
- * statements therefore do not get this rewrite.
- */
-/**
- * `export { defineRule } from 'oxlint'` → `'vite-plus/lint/plugins'`.
- *
- * A named re-export identifies the surface exactly as an import does, so it
- * follows the same rules. A bare `export * from 'oxlint'` names nothing and is
- * left alone.
- */
+// Bare `oxlint` needs named-binding checks beyond maybeReportLiteral's mapping.
 function reportLegacyOxlintPluginApiExport(
   context: Context,
   node: ESTree.ExportNamedDeclaration,
   ownsOxlintApi: boolean,
-) {
+): void {
   const literal = node.source;
   if (!literal || literal.value !== OXLINT_PACKAGE || ownsOxlintApi) {
     return;
   }
-  const named = node.specifiers;
-  if (named.length === 0) {
+  if (node.specifiers.length === 0) {
     return;
   }
-  const allPluginApi = named.every((specifier) => {
+  const allPluginApi = node.specifiers.every((specifier) => {
     const local = specifier.local;
-    const name = local.type === 'Identifier' ? local.name : undefined;
-    return name !== undefined && !OXLINT_CONFIG_SURFACE_EXPORTS.has(name);
+    return local.type === 'Identifier' && !OXLINT_CONFIG_SURFACE_EXPORTS.has(local.name);
   });
   if (!allPluginApi) {
     return;
@@ -437,12 +347,9 @@ function reportLegacyOxlintPluginApiImport(
   context: Context,
   node: ESTree.ImportDeclaration,
   ownsOxlintApi: boolean,
-) {
+): void {
   const literal = node.source;
-  if (literal.value !== OXLINT_PACKAGE || !importsOxlintPluginApi(node)) {
-    return;
-  }
-  if (ownsOxlintApi) {
+  if (literal.value !== OXLINT_PACKAGE || ownsOxlintApi || !importsOxlintPluginApi(node)) {
     return;
   }
   reportSpecifier(context, literal, VITE_PLUS_LINT_PLUGINS);
@@ -462,61 +369,33 @@ export const preferVitePlusImportsRule = defineRule({
     },
   },
   createOnce(context: Context) {
-    let preserveUpstreamVitest = false;
-    let fileIsViteConfig = false;
-    let ownsOxlintApi = false;
+    const options: ImportRewriteOptions = {
+      preserveUpstreamVitest: false,
+      fileIsViteConfig: false,
+      ownsOxlintApi: false,
+    };
     return {
       Program() {
-        preserveUpstreamVitest = nearestPackageUsesNuxtTestUtils(context.filename);
-        fileIsViteConfig = isViteConfigFile(context.filename);
-        ownsOxlintApi = nearestPackageOwnsOxlintApi(context.filename);
+        options.preserveUpstreamVitest = nearestPackageUsesNuxtTestUtils(context.filename);
+        options.fileIsViteConfig = isViteConfigFile(context.filename);
+        options.ownsOxlintApi = nearestPackageOwnsOxlintApi(context.filename);
       },
       ImportDeclaration(node) {
-        maybeReportLiteral(
-          context,
-          node.source,
-          preserveUpstreamVitest,
-          fileIsViteConfig,
-          ownsOxlintApi,
-        );
-        reportLegacyOxlintPluginApiImport(context, node, ownsOxlintApi);
+        maybeReportLiteral(context, node.source, options);
+        reportLegacyOxlintPluginApiImport(context, node, options.ownsOxlintApi);
       },
       ExportAllDeclaration(node) {
-        maybeReportLiteral(
-          context,
-          node.source,
-          preserveUpstreamVitest,
-          fileIsViteConfig,
-          ownsOxlintApi,
-        );
+        maybeReportLiteral(context, node.source, options);
       },
       ExportNamedDeclaration(node) {
-        maybeReportLiteral(
-          context,
-          node.source,
-          preserveUpstreamVitest,
-          fileIsViteConfig,
-          ownsOxlintApi,
-        );
-        reportLegacyOxlintPluginApiExport(context, node, ownsOxlintApi);
+        maybeReportLiteral(context, node.source, options);
+        reportLegacyOxlintPluginApiExport(context, node, options.ownsOxlintApi);
       },
       ImportExpression(node) {
-        maybeReportLiteral(
-          context,
-          node.source,
-          preserveUpstreamVitest,
-          fileIsViteConfig,
-          ownsOxlintApi,
-        );
+        maybeReportLiteral(context, node.source, options);
       },
       TSImportType(node) {
-        maybeReportLiteral(
-          context,
-          node.source,
-          preserveUpstreamVitest,
-          fileIsViteConfig,
-          ownsOxlintApi,
-        );
+        maybeReportLiteral(context, node.source, options);
       },
       TSExternalModuleReference(node) {
         // Keep import-equals declarations unchanged, matching the migrator's
@@ -528,13 +407,7 @@ export const preferVitePlusImportsRule = defineRule({
         ) {
           return;
         }
-        maybeReportLiteral(
-          context,
-          node.expression,
-          preserveUpstreamVitest,
-          fileIsViteConfig,
-          ownsOxlintApi,
-        );
+        maybeReportLiteral(context, node.expression, options);
       },
       TSModuleDeclaration(node) {
         if (node.global) {
@@ -549,7 +422,7 @@ export const preferVitePlusImportsRule = defineRule({
         ) {
           return;
         }
-        maybeReportLiteral(context, id, preserveUpstreamVitest, fileIsViteConfig, ownsOxlintApi);
+        maybeReportLiteral(context, id, options);
       },
     };
   },

--- a/packages/cli/src/oxlint-plugin.ts
+++ b/packages/cli/src/oxlint-plugin.ts
@@ -156,12 +156,8 @@ function rewriteVitePlusImportSpecifier(specifier: string): string | null {
   return null;
 }
 
-function importedName(specifier: ESTree.ImportSpecifier): string | undefined {
-  const imported = specifier.imported;
-  if (imported.type === 'Identifier') {
-    return imported.name;
-  }
-  return typeof imported.value === 'string' ? imported.value : undefined;
+function moduleBindingName(node: ESTree.ImportSpecifier['imported']): string {
+  return node.type === 'Identifier' ? node.name : node.value;
 }
 
 // Replacing the source affects the whole import. Require named plugin bindings
@@ -172,7 +168,7 @@ function importsOxlintPluginApi(node: ESTree.ImportDeclaration): boolean {
     node.specifiers.every(
       (specifier) =>
         specifier.type === 'ImportSpecifier' &&
-        !OXLINT_CONFIG_SURFACE_EXPORTS.has(importedName(specifier) ?? ''),
+        !OXLINT_CONFIG_SURFACE_EXPORTS.has(moduleBindingName(specifier.imported)),
     )
   );
 }
@@ -333,10 +329,9 @@ function reportLegacyOxlintPluginApiExport(
   if (node.specifiers.length === 0) {
     return;
   }
-  const allPluginApi = node.specifiers.every((specifier) => {
-    const local = specifier.local;
-    return local.type === 'Identifier' && !OXLINT_CONFIG_SURFACE_EXPORTS.has(local.name);
-  });
+  const allPluginApi = node.specifiers.every(
+    (specifier) => !OXLINT_CONFIG_SURFACE_EXPORTS.has(moduleBindingName(specifier.local)),
+  );
   if (!allPluginApi) {
     return;
   }

--- a/packages/cli/src/oxlint-plugin.ts
+++ b/packages/cli/src/oxlint-plugin.ts
@@ -516,9 +516,8 @@ export const preferVitePlusImportsRule = defineRule({
         );
       },
       TSExternalModuleReference(node) {
-        // `import plugins = require('...')` has require semantics, and the
-        // `vite-plus/lint/*` subpaths are ESM-only, so they are skipped here
-        // for the same reason the migrate rewriter skips `require()`.
+        // Keep import-equals declarations unchanged, matching the migrator's
+        // treatment of require calls.
         if (
           node.expression.type === 'Literal' &&
           typeof node.expression.value === 'string' &&

--- a/packages/cli/src/oxlint-plugin.ts
+++ b/packages/cli/src/oxlint-plugin.ts
@@ -284,7 +284,7 @@ const oxlintOwnerPackageCache = new Map<string, { mtimeMs: number; ownsOxlintApi
 
 /**
  * True when the nearest package.json declares `oxlint` or `@oxlint/plugins` in
- * `dependencies` or `peerDependencies`.
+ * `dependencies` or `peerDependencies`, or has optional `@oxlint/plugins`.
  *
  * That shape marks a published Oxlint plugin, whose consumers may run plain
  * Oxlint. Rewriting its source to import from `vite-plus` would break them, so
@@ -319,12 +319,15 @@ function nearestPackageOwnsOxlintApi(filename: string): boolean {
         const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as {
           dependencies?: Record<string, string>;
           peerDependencies?: Record<string, string>;
+          optionalDependencies?: Record<string, string>;
         };
-        ownsOxlintApi = [pkg.dependencies, pkg.peerDependencies].some(
-          (dependencies) =>
-            dependencies?.[OXLINT_PACKAGE] !== undefined ||
-            dependencies?.[OXLINT_PLUGINS_PACKAGE] !== undefined,
-        );
+        ownsOxlintApi =
+          pkg.optionalDependencies?.[OXLINT_PLUGINS_PACKAGE] !== undefined ||
+          [pkg.dependencies, pkg.peerDependencies].some(
+            (dependencies) =>
+              dependencies?.[OXLINT_PACKAGE] !== undefined ||
+              dependencies?.[OXLINT_PLUGINS_PACKAGE] !== undefined,
+          );
       } catch {
         // Invalid or unreadable package metadata cannot opt into the exception.
       }

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -49,6 +49,8 @@ export default defineConfig([
       'define-config': './src/define-config.ts',
       fmt: './src/fmt.ts',
       lint: './src/lint.ts',
+      'lint-plugins': './src/lint-plugins.ts',
+      'lint-plugins-dev': './src/lint-plugins-dev.ts',
       'oxlint-plugin': './src/oxlint-plugin.ts',
       'tsgolint-path': './src/utils/tsgolint-path.ts',
       pack: './src/pack.ts',

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -114,12 +114,8 @@ export default defineConfig([
     entry: {
       'define-config': './src/define-config.ts',
       index: './src/index.cts',
-      // `@oxlint/plugins` ships CJS, so the shim can too. A `.cts` plugin, or
-      // a `.ts` one compiled with `module: commonjs`, emits its import as
-      // `require()`, which an ESM-only export would reject.
-      //
-      // `lint-plugins-dev` uses one ESM entry for both import and require,
-      // matching `oxlint/plugins-dev`. Node can load it synchronously.
+      // Match @oxlint/plugins' CJS support for compiled plugins. plugins-dev
+      // uses its ESM entry for both import and require, matching upstream.
       'lint-plugins': './src/lint-plugins.ts',
     },
     outDir: 'dist',

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -118,8 +118,8 @@ export default defineConfig([
       // a `.ts` one compiled with `module: commonjs`, emits its import as
       // `require()`, which an ESM-only export would reject.
       //
-      // `lint-plugins-dev` deliberately has no CJS build: `oxlint/plugins-dev`
-      // is ESM-only upstream, so the shim mirrors exactly what upstream can do.
+      // `lint-plugins-dev` uses one ESM entry for both import and require,
+      // matching `oxlint/plugins-dev`. Node can load it synchronously.
       'lint-plugins': './src/lint-plugins.ts',
     },
     outDir: 'dist',

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -114,6 +114,13 @@ export default defineConfig([
     entry: {
       'define-config': './src/define-config.ts',
       index: './src/index.cts',
+      // `@oxlint/plugins` ships CJS, so the shim can too. A `.cts` plugin, or
+      // a `.ts` one compiled with `module: commonjs`, emits its import as
+      // `require()`, which an ESM-only export would reject.
+      //
+      // `lint-plugins-dev` deliberately has no CJS build: `oxlint/plugins-dev`
+      // is ESM-only upstream, so the shim mirrors exactly what upstream can do.
+      'lint-plugins': './src/lint-plugins.ts',
     },
     outDir: 'dist',
     format: 'cjs',


### PR DESCRIPTION
`vp migrate` can break custom Oxlint plugins when it removes the dependency that provides their API.

This PR adds two entry points for the API that matches the bundled linter:

- `vite-plus/lint/plugins` exports helpers such as `definePlugin` and `defineRule`.
- `vite-plus/lint/plugins-dev` exports `RuleTester`.

Both entry points support ESM and CommonJS. Projects can use them through their `vite-plus` dependency, including with `pnpm`'s strict dependency layout.

The migrator updates supported imports from `@oxlint/plugins`, `oxlint/plugins-dev`, and the legacy plugin API in `oxlint`. The `prefer-vite-plus-imports` lint rule applies the same changes. The rewrite leaves `oxlint` config imports and ambiguous imports unchanged. It also leaves `require()` calls unchanged.

Packages that declare `oxlint` or `@oxlint/plugins` in `dependencies` or `peerDependencies` keep their upstream plugin imports and dependencies. The same exemption applies to `@oxlint/plugins` in `optionalDependencies`. This protects published plugins whose consumers do not use `vite-plus`.

The cleanup removes `@oxlint/plugins` from `devDependencies` only when no references remain in the project. It checks source files, package import aliases, and ignored build output such as `dist`, `build`, and `out`.