### PR TITLE
fix(cli): align local help with upstream tools

### DIFF
--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/builtin_script_note/snapshots/builtin_script_note.global.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/builtin_script_note/snapshots/builtin_script_note.global.md
@@ -91,20 +91,20 @@ Arguments:
   [ROOT]  Project root directory (default: current directory)
 
 Options:
-  --host [HOST]           Specify hostname
-  --port <PORT>           Specify port
-  --open [PATH]           Open browser on startup
-  --cors                  Enable CORS
-  --strictPort            Exit if specified port is already in use
-  --force                 Ignore the optimizer cache and re-bundle
-  --experimentalBundle    Use experimental full bundle mode
-  --base <PATH>           Public base path
-  -l, --logLevel <LEVEL>  Set log level
-  --clearScreen           Allow or disable clearing the screen
-  -d, --debug [FEAT]      Show debug logs
-  -f, --filter <FILTER>   Filter debug logs
-  -m, --mode <MODE>       Set env mode
-  -h, --help              Print help
+  --host [host]           [string] specify hostname
+  --port <port>           [number] specify port
+  --open [path]           [boolean | string] open browser on startup
+  --cors                  [boolean] enable CORS
+  --strictPort            [boolean] exit if specified port is already in use
+  --force                 [boolean] force the optimizer to ignore the cache and re-bundle
+  --experimentalBundle    [boolean] use experimental full bundle mode (this is highly experimental)
+  --base <path>           [string] public base path (default: /)
+  -l, --logLevel <level>  [string] info | warn | error | silent
+  --clearScreen           [boolean] allow/disable clear screen when logging
+  -d, --debug [feat]      [string | boolean] show debug logs
+  -f, --filter <filter>   [string] filter debug logs
+  -m, --mode <mode>       [string] set env mode
+  -h, --help              Display this message
 
 Examples:
   vp dev

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/builtin_script_note/snapshots/builtin_script_note.local.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/builtin_script_note/snapshots/builtin_script_note.local.md
@@ -79,20 +79,20 @@ Arguments:
   [ROOT]  Project root directory (default: current directory)
 
 Options:
-  --host [HOST]           Specify hostname
-  --port <PORT>           Specify port
-  --open [PATH]           Open browser on startup
-  --cors                  Enable CORS
-  --strictPort            Exit if specified port is already in use
-  --force                 Ignore the optimizer cache and re-bundle
-  --experimentalBundle    Use experimental full bundle mode
-  --base <PATH>           Public base path
-  -l, --logLevel <LEVEL>  Set log level
-  --clearScreen           Allow or disable clearing the screen
-  -d, --debug [FEAT]      Show debug logs
-  -f, --filter <FILTER>   Filter debug logs
-  -m, --mode <MODE>       Set env mode
-  -h, --help              Print help
+  --host [host]           [string] specify hostname
+  --port <port>           [number] specify port
+  --open [path]           [boolean | string] open browser on startup
+  --cors                  [boolean] enable CORS
+  --strictPort            [boolean] exit if specified port is already in use
+  --force                 [boolean] force the optimizer to ignore the cache and re-bundle
+  --experimentalBundle    [boolean] use experimental full bundle mode (this is highly experimental)
+  --base <path>           [string] public base path (default: /)
+  -l, --logLevel <level>  [string] info | warn | error | silent
+  --clearScreen           [boolean] allow/disable clear screen when logging
+  -d, --debug [feat]      [string | boolean] show debug logs
+  -f, --filter <filter>   [string] filter debug logs
+  -m, --mode <mode>       [string] set env mode
+  -h, --help              Display this message
 
 Examples:
   vp dev

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_fmt_help/snapshots/command_fmt_help.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_fmt_help/snapshots/command_fmt_help.md
@@ -10,27 +10,27 @@ Usage: vp fmt [PATH]... [OPTIONS]
 Format code.
 Options are forwarded to Oxfmt.
 
-Arguments:
-  [PATH]...  Files, directories, or glob patterns (default: current directory)
+Available positional items:
+  [PATH]...  Single file, path or list of paths. Glob patterns are also supported. (Be sure to quote them, otherwise your shell may expand them before passing.) Exclude patterns with `!` prefix like `'!**/fixtures/*.js'` are also supported. If not provided, current working directory is used.
 
 Mode Options:
-  --stdin-filepath <PATH>  Specify the file name used to infer the parser for stdin
+  --stdin-filepath=PATH  Specify the file name to use to infer which parser to use
 
 Output Options:
-  --write           Format and write files in place
-  --check           Check whether files are formatted and show statistics
+  --write           Format and write files in place (default)
+  --check           Check if files are formatted, also show statistics
   --list-different  List files that would be changed
 
 Ignore Options:
-  --ignore-path <PATH>  Path to an ignore file; may be specified multiple times
-  --with-node-modules   Format files in node_modules, which are skipped by default
+  --ignore-path=PATH   Path to ignore file(s). Can be specified multiple times. If not specified, .gitignore and .prettierignore in the current directory are used.
+  --with-node-modules  Format code in node_modules directory (skipped by default)
 
 Runtime Options:
-  --no-error-on-unmatched-pattern  Do not exit with an error when the pattern is unmatched
-  --threads <INT>                  Number of threads to use; set to 1 to use one CPU core
+  --no-error-on-unmatched-pattern  Do not exit with error when pattern is unmatched
+  --threads=INT                    Number of threads to use. Set to 1 for using only 1 CPU core.
 
-Options:
-  -h, --help  Print help information
+Available options:
+  -h, --help  Prints help information
 
 Examples:
   vp fmt
@@ -50,27 +50,27 @@ Usage: vp fmt [PATH]... [OPTIONS]
 Format code.
 Options are forwarded to Oxfmt.
 
-Arguments:
-  [PATH]...  Files, directories, or glob patterns (default: current directory)
+Available positional items:
+  [PATH]...  Single file, path or list of paths. Glob patterns are also supported. (Be sure to quote them, otherwise your shell may expand them before passing.) Exclude patterns with `!` prefix like `'!**/fixtures/*.js'` are also supported. If not provided, current working directory is used.
 
 Mode Options:
-  --stdin-filepath <PATH>  Specify the file name used to infer the parser for stdin
+  --stdin-filepath=PATH  Specify the file name to use to infer which parser to use
 
 Output Options:
-  --write           Format and write files in place
-  --check           Check whether files are formatted and show statistics
+  --write           Format and write files in place (default)
+  --check           Check if files are formatted, also show statistics
   --list-different  List files that would be changed
 
 Ignore Options:
-  --ignore-path <PATH>  Path to an ignore file; may be specified multiple times
-  --with-node-modules   Format files in node_modules, which are skipped by default
+  --ignore-path=PATH   Path to ignore file(s). Can be specified multiple times. If not specified, .gitignore and .prettierignore in the current directory are used.
+  --with-node-modules  Format code in node_modules directory (skipped by default)
 
 Runtime Options:
-  --no-error-on-unmatched-pattern  Do not exit with an error when the pattern is unmatched
-  --threads <INT>                  Number of threads to use; set to 1 to use one CPU core
+  --no-error-on-unmatched-pattern  Do not exit with error when pattern is unmatched
+  --threads=INT                    Number of threads to use. Set to 1 for using only 1 CPU core.
 
-Options:
-  -h, --help  Print help information
+Available options:
+  -h, --help  Prints help information
 
 Examples:
   vp fmt
@@ -90,27 +90,27 @@ Usage: vp fmt [PATH]... [OPTIONS]
 Format code.
 Options are forwarded to Oxfmt.
 
-Arguments:
-  [PATH]...  Files, directories, or glob patterns (default: current directory)
+Available positional items:
+  [PATH]...  Single file, path or list of paths. Glob patterns are also supported. (Be sure to quote them, otherwise your shell may expand them before passing.) Exclude patterns with `!` prefix like `'!**/fixtures/*.js'` are also supported. If not provided, current working directory is used.
 
 Mode Options:
-  --stdin-filepath <PATH>  Specify the file name used to infer the parser for stdin
+  --stdin-filepath=PATH  Specify the file name to use to infer which parser to use
 
 Output Options:
-  --write           Format and write files in place
-  --check           Check whether files are formatted and show statistics
+  --write           Format and write files in place (default)
+  --check           Check if files are formatted, also show statistics
   --list-different  List files that would be changed
 
 Ignore Options:
-  --ignore-path <PATH>  Path to an ignore file; may be specified multiple times
-  --with-node-modules   Format files in node_modules, which are skipped by default
+  --ignore-path=PATH   Path to ignore file(s). Can be specified multiple times. If not specified, .gitignore and .prettierignore in the current directory are used.
+  --with-node-modules  Format code in node_modules directory (skipped by default)
 
 Runtime Options:
-  --no-error-on-unmatched-pattern  Do not exit with an error when the pattern is unmatched
-  --threads <INT>                  Number of threads to use; set to 1 to use one CPU core
+  --no-error-on-unmatched-pattern  Do not exit with error when pattern is unmatched
+  --threads=INT                    Number of threads to use. Set to 1 for using only 1 CPU core.
 
-Options:
-  -h, --help  Print help information
+Available options:
+  -h, --help  Prints help information
 
 Examples:
   vp fmt
@@ -130,27 +130,27 @@ Usage: vp fmt [PATH]... [OPTIONS]
 Format code.
 Options are forwarded to Oxfmt.
 
-Arguments:
-  [PATH]...  Files, directories, or glob patterns (default: current directory)
+Available positional items:
+  [PATH]...  Single file, path or list of paths. Glob patterns are also supported. (Be sure to quote them, otherwise your shell may expand them before passing.) Exclude patterns with `!` prefix like `'!**/fixtures/*.js'` are also supported. If not provided, current working directory is used.
 
 Mode Options:
-  --stdin-filepath <PATH>  Specify the file name used to infer the parser for stdin
+  --stdin-filepath=PATH  Specify the file name to use to infer which parser to use
 
 Output Options:
-  --write           Format and write files in place
-  --check           Check whether files are formatted and show statistics
+  --write           Format and write files in place (default)
+  --check           Check if files are formatted, also show statistics
   --list-different  List files that would be changed
 
 Ignore Options:
-  --ignore-path <PATH>  Path to an ignore file; may be specified multiple times
-  --with-node-modules   Format files in node_modules, which are skipped by default
+  --ignore-path=PATH   Path to ignore file(s). Can be specified multiple times. If not specified, .gitignore and .prettierignore in the current directory are used.
+  --with-node-modules  Format code in node_modules directory (skipped by default)
 
 Runtime Options:
-  --no-error-on-unmatched-pattern  Do not exit with an error when the pattern is unmatched
-  --threads <INT>                  Number of threads to use; set to 1 to use one CPU core
+  --no-error-on-unmatched-pattern  Do not exit with error when pattern is unmatched
+  --threads=INT                    Number of threads to use. Set to 1 for using only 1 CPU core.
 
-Options:
-  -h, --help  Print help information
+Available options:
+  -h, --help  Prints help information
 
 Examples:
   vp fmt

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_helper/snapshots/command_helper.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_helper/snapshots/command_helper.md
@@ -41,51 +41,51 @@ pack help message
 ```
 VITE+ - The Unified Toolchain for the Web
 
-Usage: vp pack [...FILES] [OPTIONS]
+Usage: vp pack [...files] [OPTIONS]
 
 Build a library.
 Options are forwarded to Vite+ Pack.
 
 Arguments:
-  [...FILES]  Files to bundle
+  [...files]  Bundle files
 
 Options:
-  -f, --format <FORMAT>         Bundle format: esm, cjs, iife, umd (default: esm)
+  -f, --format <format>         Bundle format: esm, cjs, iife, umd (default: esm)
   --clean                       Clean output directory, --no-clean to disable
-  --deps.never-bundle <MODULE>  Mark dependencies as external
+  --deps.never-bundle <module>  Mark dependencies as external
   --minify                      Minify output
   --devtools                    Enable devtools integration
-  --debug [FEAT]                Show debug logs
-  --target <TARGET>             Bundle target, e.g "es2015", "esnext"
-  -l, --logLevel <LEVEL>        Set log level: info, warn, error, silent
+  --debug [feat]                Show debug logs
+  --target <target>             Bundle target, e.g "es2015", "esnext"
+  -l, --logLevel <level>        Set log level: info, warn, error, silent
   --fail-on-warn                Fail on warnings (default: true)
   --no-write                    Disable writing files to disk, incompatible with watch mode (default: true)
-  -d, --out-dir <DIR>           Output directory (default: dist)
+  -d, --out-dir <dir>           Output directory (default: dist)
   --treeshake                   Tree-shake bundle (default: true)
   --sourcemap                   Generate source map (default: false)
   --shims                       Enable cjs and esm shims (default: false)
-  --platform <PLATFORM>         Target platform (default: node)
+  --platform <platform>         Target platform (default: node)
   --dts                         Generate dts files
   --publint                     Enable publint (default: false)
   --attw                        Enable Are the types wrong integration (default: false)
   --unused                      Enable unused dependencies check (default: false)
-  -w, --watch [PATH]            Watch mode
-  --ignore-watch <PATH>         Ignore custom paths in watch mode
-  --from-vite [VITEST]          Reuse config from Vite or Vitest
+  -w, --watch [path]            Watch mode
+  --ignore-watch <path>         Ignore custom paths in watch mode
+  --from-vite [vitest]          Reuse config from Vite or Vitest
   --report                      Size report (default: true)
-  --env.* <VALUE>               Define compile-time env variables
-  --env-file <FILE>             Load environment variables from a file, when used together with --env, variables in --env take precedence
-  --env-prefix <PREFIX>         Prefix for env variables to inject into the bundle (default: VITE_PACK_,TSDOWN_)
-  --on-success <COMMAND>        Command to run on success
-  --copy <DIR>                  Copy files to output dir
-  --public-dir <DIR>            Alias for --copy, deprecated
-  --tsconfig <TSCONFIG>         Set tsconfig path
+  --env.* <value>               Define compile-time env variables
+  --env-file <file>             Load environment variables from a file, when used together with --env, variables in --env take precedence
+  --env-prefix <prefix>         Prefix for env variables to inject into the bundle (default: TSDOWN_)
+  --on-success <command>        Command to run on success
+  --copy <dir>                  Copy files to output dir
+  --public-dir <dir>            Alias for --copy, deprecated
+  --tsconfig <tsconfig>         Set tsconfig path
   --unbundle                    Unbundle mode
-  --root <DIR>                  Root directory of input files
+  --root <dir>                  Root directory of input files
   --exe                         Bundle as executable
-  -W, --workspace [DIR]         Enable workspace mode
-  --concurrency <COUNT>         Maximum number of Rolldown builds to run in parallel
-  -F, --filter <PATTERN>        Filter configs (cwd or name), e.g. /pkg-name$/ or pkg-name
+  -W, --workspace [dir]         Enable workspace mode
+  --concurrency <count>         Maximum number of Rolldown builds to run in parallel
+  -F, --filter <pattern>        Filter configs (cwd or name), e.g. /pkg-name$/ or pkg-name
   --exports                     Generate export-related metadata for package.json (experimental)
   -h, --help                    Display this message
 
@@ -109,27 +109,27 @@ Usage: vp fmt [PATH]... [OPTIONS]
 Format code.
 Options are forwarded to Oxfmt.
 
-Arguments:
-  [PATH]...  Files, directories, or glob patterns (default: current directory)
+Available positional items:
+  [PATH]...  Single file, path or list of paths. Glob patterns are also supported. (Be sure to quote them, otherwise your shell may expand them before passing.) Exclude patterns with `!` prefix like `'!**/fixtures/*.js'` are also supported. If not provided, current working directory is used.
 
 Mode Options:
-  --stdin-filepath <PATH>  Specify the file name used to infer the parser for stdin
+  --stdin-filepath=PATH  Specify the file name to use to infer which parser to use
 
 Output Options:
-  --write           Format and write files in place
-  --check           Check whether files are formatted and show statistics
+  --write           Format and write files in place (default)
+  --check           Check if files are formatted, also show statistics
   --list-different  List files that would be changed
 
 Ignore Options:
-  --ignore-path <PATH>  Path to an ignore file; may be specified multiple times
-  --with-node-modules   Format files in node_modules, which are skipped by default
+  --ignore-path=PATH   Path to ignore file(s). Can be specified multiple times. If not specified, .gitignore and .prettierignore in the current directory are used.
+  --with-node-modules  Format code in node_modules directory (skipped by default)
 
 Runtime Options:
-  --no-error-on-unmatched-pattern  Do not exit with an error when the pattern is unmatched
-  --threads <INT>                  Number of threads to use; set to 1 to use one CPU core
+  --no-error-on-unmatched-pattern  Do not exit with error when pattern is unmatched
+  --threads=INT                    Number of threads to use. Set to 1 for using only 1 CPU core.
 
-Options:
-  -h, --help  Print help information
+Available options:
+  -h, --help  Prints help information
 
 Examples:
   vp fmt
@@ -151,67 +151,80 @@ Usage: vp lint [PATH]... [OPTIONS]
 Lint code.
 Options are forwarded to Oxlint.
 
-Arguments:
-  [PATH]...  Files or directories to lint
+Available positional items:
+  [PATH]...  Single file, single path or list of paths
 
 Basic Configuration:
-  --tsconfig <PATH>  Override the TypeScript config used for import resolution
+  --tsconfig=<./tsconfig.json>  Override the TypeScript config used for import resolution. Oxlint automatically discovers the relevant `tsconfig.json` for each file. Use this only when your project uses a non-standard tsconfig name or location.
 
-Rule Severity:
-  -A, --allow <NAME>  Allow a rule or category
-  -W, --warn <NAME>   Emit a warning for a rule or category
-  -D, --deny <NAME>   Emit an error for a rule or category
+Allowing / Denying Multiple Lints:
+  Accumulate rules and categories from left to right on the command-line.
+  For example `-D correctness -A no-debugger` or `-A all -D no-debugger`.
+  The categories are:
+  * `correctness` - Code that is outright wrong or useless (default)
+  * `suspicious`  - Code that is most likely wrong or useless
+  * `pedantic`    - Lints which are rather strict or have occasional false positives
+  * `perf`        - Code that could be written in a more performant way
+  * `style`       - Code that should be written in a more idiomatic way
+  * `restriction` - Lints which prevent the use of language and library features
+  * `nursery`     - New lints that are still under development
+  * `all`         - All categories listed above except `nursery`. Does not enable plugins automatically.
+  -A, --allow=NAME  Allow the rule or category (suppress the lint)
+  -W, --warn=NAME   Deny the rule or category (emit a warning)
+  -D, --deny=NAME   Deny the rule or category (emit an error)
 
-Plugins:
-  --disable-unicorn-plugin     Disable the unicorn plugin, which is enabled by default
-  --disable-oxc-plugin         Disable Oxc-specific rules, which are enabled by default
-  --disable-typescript-plugin  Disable the TypeScript plugin, which is enabled by default
-  --import-plugin              Enable the import plugin
-  --react-plugin               Enable the React plugin
-  --jsdoc-plugin               Enable the JSDoc plugin
-  --jest-plugin                Enable the Jest plugin
-  --vitest-plugin              Enable the Vitest plugin
-  --jsx-a11y-plugin            Enable the JSX accessibility plugin
-  --nextjs-plugin              Enable the Next.js plugin
-  --react-perf-plugin          Enable the React performance plugin
-  --promise-plugin             Enable the promise plugin
-  --node-plugin                Enable the Node.js plugin
-  --vue-plugin                 Enable the Vue plugin
+Enable/Disable Plugins:
+  --disable-unicorn-plugin     Disable unicorn plugin, which is turned on by default
+  --disable-oxc-plugin         Disable oxc unique rules, which is turned on by default
+  --disable-typescript-plugin  Disable TypeScript plugin, which is turned on by default
+  --import-plugin              Enable import plugin and detect ESM problems.
+  --react-plugin               Enable react plugin, which is turned off by default
+  --jsdoc-plugin               Enable jsdoc plugin and detect JSDoc problems
+  --jest-plugin                Enable the Jest plugin and detect test problems
+  --vitest-plugin              Enable the Vitest plugin and detect test problems
+  --jsx-a11y-plugin            Enable the JSX-a11y plugin and detect accessibility problems
+  --nextjs-plugin              Enable the Next.js plugin and detect Next.js problems
+  --react-perf-plugin          Enable the React performance plugin and detect rendering performance problems
+  --promise-plugin             Enable the promise plugin and detect promise usage problems
+  --node-plugin                Enable the node plugin and detect node usage problems
+  --vue-plugin                 Enable the vue plugin and detect vue usage problems
 
 Fix Problems:
-  --fix              Fix issues when possible
-  --fix-suggestions  Apply auto-fixable suggestions
+  --fix              Fix as many issues as possible. Only unfixed issues are reported in the output.
+  --fix-suggestions  Apply auto-fixable suggestions. May change program behavior.
   --fix-dangerously  Apply dangerous fixes and suggestions
 
 Ignore Files:
-  --ignore-path <PATH>        Use the specified .eslintignore file
-  --ignore-pattern <PATTERN>  Add file patterns to ignore
-  --no-ignore                 Disable file exclusion from ignore rules
+  --ignore-path=PATH    Specify the file to use as your `.eslintignore`
+  --ignore-pattern=PAT  Specify patterns of files to ignore (in addition to those in `.eslintignore`)
+  --no-ignore           Disable excluding files from `.eslintignore` files, --ignore-path flags and --ignore-pattern flags
 
 Handle Warnings:
-  --quiet               Report errors only
-  --deny-warnings       Exit non-zero when warnings are reported
-  --max-warnings <INT>  Set the warning threshold before exiting non-zero
+  --quiet             Disable reporting on warnings, only errors are reported
+  --deny-warnings     Ensure warnings produce a non-zero exit code
+  --max-warnings=INT  Specify a warning threshold, which can be used to force exit with an error status if there are too many warning-level rule violations in your project
 
 Output:
-  -f, --format <FORMAT>  Set output format: checkstyle, default, agent, github, gitlab, json, junit, sarif, stylish, or unix
-  --debug <OPTIONS>      Enable comma-separated debug output options: files or timings
+  -f, --format=ARG  Use a specific output format. Possible values: `checkstyle`, `default`, `agent`, `github`, `gitlab`, `json`, `junit`, `sarif`, `stylish`, `unix`
+  --debug=OPTIONS   Enable debug output options. Options are comma-separated. Possible values:
+                     * `files` - Print the list of files that will be linted, then exit.
+                     * `timings` - Enable per-rule timing information.
 
 Miscellaneous:
-  --silent                         Do not display diagnostics
-  --no-error-on-unmatched-pattern  Do not exit with an error when no files are selected for linting
-  --threads <INT>                  Number of threads to use; set to 1 to use one CPU core
-  --print-config                   Print the resolved configuration without linting
+  --silent                         Do not display any diagnostics
+  --no-error-on-unmatched-pattern  Do not exit with an error when no files are selected for linting (for example, after applying ignore patterns)
+  --threads=INT                    Number of threads to use. Set to 1 for using only 1 CPU core.
+  --print-config                   This option outputs the configuration to be used. When present, no linting is performed and only config-related options are valid.
 
-Inline Configuration:
-  --report-unused-disable-directives                      Report unused oxlint-disable directives
-  --report-unused-disable-directives-severity <SEVERITY>  Report unused disable directives at the specified severity
+Inline Configuration Comments:
+  --report-unused-disable-directives                    Report directive comments like `// oxlint-disable-line`, when no errors would have been reported on that line anyway
+  --report-unused-disable-directives-severity=SEVERITY  Same as `--report-unused-disable-directives`, but allows you to specify the severity level of the reported errors. Only one of these two options can be used at a time.
 
