### PR TITLE
chore: bump Rust nightly to 2026-08-02

### DIFF
--- a/.github/actions/build-upstream/action.yml
+++ b/.github/actions/build-upstream/action.yml
@@ -101,7 +101,7 @@ runs:
       with:
         version: 0.15.2
 
-    # Rust nightly-2026-06-10 passes --fix-cortex-a53-843419 to the linker for
+    # Rust nightly-2026-08-02 passes --fix-cortex-a53-843419 to the linker for
     # aarch64-linux targets, which zig cc rejects. The filter for this arg
     # (rust-cross/cargo-zigbuild#452) is merged but unreleased, so install from
     # the pinned git commit. TODO: revert to taiki-e/install-action once

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/flavor.rs
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/flavor.rs
@@ -48,14 +48,28 @@ pub fn repo_root() -> PathBuf {
     manifest_dir().parent().unwrap().parent().unwrap().to_path_buf()
 }
 
-/// Searches for `name` next to the test executable (`target/<profile>/deps/`)
-/// and one directory up (`target/<profile>/`), where cargo puts bin targets
-/// and where nextest extracts archived binaries.
+/// Searches for `name` next to the test executable and one directory up,
+/// where Cargo puts bin targets and nextest extracts archived binaries. Also
+/// handles the custom-test layout used by newer Cargo nightlies:
+/// `target/<profile>/build/<package>/<hash>/out/`.
 fn find_beside_test_exe(name: &str) -> Result<Option<PathBuf>, String> {
     let exe = std::env::current_exe().map_err(|e| format!("current_exe failed: {e}"))?;
-    let deps_dir = exe.parent().ok_or("test executable has no parent dir")?;
-    for dir in [deps_dir, deps_dir.parent().unwrap_or(deps_dir)] {
+    let exe_dir = exe.parent().ok_or("test executable has no parent dir")?;
+    for dir in [exe_dir, exe_dir.parent().unwrap_or(exe_dir)] {
         let candidate = dir.join(name);
+        if candidate.is_file() {
+            return Ok(Some(candidate));
+        }
+    }
+
+    let profile_dir = exe_dir
+        .parent()
+        .and_then(Path::parent)
+        .and_then(Path::parent)
+        .filter(|dir| dir.file_name().is_some_and(|name| name == "build"))
+        .and_then(Path::parent);
+    if let Some(profile_dir) = profile_dir {
+        let candidate = profile_dir.join(name);
         if candidate.is_file() {
             return Ok(Some(candidate));
         }
@@ -63,11 +77,9 @@ fn find_beside_test_exe(name: &str) -> Result<Option<PathBuf>, String> {
     Ok(None)
 }
 
-/// Locates the freshly built global `vp` binary next to this test executable
-/// (test binaries run from `target/<profile>/deps/`, the product binaries sit
-/// one directory up). Build ordering is the entry-point recipe's job, so a
-/// missing binary fails fast with that instruction instead of silently
-/// testing a stale build.
+/// Locates the freshly built global `vp` binary near this test executable.
+/// Build ordering is the entry-point recipe's job, so a missing binary fails
+/// fast with that instruction instead of silently testing a stale build.
 fn global_vp_path() -> Result<PathBuf, String> {
     // `VP_SNAP_GLOBAL_VP` points at an already-built binary (CI uses the
     // release binary that `bootstrap-cli` installed), skipping the cargo
@@ -81,7 +93,7 @@ fn global_vp_path() -> Result<PathBuf, String> {
     }
     let name = format!("vp{}", std::env::consts::EXE_SUFFIX);
     find_beside_test_exe(&name)?.ok_or_else(|| {
-        "global `vp` binary not found next to the test executable; run \
+        "global `vp` binary not found near the test executable; run \
          `just snapshot-test` (or `cargo build -p vp_global_cli`) first"
             .to_owned()
     })
@@ -172,7 +184,7 @@ fn vpt_path() -> Result<PathBuf, String> {
     let name = format!("vpt{}", std::env::consts::EXE_SUFFIX);
     find_beside_test_exe(&name)?.ok_or_else(|| {
         "`vpt` binary not found (checked CARGO_BIN_EXE_vpt, the compile-time \
-         path, and next to the test executable)"
+         path, and near the test executable)"
             .to_owned()
     })
 }

--- a/crates/vp_global_cli/src/commands/env/package_metadata.rs
+++ b/crates/vp_global_cli/src/commands/env/package_metadata.rs
@@ -16,9 +16,7 @@ const INSTALL_ID_LENGTH: usize = 36;
 
 pub(crate) fn is_nested_install_id(value: &str) -> bool {
     value.len() == INSTALL_ID_LENGTH
-        && Uuid::parse_str(value)
-            .ok()
-            .is_some_and(|uuid| uuid.get_version() == Some(Version::Random))
+        && Uuid::parse_str(value).is_ok_and(|uuid| uuid.get_version() == Some(Version::Random))
 }
 
 pub(crate) fn is_legacy_install_id(value: &str) -> bool {

--- a/crates/vp_global_cli/src/commands/global/install.rs
+++ b/crates/vp_global_cli/src/commands/global/install.rs
@@ -43,8 +43,10 @@ struct InstalledPackage {
     install_dir: AbsolutePathBuf,
 }
 
-fn package_error(package_name: &str, error: impl Into<Error>) -> (Option<String>, Error) {
-    (Some(package_name.to_string()), error.into())
+type InstallError = (Option<String>, Box<Error>);
+
+fn package_error(package_name: &str, error: impl Into<Error>) -> InstallError {
+    (Some(package_name.to_string()), Box::new(error.into()))
 }
 
 /// Symlink target used for package shims on Unix (relative to the bin dir).
@@ -106,7 +108,7 @@ pub struct InstallOptions<'a> {
 pub async fn install(
     package_specs: &[String],
     options: InstallOptions<'_>,
-) -> Result<(), (Option<String>, Error)> {
+) -> Result<(), InstallError> {
     let InstallOptions { node_version, force, concurrency, update, only_bins } = options;
     if package_specs.is_empty() {
         return Ok(());
@@ -120,17 +122,17 @@ pub async fn install(
         let provider = NodeProvider::new();
         match resolve_version_alias(v, &provider).await {
             Ok(version) => version,
-            Err(error) => return Err((None, error)),
+            Err(error) => return Err((None, Box::new(error))),
         }
     } else {
         // Resolve from current directory
         let cwd = match current_dir() {
             Ok(cwd) => cwd,
-            Err(error) => return Err((None, error.into())),
+            Err(error) => return Err((None, Box::new(error.into()))),
         };
         let resolution = match resolve_version(&cwd).await {
             Ok(resolution) => resolution,
-            Err(error) => return Err((None, error)),
+            Err(error) => return Err((None, Box::new(error))),
         };
         resolution.version
     };
@@ -143,7 +145,7 @@ pub async fn install(
             Ok(runtime) => runtime,
             Err(error) => {
                 let error = Error::RuntimeDownload(error);
-                return Err((None, error));
+                return Err((None, Box::new(error)));
             }
         };
 
@@ -158,7 +160,7 @@ pub async fn install(
 
         let (package_name, _version_spec) = match parse_package_spec(package_spec) {
             Ok(result) => result,
-            Err(error) => return Err((Some(package_spec.clone()), error)),
+            Err(error) => return Err((Some(package_spec.clone()), Box::new(error))),
         };
         packages.insert(package_name, Package { spec: package_spec, install: None });
     }
@@ -219,7 +221,7 @@ pub async fn install(
             Some((package_name, Err(error))) => {
                 stop_scheduling = true;
                 if first_error.is_none() {
-                    first_error = Some((Some(package_name), error));
+                    first_error = Some((Some(package_name), Box::new(error)));
                 }
             }
             None => break,
@@ -367,11 +369,11 @@ pub async fn install(
                 if first_error.is_none() {
                     first_error = Some((
                         Some(package_name.clone()),
-                        Error::BinaryConflict {
+                        Box::new(Error::BinaryConflict {
                             bin_name: conflicts[0].0.clone(),
                             existing_package: conflicts[0].1.clone(),
                             new_package: package_name.clone(),
-                        },
+                        }),
                     ));
                 }
                 continue;

--- a/justfile
+++ b/justfile
@@ -107,6 +107,7 @@ lint:
     -A clippy::byte_char_slices \
     -A clippy::manual_assert_eq \
     -A clippy::needless_return_with_question_mark \
+    -A clippy::redundant_else \
     -A clippy::unused_async_trait_impl \
     -A clippy::useless_borrows_in_formatting
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # Needed nightly features:
 # - cargo `Z-bindeps` to build and embed preload shared libraries as dependencies of fspy
 # - `windows_process_extensions_main_thread_handle` to get the main thread handle for Detours injection
-channel = "nightly-2026-06-10"
+channel = "nightly-2026-08-02"
 profile = "default"


### PR DESCRIPTION


Bump the Rust nightly from `2026-06-10` to `2026-08-02`, the same version vite task uses in #2339.