### PR TITLE
chore(core): remove unused VitePress bundling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ vite-plus/
 │   ├── src/resolve-test.ts    # Resolves upstream Vitest for `vp test`
 │   ├── src/utils/agent.ts     # Generated agent-file marker/update logic
 │   └── binding/               # Rust NAPI binding used by the local CLI
-├── packages/core/             # @voidzero-dev/vite-plus-core bundled Vite/Rolldown/tsdown/VitePress surfaces
+├── packages/core/             # @voidzero-dev/vite-plus-core bundled Vite/Rolldown/tsdown surfaces
 ├── packages/prompts/          # Prompt UI/helpers package, including snapshot milestones
 ├── packages/tools/            # Repo tooling and local npm registry
 ├── crates/vite_cli_snapshots/ # PTY snapshot test runner + vpt helper (CLI tests)

--- a/packages/cli/BUNDLING.md
+++ b/packages/cli/BUNDLING.md
@@ -290,7 +290,7 @@ The CLI package creates thin shim files that re-export from `@voidzero-dev/vite-
 3. **Reduces duplication** - No file copying, just re-exports
 4. **Preserves module resolution** - Node.js resolves to the actual core package
 
-**Note**: The `@voidzero-dev/vite-plus-core` package itself bundles multiple upstream projects (vite, rolldown, tsdown, vitepress). See [Core Package Bundling](../core/BUNDLING.md) for details.
+**Note**: The `@voidzero-dev/vite-plus-core` package itself bundles multiple upstream projects (vite, rolldown, tsdown). See [Core Package Bundling](../core/BUNDLING.md) for details.
 
 ### Export Mapping (Core)
 

--- a/packages/core/BUNDLING.md
+++ b/packages/core/BUNDLING.md
@@ -4,7 +4,7 @@ This document explains how `@voidzero-dev/vite-plus-core` bundles multiple upstr
 
 ## Overview
 
-The core package uses a **multi-project bundling strategy** that combines 5 upstream projects:
+The core package uses a **multi-project bundling strategy** that combines 4 upstream projects:
 
 | Project                 | Source Location                                                 | Purpose                   |
 | ----------------------- | --------------------------------------------------------------- | ------------------------- |
@@ -12,7 +12,6 @@ The core package uses a **multi-project bundling strategy** that combines 5 upst
 | `rolldown`              | `rolldown/packages/rolldown`                                    | Rolldown bundler          |
 | `vite`                  | `vite/packages/vite`                                            | Vite v8 beta              |
 | `tsdown`                | `node_modules/tsdown`                                           | TypeScript build tool     |
-| `vitepress`             | `node_modules/vitepress`                                        | Documentation tool        |
 
 This approach enables users to access Vite, Rolldown, and related tools through a single package with consistent module specifier rewrites.
 
@@ -20,7 +19,7 @@ This approach enables users to access Vite, Rolldown, and related tools through 
 
 ## Build Steps
 
-The build process executes 6 steps in sequence:
+The build process executes 5 steps in sequence:
 
 ### Step 1: Bundle Rolldown Pluginutils (`bundleRolldownPluginutils`)
 
@@ -76,18 +75,7 @@ This is the most complex step, using the upstream `vite-rolldown.config` with mo
 **Input**: `node_modules/tsdown/dist/`
 **Output**: `dist/tsdown/`
 
-### Step 5: Bundle Vitepress (`bundleVitepress`)
-
-**Action**: Copies dist directory and rewrites vite imports.
-
-**Transformations**:
-
-- `vite` → `@voidzero-dev/vite-plus-core/vite`
-
-**Input**: `node_modules/vitepress/`
-**Output**: `dist/vitepress/`
-
-### Step 6: Merge Package.json (`mergePackageJson`)
+### Step 5: Merge Package.json (`mergePackageJson`)
 
 **Action**: Merges metadata from upstream packages and records bundled versions.
 
@@ -236,17 +224,11 @@ dist/
 │   ├── misc/
 │   ├── types/
 │   └── client.d.ts
-├── tsdown/                # TypeScript build tool
-│   ├── index.js
-│   ├── index-types.d.ts
-│   ├── run.js
-│   └── npm_entry_*.cjs    # Bundled CJS deps
-└── vitepress/             # Documentation tool
-    ├── dist/
-    ├── types/
-    ├── client.d.ts
-    ├── theme.d.ts
-    └── theme-without-fonts.d.ts
+└── tsdown/                # TypeScript build tool
+    ├── index.js
+    ├── index-types.d.ts
+    ├── run.js
+    └── npm_entry_*.cjs    # Bundled CJS deps
 ```
 
 ---
@@ -282,7 +264,6 @@ dist/
 | `rolldown`              | `../../rolldown/packages/rolldown`                                    | Git submodule  |
 | `vite`                  | `../../vite/packages/vite`                                            | Git submodule  |
 | `tsdown`                | `node_modules/tsdown`                                                 | npm dependency |
-| `vitepress`             | `node_modules/vitepress`                                              | npm dependency |
 
 ---
 
@@ -324,13 +305,6 @@ dist/
 5. Verify `bundledVersions.tsdown` in `package.json` is updated
 6. Test with `pnpm test`
 