-Options:
-  --rules       List all registered rules
-  --type-aware  Enable rules requiring type information
-  --type-check  Enable experimental type checking and compiler diagnostics
-  -h, --help    Print help information
+Available options:
+  --rules       List all the rules that are currently registered
+  --type-aware  Enable rules that require type information
+  --type-check  Enable experimental type checking (includes TypeScript compiler diagnostics)
+  -h, --help    Prints help information
 
 Examples:
   vp lint
@@ -237,25 +250,25 @@ Arguments:
   [ROOT]  Project root directory (default: current directory)
 
 Options:
-  --target <TARGET>             Transpile target
-  --outDir <DIR>                Output directory
-  --assetsDir <DIR>             Directory for generated assets
-  --assetsInlineLimit <NUMBER>  Static asset inline threshold
-  --ssr [ENTRY]                 Build for server-side rendering
-  --sourcemap [MODE]            Output source maps
-  --minify [MINIFIER]           Enable or disable minification
-  --manifest [NAME]             Emit a build manifest
-  --ssrManifest [NAME]          Emit an SSR manifest
-  --emptyOutDir                 Empty outDir even when it is outside root
-  -w, --watch                   Rebuild when files change
-  --app                         Build an application with the builder API
-  --base <PATH>                 Public base path
-  -l, --logLevel <LEVEL>        Set log level
-  --clearScreen                 Allow or disable clearing the screen
-  -d, --debug [FEAT]            Show debug logs
-  -f, --filter <FILTER>         Filter debug logs
-  -m, --mode <MODE>             Set env mode
-  -h, --help                    Print help
+  --target <target>             [string] transpile target (default: 'baseline-widely-available')
+  --outDir <dir>                [string] output directory (default: dist)
+  --assetsDir <dir>             [string] directory under outDir to place assets in (default: assets)
+  --assetsInlineLimit <number>  [number] static asset base64 inline threshold in bytes (default: 4096)
+  --ssr [entry]                 [string] build specified entry for server-side rendering
+  --sourcemap [output]          [boolean | "inline" | "hidden"] output source maps for build (default: false)
+  --minify [minifier]           [boolean | "oxc" | "terser" | "esbuild"] enable/disable minification, or specify minifier to use (default: oxc)
+  --manifest [name]             [boolean | string] emit build manifest json
+  --ssrManifest [name]          [boolean | string] emit ssr manifest json
+  --emptyOutDir                 [boolean] force empty outDir when it's outside of root
+  -w, --watch                   [boolean] rebuilds when modules have changed on disk
+  --app                         [boolean] same as `builder: {}`
+  --base <path>                 [string] public base path (default: /)
+  -l, --logLevel <level>        [string] info | warn | error | silent
+  --clearScreen                 [boolean] allow/disable clear screen when logging
+  -d, --debug [feat]            [string | boolean] show debug logs
+  -f, --filter <filter>         [string] filter debug logs
+  -m, --mode <mode>             [string] set env mode
+  -h, --help                    Display this message
 
 Examples:
   vp build
@@ -289,79 +302,79 @@ Arguments:
   [FILTERS]...  Test file filters
 
 Options:
-  -r, --root <PATH>                   Root path
-  -u, --update [TYPE]                 Update snapshot (accepts boolean, "new", "all" or "none")
+  -r, --root <path>                   Root path
+  -u, --update [type]                 Update snapshot (accepts boolean, "new", "all" or "none")
   -w, --watch                         Enable watch mode
-  -t, --testNamePattern <PATTERN>     Run tests with full names matching the specified regexp pattern
-  --dir <PATH>                        Base directory to scan for the test files
+  -t, --testNamePattern <pattern>     Run tests with full names matching the specified regexp pattern
+  --dir <path>                        Base directory to scan for the test files
   --ui                                Enable UI
   --open                              Open UI automatically (default: !process.env.CI)
-  --api [PORT]                        Specify server port; if true, defaults to 51204
-  --silent [VALUE]                    Silent console output from tests. Use 'passed-only' to see logs from failing tests only
+  --api [port]                        Specify server port. Note if the port is already being used, Vite will automatically try the next available port so this may not be the actual port the server ends up listening on. If true will be set to 51204. Use '--help --api' for more info.
+  --silent [value]                    Silent console output from tests. Use 'passed-only' to see logs from failing tests only.
   --hideSkippedTests                  Hide logs for skipped tests
-  --reporter <NAME>                   Specify reporters (default, agent, minimal, blob, verbose, dot, json, tap, tap-flat, junit, tree, hanging-process, github-actions)
-  --outputFile <FILENAME/-S>          Write test results to a file; use dot notation for individual outputs of multiple reporters (for example, --outputFile.tap=./tap.txt)
-  --coverage                          Enable coverage reporting
-  --mode <NAME>                       Override Vite mode (default: test or benchmark)
-  --isolate                           Run every test file in isolation. Use --no-isolate to disable (default: true)
-  --globals                           Inject APIs globally
+  --reporter <name>                   Specify reporters (default, agent, minimal, blob, verbose, dot, json, tap, tap-flat, junit, tree, hanging-process, github-actions)
+  --outputFile <filename/-s>          Write test results to a file when supporter reporter is also specified, use cac's dot notation for individual outputs of multiple reporters (example: --outputFile.tap=./tap.txt)
+  --coverage                          Enable coverage report. Use '--help --coverage' for more info.
+  --mode <name>                       Override Vite mode (default: test or benchmark)
+  --isolate                           Run every test file in isolation. To disable isolation, use --no-isolate (default: true)
+  --globals                           Inject apis globally
   --dom                               Mock browser API with happy-dom
-  --browser <NAME>                    Run tests in the browser; equivalent to --browser.enabled (default: false)
-  --pool <POOL>                       Specify pool when not running in the browser (default: forks)
-  --execArgv <OPTION>                 Pass additional arguments to Node.js when spawning worker threads or child processes
-  --vmMemoryLimit <LIMIT>             Memory limit for VM pools
-  --fileParallelism                   Run test files in parallel. Use --no-file-parallelism to disable (default: true)
-  --maxWorkers <WORKERS>              Maximum number or percentage of workers to run tests in
-  --environment <NAME>                Specify runner environment (default: node)
+  --browser <name>                    Run tests in the browser. Equivalent to --browser.enabled (default: false). Use '--help --browser' for more info.
+  --pool <pool>                       Specify pool, if not running in the browser (default: forks)
+  --execArgv <option>                 Pass additional arguments to node process when spawning worker_threads or child_process.
+  --vmMemoryLimit <limit>             Memory limit for VM pools. If you see memory leaks, try to tinker this value.
+  --fileParallelism                   Should all test files run in parallel. Use --no-file-parallelism to disable (default: true)
+  --maxWorkers <workers>              Maximum number or percentage of workers to run tests in
+  --environment <name>                Specify runner environment, if not running in the browser (default: node)
   --passWithNoTests                   Pass when no tests are found
-  --logHeapUsage                      Show the size of the heap for each test when running in Node.js
-  --detectAsyncLeaks                  Detect asynchronous resources leaking from test files (default: false)
-  --allowOnly                         Allow tests and suites marked as only (default: !process.env.CI)
+  --logHeapUsage                      Show the size of heap for each test when running in node
+  --detectAsyncLeaks                  Detect asynchronous resources leaking from the test file (default: false)
+  --allowOnly                         Allow tests and suites that are marked as only (default: !process.env.CI)
   --dangerouslyIgnoreUnhandledErrors  Ignore any unhandled errors that occur
-  --shard <SHARDS>                    Test suite shard to execute in the format <index>/<count>
-  --changed [SINCE]                   Run tests affected by changed files (default: false)
-  --sequence <OPTIONS>                Configure test sorting
-  --inspect [[HOST:]PORT]             Enable Node.js inspector (default: 127.0.0.1:9229)
-  --inspectBrk [[HOST:]PORT]          Enable Node.js inspector and break before tests start
-  --testTimeout <TIMEOUT>             Default test timeout in milliseconds (default: 5000; 0 disables)
-  --hookTimeout <TIMEOUT>             Default hook timeout in milliseconds (default: 10000; 0 disables)
-  --bail <NUMBER>                     Stop test execution after the given number of failures (default: 0)
-  --retry <TIMES>                     Retry failed tests (default: 0)
-  --diff <PATH>                       DiffOptions object or path to a module exporting one
-  --exclude <GLOB>                    Additional file globs to exclude from tests
-  --expandSnapshotDiff                Show the full diff when a snapshot fails
+  --shard <shards>                    Test suite shard to execute in a format of <index>/<count>
+  --changed [since]                   Run tests that are affected by the changed files (default: false)
+  --sequence <options>                Options for how tests should be sorted. Use '--help --sequence' for more info.
+  --inspect [[host:]port]             Enable Node.js inspector (default: 127.0.0.1:9229)
+  --inspectBrk [[host:]port]          Enable Node.js inspector and break before the test starts
+  --testTimeout <timeout>             Default timeout of a test in milliseconds (default: 5000). Use 0 to disable timeout completely.
+  --hookTimeout <timeout>             Default hook timeout in milliseconds (default: 10000). Use 0 to disable timeout completely.
+  --bail <number>                     Stop test execution when given number of tests have failed (default: 0)
+  --retry <times>                     Retry the test specific number of times if it fails (default: 0). Use '--help --retry' for more info.
+  --diff <path>                       DiffOptions object or a path to a module which exports DiffOptions object. Use '--help --diff' for more info.
+  --exclude <glob>                    Additional file globs to be excluded from test
+  --expandSnapshotDiff                Show full diff when snapshot fails
   --disableConsoleIntercept           Disable automatic interception of console logging (default: false)
-  --typecheck                         Enable typechecking alongside tests (default: false)
-  --project <NAME>                    Select one or more Vitest workspace projects by name or wildcard
-  --slowTestThreshold <THRESHOLD>     Threshold for a test or suite to be considered slow (default: <duration>)
-  --teardownTimeout <TIMEOUT>         Default teardown timeout in milliseconds (default: 10000)
-  --cache                             Enable cache
-  --maxConcurrency <NUMBER>           Maximum number of concurrent tests and suites (default: 5)
-  --expect                            Configure expect matchers
+  --typecheck                         Enable typechecking alongside tests (default: false). Use '--help --typecheck' for more info.
+  --project <name>                    The name of the project to run if you are using Vitest workspace feature. This can be repeated for multiple projects: --project=1 --project=2. You can also filter projects using wildcards like --project=packages*, and exclude projects with --project=!pattern.
+  --slowTestThreshold <threshold>     Threshold in milliseconds for a test or suite to be considered slow (default: 300)
+  --teardownTimeout <timeout>         Default timeout of a teardown function in milliseconds (default: 10000)
+  --cache                             Enable cache. Use '--help --cache' for more info.
+  --maxConcurrency <number>           Maximum number of concurrent tests and suites during test file execution (default: 5)
+  --expect                            Configuration options for expect() matches. Use '--help --expect' for more info.
   --printConsoleTrace                 Always print console stack traces
   --includeTaskLocation               Collect test and suite locations in the location property
-  --attachmentsDir <DIR>              Directory for attachments created with context.annotate (default: .vitest-attachments)
+  --attachmentsDir <dir>              The directory where attachments from context.annotate are stored in (default: .vitest-attachments)
   --run                               Disable watch mode
-  --no-color                          Remove colors from console output (default: true)
-  --clearScreen                       Clear the terminal when rerunning tests in watch mode (default: true)
-  --standalone                        Start Vitest without running tests until files change (default: false)
-  --mergeReports [PATH]               Merge previously recorded blob reports without running tests
-  --listTags [TYPE]                   List available tags; --list-tags=json outputs JSON
-  --clearCache                        Delete all Vitest caches without running tests
-  --tagsFilter <EXPRESSION>           Run only tests matching the tag expression
-  --strictTags                        Error when a test uses an undefined tag (default: true)
-  --experimental <FEATURES>           Enable experimental features
+  --no-color                          Removes colors from the console output (default: true)
+  --clearScreen                       Clear terminal screen when re-running tests during watch mode (default: true)
+  --standalone                        Start Vitest without running tests. Tests will be running only on change. If browser mode is enabled, the UI will be opened automatically. This option is ignored when CLI file filters are passed. (default: false)
+  --mergeReports [path]               Path to a blob reports directory. If this options is used, Vitest won't run any tests, it will only report previously recorded tests
+  --listTags [type]                   List all available tags instead of running tests. --list-tags=json will output tags in JSON format, unless there are no tags.
+  --clearCache                        Delete all Vitest caches, including experimental.fsModuleCache, without running any tests. This will reduce the performance in the subsequent test run.
+  --tagsFilter <expression>           Run only tests with the specified tags. You can use logical operators && (and), || (or) and ! (not) to create complex expressions, see https://vitest.dev/guide/test-tags#syntax for more information.
+  --strictTags                        Should Vitest throw an error if test has a tag that is not defined in the config. (default: true)
+  --experimental <features>           Experimental features.. Use '--help --experimental' for more info.
   -h, --help                          Display this message
 
 Bench Options:
-  --compare <FILENAME>     Benchmark output file to compare against
-  --outputJson <FILENAME>  Benchmark output file
+  --compare <filename>     Benchmark output file to compare against
+  --outputJson <filename>  Benchmark output file
 
 List Options:
-  --json [TRUE/PATH]                Print collected tests as JSON or write to a file (default: false)
-  --filesOnly                       Print only test files without test cases
-  --staticParse                     Parse files statically instead of running them (default: false)
-  --staticParseConcurrency <LIMIT>  Number of test files to process concurrently
+  --json [true/path]                Print collected tests as JSON or write to a file (Default: false)
+  --filesOnly                       Print only test files with out the test cases
+  --staticParse                     Parse files statically instead of running them to collect tests (default: false)
+  --staticParseConcurrency <limit>  How many tests to process at the same time (default: os.availableParallelism())
 
 Examples:
   vp test
@@ -387,18 +400,18 @@ Arguments:
   [ROOT]  Project root directory (default: current directory)
 
 Options:
-  --host [HOST]           Specify hostname
-  --port <PORT>           Specify port
-  --strictPort            Exit if specified port is already in use
-  --open [PATH]           Open browser on startup
-  --outDir <DIR>          Output directory to preview
-  --base <PATH>           Public base path
-  -l, --logLevel <LEVEL>  Set log level
-  --clearScreen           Allow or disable clearing the screen
-  -d, --debug [FEAT]      Show debug logs
-  -f, --filter <FILTER>   Filter debug logs
-  -m, --mode <MODE>       Set env mode
-  -h, --help              Print help
+  --host [host]           [string] specify hostname
+  --port <port>           [number] specify port
+  --strictPort            [boolean] exit if specified port is already in use
+  --open [path]           [boolean | string] open browser on startup
+  --outDir <dir>          [string] output directory (default: dist)
+  --base <path>           [string] public base path (default: /)
+  -l, --logLevel <level>  [string] info | warn | error | silent
+  --clearScreen           [boolean] allow/disable clear screen when logging
+  -d, --debug [feat]      [string | boolean] show debug logs
+  -f, --filter <filter>   [string] filter debug logs
+  -m, --mode <mode>       [string] set env mode
+  -h, --help              Display this message
 
 Examples:
   vp preview
@@ -423,20 +436,20 @@ Arguments:
   [ROOT]  Project root directory (default: current directory)
 
 Options:
-  --host [HOST]           Specify hostname
-  --port <PORT>           Specify port
-  --open [PATH]           Open browser on startup
-  --cors                  Enable CORS
-  --strictPort            Exit if specified port is already in use
-  --force                 Ignore the optimizer cache and re-bundle
-  --experimentalBundle    Use experimental full bundle mode
-  --base <PATH>           Public base path
-  -l, --logLevel <LEVEL>  Set log level
-  --clearScreen           Allow or disable clearing the screen
-  -d, --debug [FEAT]      Show debug logs
-  -f, --filter <FILTER>   Filter debug logs
-  -m, --mode <MODE>       Set env mode
-  -h, --help              Print help
+  --host [host]           [string] specify hostname
+  --port <port>           [number] specify port
+  --open [path]           [boolean | string] open browser on startup
+  --cors                  [boolean] enable CORS
+  --strictPort            [boolean] exit if specified port is already in use
+  --force                 [boolean] force the optimizer to ignore the cache and re-bundle
+  --experimentalBundle    [boolean] use experimental full bundle mode (this is highly experimental)
+  --base <path>           [string] public base path (default: /)
+  -l, --logLevel <level>  [string] info | warn | error | silent
+  --clearScreen           [boolean] allow/disable clear screen when logging
+  -d, --debug [feat]      [string | boolean] show debug logs
+  -f, --filter <filter>   [string] filter debug logs
+  -m, --mode <mode>       [string] set env mode
+  -h, --help              Display this message
 
 Examples:
   vp dev

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_lint_help/snapshots/command_lint_help.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_lint_help/snapshots/command_lint_help.md
@@ -10,67 +10,80 @@ Usage: vp lint [PATH]... [OPTIONS]
 Lint code.
 Options are forwarded to Oxlint.
 
-Arguments:
-  [PATH]...  Files or directories to lint
+Available positional items:
+  [PATH]...  Single file, single path or list of paths
 
 Basic Configuration:
-  --tsconfig <PATH>  Override the TypeScript config used for import resolution
+  --tsconfig=<./tsconfig.json>  Override the TypeScript config used for import resolution. Oxlint automatically discovers the relevant `tsconfig.json` for each file. Use this only when your project uses a non-standard tsconfig name or location.
 
-Rule Severity:
-  -A, --allow <NAME>  Allow a rule or category
-  -W, --warn <NAME>   Emit a warning for a rule or category
-  -D, --deny <NAME>   Emit an error for a rule or category
+Allowing / Denying Multiple Lints:
+  Accumulate rules and categories from left to right on the command-line.
+  For example `-D correctness -A no-debugger` or `-A all -D no-debugger`.
+  The categories are:
+  * `correctness` - Code that is outright wrong or useless (default)
+  * `suspicious`  - Code that is most likely wrong or useless
+  * `pedantic`    - Lints which are rather strict or have occasional false positives
+  * `perf`        - Code that could be written in a more performant way
+  * `style`       - Code that should be written in a more idiomatic way
+  * `restriction` - Lints which prevent the use of language and library features
+  * `nursery`     - New lints that are still under development
+  * `all`         - All categories listed above except `nursery`. Does not enable plugins automatically.
+  -A, --allow=NAME  Allow the rule or category (suppress the lint)
+  -W, --warn=NAME   Deny the rule or category (emit a warning)
+  -D, --deny=NAME   Deny the rule or category (emit an error)
 
