### PR TITLE
docs(cli): fix config/staged paths in BUNDLING.md

### DIFF
--- a/packages/cli/BUNDLING.md
+++ b/packages/cli/BUNDLING.md
@@ -129,9 +129,9 @@ packages/cli/
 │   ├── create.js             # Global command: vp create
 │   ├── migrate.js            # Global command: vp migrate
 │   ├── version.js            # Global command: vp --version
-│   ├── config.js             # Global command: vp config
+│   ├── config/bin.js         # Global command: vp config
 │   ├── mcp.js                # Global command: vp mcp
-│   ├── staged.js             # Global command: vp staged
+│   ├── staged/bin.js         # Global command: vp staged
 │   ├── *-<hash>.js           # Shared chunks (code splitting)
 │   ├── versions.js           # Generated tool versions
 │   ├── client.d.ts           # ./client types (triple-slash ref)


### PR DESCRIPTION
### Description

The CLI package architecture tree in `packages/cli/BUNDLING.md` still listed flat `config.js` and `staged.js` outputs. tsdown already emits nested entrypoints:

- `dist/config/bin.js`
- `dist/staged/bin.js`

This updates the tree to match the real layout so the bundling docs stay accurate for contributors.

### Additional context

- Docs-only; no runtime behavior change
- Spotted while working on related CLI hooks docs