-### Updating Vitepress
-
-1. Update `vitepress` version in `devDependencies`
-2. Run `pnpm install`
-3. Run `pnpm -C packages/core build`
-4. Test documentation builds
-
 ---
 
 ## Build Commands
@@ -361,8 +335,7 @@ RELEASE_BUILD=1 pnpm -C packages/core build
    ├── Bundle tsdown with Rolldown    Find CJS modules
    ├── buildCjsDeps()                 Bundle detected CJS deps
    └── Bundle types with dts plugin   Generate declarations
-5. bundleVitepress()              Copy + rewrite vite imports
-6. mergePackageJson()             Merge metadata + record versions
+5. mergePackageJson()             Merge metadata + record versions
 ```
 
 ### Key Constants

--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs';
 import { copyFile, cp, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import path from 'node:path';
-import { dirname, join, parse, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { format } from 'oxfmt';
@@ -58,7 +58,6 @@ await buildVite();
 await bundleTsdown();
 await brandTsdown();
 await wireBundledTsdownExtensions();
-await bundleVitepress();
 generateLicenseFile({
   title: 'Vite-Plus core license',
   packageName: 'Vite-Plus',
@@ -85,9 +84,6 @@ generateLicenseFile({
     },
     {
       packageDir: tsdownSourceDir,
-    },
-    {
-      packageDir: join(projectDir, '..', '..', 'node_modules', 'vitepress'),
     },
   ],
 });
@@ -807,89 +803,6 @@ async function wireBundledTsdownExtensions() {
   }
   if (!cssLoadWired) {
     throw new Error('wireBundledTsdownExtensions: bundled `./tsdown-css.js` is never imported');
-  }
-}
-
-// Actually do nothing now, we will polish it in the future when `vitepress` is ready
-async function bundleVitepress() {
-  const vitepressSourceDir = resolve(projectDir, 'node_modules/vitepress');
-  const vitepressDestDir = join(projectDir, 'dist/vitepress');
-
-  await mkdir(vitepressDestDir, { recursive: true });
-
-  // Copy dist directory
-  // Normalize glob pattern to use forward slashes on Windows
-  const vitepressDistFiles = await glob(toPosixPath(join(vitepressSourceDir, 'dist', '**/*')), {
-    absolute: true,
-  });
-
-  for (const file of vitepressDistFiles) {
-    const stats = await stat(file);
-    if (!stats.isFile()) {
-      continue;
-    }
-
-    // Normalize paths to use forward slashes for consistent replacement on Windows
-    const relativePath = toPosixPath(file).replace(
-      toPosixPath(join(vitepressSourceDir, 'dist')),
-      '',
-    );
-    const destPath = join(vitepressDestDir, relativePath);
-
-    await mkdir(parse(destPath).dir, { recursive: true });
-
-    // Rewrite vite imports in .js and .mjs files
-    if (
-      file.endsWith('.js') ||
-      file.endsWith('.mjs') ||
-      file.endsWith('.d.mts') ||
-      file.endsWith('.d.ts')
-    ) {
-      const content = await readFile(file, 'utf-8');
-      // Note: For vitepress, 'vite' -> 'pkgJson.name/vite' (vite subpath)
-      const rewrittenContent = rewriteModuleSpecifiers(content, file, {
-        rules: [{ from: 'vite', to: `${pkgJson.name}/vite` }],
-      });
-      await writeFile(destPath, rewrittenContent, 'utf-8');
-    } else {
-      await copyFile(file, destPath);
-    }
-  }
-
-  // Copy top-level .d.ts files
-  const vitepressTypeFiles = ['client.d.ts', 'theme.d.ts', 'theme-without-fonts.d.ts'];
-  for (const typeFile of vitepressTypeFiles) {
-    const sourcePath = join(vitepressSourceDir, typeFile);
-    const destPath = join(vitepressDestDir, typeFile);
-    try {
-      await copyFile(sourcePath, destPath);
-    } catch {
-      // File might not exist, skip
-    }
-  }
-
-  // Copy types directory
-  const vitepressTypesDir = join(vitepressSourceDir, 'types');
-  const vitepressTypesDestDir = join(vitepressDestDir, 'types');
-  await mkdir(vitepressTypesDestDir, { recursive: true });
-
-  // Normalize glob pattern to use forward slashes on Windows
-  const vitepressTypesFiles = await glob(toPosixPath(join(vitepressTypesDir, '**/*')), {
-    absolute: true,
-  });
-
-  for (const file of vitepressTypesFiles) {
-    const stats = await stat(file);
-    if (!stats.isFile()) {
-      continue;
-    }
-
-    // Normalize paths to use forward slashes for consistent replacement on Windows
-    const relativePath = toPosixPath(file).replace(toPosixPath(vitepressTypesDir), '');
-    const destPath = join(vitepressTypesDestDir, relativePath);
-
-    await mkdir(parse(destPath).dir, { recursive: true });
-    await copyFile(file, destPath);
   }
 }
 


### PR DESCRIPTION
## Summary

 VitePress does not appear to be included in core. `packages/core` does not declare it as a dependency, and the build
only looks under `packages/core/node_modules/vitepress`, so the related globs match no files. No package export consumes the generated `dist/vitepress` output either.

Remove the unused copy, import-rewriting, and license-collection paths, then align `BUNDLING.md` with the actual core
output.