-Plugins:
-  --disable-unicorn-plugin     Disable the unicorn plugin, which is enabled by default
-  --disable-oxc-plugin         Disable Oxc-specific rules, which are enabled by default
-  --disable-typescript-plugin  Disable the TypeScript plugin, which is enabled by default
-  --import-plugin              Enable the import plugin
-  --react-plugin               Enable the React plugin
-  --jsdoc-plugin               Enable the JSDoc plugin
-  --jest-plugin                Enable the Jest plugin
-  --vitest-plugin              Enable the Vitest plugin
-  --jsx-a11y-plugin            Enable the JSX accessibility plugin
-  --nextjs-plugin              Enable the Next.js plugin
-  --react-perf-plugin          Enable the React performance plugin
-  --promise-plugin             Enable the promise plugin
-  --node-plugin                Enable the Node.js plugin
-  --vue-plugin                 Enable the Vue plugin
+Enable/Disable Plugins:
+  --disable-unicorn-plugin     Disable unicorn plugin, which is turned on by default
+  --disable-oxc-plugin         Disable oxc unique rules, which is turned on by default
+  --disable-typescript-plugin  Disable TypeScript plugin, which is turned on by default
+  --import-plugin              Enable import plugin and detect ESM problems.
+  --react-plugin               Enable react plugin, which is turned off by default
+  --jsdoc-plugin               Enable jsdoc plugin and detect JSDoc problems
+  --jest-plugin                Enable the Jest plugin and detect test problems
+  --vitest-plugin              Enable the Vitest plugin and detect test problems
+  --jsx-a11y-plugin            Enable the JSX-a11y plugin and detect accessibility problems
+  --nextjs-plugin              Enable the Next.js plugin and detect Next.js problems
+  --react-perf-plugin          Enable the React performance plugin and detect rendering performance problems
+  --promise-plugin             Enable the promise plugin and detect promise usage problems
+  --node-plugin                Enable the node plugin and detect node usage problems
+  --vue-plugin                 Enable the vue plugin and detect vue usage problems
 
 Fix Problems:
-  --fix              Fix issues when possible
-  --fix-suggestions  Apply auto-fixable suggestions
+  --fix              Fix as many issues as possible. Only unfixed issues are reported in the output.
+  --fix-suggestions  Apply auto-fixable suggestions. May change program behavior.
   --fix-dangerously  Apply dangerous fixes and suggestions
 
 Ignore Files:
-  --ignore-path <PATH>        Use the specified .eslintignore file
-  --ignore-pattern <PATTERN>  Add file patterns to ignore
-  --no-ignore                 Disable file exclusion from ignore rules
+  --ignore-path=PATH    Specify the file to use as your `.eslintignore`
+  --ignore-pattern=PAT  Specify patterns of files to ignore (in addition to those in `.eslintignore`)
+  --no-ignore           Disable excluding files from `.eslintignore` files, --ignore-path flags and --ignore-pattern flags
 
 Handle Warnings:
-  --quiet               Report errors only
-  --deny-warnings       Exit non-zero when warnings are reported
-  --max-warnings <INT>  Set the warning threshold before exiting non-zero
+  --quiet             Disable reporting on warnings, only errors are reported
+  --deny-warnings     Ensure warnings produce a non-zero exit code
+  --max-warnings=INT  Specify a warning threshold, which can be used to force exit with an error status if there are too many warning-level rule violations in your project
 
 Output:
-  -f, --format <FORMAT>  Set output format: checkstyle, default, agent, github, gitlab, json, junit, sarif, stylish, or unix
-  --debug <OPTIONS>      Enable comma-separated debug output options: files or timings
+  -f, --format=ARG  Use a specific output format. Possible values: `checkstyle`, `default`, `agent`, `github`, `gitlab`, `json`, `junit`, `sarif`, `stylish`, `unix`
+  --debug=OPTIONS   Enable debug output options. Options are comma-separated. Possible values:
+                     * `files` - Print the list of files that will be linted, then exit.
+                     * `timings` - Enable per-rule timing information.
 
 Miscellaneous:
-  --silent                         Do not display diagnostics
-  --no-error-on-unmatched-pattern  Do not exit with an error when no files are selected for linting
-  --threads <INT>                  Number of threads to use; set to 1 to use one CPU core
-  --print-config                   Print the resolved configuration without linting
+  --silent                         Do not display any diagnostics
+  --no-error-on-unmatched-pattern  Do not exit with an error when no files are selected for linting (for example, after applying ignore patterns)
+  --threads=INT                    Number of threads to use. Set to 1 for using only 1 CPU core.
+  --print-config                   This option outputs the configuration to be used. When present, no linting is performed and only config-related options are valid.
 
-Inline Configuration:
-  --report-unused-disable-directives                      Report unused oxlint-disable directives
-  --report-unused-disable-directives-severity <SEVERITY>  Report unused disable directives at the specified severity
+Inline Configuration Comments:
+  --report-unused-disable-directives                    Report directive comments like `// oxlint-disable-line`, when no errors would have been reported on that line anyway
+  --report-unused-disable-directives-severity=SEVERITY  Same as `--report-unused-disable-directives`, but allows you to specify the severity level of the reported errors. Only one of these two options can be used at a time.
 
-Options:
-  --rules       List all registered rules
-  --type-aware  Enable rules requiring type information
-  --type-check  Enable experimental type checking and compiler diagnostics
-  -h, --help    Print help information
+Available options:
+  --rules       List all the rules that are currently registered
+  --type-aware  Enable rules that require type information
+  --type-check  Enable experimental type checking (includes TypeScript compiler diagnostics)
+  -h, --help    Prints help information
 
 Examples:
   vp lint
@@ -90,67 +103,80 @@ Usage: vp lint [PATH]... [OPTIONS]
 Lint code.
 Options are forwarded to Oxlint.
 
-Arguments:
-  [PATH]...  Files or directories to lint
+Available positional items:
+  [PATH]...  Single file, single path or list of paths
 
 Basic Configuration:
-  --tsconfig <PATH>  Override the TypeScript config used for import resolution
+  --tsconfig=<./tsconfig.json>  Override the TypeScript config used for import resolution. Oxlint automatically discovers the relevant `tsconfig.json` for each file. Use this only when your project uses a non-standard tsconfig name or location.
 
-Rule Severity:
-  -A, --allow <NAME>  Allow a rule or category
-  -W, --warn <NAME>   Emit a warning for a rule or category
-  -D, --deny <NAME>   Emit an error for a rule or category
+Allowing / Denying Multiple Lints:
+  Accumulate rules and categories from left to right on the command-line.
+  For example `-D correctness -A no-debugger` or `-A all -D no-debugger`.
+  The categories are:
+  * `correctness` - Code that is outright wrong or useless (default)
+  * `suspicious`  - Code that is most likely wrong or useless
+  * `pedantic`    - Lints which are rather strict or have occasional false positives
+  * `perf`        - Code that could be written in a more performant way
+  * `style`       - Code that should be written in a more idiomatic way
+  * `restriction` - Lints which prevent the use of language and library features
+  * `nursery`     - New lints that are still under development
+  * `all`         - All categories listed above except `nursery`. Does not enable plugins automatically.
+  -A, --allow=NAME  Allow the rule or category (suppress the lint)
+  -W, --warn=NAME   Deny the rule or category (emit a warning)
+  -D, --deny=NAME   Deny the rule or category (emit an error)
 
-Plugins:
-  --disable-unicorn-plugin     Disable the unicorn plugin, which is enabled by default
-  --disable-oxc-plugin         Disable Oxc-specific rules, which are enabled by default
-  --disable-typescript-plugin  Disable the TypeScript plugin, which is enabled by default
-  --import-plugin              Enable the import plugin
-  --react-plugin               Enable the React plugin
-  --jsdoc-plugin               Enable the JSDoc plugin
-  --jest-plugin                Enable the Jest plugin
-  --vitest-plugin              Enable the Vitest plugin
-  --jsx-a11y-plugin            Enable the JSX accessibility plugin
-  --nextjs-plugin              Enable the Next.js plugin
-  --react-perf-plugin          Enable the React performance plugin
-  --promise-plugin             Enable the promise plugin
-  --node-plugin                Enable the Node.js plugin
-  --vue-plugin                 Enable the Vue plugin
+Enable/Disable Plugins:
+  --disable-unicorn-plugin     Disable unicorn plugin, which is turned on by default
+  --disable-oxc-plugin         Disable oxc unique rules, which is turned on by default
+  --disable-typescript-plugin  Disable TypeScript plugin, which is turned on by default
+  --import-plugin              Enable import plugin and detect ESM problems.
+  --react-plugin               Enable react plugin, which is turned off by default
+  --jsdoc-plugin               Enable jsdoc plugin and detect JSDoc problems
+  --jest-plugin                Enable the Jest plugin and detect test problems
+  --vitest-plugin              Enable the Vitest plugin and detect test problems
+  --jsx-a11y-plugin            Enable the JSX-a11y plugin and detect accessibility problems
+  --nextjs-plugin              Enable the Next.js plugin and detect Next.js problems
+  --react-perf-plugin          Enable the React performance plugin and detect rendering performance problems
+  --promise-plugin             Enable the promise plugin and detect promise usage problems
+  --node-plugin                Enable the node plugin and detect node usage problems
+  --vue-plugin                 Enable the vue plugin and detect vue usage problems
 
 Fix Problems:
-  --fix              Fix issues when possible
-  --fix-suggestions  Apply auto-fixable suggestions
+  --fix              Fix as many issues as possible. Only unfixed issues are reported in the output.
+  --fix-suggestions  Apply auto-fixable suggestions. May change program behavior.
   --fix-dangerously  Apply dangerous fixes and suggestions
 
 Ignore Files:
-  --ignore-path <PATH>        Use the specified .eslintignore file
-  --ignore-pattern <PATTERN>  Add file patterns to ignore
-  --no-ignore                 Disable file exclusion from ignore rules
+  --ignore-path=PATH    Specify the file to use as your `.eslintignore`
+  --ignore-pattern=PAT  Specify patterns of files to ignore (in addition to those in `.eslintignore`)
+  --no-ignore           Disable excluding files from `.eslintignore` files, --ignore-path flags and --ignore-pattern flags
 
 Handle Warnings:
-  --quiet               Report errors only
-  --deny-warnings       Exit non-zero when warnings are reported
-  --max-warnings <INT>  Set the warning threshold before exiting non-zero
+  --quiet             Disable reporting on warnings, only errors are reported
+  --deny-warnings     Ensure warnings produce a non-zero exit code
+  --max-warnings=INT  Specify a warning threshold, which can be used to force exit with an error status if there are too many warning-level rule violations in your project
 
 Output:
-  -f, --format <FORMAT>  Set output format: checkstyle, default, agent, github, gitlab, json, junit, sarif, stylish, or unix
-  --debug <OPTIONS>      Enable comma-separated debug output options: files or timings
+  -f, --format=ARG  Use a specific output format. Possible values: `checkstyle`, `default`, `agent`, `github`, `gitlab`, `json`, `junit`, `sarif`, `stylish`, `unix`
+  --debug=OPTIONS   Enable debug output options. Options are comma-separated. Possible values:
+                     * `files` - Print the list of files that will be linted, then exit.
+                     * `timings` - Enable per-rule timing information.
 
 Miscellaneous:
-  --silent                         Do not display diagnostics
-  --no-error-on-unmatched-pattern  Do not exit with an error when no files are selected for linting
-  --threads <INT>                  Number of threads to use; set to 1 to use one CPU core
-  --print-config                   Print the resolved configuration without linting
+  --silent                         Do not display any diagnostics
+  --no-error-on-unmatched-pattern  Do not exit with an error when no files are selected for linting (for example, after applying ignore patterns)
+  --threads=INT                    Number of threads to use. Set to 1 for using only 1 CPU core.
+  --print-config                   This option outputs the configuration to be used. When present, no linting is performed and only config-related options are valid.
 
-Inline Configuration:
-  --report-unused-disable-directives                      Report unused oxlint-disable directives
-  --report-unused-disable-directives-severity <SEVERITY>  Report unused disable directives at the specified severity
+Inline Configuration Comments:
+  --report-unused-disable-directives                    Report directive comments like `// oxlint-disable-line`, when no errors would have been reported on that line anyway
+  --report-unused-disable-directives-severity=SEVERITY  Same as `--report-unused-disable-directives`, but allows you to specify the severity level of the reported errors. Only one of these two options can be used at a time.
 
-Options:
-  --rules       List all registered rules
-  --type-aware  Enable rules requiring type information
-  --type-check  Enable experimental type checking and compiler diagnostics
-  -h, --help    Print help information
+Available options:
+  --rules       List all the rules that are currently registered
+  --type-aware  Enable rules that require type information
+  --type-check  Enable experimental type checking (includes TypeScript compiler diagnostics)
+  -h, --help    Prints help information
 
 Examples:
   vp lint
@@ -170,67 +196,80 @@ Usage: vp lint [PATH]... [OPTIONS]
 Lint code.
 Options are forwarded to Oxlint.
 
-Arguments:
-  [PATH]...  Files or directories to lint
+Available positional items:
+  [PATH]...  Single file, single path or list of paths
 
 Basic Configuration:
-  --tsconfig <PATH>  Override the TypeScript config used for import resolution
+  --tsconfig=<./tsconfig.json>  Override the TypeScript config used for import resolution. Oxlint automatically discovers the relevant `tsconfig.json` for each file. Use this only when your project uses a non-standard tsconfig name or location.
 
-Rule Severity:
-  -A, --allow <NAME>  Allow a rule or category
-  -W, --warn <NAME>   Emit a warning for a rule or category
-  -D, --deny <NAME>   Emit an error for a rule or category
+Allowing / Denying Multiple Lints:
+  Accumulate rules and categories from left to right on the command-line.
+  For example `-D correctness -A no-debugger` or `-A all -D no-debugger`.
+  The categories are:
+  * `correctness` - Code that is outright wrong or useless (default)
+  * `suspicious`  - Code that is most likely wrong or useless
+  * `pedantic`    - Lints which are rather strict or have occasional false positives
+  * `perf`        - Code that could be written in a more performant way
+  * `style`       - Code that should be written in a more idiomatic way
+  * `restriction` - Lints which prevent the use of language and library features
+  * `nursery`     - New lints that are still under development
+  * `all`         - All categories listed above except `nursery`. Does not enable plugins automatically.
+  -A, --allow=NAME  Allow the rule or category (suppress the lint)
+  -W, --warn=NAME   Deny the rule or category (emit a warning)
+  -D, --deny=NAME   Deny the rule or category (emit an error)
 
-Plugins:
-  --disable-unicorn-plugin     Disable the unicorn plugin, which is enabled by default
-  --disable-oxc-plugin         Disable Oxc-specific rules, which are enabled by default
-  --disable-typescript-plugin  Disable the TypeScript plugin, which is enabled by default
-  --import-plugin              Enable the import plugin
-  --react-plugin               Enable the React plugin
-  --jsdoc-plugin               Enable the JSDoc plugin
-  --jest-plugin                Enable the Jest plugin
-  --vitest-plugin              Enable the Vitest plugin
-  --jsx-a11y-plugin            Enable the JSX accessibility plugin
-  --nextjs-plugin              Enable the Next.js plugin
-  --react-perf-plugin          Enable the React performance plugin
-  --promise-plugin             Enable the promise plugin
-  --node-plugin                Enable the Node.js plugin
-  --vue-plugin                 Enable the Vue plugin
+Enable/Disable Plugins:
+  --disable-unicorn-plugin     Disable unicorn plugin, which is turned on by default
+  --disable-oxc-plugin         Disable oxc unique rules, which is turned on by default
+  --disable-typescript-plugin  Disable TypeScript plugin, which is turned on by default
+  --import-plugin              Enable import plugin and detect ESM problems.
+  --react-plugin               Enable react plugin, which is turned off by default
+  --jsdoc-plugin               Enable jsdoc plugin and detect JSDoc problems
+  --jest-plugin                Enable the Jest plugin and detect test problems
+  --vitest-plugin              Enable the Vitest plugin and detect test problems
+  --jsx-a11y-plugin            Enable the JSX-a11y plugin and detect accessibility problems
+  --nextjs-plugin              Enable the Next.js plugin and detect Next.js problems
+  --react-perf-plugin          Enable the React performance plugin and detect rendering performance problems
+  --promise-plugin             Enable the promise plugin and detect promise usage problems
+  --node-plugin                Enable the node plugin and detect node usage problems
+  --vue-plugin                 Enable the vue plugin and detect vue usage problems
 
 Fix Problems:
-  --fix              Fix issues when possible
-  --fix-suggestions  Apply auto-fixable suggestions
+  --fix              Fix as many issues as possible. Only unfixed issues are reported in the output.
+  --fix-suggestions  Apply auto-fixable suggestions. May change program behavior.
   --fix-dangerously  Apply dangerous fixes and suggestions
 
 Ignore Files:
-  --ignore-path <PATH>        Use the specified .eslintignore file
-  --ignore-pattern <PATTERN>  Add file patterns to ignore
-  --no-ignore                 Disable file exclusion from ignore rules
+  --ignore-path=PATH    Specify the file to use as your `.eslintignore`
+  --ignore-pattern=PAT  Specify patterns of files to ignore (in addition to those in `.eslintignore`)
+  --no-ignore           Disable excluding files from `.eslintignore` files, --ignore-path flags and --ignore-pattern flags
 
 Handle Warnings:
-  --quiet               Report errors only
-  --deny-warnings       Exit non-zero when warnings are reported
-  --max-warnings <INT>  Set the warning threshold before exiting non-zero
+  --quiet             Disable reporting on warnings, only errors are reported
+  --deny-warnings     Ensure warnings produce a non-zero exit code
+  --max-warnings=INT  Specify a warning threshold, which can be used to force exit with an error status if there are too many warning-level rule violations in your project
 
 Output:
-  -f, --format <FORMAT>  Set output format: checkstyle, default, agent, github, gitlab, json, junit, sarif, stylish, or unix
-  --debug <OPTIONS>      Enable comma-separated debug output options: files or timings
+  -f, --format=ARG  Use a specific output format. Possible values: `checkstyle`, `default`, `agent`, `github`, `gitlab`, `json`, `junit`, `sarif`, `stylish`, `unix`
+  --debug=OPTIONS   Enable debug output options. Options are comma-separated. Possible values:
+                     * `files` - Print the list of files that will be linted, then exit.
+                     * `timings` - Enable per-rule timing information.
 
 Miscellaneous:
-  --silent                         Do not display diagnostics
-  --no-error-on-unmatched-pattern  Do not exit with an error when no files are selected for linting
-  --threads <INT>                  Number of threads to use; set to 1 to use one CPU core
-  --print-config                   Print the resolved configuration without linting
+  --silent                         Do not display any diagnostics
+  --no-error-on-unmatched-pattern  Do not exit with an error when no files are selected for linting (for example, after applying ignore patterns)
+  --threads=INT                    Number of threads to use. Set to 1 for using only 1 CPU core.
+  --print-config                   This option outputs the configuration to be used. When present, no linting is performed and only config-related options are valid.
 
-Inline Configuration:
-  --report-unused-disable-directives                      Report unused oxlint-disable directives
-  --report-unused-disable-directives-severity <SEVERITY>  Report unused disable directives at the specified severity
+Inline Configuration Comments:
+  --report-unused-disable-directives                    Report directive comments like `// oxlint-disable-line`, when no errors would have been reported on that line anyway
+  --report-unused-disable-directives-severity=SEVERITY  Same as `--report-unused-disable-directives`, but allows you to specify the severity level of the reported errors. Only one of these two options can be used at a time.
 
