### PR TITLE
refactor(create): replace hand-rolled copy helpers with fs.cpSync

### DIFF
--- a/packages/cli/src/create/utils.ts
+++ b/packages/cli/src/create/utils.ts
@@ -39,23 +39,10 @@ export function shouldConfigureEditorsForCreate({
   return hasExplicitEditorOptIn(editor);
 }
 
-// Helper functions for file operations
-export function copy(src: string, dest: string) {
-  const stat = fs.statSync(src);
-  if (stat.isDirectory()) {
-    copyDir(src, dest);
-  } else {
-    fs.copyFileSync(src, dest);
-  }
-}
-
+// Helper function for file operations
 export function copyDir(srcDir: string, destDir: string) {
-  fs.mkdirSync(destDir, { recursive: true });
-  for (const file of fs.readdirSync(srcDir)) {
-    const srcFile = path.resolve(srcDir, file);
-    const destFile = path.resolve(destDir, file);
-    copy(srcFile, destFile);
-  }
+  // dereference matches the previous statSync-based copy, which followed symlinks
+  fs.cpSync(srcDir, destDir, { recursive: true, dereference: true });
 }
 
 /**


### PR DESCRIPTION
## Description

Replaces the hand-written recursive `copy()`/`copyDir()` helpers in `packages/cli/src/create/utils.ts` with a single `copyDir()` wrapper over `fs.cpSync(src, dest, { recursive: true, dereference: true })`.

- `copy()` had no external callers, so it is removed. All three call sites (`templates/bundled.ts`, `templates/generator.ts`, `templates/monorepo.ts`) only use `copyDir` and are unchanged.
- `dereference: true` preserves the previous behavior, because the old implementation used `statSync` which follows symlinks.
- Overwrite behavior and parent directory creation match the previous implementation via `cpSync` defaults.
- `fs.cpSync` is available across the package's supported Node range (`^20.19.0 || ^22.18.0 || >=24.11.0`).

## Validation

- `tsc --noEmit` on `packages/cli` passes.
- No remaining imports of the removed `copy` export.