-Options:
-  --rules       List all registered rules
-  --type-aware  Enable rules requiring type information
-  --type-check  Enable experimental type checking and compiler diagnostics
-  -h, --help    Print help information
+Available options:
+  --rules       List all the rules that are currently registered
+  --type-aware  Enable rules that require type information
+  --type-check  Enable experimental type checking (includes TypeScript compiler diagnostics)
+  -h, --help    Prints help information
 
 Examples:
   vp lint

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_pack/snapshots/command_pack.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_pack/snapshots/command_pack.md
@@ -7,51 +7,51 @@ should print the help message
 ```
 VITE+ - The Unified Toolchain for the Web
 
-Usage: vp pack [...FILES] [OPTIONS]
+Usage: vp pack [...files] [OPTIONS]
 
 Build a library.
 Options are forwarded to Vite+ Pack.
 
 Arguments:
-  [...FILES]  Files to bundle
+  [...files]  Bundle files
 
 Options:
-  -f, --format <FORMAT>         Bundle format: esm, cjs, iife, umd (default: esm)
+  -f, --format <format>         Bundle format: esm, cjs, iife, umd (default: esm)
   --clean                       Clean output directory, --no-clean to disable
-  --deps.never-bundle <MODULE>  Mark dependencies as external
+  --deps.never-bundle <module>  Mark dependencies as external
   --minify                      Minify output
   --devtools                    Enable devtools integration
-  --debug [FEAT]                Show debug logs
-  --target <TARGET>             Bundle target, e.g "es2015", "esnext"
-  -l, --logLevel <LEVEL>        Set log level: info, warn, error, silent
+  --debug [feat]                Show debug logs
+  --target <target>             Bundle target, e.g "es2015", "esnext"
+  -l, --logLevel <level>        Set log level: info, warn, error, silent
   --fail-on-warn                Fail on warnings (default: true)
   --no-write                    Disable writing files to disk, incompatible with watch mode (default: true)
-  -d, --out-dir <DIR>           Output directory (default: dist)
+  -d, --out-dir <dir>           Output directory (default: dist)
   --treeshake                   Tree-shake bundle (default: true)
   --sourcemap                   Generate source map (default: false)
   --shims                       Enable cjs and esm shims (default: false)
-  --platform <PLATFORM>         Target platform (default: node)
+  --platform <platform>         Target platform (default: node)
   --dts                         Generate dts files
   --publint                     Enable publint (default: false)
   --attw                        Enable Are the types wrong integration (default: false)
   --unused                      Enable unused dependencies check (default: false)
-  -w, --watch [PATH]            Watch mode
-  --ignore-watch <PATH>         Ignore custom paths in watch mode
-  --from-vite [VITEST]          Reuse config from Vite or Vitest
+  -w, --watch [path]            Watch mode
+  --ignore-watch <path>         Ignore custom paths in watch mode
+  --from-vite [vitest]          Reuse config from Vite or Vitest
   --report                      Size report (default: true)
-  --env.* <VALUE>               Define compile-time env variables
-  --env-file <FILE>             Load environment variables from a file, when used together with --env, variables in --env take precedence
-  --env-prefix <PREFIX>         Prefix for env variables to inject into the bundle (default: VITE_PACK_,TSDOWN_)
-  --on-success <COMMAND>        Command to run on success
-  --copy <DIR>                  Copy files to output dir
-  --public-dir <DIR>            Alias for --copy, deprecated
-  --tsconfig <TSCONFIG>         Set tsconfig path
+  --env.* <value>               Define compile-time env variables
+  --env-file <file>             Load environment variables from a file, when used together with --env, variables in --env take precedence
+  --env-prefix <prefix>         Prefix for env variables to inject into the bundle (default: TSDOWN_)
+  --on-success <command>        Command to run on success
+  --copy <dir>                  Copy files to output dir
+  --public-dir <dir>            Alias for --copy, deprecated
+  --tsconfig <tsconfig>         Set tsconfig path
   --unbundle                    Unbundle mode
-  --root <DIR>                  Root directory of input files
+  --root <dir>                  Root directory of input files
   --exe                         Bundle as executable
-  -W, --workspace [DIR]         Enable workspace mode
-  --concurrency <COUNT>         Maximum number of Rolldown builds to run in parallel
-  -F, --filter <PATTERN>        Filter configs (cwd or name), e.g. /pkg-name$/ or pkg-name
+  -W, --workspace [dir]         Enable workspace mode
+  --concurrency <count>         Maximum number of Rolldown builds to run in parallel
+  -F, --filter <pattern>        Filter configs (cwd or name), e.g. /pkg-name$/ or pkg-name
   --exports                     Generate export-related metadata for package.json (experimental)
   -h, --help                    Display this message
 

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_tool_help/package.json
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_tool_help/package.json
@@ -1,5 +1,3 @@
 {
-  "scripts": {
-    "localhelp": "vp dev --help"
-  }
+  "private": true
 }

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_tool_help/snapshots.toml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_tool_help/snapshots.toml
@@ -14,8 +14,14 @@ steps = [
 [[case]]
 name = "command_tool_help_global_delegation"
 vp = "global"
-comment = "Global and task-script help delegate to the local vite-plus CLI."
+comment = "Global top-level help uses the local vite-plus CLI, while extra task arguments reach the wrapped command."
 steps = [
   ["vp", "dev", "--help"],
   ["vpr", "localhelp", "--help"],
 ]
+
+[[case]]
+name = "command_tool_deep_help_delegation"
+vp = "local"
+comment = "Help requests with additional arguments delegate to the underlying tool."
+steps = [["vp", "test", "--help", "--coverage"]]

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_tool_help/snapshots.toml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_tool_help/snapshots.toml
@@ -14,11 +14,8 @@ steps = [
 [[case]]
 name = "command_tool_help_global_delegation"
 vp = "global"
-comment = "Global top-level help uses the local vite-plus CLI, while extra task arguments reach the wrapped command."
-steps = [
-  ["vp", "dev", "--help"],
-  ["vpr", "localhelp", "--help"],
-]
+comment = "Global top-level help delegates to the local vite-plus CLI."
+steps = [["vp", "dev", "--help"]]
 
 [[case]]
 name = "command_tool_deep_help_delegation"

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_tool_help/snapshots/command_tool_deep_help_delegation.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_tool_help/snapshots/command_tool_deep_help_delegation.md
@@ -1,0 +1,66 @@
+# command_tool_deep_help_delegation
+
+Help requests with additional arguments delegate to the underlying tool.
+
+## `vp test --help --coverage`
+
+```
+vitest/4.1.10
+
+Usage:
+  $ vitest [...filters]
+
+Commands:
+  run [...filters]
+  related [...filters]
+  watch [...filters]
+  dev [...filters]
+  bench [...filters]
+  init <project>
+  list [...filters]
+  [...filters]
+  complete [shell]
+
+For more info, run any command with the `--help` flag:
+  $ vitest run --help
+  $ vitest related --help
+  $ vitest watch --help
+  $ vitest dev --help
+  $ vitest bench --help
+  $ vitest init --help
+  $ vitest list --help
+  $ vitest --help
+  $ vitest complete --help
+  $ vitest --help --expand-help
+
+Options:
+  --coverage                                                 Enable coverage report. Use '--help --coverage' for more info.
+  --coverage.provider <name>                                 Select the tool for coverage collection, available values are: "v8", "istanbul" and "custom"
+  --coverage.enabled                                         Enables coverage collection. Can be overridden using the --coverage CLI option (default: false)
+  --coverage.include <pattern>                               Files included in coverage as glob patterns. May be specified more than once when using multiple patterns. By default only files covered by tests are included.
+  --coverage.exclude <pattern>                               Files to be excluded in coverage. May be specified more than once when using multiple extensions.
+  --coverage.clean                                           Clean coverage results before running tests (default: true)
+  --coverage.cleanOnRerun                                    Clean coverage report on watch rerun (default: true)
+  --coverage.reportsDirectory <path>                         Directory to write coverage report to (default: ./coverage)
+  --coverage.reporter <name>                                 Coverage reporters to use. Visit https://vitest.dev/config/coverage#coverage-reporter) for more information (default: ["text", "html", "clover", "json"]
+  --coverage.reportOnFailure                                 Generate coverage report even when tests fail (default: false)
+  --coverage.allowExternal                                   Collect coverage of files outside the project root (default: false)
+  --coverage.skipFull                                        Do not show files with 100% statement, branch, and function coverage (default: false)
+  --coverage.thresholds.100                                  Shortcut to set all coverage thresholds to 100 (default: false)
+  --coverage.thresholds.perFile                              Check thresholds per file. See --coverage.thresholds.lines, --coverage.thresholds.functions, --coverage.thresholds.branches and --coverage.thresholds.statements for the actual thresholds (default: false)
+  --coverage.thresholds.autoUpdate <boolean|function>        Update threshold values: "lines", "functions", "branches" and "statements" to configuration file when current coverage is above the configured thresholds (default: false)
+  --coverage.thresholds.lines <number>                       Threshold for lines. Visit https://github.com/istanbuljs/nyc#coverage-thresholds for more information. This option is not available for custom providers
+  --coverage.thresholds.functions <number>                   Threshold for functions. Visit https://github.com/istanbuljs/nyc#coverage-thresholds for more information. This option is not available for custom providers
+  --coverage.thresholds.branches <number>                    Threshold for branches. Visit https://github.com/istanbuljs/nyc#coverage-thresholds for more information. This option is not available for custom providers
+  --coverage.thresholds.statements <number>                  Threshold for statements. Visit https://github.com/istanbuljs/nyc#coverage-thresholds for more information. This option is not available for custom providers
+  --coverage.ignoreClassMethods <name>                       Array of class method names to ignore for coverage. Visit https://github.com/istanbuljs/nyc#ignoring-methods) for more information. This option is only available for the istanbul providers (default: []
+  --coverage.processingConcurrency <number>                  Concurrency limit used when processing the coverage results. (default min between 20 and the number of CPUs)
+  --coverage.customProviderModule <path>                     Specifies the module name or path for the custom coverage provider module. Visit https://vitest.dev/guide/coverage#custom-coverage-provider for more information. This option is only available for custom providers
+  --coverage.watermarks.statements <watermarks>              High and low watermarks for statements in the format of <high>,<low>
+  --coverage.watermarks.lines <watermarks>                   High and low watermarks for lines in the format of <high>,<low>
+  --coverage.watermarks.branches <watermarks>                High and low watermarks for branches in the format of <high>,<low>
+  --coverage.watermarks.functions <watermarks>               High and low watermarks for functions in the format of <high>,<low>
+  --coverage.changed <commit/branch>                         Collect coverage only for files changed since a specified commit or branch (e.g., origin/main or HEAD~1). Inherits value from --changed by default.
+  --coverage.excludeAfterRemap                               Apply exclusions again after coverage has been remapped to original sources. (default: false)
+  --coverage.htmlDir <path>                                  Directory of HTML coverage output to be served in UI mode and HTML reporter.
+```

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_tool_help/snapshots/command_tool_help.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_tool_help/snapshots/command_tool_help.md
@@ -16,20 +16,20 @@ Arguments:
   [ROOT]  Project root directory (default: current directory)
 
 Options:
-  --host [HOST]           Specify hostname
-  --port <PORT>           Specify port
-  --open [PATH]           Open browser on startup
-  --cors                  Enable CORS
-  --strictPort            Exit if specified port is already in use
-  --force                 Ignore the optimizer cache and re-bundle
-  --experimentalBundle    Use experimental full bundle mode
-  --base <PATH>           Public base path
-  -l, --logLevel <LEVEL>  Set log level
-  --clearScreen           Allow or disable clearing the screen
-  -d, --debug [FEAT]      Show debug logs
-  -f, --filter <FILTER>   Filter debug logs
-  -m, --mode <MODE>       Set env mode
-  -h, --help              Print help
+  --host [host]           [string] specify hostname
+  --port <port>           [number] specify port
+  --open [path]           [boolean | string] open browser on startup
+  --cors                  [boolean] enable CORS
+  --strictPort            [boolean] exit if specified port is already in use
+  --force                 [boolean] force the optimizer to ignore the cache and re-bundle
+  --experimentalBundle    [boolean] use experimental full bundle mode (this is highly experimental)
+  --base <path>           [string] public base path (default: /)
+  -l, --logLevel <level>  [string] info | warn | error | silent
+  --clearScreen           [boolean] allow/disable clear screen when logging
+  -d, --debug [feat]      [string | boolean] show debug logs
+  -f, --filter <filter>   [string] filter debug logs
+  -m, --mode <mode>       [string] set env mode
+  -h, --help              Display this message
 
 Examples:
   vp dev
@@ -53,25 +53,25 @@ Arguments:
   [ROOT]  Project root directory (default: current directory)
 
 Options:
-  --target <TARGET>             Transpile target
-  --outDir <DIR>                Output directory
-  --assetsDir <DIR>             Directory for generated assets
-  --assetsInlineLimit <NUMBER>  Static asset inline threshold
-  --ssr [ENTRY]                 Build for server-side rendering
-  --sourcemap [MODE]            Output source maps
-  --minify [MINIFIER]           Enable or disable minification
-  --manifest [NAME]             Emit a build manifest
-  --ssrManifest [NAME]          Emit an SSR manifest
-  --emptyOutDir                 Empty outDir even when it is outside root
-  -w, --watch                   Rebuild when files change
-  --app                         Build an application with the builder API
-  --base <PATH>                 Public base path
-  -l, --logLevel <LEVEL>        Set log level
-  --clearScreen                 Allow or disable clearing the screen
-  -d, --debug [FEAT]            Show debug logs
-  -f, --filter <FILTER>         Filter debug logs
-  -m, --mode <MODE>             Set env mode
-  -h, --help                    Print help
+  --target <target>             [string] transpile target (default: 'baseline-widely-available')
+  --outDir <dir>                [string] output directory (default: dist)
+  --assetsDir <dir>             [string] directory under outDir to place assets in (default: assets)
+  --assetsInlineLimit <number>  [number] static asset base64 inline threshold in bytes (default: 4096)
+  --ssr [entry]                 [string] build specified entry for server-side rendering
+  --sourcemap [output]          [boolean | "inline" | "hidden"] output source maps for build (default: false)
+  --minify [minifier]           [boolean | "oxc" | "terser" | "esbuild"] enable/disable minification, or specify minifier to use (default: oxc)
+  --manifest [name]             [boolean | string] emit build manifest json
+  --ssrManifest [name]          [boolean | string] emit ssr manifest json
+  --emptyOutDir                 [boolean] force empty outDir when it's outside of root
+  -w, --watch                   [boolean] rebuilds when modules have changed on disk
+  --app                         [boolean] same as `builder: {}`
+  --base <path>                 [string] public base path (default: /)
+  -l, --logLevel <level>        [string] info | warn | error | silent
+  --clearScreen                 [boolean] allow/disable clear screen when logging
+  -d, --debug [feat]            [string | boolean] show debug logs
+  -f, --filter <filter>         [string] filter debug logs
+  -m, --mode <mode>             [string] set env mode
+  -h, --help                    Display this message
 
 Examples:
   vp build
@@ -95,18 +95,18 @@ Arguments:
   [ROOT]  Project root directory (default: current directory)
 
 Options:
-  --host [HOST]           Specify hostname
-  --port <PORT>           Specify port
-  --strictPort            Exit if specified port is already in use
-  --open [PATH]           Open browser on startup
-  --outDir <DIR>          Output directory to preview
-  --base <PATH>           Public base path
-  -l, --logLevel <LEVEL>  Set log level
-  --clearScreen           Allow or disable clearing the screen
-  -d, --debug [FEAT]      Show debug logs
-  -f, --filter <FILTER>   Filter debug logs
-  -m, --mode <MODE>       Set env mode
-  -h, --help              Print help
+  --host [host]           [string] specify hostname
+  --port <port>           [number] specify port
+  --strictPort            [boolean] exit if specified port is already in use
+  --open [path]           [boolean | string] open browser on startup
+  --outDir <dir>          [string] output directory (default: dist)
+  --base <path>           [string] public base path (default: /)
+  -l, --logLevel <level>  [string] info | warn | error | silent
+  --clearScreen           [boolean] allow/disable clear screen when logging
+  -d, --debug [feat]      [string | boolean] show debug logs
+  -f, --filter <filter>   [string] filter debug logs
+  -m, --mode <mode>       [string] set env mode
+  -h, --help              Display this message
 
 Examples:
   vp preview
@@ -137,79 +137,79 @@ Arguments:
   [FILTERS]...  Test file filters
 
 Options:
-  -r, --root <PATH>                   Root path
-  -u, --update [TYPE]                 Update snapshot (accepts boolean, "new", "all" or "none")
+  -r, --root <path>                   Root path
+  -u, --update [type]                 Update snapshot (accepts boolean, "new", "all" or "none")
   -w, --watch                         Enable watch mode
-  -t, --testNamePattern <PATTERN>     Run tests with full names matching the specified regexp pattern
-  --dir <PATH>                        Base directory to scan for the test files
+  -t, --testNamePattern <pattern>     Run tests with full names matching the specified regexp pattern
+  --dir <path>                        Base directory to scan for the test files
   --ui                                Enable UI
   --open                              Open UI automatically (default: !process.env.CI)
-  --api [PORT]                        Specify server port; if true, defaults to 51204
-  --silent [VALUE]                    Silent console output from tests. Use 'passed-only' to see logs from failing tests only
+  --api [port]                        Specify server port. Note if the port is already being used, Vite will automatically try the next available port so this may not be the actual port the server ends up listening on. If true will be set to 51204. Use '--help --api' for more info.
+  --silent [value]                    Silent console output from tests. Use 'passed-only' to see logs from failing tests only.
   --hideSkippedTests                  Hide logs for skipped tests
-  --reporter <NAME>                   Specify reporters (default, agent, minimal, blob, verbose, dot, json, tap, tap-flat, junit, tree, hanging-process, github-actions)
-  --outputFile <FILENAME/-S>          Write test results to a file; use dot notation for individual outputs of multiple reporters (for example, --outputFile.tap=./tap.txt)
-  --coverage                          Enable coverage reporting
-  --mode <NAME>                       Override Vite mode (default: test or benchmark)
-  --isolate                           Run every test file in isolation. Use --no-isolate to disable (default: true)
-  --globals                           Inject APIs globally
+  --reporter <name>                   Specify reporters (default, agent, minimal, blob, verbose, dot, json, tap, tap-flat, junit, tree, hanging-process, github-actions)
+  --outputFile <filename/-s>          Write test results to a file when supporter reporter is also specified, use cac's dot notation for individual outputs of multiple reporters (example: --outputFile.tap=./tap.txt)
+  --coverage                          Enable coverage report. Use '--help --coverage' for more info.
+  --mode <name>                       Override Vite mode (default: test or benchmark)
+  --isolate                           Run every test file in isolation. To disable isolation, use --no-isolate (default: true)
+  --globals                           Inject apis globally
   --dom                               Mock browser API with happy-dom
-  --browser <NAME>                    Run tests in the browser; equivalent to --browser.enabled (default: false)
-  --pool <POOL>                       Specify pool when not running in the browser (default: forks)
-  --execArgv <OPTION>                 Pass additional arguments to Node.js when spawning worker threads or child processes
-  --vmMemoryLimit <LIMIT>             Memory limit for VM pools
-  --fileParallelism                   Run test files in parallel. Use --no-file-parallelism to disable (default: true)
-  --maxWorkers <WORKERS>              Maximum number or percentage of workers to run tests in
-  --environment <NAME>                Specify runner environment (default: node)
+  --browser <name>                    Run tests in the browser. Equivalent to --browser.enabled (default: false). Use '--help --browser' for more info.
+  --pool <pool>                       Specify pool, if not running in the browser (default: forks)
+  --execArgv <option>                 Pass additional arguments to node process when spawning worker_threads or child_process.
+  --vmMemoryLimit <limit>             Memory limit for VM pools. If you see memory leaks, try to tinker this value.
+  --fileParallelism                   Should all test files run in parallel. Use --no-file-parallelism to disable (default: true)
+  --maxWorkers <workers>              Maximum number or percentage of workers to run tests in
+  --environment <name>                Specify runner environment, if not running in the browser (default: node)
   --passWithNoTests                   Pass when no tests are found
-  --logHeapUsage                      Show the size of the heap for each test when running in Node.js
-  --detectAsyncLeaks                  Detect asynchronous resources leaking from test files (default: false)
-  --allowOnly                         Allow tests and suites marked as only (default: !process.env.CI)
+  --logHeapUsage                      Show the size of heap for each test when running in node
+  --detectAsyncLeaks                  Detect asynchronous resources leaking from the test file (default: false)
+  --allowOnly                         Allow tests and suites that are marked as only (default: !process.env.CI)
   --dangerouslyIgnoreUnhandledErrors  Ignore any unhandled errors that occur
-  --shard <SHARDS>                    Test suite shard to execute in the format <index>/<count>
-  --changed [SINCE]                   Run tests affected by changed files (default: false)
-  --sequence <OPTIONS>                Configure test sorting
-  --inspect [[HOST:]PORT]             Enable Node.js inspector (default: 127.0.0.1:9229)
-  --inspectBrk [[HOST:]PORT]          Enable Node.js inspector and break before tests start
-  --testTimeout <TIMEOUT>             Default test timeout in milliseconds (default: 5000; 0 disables)
-  --hookTimeout <TIMEOUT>             Default hook timeout in milliseconds (default: 10000; 0 disables)
-  --bail <NUMBER>                     Stop test execution after the given number of failures (default: 0)
-  --retry <TIMES>                     Retry failed tests (default: 0)
-  --diff <PATH>                       DiffOptions object or path to a module exporting one
-  --exclude <GLOB>                    Additional file globs to exclude from tests
-  --expandSnapshotDiff                Show the full diff when a snapshot fails
+  --shard <shards>                    Test suite shard to execute in a format of <index>/<count>
+  --changed [since]                   Run tests that are affected by the changed files (default: false)
+  --sequence <options>                Options for how tests should be sorted. Use '--help --sequence' for more info.
+  --inspect [[host:]port]             Enable Node.js inspector (default: 127.0.0.1:9229)
+  --inspectBrk [[host:]port]          Enable Node.js inspector and break before the test starts
+  --testTimeout <timeout>             Default timeout of a test in milliseconds (default: 5000). Use 0 to disable timeout completely.
+  --hookTimeout <timeout>             Default hook timeout in milliseconds (default: 10000). Use 0 to disable timeout completely.
+  --bail <number>                     Stop test execution when given number of tests have failed (default: 0)
+  --retry <times>                     Retry the test specific number of times if it fails (default: 0). Use '--help --retry' for more info.
+  --diff <path>                       DiffOptions object or a path to a module which exports DiffOptions object. Use '--help --diff' for more info.
+  --exclude <glob>                    Additional file globs to be excluded from test
+  --expandSnapshotDiff                Show full diff when snapshot fails
   --disableConsoleIntercept           Disable automatic interception of console logging (default: false)
-  --typecheck                         Enable typechecking alongside tests (default: false)
-  --project <NAME>                    Select one or more Vitest workspace projects by name or wildcard
-  --slowTestThreshold <THRESHOLD>     Threshold for a test or suite to be considered slow (default: <duration>)
-  --teardownTimeout <TIMEOUT>         Default teardown timeout in milliseconds (default: 10000)
-  --cache                             Enable cache
-  --maxConcurrency <NUMBER>           Maximum number of concurrent tests and suites (default: 5)
-  --expect                            Configure expect matchers
+  --typecheck                         Enable typechecking alongside tests (default: false). Use '--help --typecheck' for more info.
+  --project <name>                    The name of the project to run if you are using Vitest workspace feature. This can be repeated for multiple projects: --project=1 --project=2. You can also filter projects using wildcards like --project=packages*, and exclude projects with --project=!pattern.
+  --slowTestThreshold <threshold>     Threshold in milliseconds for a test or suite to be considered slow (default: 300)
+  --teardownTimeout <timeout>         Default timeout of a teardown function in milliseconds (default: 10000)
+  --cache                             Enable cache. Use '--help --cache' for more info.
+  --maxConcurrency <number>           Maximum number of concurrent tests and suites during test file execution (default: 5)
+  --expect                            Configuration options for expect() matches. Use '--help --expect' for more info.
   --printConsoleTrace                 Always print console stack traces
   --includeTaskLocation               Collect test and suite locations in the location property
-  --attachmentsDir <DIR>              Directory for attachments created with context.annotate (default: .vitest-attachments)
+  --attachmentsDir <dir>              The directory where attachments from context.annotate are stored in (default: .vitest-attachments)
   --run                               Disable watch mode
-  --no-color                          Remove colors from console output (default: true)
-  --clearScreen                       Clear the terminal when rerunning tests in watch mode (default: true)
-  --standalone                        Start Vitest without running tests until files change (default: false)
-  --mergeReports [PATH]               Merge previously recorded blob reports without running tests
-  --listTags [TYPE]                   List available tags; --list-tags=json outputs JSON
-  --clearCache                        Delete all Vitest caches without running tests
-  --tagsFilter <EXPRESSION>           Run only tests matching the tag expression
-  --strictTags                        Error when a test uses an undefined tag (default: true)
-  --experimental <FEATURES>           Enable experimental features
+  --no-color                          Removes colors from the console output (default: true)
+  --clearScreen                       Clear terminal screen when re-running tests during watch mode (default: true)
+  --standalone                        Start Vitest without running tests. Tests will be running only on change. If browser mode is enabled, the UI will be opened automatically. This option is ignored when CLI file filters are passed. (default: false)
+  --mergeReports [path]               Path to a blob reports directory. If this options is used, Vitest won't run any tests, it will only report previously recorded tests
+  --listTags [type]                   List all available tags instead of running tests. --list-tags=json will output tags in JSON format, unless there are no tags.
+  --clearCache                        Delete all Vitest caches, including experimental.fsModuleCache, without running any tests. This will reduce the performance in the subsequent test run.
+  --tagsFilter <expression>           Run only tests with the specified tags. You can use logical operators && (and), || (or) and ! (not) to create complex expressions, see https://vitest.dev/guide/test-tags#syntax for more information.
+  --strictTags                        Should Vitest throw an error if test has a tag that is not defined in the config. (default: true)
+  --experimental <features>           Experimental features.. Use '--help --experimental' for more info.
   -h, --help                          Display this message
 
 Bench Options:
-  --compare <FILENAME>     Benchmark output file to compare against
-  --outputJson <FILENAME>  Benchmark output file
+  --compare <filename>     Benchmark output file to compare against
+  --outputJson <filename>  Benchmark output file
 
 List Options:
-  --json [TRUE/PATH]                Print collected tests as JSON or write to a file (default: false)
-  --filesOnly                       Print only test files without test cases
-  --staticParse                     Parse files statically instead of running them (default: false)
-  --staticParseConcurrency <LIMIT>  Number of test files to process concurrently
+  --json [true/path]                Print collected tests as JSON or write to a file (Default: false)
+  --filesOnly                       Print only test files with out the test cases
+  --staticParse                     Parse files statically instead of running them to collect tests (default: false)
+  --staticParseConcurrency <limit>  How many tests to process at the same time (default: os.availableParallelism())
 
 Examples:
   vp test
@@ -224,51 +224,51 @@ Documentation: https://viteplus.dev/guide/test
 ```
 VITE+ - The Unified Toolchain for the Web
 
-Usage: vp pack [...FILES] [OPTIONS]
+Usage: vp pack [...files] [OPTIONS]
 
 Build a library.
 Options are forwarded to Vite+ Pack.
 
 Arguments:
-  [...FILES]  Files to bundle
+  [...files]  Bundle files
 
 Options:
-  -f, --format <FORMAT>         Bundle format: esm, cjs, iife, umd (default: esm)
+  -f, --format <format>         Bundle format: esm, cjs, iife, umd (default: esm)
   --clean                       Clean output directory, --no-clean to disable
-  --deps.never-bundle <MODULE>  Mark dependencies as external
+  --deps.never-bundle <module>  Mark dependencies as external
   --minify                      Minify output
   --devtools                    Enable devtools integration
-  --debug [FEAT]                Show debug logs
-  --target <TARGET>             Bundle target, e.g "es2015", "esnext"
-  -l, --logLevel <LEVEL>        Set log level: info, warn, error, silent
+  --debug [feat]                Show debug logs
+  --target <target>             Bundle target, e.g "es2015", "esnext"
+  -l, --logLevel <level>        Set log level: info, warn, error, silent
   --fail-on-warn                Fail on warnings (default: true)
   --no-write                    Disable writing files to disk, incompatible with watch mode (default: true)
-  -d, --out-dir <DIR>           Output directory (default: dist)
+  -d, --out-dir <dir>           Output directory (default: dist)
   --treeshake                   Tree-shake bundle (default: true)
   --sourcemap                   Generate source map (default: false)
   --shims                       Enable cjs and esm shims (default: false)
-  --platform <PLATFORM>         Target platform (default: node)
+  --platform <platform>         Target platform (default: node)
   --dts                         Generate dts files
   --publint                     Enable publint (default: false)
   --attw                        Enable Are the types wrong integration (default: false)
   --unused                      Enable unused dependencies check (default: false)
-  -w, --watch [PATH]            Watch mode
-  --ignore-watch <PATH>         Ignore custom paths in watch mode
-  --from-vite [VITEST]          Reuse config from Vite or Vitest
+  -w, --watch [path]            Watch mode
+  --ignore-watch <path>         Ignore custom paths in watch mode
+  --from-vite [vitest]          Reuse config from Vite or Vitest
   --report                      Size report (default: true)
-  --env.* <VALUE>               Define compile-time env variables
-  --env-file <FILE>             Load environment variables from a file, when used together with --env, variables in --env take precedence
-  --env-prefix <PREFIX>         Prefix for env variables to inject into the bundle (default: VITE_PACK_,TSDOWN_)
-  --on-success <COMMAND>        Command to run on success
-  --copy <DIR>                  Copy files to output dir
-  --public-dir <DIR>            Alias for --copy, deprecated
-  --tsconfig <TSCONFIG>         Set tsconfig path
+  --env.* <value>               Define compile-time env variables
+  --env-file <file>             Load environment variables from a file, when used together with --env, variables in --env take precedence
+  --env-prefix <prefix>         Prefix for env variables to inject into the bundle (default: TSDOWN_)
+  --on-success <command>        Command to run on success
+  --copy <dir>                  Copy files to output dir
+  --public-dir <dir>            Alias for --copy, deprecated
+  --tsconfig <tsconfig>         Set tsconfig path
   --unbundle                    Unbundle mode
-  --root <DIR>                  Root directory of input files
+  --root <dir>                  Root directory of input files
   --exe                         Bundle as executable
-  -W, --workspace [DIR]         Enable workspace mode
-  --concurrency <COUNT>         Maximum number of Rolldown builds to run in parallel
-  -F, --filter <PATTERN>        Filter configs (cwd or name), e.g. /pkg-name$/ or pkg-name
+  -W, --workspace [dir]         Enable workspace mode
+  --concurrency <count>         Maximum number of Rolldown builds to run in parallel
+  -F, --filter <pattern>        Filter configs (cwd or name), e.g. /pkg-name$/ or pkg-name
   --exports                     Generate export-related metadata for package.json (experimental)
   -h, --help                    Display this message
 

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_tool_help/snapshots/command_tool_help_global_delegation.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_tool_help/snapshots/command_tool_help_global_delegation.md
@@ -1,6 +1,6 @@
 # command_tool_help_global_delegation
 
-Global and task-script help delegate to the local vite-plus CLI.
+Global top-level help uses the local vite-plus CLI, while extra task arguments reach the wrapped command.
 
 ## `vp dev --help`
 
@@ -43,36 +43,39 @@ Documentation: https://viteplus.dev/guide/dev
 
 ```
 $ vp dev --help --help ⊘ cache disabled
-VITE+ - The Unified Toolchain for the Web
+vp/<version>
 
-Usage: vp dev [ROOT] [OPTIONS]
+Usage:
+  $ vp [root]
 
-Run the development server.
-Options are forwarded to Vite.
+Commands:
+  [root]           start dev server
+  build [root]     build for production
+  optimize [root]  pre-bundle dependencies (deprecated, the pre-bundle process runs automatically and does not need to be called)
+  preview [root]   locally preview production build
 
-Arguments:
-  [ROOT]  Project root directory (default: current directory)
+For more info, run any command with the `--help` flag:
+  $ vp --help
+  $ vp build --help
+  $ vp optimize --help
+  $ vp preview --help
 
 Options:
-  --host [host]           [string] specify hostname
-  --port <port>           [number] specify port
-  --open [path]           [boolean | string] open browser on startup
-  --cors                  [boolean] enable CORS
-  --strictPort            [boolean] exit if specified port is already in use
-  --force                 [boolean] force the optimizer to ignore the cache and re-bundle
-  --experimentalBundle    [boolean] use experimental full bundle mode (this is highly experimental)
-  --base <path>           [string] public base path (default: /)
-  -l, --logLevel <level>  [string] info | warn | error | silent
-  --clearScreen           [boolean] allow/disable clear screen when logging
-  -d, --debug [feat]      [string | boolean] show debug logs
-  -f, --filter <filter>   [string] filter debug logs
-  -m, --mode <mode>       [string] set env mode
-  -h, --help              Display this message
-
-Examples:
-  vp dev
-  vp dev --open
-  vp dev --host localhost --port 5173
-
-Documentation: https://viteplus.dev/guide/dev
+  --host [host]            [string] specify hostname
+  --port <port>            [number] specify port
+  --open [path]            [boolean | string] open browser on startup
+  --cors                   [boolean] enable CORS
+  --strictPort             [boolean] exit if specified port is already in use
+  --force                  [boolean] force the optimizer to ignore the cache and re-bundle
+  --experimentalBundle     [boolean] use experimental full bundle mode (this is highly experimental)
+  -c, --config <file>      [string] use specified config file
+  --base <path>            [string] public base path (default: /)
+  -l, --logLevel <level>   [string] info | warn | error | silent
+  --clearScreen            [boolean] allow/disable clear screen when logging
+  --configLoader <loader>  [string] use 'bundle' to bundle the config with Rolldown, or 'runner' (experimental) to process it on the fly, or 'native' (experimental) to load using the native runtime (default: bundle)
+  -d, --debug [feat]       [string | boolean] show debug logs
+  -f, --filter <filter>    [string] filter debug logs
+  -m, --mode <mode>        [string] set env mode
+  -h, --help               Display this message
+  -v, --version            Display version number
 ```

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_tool_help/snapshots/command_tool_help_global_delegation.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_tool_help/snapshots/command_tool_help_global_delegation.md
@@ -1,6 +1,6 @@
 # command_tool_help_global_delegation
 
-Global top-level help uses the local vite-plus CLI, while extra task arguments reach the wrapped command.
+Global top-level help delegates to the local vite-plus CLI.
 
 ## `vp dev --help`
 
@@ -37,45 +37,4 @@ Examples:
   vp dev --host localhost --port 5173
 
 Documentation: https://viteplus.dev/guide/dev
-```
-
-## `vpr localhelp --help`
-
-```
-$ vp dev --help --help ⊘ cache disabled
-vp/<version>
-
-Usage:
-  $ vp [root]
-
-Commands:
-  [root]           start dev server
-  build [root]     build for production
-  optimize [root]  pre-bundle dependencies (deprecated, the pre-bundle process runs automatically and does not need to be called)
-  preview [root]   locally preview production build
-
-For more info, run any command with the `--help` flag:
-  $ vp --help
-  $ vp build --help
-  $ vp optimize --help
-  $ vp preview --help
-
-Options:
-  --host [host]            [string] specify hostname
-  --port <port>            [number] specify port
-  --open [path]            [boolean | string] open browser on startup
-  --cors                   [boolean] enable CORS
-  --strictPort             [boolean] exit if specified port is already in use
-  --force                  [boolean] force the optimizer to ignore the cache and re-bundle
-  --experimentalBundle     [boolean] use experimental full bundle mode (this is highly experimental)
-  -c, --config <file>      [string] use specified config file
-  --base <path>            [string] public base path (default: /)
-  -l, --logLevel <level>   [string] info | warn | error | silent
-  --clearScreen            [boolean] allow/disable clear screen when logging
-  --configLoader <loader>  [string] use 'bundle' to bundle the config with Rolldown, or 'runner' (experimental) to process it on the fly, or 'native' (experimental) to load using the native runtime (default: bundle)
-  -d, --debug [feat]       [string | boolean] show debug logs
-  -f, --filter <filter>    [string] filter debug logs
-  -m, --mode <mode>        [string] set env mode
-  -h, --help               Display this message
-  -v, --version            Display version number
 ```

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_tool_help/snapshots/command_tool_help_global_delegation.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_tool_help/snapshots/command_tool_help_global_delegation.md
@@ -16,20 +16,20 @@ Arguments:
   [ROOT]  Project root directory (default: current directory)
 
 Options:
-  --host [HOST]           Specify hostname
-  --port <PORT>           Specify port
-  --open [PATH]           Open browser on startup
-  --cors                  Enable CORS
-  --strictPort            Exit if specified port is already in use
-  --force                 Ignore the optimizer cache and re-bundle
-  --experimentalBundle    Use experimental full bundle mode
-  --base <PATH>           Public base path
-  -l, --logLevel <LEVEL>  Set log level
-  --clearScreen           Allow or disable clearing the screen
-  -d, --debug [FEAT]      Show debug logs
-  -f, --filter <FILTER>   Filter debug logs
-  -m, --mode <MODE>       Set env mode
-  -h, --help              Print help
+  --host [host]           [string] specify hostname
+  --port <port>           [number] specify port
+  --open [path]           [boolean | string] open browser on startup
+  --cors                  [boolean] enable CORS
+  --strictPort            [boolean] exit if specified port is already in use
+  --force                 [boolean] force the optimizer to ignore the cache and re-bundle
+  --experimentalBundle    [boolean] use experimental full bundle mode (this is highly experimental)
+  --base <path>           [string] public base path (default: /)
+  -l, --logLevel <level>  [string] info | warn | error | silent
+  --clearScreen           [boolean] allow/disable clear screen when logging
+  -d, --debug [feat]      [string | boolean] show debug logs
+  -f, --filter <filter>   [string] filter debug logs
+  -m, --mode <mode>       [string] set env mode
+  -h, --help              Display this message
 
 Examples:
   vp dev
@@ -54,20 +54,20 @@ Arguments:
   [ROOT]  Project root directory (default: current directory)
 
 Options:
-  --host [HOST]           Specify hostname
-  --port <PORT>           Specify port
-  --open [PATH]           Open browser on startup
-  --cors                  Enable CORS
-  --strictPort            Exit if specified port is already in use
-  --force                 Ignore the optimizer cache and re-bundle
-  --experimentalBundle    Use experimental full bundle mode
-  --base <PATH>           Public base path
-  -l, --logLevel <LEVEL>  Set log level
-  --clearScreen           Allow or disable clearing the screen
-  -d, --debug [FEAT]      Show debug logs
-  -f, --filter <FILTER>   Filter debug logs
-  -m, --mode <MODE>       Set env mode
-  -h, --help              Print help
+  --host [host]           [string] specify hostname
+  --port <port>           [number] specify port
+  --open [path]           [boolean | string] open browser on startup
+  --cors                  [boolean] enable CORS
+  --strictPort            [boolean] exit if specified port is already in use
+  --force                 [boolean] force the optimizer to ignore the cache and re-bundle
+  --experimentalBundle    [boolean] use experimental full bundle mode (this is highly experimental)
+  --base <path>           [string] public base path (default: /)
+  -l, --logLevel <level>  [string] info | warn | error | silent
+  --clearScreen           [boolean] allow/disable clear screen when logging
+  -d, --debug [feat]      [string | boolean] show debug logs
+  -f, --filter <filter>   [string] filter debug logs
+  -m, --mode <mode>       [string] set env mode
+  -h, --help              Display this message
 
 Examples:
   vp dev

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/global_cli_fallback/snapshots/global_cli_fallback.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/global_cli_fallback/snapshots/global_cli_fallback.md
@@ -16,25 +16,25 @@ Arguments:
   [ROOT]  Project root directory (default: current directory)
 
 Options:
-  --target <TARGET>             Transpile target
-  --outDir <DIR>                Output directory
-  --assetsDir <DIR>             Directory for generated assets
-  --assetsInlineLimit <NUMBER>  Static asset inline threshold
-  --ssr [ENTRY]                 Build for server-side rendering
-  --sourcemap [MODE]            Output source maps
-  --minify [MINIFIER]           Enable or disable minification
-  --manifest [NAME]             Emit a build manifest
-  --ssrManifest [NAME]          Emit an SSR manifest
-  --emptyOutDir                 Empty outDir even when it is outside root
-  -w, --watch                   Rebuild when files change
-  --app                         Build an application with the builder API
-  --base <PATH>                 Public base path
-  -l, --logLevel <LEVEL>        Set log level
-  --clearScreen                 Allow or disable clearing the screen
-  -d, --debug [FEAT]            Show debug logs
-  -f, --filter <FILTER>         Filter debug logs
-  -m, --mode <MODE>             Set env mode
-  -h, --help                    Print help
+  --target <target>             [string] transpile target (default: 'baseline-widely-available')
+  --outDir <dir>                [string] output directory (default: dist)
+  --assetsDir <dir>             [string] directory under outDir to place assets in (default: assets)
+  --assetsInlineLimit <number>  [number] static asset base64 inline threshold in bytes (default: 4096)
+  --ssr [entry]                 [string] build specified entry for server-side rendering
+  --sourcemap [output]          [boolean | "inline" | "hidden"] output source maps for build (default: false)
+  --minify [minifier]           [boolean | "oxc" | "terser" | "esbuild"] enable/disable minification, or specify minifier to use (default: oxc)
+  --manifest [name]             [boolean | string] emit build manifest json
+  --ssrManifest [name]          [boolean | string] emit ssr manifest json
+  --emptyOutDir                 [boolean] force empty outDir when it's outside of root
+  -w, --watch                   [boolean] rebuilds when modules have changed on disk
+  --app                         [boolean] same as `builder: {}`
+  --base <path>                 [string] public base path (default: /)
+  -l, --logLevel <level>        [string] info | warn | error | silent
+  --clearScreen                 [boolean] allow/disable clear screen when logging
+  -d, --debug [feat]            [string | boolean] show debug logs
+  -f, --filter <filter>         [string] filter debug logs
+  -m, --mode <mode>             [string] set env mode
+  -h, --help                    Display this message
 
 Examples:
   vp build
@@ -60,20 +60,20 @@ Arguments:
   [ROOT]  Project root directory (default: current directory)
 
 Options:
-  --host [HOST]           Specify hostname
-  --port <PORT>           Specify port
-  --open [PATH]           Open browser on startup
-  --cors                  Enable CORS
-  --strictPort            Exit if specified port is already in use
-  --force                 Ignore the optimizer cache and re-bundle
-  --experimentalBundle    Use experimental full bundle mode
-  --base <PATH>           Public base path
-  -l, --logLevel <LEVEL>  Set log level
-  --clearScreen           Allow or disable clearing the screen
-  -d, --debug [FEAT]      Show debug logs
-  -f, --filter <FILTER>   Filter debug logs
-  -m, --mode <MODE>       Set env mode
-  -h, --help              Print help
+  --host [host]           [string] specify hostname
+  --port <port>           [number] specify port
+  --open [path]           [boolean | string] open browser on startup
+  --cors                  [boolean] enable CORS
+  --strictPort            [boolean] exit if specified port is already in use
+  --force                 [boolean] force the optimizer to ignore the cache and re-bundle
+  --experimentalBundle    [boolean] use experimental full bundle mode (this is highly experimental)
+  --base <path>           [string] public base path (default: /)
+  -l, --logLevel <level>  [string] info | warn | error | silent
+  --clearScreen           [boolean] allow/disable clear screen when logging
+  -d, --debug [feat]      [string | boolean] show debug logs
+  -f, --filter <filter>   [string] filter debug logs
+  -m, --mode <mode>       [string] set env mode
+  -h, --help              Display this message
 
 Examples:
   vp dev
@@ -107,79 +107,79 @@ Arguments:
   [FILTERS]...  Test file filters
 
 Options:
-  -r, --root <PATH>                   Root path
-  -u, --update [TYPE]                 Update snapshot (accepts boolean, "new", "all" or "none")
+  -r, --root <path>                   Root path
+  -u, --update [type]                 Update snapshot (accepts boolean, "new", "all" or "none")
   -w, --watch                         Enable watch mode
-  -t, --testNamePattern <PATTERN>     Run tests with full names matching the specified regexp pattern
-  --dir <PATH>                        Base directory to scan for the test files
+  -t, --testNamePattern <pattern>     Run tests with full names matching the specified regexp pattern
+  --dir <path>                        Base directory to scan for the test files
   --ui                                Enable UI
   --open                              Open UI automatically (default: !process.env.CI)
-  --api [PORT]                        Specify server port; if true, defaults to 51204
-  --silent [VALUE]                    Silent console output from tests. Use 'passed-only' to see logs from failing tests only
+  --api [port]                        Specify server port. Note if the port is already being used, Vite will automatically try the next available port so this may not be the actual port the server ends up listening on. If true will be set to 51204. Use '--help --api' for more info.
+  --silent [value]                    Silent console output from tests. Use 'passed-only' to see logs from failing tests only.
   --hideSkippedTests                  Hide logs for skipped tests
-  --reporter <NAME>                   Specify reporters (default, agent, minimal, blob, verbose, dot, json, tap, tap-flat, junit, tree, hanging-process, github-actions)
-  --outputFile <FILENAME/-S>          Write test results to a file; use dot notation for individual outputs of multiple reporters (for example, --outputFile.tap=./tap.txt)
-  --coverage                          Enable coverage reporting
-  --mode <NAME>                       Override Vite mode (default: test or benchmark)
-  --isolate                           Run every test file in isolation. Use --no-isolate to disable (default: true)
-  --globals                           Inject APIs globally
+  --reporter <name>                   Specify reporters (default, agent, minimal, blob, verbose, dot, json, tap, tap-flat, junit, tree, hanging-process, github-actions)
+  --outputFile <filename/-s>          Write test results to a file when supporter reporter is also specified, use cac's dot notation for individual outputs of multiple reporters (example: --outputFile.tap=./tap.txt)
+  --coverage                          Enable coverage report. Use '--help --coverage' for more info.
+  --mode <name>                       Override Vite mode (default: test or benchmark)
+  --isolate                           Run every test file in isolation. To disable isolation, use --no-isolate (default: true)
+  --globals                           Inject apis globally
   --dom                               Mock browser API with happy-dom
-  --browser <NAME>                    Run tests in the browser; equivalent to --browser.enabled (default: false)
-  --pool <POOL>                       Specify pool when not running in the browser (default: forks)
-  --execArgv <OPTION>                 Pass additional arguments to Node.js when spawning worker threads or child processes
-  --vmMemoryLimit <LIMIT>             Memory limit for VM pools
-  --fileParallelism                   Run test files in parallel. Use --no-file-parallelism to disable (default: true)
-  --maxWorkers <WORKERS>              Maximum number or percentage of workers to run tests in
-  --environment <NAME>                Specify runner environment (default: node)
+  --browser <name>                    Run tests in the browser. Equivalent to --browser.enabled (default: false). Use '--help --browser' for more info.
+  --pool <pool>                       Specify pool, if not running in the browser (default: forks)
+  --execArgv <option>                 Pass additional arguments to node process when spawning worker_threads or child_process.
+  --vmMemoryLimit <limit>             Memory limit for VM pools. If you see memory leaks, try to tinker this value.
+  --fileParallelism                   Should all test files run in parallel. Use --no-file-parallelism to disable (default: true)
+  --maxWorkers <workers>              Maximum number or percentage of workers to run tests in
+  --environment <name>                Specify runner environment, if not running in the browser (default: node)
   --passWithNoTests                   Pass when no tests are found
-  --logHeapUsage                      Show the size of the heap for each test when running in Node.js
-  --detectAsyncLeaks                  Detect asynchronous resources leaking from test files (default: false)
-  --allowOnly                         Allow tests and suites marked as only (default: !process.env.CI)
+  --logHeapUsage                      Show the size of heap for each test when running in node
+  --detectAsyncLeaks                  Detect asynchronous resources leaking from the test file (default: false)
+  --allowOnly                         Allow tests and suites that are marked as only (default: !process.env.CI)
   --dangerouslyIgnoreUnhandledErrors  Ignore any unhandled errors that occur
-  --shard <SHARDS>                    Test suite shard to execute in the format <index>/<count>
-  --changed [SINCE]                   Run tests affected by changed files (default: false)
-  --sequence <OPTIONS>                Configure test sorting
-  --inspect [[HOST:]PORT]             Enable Node.js inspector (default: 127.0.0.1:9229)
-  --inspectBrk [[HOST:]PORT]          Enable Node.js inspector and break before tests start
-  --testTimeout <TIMEOUT>             Default test timeout in milliseconds (default: 5000; 0 disables)
-  --hookTimeout <TIMEOUT>             Default hook timeout in milliseconds (default: 10000; 0 disables)
-  --bail <NUMBER>                     Stop test execution after the given number of failures (default: 0)
-  --retry <TIMES>                     Retry failed tests (default: 0)
-  --diff <PATH>                       DiffOptions object or path to a module exporting one
-  --exclude <GLOB>                    Additional file globs to exclude from tests
-  --expandSnapshotDiff                Show the full diff when a snapshot fails
+  --shard <shards>                    Test suite shard to execute in a format of <index>/<count>
+  --changed [since]                   Run tests that are affected by the changed files (default: false)
+  --sequence <options>                Options for how tests should be sorted. Use '--help --sequence' for more info.
+  --inspect [[host:]port]             Enable Node.js inspector (default: 127.0.0.1:9229)
+  --inspectBrk [[host:]port]          Enable Node.js inspector and break before the test starts
+  --testTimeout <timeout>             Default timeout of a test in milliseconds (default: 5000). Use 0 to disable timeout completely.
+  --hookTimeout <timeout>             Default hook timeout in milliseconds (default: 10000). Use 0 to disable timeout completely.
+  --bail <number>                     Stop test execution when given number of tests have failed (default: 0)
+  --retry <times>                     Retry the test specific number of times if it fails (default: 0). Use '--help --retry' for more info.
+  --diff <path>                       DiffOptions object or a path to a module which exports DiffOptions object. Use '--help --diff' for more info.
+  --exclude <glob>                    Additional file globs to be excluded from test
+  --expandSnapshotDiff                Show full diff when snapshot fails
   --disableConsoleIntercept           Disable automatic interception of console logging (default: false)
-  --typecheck                         Enable typechecking alongside tests (default: false)
-  --project <NAME>                    Select one or more Vitest workspace projects by name or wildcard
-  --slowTestThreshold <THRESHOLD>     Threshold for a test or suite to be considered slow (default: <duration>)
-  --teardownTimeout <TIMEOUT>         Default teardown timeout in milliseconds (default: 10000)
-  --cache                             Enable cache
-  --maxConcurrency <NUMBER>           Maximum number of concurrent tests and suites (default: 5)
-  --expect                            Configure expect matchers
+  --typecheck                         Enable typechecking alongside tests (default: false). Use '--help --typecheck' for more info.
+  --project <name>                    The name of the project to run if you are using Vitest workspace feature. This can be repeated for multiple projects: --project=1 --project=2. You can also filter projects using wildcards like --project=packages*, and exclude projects with --project=!pattern.
+  --slowTestThreshold <threshold>     Threshold in milliseconds for a test or suite to be considered slow (default: 300)
+  --teardownTimeout <timeout>         Default timeout of a teardown function in milliseconds (default: 10000)
+  --cache                             Enable cache. Use '--help --cache' for more info.
+  --maxConcurrency <number>           Maximum number of concurrent tests and suites during test file execution (default: 5)
+  --expect                            Configuration options for expect() matches. Use '--help --expect' for more info.
   --printConsoleTrace                 Always print console stack traces
   --includeTaskLocation               Collect test and suite locations in the location property
-  --attachmentsDir <DIR>              Directory for attachments created with context.annotate (default: .vitest-attachments)
+  --attachmentsDir <dir>              The directory where attachments from context.annotate are stored in (default: .vitest-attachments)
   --run                               Disable watch mode
-  --no-color                          Remove colors from console output (default: true)
-  --clearScreen                       Clear the terminal when rerunning tests in watch mode (default: true)
-  --standalone                        Start Vitest without running tests until files change (default: false)
-  --mergeReports [PATH]               Merge previously recorded blob reports without running tests
-  --listTags [TYPE]                   List available tags; --list-tags=json outputs JSON
-  --clearCache                        Delete all Vitest caches without running tests
-  --tagsFilter <EXPRESSION>           Run only tests matching the tag expression
-  --strictTags                        Error when a test uses an undefined tag (default: true)
-  --experimental <FEATURES>           Enable experimental features
+  --no-color                          Removes colors from the console output (default: true)
+  --clearScreen                       Clear terminal screen when re-running tests during watch mode (default: true)
+  --standalone                        Start Vitest without running tests. Tests will be running only on change. If browser mode is enabled, the UI will be opened automatically. This option is ignored when CLI file filters are passed. (default: false)
+  --mergeReports [path]               Path to a blob reports directory. If this options is used, Vitest won't run any tests, it will only report previously recorded tests
+  --listTags [type]                   List all available tags instead of running tests. --list-tags=json will output tags in JSON format, unless there are no tags.
+  --clearCache                        Delete all Vitest caches, including experimental.fsModuleCache, without running any tests. This will reduce the performance in the subsequent test run.
+  --tagsFilter <expression>           Run only tests with the specified tags. You can use logical operators && (and), || (or) and ! (not) to create complex expressions, see https://vitest.dev/guide/test-tags#syntax for more information.
+  --strictTags                        Should Vitest throw an error if test has a tag that is not defined in the config. (default: true)
+  --experimental <features>           Experimental features.. Use '--help --experimental' for more info.
   -h, --help                          Display this message
 
 Bench Options:
-  --compare <FILENAME>     Benchmark output file to compare against
-  --outputJson <FILENAME>  Benchmark output file
+  --compare <filename>     Benchmark output file to compare against
+  --outputJson <filename>  Benchmark output file
 
 List Options:
-  --json [TRUE/PATH]                Print collected tests as JSON or write to a file (default: false)
-  --filesOnly                       Print only test files without test cases
-  --staticParse                     Parse files statically instead of running them (default: false)
-  --staticParseConcurrency <LIMIT>  Number of test files to process concurrently
+  --json [true/path]                Print collected tests as JSON or write to a file (Default: false)
+  --filesOnly                       Print only test files with out the test cases
+  --staticParse                     Parse files statically instead of running them to collect tests (default: false)
+  --staticParseConcurrency <limit>  How many tests to process at the same time (default: os.availableParallelism())
 
 Examples:
   vp test

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/test_panicked_fix/snapshots/test_panicked_fix.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/test_panicked_fix/snapshots/test_panicked_fix.md
@@ -12,67 +12,80 @@ Usage: vp lint [PATH]... [OPTIONS]
 Lint code.
 Options are forwarded to Oxlint.
 
-Arguments:
-  [PATH]...  Files or directories to lint
+Available positional items:
+  [PATH]...  Single file, single path or list of paths
 
 Basic Configuration:
-  --tsconfig <PATH>  Override the TypeScript config used for import resolution
+  --tsconfig=<./tsconfig.json>  Override the TypeScript config used for import resolution. Oxlint automatically discovers the relevant `tsconfig.json` for each file. Use this only when your project uses a non-standard tsconfig name or location.
 
-Rule Severity:
-  -A, --allow <NAME>  Allow a rule or category
-  -W, --warn <NAME>   Emit a warning for a rule or category
-  -D, --deny <NAME>   Emit an error for a rule or category
+Allowing / Denying Multiple Lints:
+  Accumulate rules and categories from left to right on the command-line.
+  For example `-D correctness -A no-debugger` or `-A all -D no-debugger`.
+  The categories are:
+  * `correctness` - Code that is outright wrong or useless (default)
+  * `suspicious`  - Code that is most likely wrong or useless
+  * `pedantic`    - Lints which are rather strict or have occasional false positives
+  * `perf`        - Code that could be written in a more performant way
+  * `style`       - Code that should be written in a more idiomatic way
+  * `restriction` - Lints which prevent the use of language and library features
+  * `nursery`     - New lints that are still under development
+  * `all`         - All categories listed above except `nursery`. Does not enable plugins automatically.
+  -A, --allow=NAME  Allow the rule or category (suppress the lint)
+  -W, --warn=NAME   Deny the rule or category (emit a warning)
+  -D, --deny=NAME   Deny the rule or category (emit an error)
 
-Plugins:
-  --disable-unicorn-plugin     Disable the unicorn plugin, which is enabled by default
-  --disable-oxc-plugin         Disable Oxc-specific rules, which are enabled by default
-  --disable-typescript-plugin  Disable the TypeScript plugin, which is enabled by default
-  --import-plugin              Enable the import plugin
-  --react-plugin               Enable the React plugin
-  --jsdoc-plugin               Enable the JSDoc plugin
-  --jest-plugin                Enable the Jest plugin
-  --vitest-plugin              Enable the Vitest plugin
-  --jsx-a11y-plugin            Enable the JSX accessibility plugin
-  --nextjs-plugin              Enable the Next.js plugin
-  --react-perf-plugin          Enable the React performance plugin
-  --promise-plugin             Enable the promise plugin
-  --node-plugin                Enable the Node.js plugin
-  --vue-plugin                 Enable the Vue plugin
+Enable/Disable Plugins:
+  --disable-unicorn-plugin     Disable unicorn plugin, which is turned on by default
+  --disable-oxc-plugin         Disable oxc unique rules, which is turned on by default
+  --disable-typescript-plugin  Disable TypeScript plugin, which is turned on by default
+  --import-plugin              Enable import plugin and detect ESM problems.
+  --react-plugin               Enable react plugin, which is turned off by default
+  --jsdoc-plugin               Enable jsdoc plugin and detect JSDoc problems
+  --jest-plugin                Enable the Jest plugin and detect test problems
+  --vitest-plugin              Enable the Vitest plugin and detect test problems
+  --jsx-a11y-plugin            Enable the JSX-a11y plugin and detect accessibility problems
+  --nextjs-plugin              Enable the Next.js plugin and detect Next.js problems
+  --react-perf-plugin          Enable the React performance plugin and detect rendering performance problems
+  --promise-plugin             Enable the promise plugin and detect promise usage problems
+  --node-plugin                Enable the node plugin and detect node usage problems
+  --vue-plugin                 Enable the vue plugin and detect vue usage problems
 
 Fix Problems:
-  --fix              Fix issues when possible
-  --fix-suggestions  Apply auto-fixable suggestions
+  --fix              Fix as many issues as possible. Only unfixed issues are reported in the output.
+  --fix-suggestions  Apply auto-fixable suggestions. May change program behavior.
   --fix-dangerously  Apply dangerous fixes and suggestions
 
 Ignore Files:
-  --ignore-path <PATH>        Use the specified .eslintignore file
-  --ignore-pattern <PATTERN>  Add file patterns to ignore
-  --no-ignore                 Disable file exclusion from ignore rules
+  --ignore-path=PATH    Specify the file to use as your `.eslintignore`
+  --ignore-pattern=PAT  Specify patterns of files to ignore (in addition to those in `.eslintignore`)
+  --no-ignore           Disable excluding files from `.eslintignore` files, --ignore-path flags and --ignore-pattern flags
 
 Handle Warnings:
-  --quiet               Report errors only
-  --deny-warnings       Exit non-zero when warnings are reported
-  --max-warnings <INT>  Set the warning threshold before exiting non-zero
+  --quiet             Disable reporting on warnings, only errors are reported
+  --deny-warnings     Ensure warnings produce a non-zero exit code
+  --max-warnings=INT  Specify a warning threshold, which can be used to force exit with an error status if there are too many warning-level rule violations in your project
 
 Output:
-  -f, --format <FORMAT>  Set output format: checkstyle, default, agent, github, gitlab, json, junit, sarif, stylish, or unix
-  --debug <OPTIONS>      Enable comma-separated debug output options: files or timings
+  -f, --format=ARG  Use a specific output format. Possible values: `checkstyle`, `default`, `agent`, `github`, `gitlab`, `json`, `junit`, `sarif`, `stylish`, `unix`
+  --debug=OPTIONS   Enable debug output options. Options are comma-separated. Possible values:
+                     * `files` - Print the list of files that will be linted, then exit.
+                     * `timings` - Enable per-rule timing information.
 
 Miscellaneous:
-  --silent                         Do not display diagnostics
-  --no-error-on-unmatched-pattern  Do not exit with an error when no files are selected for linting
-  --threads <INT>                  Number of threads to use; set to 1 to use one CPU core
-  --print-config                   Print the resolved configuration without linting
+  --silent                         Do not display any diagnostics
+  --no-error-on-unmatched-pattern  Do not exit with an error when no files are selected for linting (for example, after applying ignore patterns)
+  --threads=INT                    Number of threads to use. Set to 1 for using only 1 CPU core.
+  --print-config                   This option outputs the configuration to be used. When present, no linting is performed and only config-related options are valid.
 
-Inline Configuration:
-  --report-unused-disable-directives                      Report unused oxlint-disable directives
-  --report-unused-disable-directives-severity <SEVERITY>  Report unused disable directives at the specified severity
+Inline Configuration Comments:
+  --report-unused-disable-directives                    Report directive comments like `// oxlint-disable-line`, when no errors would have been reported on that line anyway
+  --report-unused-disable-directives-severity=SEVERITY  Same as `--report-unused-disable-directives`, but allows you to specify the severity level of the reported errors. Only one of these two options can be used at a time.
 
-Options:
-  --rules       List all registered rules
-  --type-aware  Enable rules requiring type information
-  --type-check  Enable experimental type checking and compiler diagnostics
-  -h, --help    Print help information
+Available options:
+  --rules       List all the rules that are currently registered
+  --type-aware  Enable rules that require type information
+  --type-check  Enable experimental type checking (includes TypeScript compiler diagnostics)
+  -h, --help    Prints help information
 
 Examples:
   vp lint

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -16,20 +16,36 @@ const commandHelpDocs = {
       {
         title: 'Options',
         rows: [
-          { label: '--host [HOST]', description: 'Specify hostname' },
-          { label: '--port <PORT>', description: 'Specify port' },
-          { label: '--open [PATH]', description: 'Open browser on startup' },
-          { label: '--cors', description: 'Enable CORS' },
-          { label: '--strictPort', description: 'Exit if specified port is already in use' },
-          { label: '--force', description: 'Ignore the optimizer cache and re-bundle' },
-          { label: '--experimentalBundle', description: 'Use experimental full bundle mode' },
-          { label: '--base <PATH>', description: 'Public base path' },
-          { label: '-l, --logLevel <LEVEL>', description: 'Set log level' },
-          { label: '--clearScreen', description: 'Allow or disable clearing the screen' },
-          { label: '-d, --debug [FEAT]', description: 'Show debug logs' },
-          { label: '-f, --filter <FILTER>', description: 'Filter debug logs' },
-          { label: '-m, --mode <MODE>', description: 'Set env mode' },
-          { label: '-h, --help', description: 'Print help' },
+          { label: '--host [host]', description: '[string] specify hostname' },
+          { label: '--port <port>', description: '[number] specify port' },
+          { label: '--open [path]', description: '[boolean | string] open browser on startup' },
+          { label: '--cors', description: '[boolean] enable CORS' },
+          {
+            label: '--strictPort',
+            description: '[boolean] exit if specified port is already in use',
+          },
+          {
+            label: '--force',
+            description: '[boolean] force the optimizer to ignore the cache and re-bundle',
+          },
+          {
+            label: '--experimentalBundle',
+            description:
+              '[boolean] use experimental full bundle mode (this is highly experimental)',
+          },
+          { label: '--base <path>', description: '[string] public base path (default: /)' },
+          {
+            label: '-l, --logLevel <level>',
+            description: '[string] info | warn | error | silent',
+          },
+          {
+            label: '--clearScreen',
+            description: '[boolean] allow/disable clear screen when logging',
+          },
+          { label: '-d, --debug [feat]', description: '[string | boolean] show debug logs' },
+          { label: '-f, --filter <filter>', description: '[string] filter debug logs' },
+          { label: '-m, --mode <mode>', description: '[string] set env mode' },
+          { label: '-h, --help', description: 'Display this message' },
         ],
       },
       {
@@ -52,25 +68,63 @@ const commandHelpDocs = {
       {
         title: 'Options',
         rows: [
-          { label: '--target <TARGET>', description: 'Transpile target' },
-          { label: '--outDir <DIR>', description: 'Output directory' },
-          { label: '--assetsDir <DIR>', description: 'Directory for generated assets' },
-          { label: '--assetsInlineLimit <NUMBER>', description: 'Static asset inline threshold' },
-          { label: '--ssr [ENTRY]', description: 'Build for server-side rendering' },
-          { label: '--sourcemap [MODE]', description: 'Output source maps' },
-          { label: '--minify [MINIFIER]', description: 'Enable or disable minification' },
-          { label: '--manifest [NAME]', description: 'Emit a build manifest' },
-          { label: '--ssrManifest [NAME]', description: 'Emit an SSR manifest' },
-          { label: '--emptyOutDir', description: 'Empty outDir even when it is outside root' },
-          { label: '-w, --watch', description: 'Rebuild when files change' },
-          { label: '--app', description: 'Build an application with the builder API' },
-          { label: '--base <PATH>', description: 'Public base path' },
-          { label: '-l, --logLevel <LEVEL>', description: 'Set log level' },
-          { label: '--clearScreen', description: 'Allow or disable clearing the screen' },
-          { label: '-d, --debug [FEAT]', description: 'Show debug logs' },
-          { label: '-f, --filter <FILTER>', description: 'Filter debug logs' },
-          { label: '-m, --mode <MODE>', description: 'Set env mode' },
-          { label: '-h, --help', description: 'Print help' },
+          {
+            label: '--target <target>',
+            description: "[string] transpile target (default: 'baseline-widely-available')",
+          },
+          { label: '--outDir <dir>', description: '[string] output directory (default: dist)' },
+          {
+            label: '--assetsDir <dir>',
+            description: '[string] directory under outDir to place assets in (default: assets)',
+          },
+          {
+            label: '--assetsInlineLimit <number>',
+            description: '[number] static asset base64 inline threshold in bytes (default: 4096)',
+          },
+          {
+            label: '--ssr [entry]',
+            description: '[string] build specified entry for server-side rendering',
+          },
+          {
+            label: '--sourcemap [output]',
+            description:
+              '[boolean | "inline" | "hidden"] output source maps for build (default: false)',
+          },
+          {
+            label: '--minify [minifier]',
+            description:
+              '[boolean | "oxc" | "terser" | "esbuild"] enable/disable minification, or specify minifier to use (default: oxc)',
+          },
+          {
+            label: '--manifest [name]',
+            description: '[boolean | string] emit build manifest json',
+          },
+          {
+            label: '--ssrManifest [name]',
+            description: '[boolean | string] emit ssr manifest json',
+          },
+          {
+            label: '--emptyOutDir',
+            description: "[boolean] force empty outDir when it's outside of root",
+          },
+          {
+            label: '-w, --watch',
+            description: '[boolean] rebuilds when modules have changed on disk',
+          },
+          { label: '--app', description: '[boolean] same as `builder: {}`' },
+          { label: '--base <path>', description: '[string] public base path (default: /)' },
+          {
+            label: '-l, --logLevel <level>',
+            description: '[string] info | warn | error | silent',
+          },
+          {
+            label: '--clearScreen',
+            description: '[boolean] allow/disable clear screen when logging',
+          },
+          { label: '-d, --debug [feat]', description: '[string | boolean] show debug logs' },
+          { label: '-f, --filter <filter>', description: '[string] filter debug logs' },
+          { label: '-m, --mode <mode>', description: '[string] set env mode' },
+          { label: '-h, --help', description: 'Display this message' },
         ],
       },
       {
@@ -93,18 +147,27 @@ const commandHelpDocs = {
       {
         title: 'Options',
         rows: [
-          { label: '--host [HOST]', description: 'Specify hostname' },
-          { label: '--port <PORT>', description: 'Specify port' },
-          { label: '--strictPort', description: 'Exit if specified port is already in use' },
-          { label: '--open [PATH]', description: 'Open browser on startup' },
-          { label: '--outDir <DIR>', description: 'Output directory to preview' },
-          { label: '--base <PATH>', description: 'Public base path' },
-          { label: '-l, --logLevel <LEVEL>', description: 'Set log level' },
-          { label: '--clearScreen', description: 'Allow or disable clearing the screen' },
-          { label: '-d, --debug [FEAT]', description: 'Show debug logs' },
-          { label: '-f, --filter <FILTER>', description: 'Filter debug logs' },
-          { label: '-m, --mode <MODE>', description: 'Set env mode' },
-          { label: '-h, --help', description: 'Print help' },
+          { label: '--host [host]', description: '[string] specify hostname' },
+          { label: '--port <port>', description: '[number] specify port' },
+          {
+            label: '--strictPort',
+            description: '[boolean] exit if specified port is already in use',
+          },
+          { label: '--open [path]', description: '[boolean | string] open browser on startup' },
+          { label: '--outDir <dir>', description: '[string] output directory (default: dist)' },
+          { label: '--base <path>', description: '[string] public base path (default: /)' },
+          {
+            label: '-l, --logLevel <level>',
+            description: '[string] info | warn | error | silent',
+          },
+          {
+            label: '--clearScreen',
+            description: '[boolean] allow/disable clear screen when logging',
+          },
+          { label: '-d, --debug [feat]', description: '[string | boolean] show debug logs' },
+          { label: '-f, --filter <filter>', description: '[string] filter debug logs' },
+          { label: '-m, --mode <mode>', description: '[string] set env mode' },
+          { label: '-h, --help', description: 'Display this message' },
         ],
       },
       { title: 'Examples', lines: ['  vp preview', '  vp preview --port 4173'] },
@@ -133,149 +196,159 @@ const commandHelpDocs = {
       {
         title: 'Options',
         rows: [
-          { label: '-r, --root <PATH>', description: 'Root path' },
+          { label: '-r, --root <path>', description: 'Root path' },
           {
-            label: '-u, --update [TYPE]',
+            label: '-u, --update [type]',
             description: 'Update snapshot (accepts boolean, "new", "all" or "none")',
           },
           { label: '-w, --watch', description: 'Enable watch mode' },
           {
-            label: '-t, --testNamePattern <PATTERN>',
+            label: '-t, --testNamePattern <pattern>',
             description: 'Run tests with full names matching the specified regexp pattern',
           },
-          { label: '--dir <PATH>', description: 'Base directory to scan for the test files' },
+          { label: '--dir <path>', description: 'Base directory to scan for the test files' },
           { label: '--ui', description: 'Enable UI' },
           { label: '--open', description: 'Open UI automatically (default: !process.env.CI)' },
           {
-            label: '--api [PORT]',
-            description: 'Specify server port; if true, defaults to 51204',
+            label: '--api [port]',
+            description:
+              "Specify server port. Note if the port is already being used, Vite will automatically try the next available port so this may not be the actual port the server ends up listening on. If true will be set to 51204. Use '--help --api' for more info.",
           },
           {
-            label: '--silent [VALUE]',
+            label: '--silent [value]',
             description:
-              "Silent console output from tests. Use 'passed-only' to see logs from failing tests only",
+              "Silent console output from tests. Use 'passed-only' to see logs from failing tests only.",
           },
           { label: '--hideSkippedTests', description: 'Hide logs for skipped tests' },
           {
-            label: '--reporter <NAME>',
+            label: '--reporter <name>',
             description:
               'Specify reporters (default, agent, minimal, blob, verbose, dot, json, tap, tap-flat, junit, tree, hanging-process, github-actions)',
           },
           {
-            label: '--outputFile <FILENAME/-S>',
+            label: '--outputFile <filename/-s>',
             description:
-              'Write test results to a file; use dot notation for individual outputs of multiple reporters (for example, --outputFile.tap=./tap.txt)',
+              "Write test results to a file when supporter reporter is also specified, use cac's dot notation for individual outputs of multiple reporters (example: --outputFile.tap=./tap.txt)",
           },
           {
             label: '--coverage',
-            description: 'Enable coverage reporting',
+            description: "Enable coverage report. Use '--help --coverage' for more info.",
           },
           {
-            label: '--mode <NAME>',
+            label: '--mode <name>',
             description: 'Override Vite mode (default: test or benchmark)',
           },
           {
             label: '--isolate',
             description:
-              'Run every test file in isolation. Use --no-isolate to disable (default: true)',
+              'Run every test file in isolation. To disable isolation, use --no-isolate (default: true)',
           },
-          { label: '--globals', description: 'Inject APIs globally' },
+          { label: '--globals', description: 'Inject apis globally' },
           { label: '--dom', description: 'Mock browser API with happy-dom' },
           {
-            label: '--browser <NAME>',
+            label: '--browser <name>',
             description:
-              'Run tests in the browser; equivalent to --browser.enabled (default: false)',
+              "Run tests in the browser. Equivalent to --browser.enabled (default: false). Use '--help --browser' for more info.",
           },
           {
-            label: '--pool <POOL>',
-            description: 'Specify pool when not running in the browser (default: forks)',
+            label: '--pool <pool>',
+            description: 'Specify pool, if not running in the browser (default: forks)',
           },
           {
-            label: '--execArgv <OPTION>',
+            label: '--execArgv <option>',
             description:
-              'Pass additional arguments to Node.js when spawning worker threads or child processes',
+              'Pass additional arguments to node process when spawning worker_threads or child_process.',
           },
           {
-            label: '--vmMemoryLimit <LIMIT>',
-            description: 'Memory limit for VM pools',
+            label: '--vmMemoryLimit <limit>',
+            description:
+              'Memory limit for VM pools. If you see memory leaks, try to tinker this value.',
           },
           {
             label: '--fileParallelism',
             description:
-              'Run test files in parallel. Use --no-file-parallelism to disable (default: true)',
+              'Should all test files run in parallel. Use --no-file-parallelism to disable (default: true)',
           },
           {
-            label: '--maxWorkers <WORKERS>',
+            label: '--maxWorkers <workers>',
             description: 'Maximum number or percentage of workers to run tests in',
           },
           {
-            label: '--environment <NAME>',
-            description: 'Specify runner environment (default: node)',
+            label: '--environment <name>',
+            description:
+              'Specify runner environment, if not running in the browser (default: node)',
           },
           { label: '--passWithNoTests', description: 'Pass when no tests are found' },
           {
             label: '--logHeapUsage',
-            description: 'Show the size of the heap for each test when running in Node.js',
+            description: 'Show the size of heap for each test when running in node',
           },
           {
             label: '--detectAsyncLeaks',
-            description: 'Detect asynchronous resources leaking from test files (default: false)',
+            description:
+              'Detect asynchronous resources leaking from the test file (default: false)',
           },
           {
             label: '--allowOnly',
-            description: 'Allow tests and suites marked as only (default: !process.env.CI)',
+            description:
+              'Allow tests and suites that are marked as only (default: !process.env.CI)',
           },
           {
             label: '--dangerouslyIgnoreUnhandledErrors',
             description: 'Ignore any unhandled errors that occur',
           },
           {
-            label: '--shard <SHARDS>',
-            description: 'Test suite shard to execute in the format <index>/<count>',
+            label: '--shard <shards>',
+            description: 'Test suite shard to execute in a format of <index>/<count>',
           },
           {
-            label: '--changed [SINCE]',
-            description: 'Run tests affected by changed files (default: false)',
+            label: '--changed [since]',
+            description: 'Run tests that are affected by the changed files (default: false)',
           },
           {
-            label: '--sequence <OPTIONS>',
-            description: 'Configure test sorting',
+            label: '--sequence <options>',
+            description:
+              "Options for how tests should be sorted. Use '--help --sequence' for more info.",
           },
           {
-            label: '--inspect [[HOST:]PORT]',
+            label: '--inspect [[host:]port]',
             description: 'Enable Node.js inspector (default: 127.0.0.1:9229)',
           },
           {
-            label: '--inspectBrk [[HOST:]PORT]',
-            description: 'Enable Node.js inspector and break before tests start',
+            label: '--inspectBrk [[host:]port]',
+            description: 'Enable Node.js inspector and break before the test starts',
           },
           {
-            label: '--testTimeout <TIMEOUT>',
-            description: 'Default test timeout in milliseconds (default: 5000; 0 disables)',
+            label: '--testTimeout <timeout>',
+            description:
+              'Default timeout of a test in milliseconds (default: 5000). Use 0 to disable timeout completely.',
           },
           {
-            label: '--hookTimeout <TIMEOUT>',
-            description: 'Default hook timeout in milliseconds (default: 10000; 0 disables)',
+            label: '--hookTimeout <timeout>',
+            description:
+              'Default hook timeout in milliseconds (default: 10000). Use 0 to disable timeout completely.',
           },
           {
-            label: '--bail <NUMBER>',
-            description: 'Stop test execution after the given number of failures (default: 0)',
+            label: '--bail <number>',
+            description: 'Stop test execution when given number of tests have failed (default: 0)',
           },
           {
-            label: '--retry <TIMES>',
-            description: 'Retry failed tests (default: 0)',
+            label: '--retry <times>',
+            description:
+              "Retry the test specific number of times if it fails (default: 0). Use '--help --retry' for more info.",
           },
           {
-            label: '--diff <PATH>',
-            description: 'DiffOptions object or path to a module exporting one',
+            label: '--diff <path>',
+            description:
+              "DiffOptions object or a path to a module which exports DiffOptions object. Use '--help --diff' for more info.",
           },
           {
-            label: '--exclude <GLOB>',
-            description: 'Additional file globs to exclude from tests',
+            label: '--exclude <glob>',
+            description: 'Additional file globs to be excluded from test',
           },
           {
             label: '--expandSnapshotDiff',
-            description: 'Show the full diff when a snapshot fails',
+            description: 'Show full diff when snapshot fails',
           },
           {
             label: '--disableConsoleIntercept',
@@ -283,31 +356,36 @@ const commandHelpDocs = {
           },
           {
             label: '--typecheck',
-            description: 'Enable typechecking alongside tests (default: false)',
+            description:
+              "Enable typechecking alongside tests (default: false). Use '--help --typecheck' for more info.",
           },
           {
-            label: '--project <NAME>',
-            description: 'Select one or more Vitest workspace projects by name or wildcard',
+            label: '--project <name>',
+            description:
+              'The name of the project to run if you are using Vitest workspace feature. This can be repeated for multiple projects: --project=1 --project=2. You can also filter projects using wildcards like --project=packages*, and exclude projects with --project=!pattern.',
           },
           {
-            label: '--slowTestThreshold <THRESHOLD>',
-            description: 'Threshold for a test or suite to be considered slow (default: 300ms)',
+            label: '--slowTestThreshold <threshold>',
+            description:
+              'Threshold in milliseconds for a test or suite to be considered slow (default: 300)',
           },
           {
-            label: '--teardownTimeout <TIMEOUT>',
-            description: 'Default teardown timeout in milliseconds (default: 10000)',
+            label: '--teardownTimeout <timeout>',
+            description: 'Default timeout of a teardown function in milliseconds (default: 10000)',
           },
           {
             label: '--cache',
-            description: 'Enable cache',
+            description: "Enable cache. Use '--help --cache' for more info.",
           },
           {
-            label: '--maxConcurrency <NUMBER>',
-            description: 'Maximum number of concurrent tests and suites (default: 5)',
+            label: '--maxConcurrency <number>',
+            description:
+              'Maximum number of concurrent tests and suites during test file execution (default: 5)',
           },
           {
             label: '--expect',
-            description: 'Configure expect matchers',
+            description:
+              "Configuration options for expect() matches. Use '--help --expect' for more info.",
           },
           { label: '--printConsoleTrace', description: 'Always print console stack traces' },
           {
@@ -315,46 +393,53 @@ const commandHelpDocs = {
             description: 'Collect test and suite locations in the location property',
           },
           {
-            label: '--attachmentsDir <DIR>',
+            label: '--attachmentsDir <dir>',
             description:
-              'Directory for attachments created with context.annotate (default: .vitest-attachments)',
+              'The directory where attachments from context.annotate are stored in (default: .vitest-attachments)',
           },
           { label: '--run', description: 'Disable watch mode' },
           {
             label: '--no-color',
-            description: 'Remove colors from console output (default: true)',
+            description: 'Removes colors from the console output (default: true)',
           },
           {
             label: '--clearScreen',
-            description: 'Clear the terminal when rerunning tests in watch mode (default: true)',
+            description:
+              'Clear terminal screen when re-running tests during watch mode (default: true)',
           },
           {
             label: '--standalone',
-            description: 'Start Vitest without running tests until files change (default: false)',
+            description:
+              'Start Vitest without running tests. Tests will be running only on change. If browser mode is enabled, the UI will be opened automatically. This option is ignored when CLI file filters are passed. (default: false)',
           },
           {
-            label: '--mergeReports [PATH]',
-            description: 'Merge previously recorded blob reports without running tests',
+            label: '--mergeReports [path]',
+            description:
+              "Path to a blob reports directory. If this options is used, Vitest won't run any tests, it will only report previously recorded tests",
           },
           {
-            label: '--listTags [TYPE]',
-            description: 'List available tags; --list-tags=json outputs JSON',
+            label: '--listTags [type]',
+            description:
+              'List all available tags instead of running tests. --list-tags=json will output tags in JSON format, unless there are no tags.',
           },
           {
             label: '--clearCache',
-            description: 'Delete all Vitest caches without running tests',
+            description:
+              'Delete all Vitest caches, including experimental.fsModuleCache, without running any tests. This will reduce the performance in the subsequent test run.',
           },
           {
-            label: '--tagsFilter <EXPRESSION>',
-            description: 'Run only tests matching the tag expression',
+            label: '--tagsFilter <expression>',
+            description:
+              'Run only tests with the specified tags. You can use logical operators && (and), || (or) and ! (not) to create complex expressions, see https://vitest.dev/guide/test-tags#syntax for more information.',
           },
           {
             label: '--strictTags',
-            description: 'Error when a test uses an undefined tag (default: true)',
+            description:
+              'Should Vitest throw an error if test has a tag that is not defined in the config. (default: true)',
           },
           {
-            label: '--experimental <FEATURES>',
-            description: 'Enable experimental features',
+            label: '--experimental <features>',
+            description: "Experimental features.. Use '--help --experimental' for more info.",
           },
           { label: '-h, --help', description: 'Display this message' },
         ],
@@ -363,27 +448,29 @@ const commandHelpDocs = {
         title: 'Bench Options',
         rows: [
           {
-            label: '--compare <FILENAME>',
+            label: '--compare <filename>',
             description: 'Benchmark output file to compare against',
           },
-          { label: '--outputJson <FILENAME>', description: 'Benchmark output file' },
+          { label: '--outputJson <filename>', description: 'Benchmark output file' },
         ],
       },
       {
         title: 'List Options',
         rows: [
           {
-            label: '--json [TRUE/PATH]',
-            description: 'Print collected tests as JSON or write to a file (default: false)',
+            label: '--json [true/path]',
+            description: 'Print collected tests as JSON or write to a file (Default: false)',
           },
-          { label: '--filesOnly', description: 'Print only test files without test cases' },
+          { label: '--filesOnly', description: 'Print only test files with out the test cases' },
           {
             label: '--staticParse',
-            description: 'Parse files statically instead of running them (default: false)',
+            description:
+              'Parse files statically instead of running them to collect tests (default: false)',
           },
           {
-            label: '--staticParseConcurrency <LIMIT>',
-            description: 'Number of test files to process concurrently',
+            label: '--staticParseConcurrency <limit>',
+            description:
+              'How many tests to process at the same time (default: os.availableParallelism())',
           },
         ],
       },
@@ -399,81 +486,162 @@ const commandHelpDocs = {
     summary: ['Lint code.', 'Options are forwarded to Oxlint.'],
     sections: [
       {
-        title: 'Arguments',
-        rows: [{ label: '[PATH]...', description: 'Files or directories to lint' }],
+        title: 'Available positional items',
+        rows: [
+          {
+            label: '[PATH]...',
+            description: 'Single file, single path or list of paths',
+          },
+        ],
       },
       {
         title: 'Basic Configuration',
         rows: [
           {
-            label: '--tsconfig <PATH>',
-            description: 'Override the TypeScript config used for import resolution',
+            label: '--tsconfig=<./tsconfig.json>',
+            description:
+              'Override the TypeScript config used for import resolution. Oxlint automatically discovers the relevant `tsconfig.json` for each file. Use this only when your project uses a non-standard tsconfig name or location.',
           },
         ],
       },
       {
-        title: 'Rule Severity',
+        title: 'Allowing / Denying Multiple Lints',
+        lines: [
+          '  Accumulate rules and categories from left to right on the command-line.',
+          '  For example `-D correctness -A no-debugger` or `-A all -D no-debugger`.',
+          '  The categories are:',
+          '  * `correctness` - Code that is outright wrong or useless (default)',
+          '  * `suspicious`  - Code that is most likely wrong or useless',
+          '  * `pedantic`    - Lints which are rather strict or have occasional false positives',
+          '  * `perf`        - Code that could be written in a more performant way',
+          '  * `style`       - Code that should be written in a more idiomatic way',
+          '  * `restriction` - Lints which prevent the use of language and library features',
+          '  * `nursery`     - New lints that are still under development',
+          '  * `all`         - All categories listed above except `nursery`. Does not enable plugins automatically.',
+        ],
         rows: [
-          { label: '-A, --allow <NAME>', description: 'Allow a rule or category' },
-          { label: '-W, --warn <NAME>', description: 'Emit a warning for a rule or category' },
-          { label: '-D, --deny <NAME>', description: 'Emit an error for a rule or category' },
+          {
+            label: '-A, --allow=NAME',
+            description: 'Allow the rule or category (suppress the lint)',
+          },
+          {
+            label: '-W, --warn=NAME',
+            description: 'Deny the rule or category (emit a warning)',
+          },
+          {
+            label: '-D, --deny=NAME',
+            description: 'Deny the rule or category (emit an error)',
+          },
         ],
       },
       {
-        title: 'Plugins',
+        title: 'Enable/Disable Plugins',
         rows: [
           {
             label: '--disable-unicorn-plugin',
-            description: 'Disable the unicorn plugin, which is enabled by default',
+            description: 'Disable unicorn plugin, which is turned on by default',
           },
           {
             label: '--disable-oxc-plugin',
-            description: 'Disable Oxc-specific rules, which are enabled by default',
+            description: 'Disable oxc unique rules, which is turned on by default',
           },
           {
             label: '--disable-typescript-plugin',
-            description: 'Disable the TypeScript plugin, which is enabled by default',
+            description: 'Disable TypeScript plugin, which is turned on by default',
           },
-          { label: '--import-plugin', description: 'Enable the import plugin' },
-          { label: '--react-plugin', description: 'Enable the React plugin' },
-          { label: '--jsdoc-plugin', description: 'Enable the JSDoc plugin' },
-          { label: '--jest-plugin', description: 'Enable the Jest plugin' },
-          { label: '--vitest-plugin', description: 'Enable the Vitest plugin' },
-          { label: '--jsx-a11y-plugin', description: 'Enable the JSX accessibility plugin' },
-          { label: '--nextjs-plugin', description: 'Enable the Next.js plugin' },
-          { label: '--react-perf-plugin', description: 'Enable the React performance plugin' },
-          { label: '--promise-plugin', description: 'Enable the promise plugin' },
-          { label: '--node-plugin', description: 'Enable the Node.js plugin' },
-          { label: '--vue-plugin', description: 'Enable the Vue plugin' },
+          {
+            label: '--import-plugin',
+            description: 'Enable import plugin and detect ESM problems.',
+          },
+          {
+            label: '--react-plugin',
+            description: 'Enable react plugin, which is turned off by default',
+          },
+          { label: '--jsdoc-plugin', description: 'Enable jsdoc plugin and detect JSDoc problems' },
+          {
+            label: '--jest-plugin',
+            description: 'Enable the Jest plugin and detect test problems',
+          },
+          {
+            label: '--vitest-plugin',
+            description: 'Enable the Vitest plugin and detect test problems',
+          },
+          {
+            label: '--jsx-a11y-plugin',
+            description: 'Enable the JSX-a11y plugin and detect accessibility problems',
+          },
+          {
+            label: '--nextjs-plugin',
+            description: 'Enable the Next.js plugin and detect Next.js problems',
+          },
+          {
+            label: '--react-perf-plugin',
+            description:
+              'Enable the React performance plugin and detect rendering performance problems',
+          },
+          {
+            label: '--promise-plugin',
+            description: 'Enable the promise plugin and detect promise usage problems',
+          },
+          {
+            label: '--node-plugin',
+            description: 'Enable the node plugin and detect node usage problems',
+          },
+          {
+            label: '--vue-plugin',
+            description: 'Enable the vue plugin and detect vue usage problems',
+          },
         ],
       },
       {
         title: 'Fix Problems',
         rows: [
-          { label: '--fix', description: 'Fix issues when possible' },
-          { label: '--fix-suggestions', description: 'Apply auto-fixable suggestions' },
+          {
+            label: '--fix',
+            description:
+              'Fix as many issues as possible. Only unfixed issues are reported in the output.',
+          },
+          {
+            label: '--fix-suggestions',
+            description: 'Apply auto-fixable suggestions. May change program behavior.',
+          },
           { label: '--fix-dangerously', description: 'Apply dangerous fixes and suggestions' },
         ],
       },
       {
         title: 'Ignore Files',
         rows: [
-          { label: '--ignore-path <PATH>', description: 'Use the specified .eslintignore file' },
           {
-            label: '--ignore-pattern <PATTERN>',
-            description: 'Add file patterns to ignore',
+            label: '--ignore-path=PATH',
+            description: 'Specify the file to use as your `.eslintignore`',
           },
-          { label: '--no-ignore', description: 'Disable file exclusion from ignore rules' },
+          {
+            label: '--ignore-pattern=PAT',
+            description:
+              'Specify patterns of files to ignore (in addition to those in `.eslintignore`)',
+          },
+          {
+            label: '--no-ignore',
+            description:
+              'Disable excluding files from `.eslintignore` files, --ignore-path flags and --ignore-pattern flags',
+          },
         ],
       },
       {
         title: 'Handle Warnings',
         rows: [
-          { label: '--quiet', description: 'Report errors only' },
-          { label: '--deny-warnings', description: 'Exit non-zero when warnings are reported' },
           {
-            label: '--max-warnings <INT>',
-            description: 'Set the warning threshold before exiting non-zero',
+            label: '--quiet',
+            description: 'Disable reporting on warnings, only errors are reported',
+          },
+          {
+            label: '--deny-warnings',
+            description: 'Ensure warnings produce a non-zero exit code',
+          },
+          {
+            label: '--max-warnings=INT',
+            description:
+              'Specify a warning threshold, which can be used to force exit with an error status if there are too many warning-level rule violations in your project',
           },
         ],
       },
@@ -481,57 +649,66 @@ const commandHelpDocs = {
         title: 'Output',
         rows: [
           {
-            label: '-f, --format <FORMAT>',
+            label: '-f, --format=ARG',
             description:
-              'Set output format: checkstyle, default, agent, github, gitlab, json, junit, sarif, stylish, or unix',
+              'Use a specific output format. Possible values: `checkstyle`, `default`, `agent`, `github`, `gitlab`, `json`, `junit`, `sarif`, `stylish`, `unix`',
           },
           {
-            label: '--debug <OPTIONS>',
-            description: 'Enable comma-separated debug output options: files or timings',
+            label: '--debug=OPTIONS',
+            description: [
+              'Enable debug output options. Options are comma-separated. Possible values:',
+              ' * `files` - Print the list of files that will be linted, then exit.',
+              ' * `timings` - Enable per-rule timing information.',
+            ],
           },
         ],
       },
       {
         title: 'Miscellaneous',
         rows: [
-          { label: '--silent', description: 'Do not display diagnostics' },
+          { label: '--silent', description: 'Do not display any diagnostics' },
           {
             label: '--no-error-on-unmatched-pattern',
-            description: 'Do not exit with an error when no files are selected for linting',
+            description:
+              'Do not exit with an error when no files are selected for linting (for example, after applying ignore patterns)',
           },
           {
-            label: '--threads <INT>',
-            description: 'Number of threads to use; set to 1 to use one CPU core',
+            label: '--threads=INT',
+            description: 'Number of threads to use. Set to 1 for using only 1 CPU core.',
           },
           {
             label: '--print-config',
-            description: 'Print the resolved configuration without linting',
+            description:
+              'This option outputs the configuration to be used. When present, no linting is performed and only config-related options are valid.',
           },
         ],
       },
       {
-        title: 'Inline Configuration',
+        title: 'Inline Configuration Comments',
         rows: [
           {
             label: '--report-unused-disable-directives',
-            description: 'Report unused oxlint-disable directives',
+            description:
+              'Report directive comments like `// oxlint-disable-line`, when no errors would have been reported on that line anyway',
           },
           {
-            label: '--report-unused-disable-directives-severity <SEVERITY>',
-            description: 'Report unused disable directives at the specified severity',
+            label: '--report-unused-disable-directives-severity=SEVERITY',
+            description:
+              'Same as `--report-unused-disable-directives`, but allows you to specify the severity level of the reported errors. Only one of these two options can be used at a time.',
           },
         ],
       },
       {
-        title: 'Options',
+        title: 'Available options',
         rows: [
-          { label: '--rules', description: 'List all registered rules' },
-          { label: '--type-aware', description: 'Enable rules requiring type information' },
+          { label: '--rules', description: 'List all the rules that are currently registered' },
+          { label: '--type-aware', description: 'Enable rules that require type information' },
           {
             label: '--type-check',
-            description: 'Enable experimental type checking and compiler diagnostics',
+            description:
+              'Enable experimental type checking (includes TypeScript compiler diagnostics)',
           },
-          { label: '-h, --help', description: 'Print help information' },
+          { label: '-h, --help', description: 'Prints help information' },
         ],
       },
       {
@@ -550,11 +727,12 @@ const commandHelpDocs = {
     summary: ['Format code.', 'Options are forwarded to Oxfmt.'],
     sections: [
       {
-        title: 'Arguments',
+        title: 'Available positional items',
         rows: [
           {
             label: '[PATH]...',
-            description: 'Files, directories, or glob patterns (default: current directory)',
+            description:
+              "Single file, path or list of paths. Glob patterns are also supported. (Be sure to quote them, otherwise your shell may expand them before passing.) Exclude patterns with `!` prefix like `'!**/fixtures/*.js'` are also supported. If not provided, current working directory is used.",
           },
         ],
       },
@@ -562,18 +740,18 @@ const commandHelpDocs = {
         title: 'Mode Options',
         rows: [
           {
-            label: '--stdin-filepath <PATH>',
-            description: 'Specify the file name used to infer the parser for stdin',
+            label: '--stdin-filepath=PATH',
+            description: 'Specify the file name to use to infer which parser to use',
           },
         ],
       },
       {
         title: 'Output Options',
         rows: [
-          { label: '--write', description: 'Format and write files in place' },
+          { label: '--write', description: 'Format and write files in place (default)' },
           {
             label: '--check',
-            description: 'Check whether files are formatted and show statistics',
+            description: 'Check if files are formatted, also show statistics',
           },
           { label: '--list-different', description: 'List files that would be changed' },
         ],
@@ -582,12 +760,13 @@ const commandHelpDocs = {
         title: 'Ignore Options',
         rows: [
           {
-            label: '--ignore-path <PATH>',
-            description: 'Path to an ignore file; may be specified multiple times',
+            label: '--ignore-path=PATH',
+            description:
+              'Path to ignore file(s). Can be specified multiple times. If not specified, .gitignore and .prettierignore in the current directory are used.',
           },
           {
             label: '--with-node-modules',
-            description: 'Format files in node_modules, which are skipped by default',
+            description: 'Format code in node_modules directory (skipped by default)',
           },
         ],
       },
@@ -596,17 +775,17 @@ const commandHelpDocs = {
         rows: [
           {
             label: '--no-error-on-unmatched-pattern',
-            description: 'Do not exit with an error when the pattern is unmatched',
+            description: 'Do not exit with error when pattern is unmatched',
           },
           {
-            label: '--threads <INT>',
-            description: 'Number of threads to use; set to 1 to use one CPU core',
+            label: '--threads=INT',
+            description: 'Number of threads to use. Set to 1 for using only 1 CPU core.',
           },
         ],
       },
       {
-        title: 'Options',
-        rows: [{ label: '-h, --help', description: 'Print help information' }],
+        title: 'Available options',
+        rows: [{ label: '-h, --help', description: 'Prints help information' }],
       },
       { title: 'Examples', lines: ['  vp fmt', '  vp fmt src --check', '  vp fmt . --write'] },
     ],
@@ -645,34 +824,34 @@ const commandHelpDocs = {
     documentationUrl: 'https://viteplus.dev/guide/check',
   },
   pack: {
-    usage: 'vp pack [...FILES] [OPTIONS]',
+    usage: 'vp pack [...files] [OPTIONS]',
     summary: ['Build a library.', 'Options are forwarded to Vite+ Pack.'],
     sections: [
       {
         title: 'Arguments',
-        rows: [{ label: '[...FILES]', description: 'Files to bundle' }],
+        rows: [{ label: '[...files]', description: 'Bundle files' }],
       },
       {
         title: 'Options',
         rows: [
           {
-            label: '-f, --format <FORMAT>',
+            label: '-f, --format <format>',
             description: 'Bundle format: esm, cjs, iife, umd (default: esm)',
           },
           { label: '--clean', description: 'Clean output directory, --no-clean to disable' },
           {
-            label: '--deps.never-bundle <MODULE>',
+            label: '--deps.never-bundle <module>',
             description: 'Mark dependencies as external',
           },
           { label: '--minify', description: 'Minify output' },
           { label: '--devtools', description: 'Enable devtools integration' },
-          { label: '--debug [FEAT]', description: 'Show debug logs' },
+          { label: '--debug [feat]', description: 'Show debug logs' },
           {
-            label: '--target <TARGET>',
+            label: '--target <target>',
             description: 'Bundle target, e.g "es2015", "esnext"',
           },
           {
-            label: '-l, --logLevel <LEVEL>',
+            label: '-l, --logLevel <level>',
             description: 'Set log level: info, warn, error, silent',
           },
           { label: '--fail-on-warn', description: 'Fail on warnings (default: true)' },
@@ -681,11 +860,11 @@ const commandHelpDocs = {
             description:
               'Disable writing files to disk, incompatible with watch mode (default: true)',
           },
-          { label: '-d, --out-dir <DIR>', description: 'Output directory (default: dist)' },
+          { label: '-d, --out-dir <dir>', description: 'Output directory (default: dist)' },
           { label: '--treeshake', description: 'Tree-shake bundle (default: true)' },
           { label: '--sourcemap', description: 'Generate source map (default: false)' },
           { label: '--shims', description: 'Enable cjs and esm shims (default: false)' },
-          { label: '--platform <PLATFORM>', description: 'Target platform (default: node)' },
+          { label: '--platform <platform>', description: 'Target platform (default: node)' },
           { label: '--dts', description: 'Generate dts files' },
           { label: '--publint', description: 'Enable publint (default: false)' },
           {
@@ -696,38 +875,37 @@ const commandHelpDocs = {
             label: '--unused',
             description: 'Enable unused dependencies check (default: false)',
           },
-          { label: '-w, --watch [PATH]', description: 'Watch mode' },
-          { label: '--ignore-watch <PATH>', description: 'Ignore custom paths in watch mode' },
-          { label: '--from-vite [VITEST]', description: 'Reuse config from Vite or Vitest' },
+          { label: '-w, --watch [path]', description: 'Watch mode' },
+          { label: '--ignore-watch <path>', description: 'Ignore custom paths in watch mode' },
+          { label: '--from-vite [vitest]', description: 'Reuse config from Vite or Vitest' },
           { label: '--report', description: 'Size report (default: true)' },
           {
-            label: '--env.* <VALUE>',
+            label: '--env.* <value>',
             description: 'Define compile-time env variables',
           },
           {
-            label: '--env-file <FILE>',
+            label: '--env-file <file>',
             description:
               'Load environment variables from a file, when used together with --env, variables in --env take precedence',
           },
           {
-            label: '--env-prefix <PREFIX>',
-            description:
-              'Prefix for env variables to inject into the bundle (default: VITE_PACK_,TSDOWN_)',
+            label: '--env-prefix <prefix>',
+            description: 'Prefix for env variables to inject into the bundle (default: TSDOWN_)',
           },
-          { label: '--on-success <COMMAND>', description: 'Command to run on success' },
-          { label: '--copy <DIR>', description: 'Copy files to output dir' },
-          { label: '--public-dir <DIR>', description: 'Alias for --copy, deprecated' },
-          { label: '--tsconfig <TSCONFIG>', description: 'Set tsconfig path' },
+          { label: '--on-success <command>', description: 'Command to run on success' },
+          { label: '--copy <dir>', description: 'Copy files to output dir' },
+          { label: '--public-dir <dir>', description: 'Alias for --copy, deprecated' },
+          { label: '--tsconfig <tsconfig>', description: 'Set tsconfig path' },
           { label: '--unbundle', description: 'Unbundle mode' },
-          { label: '--root <DIR>', description: 'Root directory of input files' },
+          { label: '--root <dir>', description: 'Root directory of input files' },
           { label: '--exe', description: 'Bundle as executable' },
-          { label: '-W, --workspace [DIR]', description: 'Enable workspace mode' },
+          { label: '-W, --workspace [dir]', description: 'Enable workspace mode' },
           {
-            label: '--concurrency <COUNT>',
+            label: '--concurrency <count>',
             description: 'Maximum number of Rolldown builds to run in parallel',
           },
           {
-            label: '-F, --filter <PATTERN>',
+            label: '-F, --filter <pattern>',
             description: 'Filter configs (cwd or name), e.g. /pkg-name$/ or pkg-name',
           },
           {

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -1079,18 +1079,10 @@ export function maybePrintCommandHelp(args: readonly string[]): boolean {
   }
 
   const commandArgs = args.slice(1);
-  const terminatorIndex = commandArgs.indexOf('--');
-  const ownArgs = terminatorIndex === -1 ? commandArgs : commandArgs.slice(0, terminatorIndex);
-  const hasHelpFlag = ownArgs.some((arg) => arg === '-h' || arg === '--help');
-  if (!hasHelpFlag) {
+  const isTopLevelHelp =
+    commandArgs.length === 1 && (commandArgs[0] === '-h' || commandArgs[0] === '--help');
+  if (!isTopLevelHelp) {
     return false;
-  }
-
-  // Arguments after the task/command belong to the wrapped process, not to vp.
-  if (command === 'run' || command === 'exec' || command === 'cache') {
-    if (commandArgs.length !== 1) {
-      return false;
-    }
   }
 
   printHeader();

--- a/packages/cli/src/utils/__tests__/help.spec.ts
+++ b/packages/cli/src/utils/__tests__/help.spec.ts
@@ -71,6 +71,49 @@ describe('renderCliDoc', () => {
     `);
   });
 
+  it('aligns wrapped help text within the terminal width', () => {
+    Object.defineProperty(process.stdout, 'columns', { configurable: true, value: 40 });
+
+    try {
+      const output = renderCliDoc(
+        {
+          sections: [
+            {
+              title: 'Details',
+              lines: ['  * `all`  - Include every category except one.'],
+            },
+            {
+              title: 'Options',
+              rows: [
+                {
+                  label: '--config=<path>',
+                  description: 'Override the configuration file used for import resolution.',
+                },
+              ],
+            },
+          ],
+        },
+        { color: false },
+      );
+
+      expect(output).toMatchInlineSnapshot(`
+        "Details:
+          * \`all\`  - Include every category
+          except one.
+
+        Options:
+          --config=<path>  Override the
+                           configuration
+                           file used for
+                           import
+                           resolution.
+        "
+      `);
+    } finally {
+      Reflect.deleteProperty(process.stdout, 'columns');
+    }
+  });
+
   it('renders documentation footer when present', () => {
     const output = renderCliDoc({
       usage: 'vp demo',

--- a/packages/cli/src/utils/help.ts
+++ b/packages/cli/src/utils/help.ts
@@ -22,6 +22,8 @@ export type RenderCliDocOptions = {
   color?: boolean;
 };
 
+const HELP_RIGHT_MARGIN = 4;
+
 function toLines(value?: readonly string[] | string): string[] {
   if (!value) {
     return [];
@@ -39,16 +41,54 @@ function padVisible(value: string, width: number): string {
   return `${value}${' '.repeat(padding)}`;
 }
 
+function contentWidth(): number {
+  const terminalWidth = process.stdout.columns;
+  return Number.isFinite(terminalWidth) ? Math.max(0, terminalWidth - HELP_RIGHT_MARGIN) : Infinity;
+}
+
+function wrapLine(line: string, width: number): string[] {
+  if (!Number.isFinite(width) || width <= 0 || visibleLength(line) <= width) {
+    return [line];
+  }
+
+  const content = line.trim();
+  if (!content) {
+    return [line];
+  }
+
+  const indent = line.slice(0, line.length - line.trimStart().length);
+  const output: string[] = [];
+  let current = indent;
+
+  for (const [, whitespace, word] of content.matchAll(/(\s*)(\S+)/gu)) {
+    const separator = current === indent ? '' : whitespace;
+    const candidate = `${current}${separator}${word}`;
+
+    if (current === indent || visibleLength(candidate) <= width) {
+      current = candidate;
+    } else {
+      output.push(current);
+      current = `${indent}${word}`;
+    }
+  }
+
+  output.push(current);
+  return output;
+}
+
 function renderRows(rows: readonly CliRow[]): string[] {
   if (rows.length === 0) {
     return [];
   }
 
   const labelWidth = Math.max(...rows.map((row) => visibleLength(row.label)));
+  const descriptionWidth = contentWidth() - labelWidth - 4;
   const output: string[] = [];
 
   for (const row of rows) {
-    const descriptionLines = toLines(row.description);
+    const descriptionLines = toLines(row.description).flatMap((line) =>
+      wrapLine(line, descriptionWidth),
+    );
 
     if (descriptionLines.length === 0) {
       output.push(`  ${row.label}`);
@@ -114,7 +154,9 @@ export function renderCliDoc(doc: CliDoc, options: RenderCliDocOptions = {}): st
 
     const lines = toLines(section.lines);
     if (lines.length > 0) {
-      output.push(...lines.map((line) => renderMutedCommentSuffix(line, color)));
+      output.push(
+        ...lines.flatMap((line) => wrapLine(renderMutedCommentSuffix(line, color), contentWidth())),
+      );
     }
 
     if (section.rows && section.rows.length > 0) {


### PR DESCRIPTION
Refs: [#2330 discussion](https://github.com/voidzero-dev/vite-plus/pull/2330#issuecomment-5190411902)

Vite+ owns only top-level help for tool-backed commands. Exact `vp <command> --help` and `vp <command> -h` requests use the local themed help, while requests with additional arguments, such as `vp test --help --coverage` or `vp test list --help`, delegate to the bundled tool. This keeps deep and subcommand help complete without mirroring every upstream help level.

The local CLI maintains its own top-level help entries for commands backed by Vite, Vitest, Oxlint, Oxfmt, and tsdown. Some entries paraphrased or shortened the upstream help, so option types, defaults, caveats, and lint-category guidance drifted from the bundled tool versions.

This PR updates those entries to match the upstream wording and casing. It also wraps long descriptions to the available terminal width while keeping option columns aligned, so the fuller text remains readable.

It does not add or remove options or change non-help command behavior.

🤖 Generated with Codex