### PR TITLE
refactor(cli): deduplicate shared helpers into utils

### DIFF
--- a/packages/cli/src/create/bin.ts
+++ b/packages/cli/src/create/bin.ts
@@ -37,11 +37,12 @@ import {
   resolveApproveBuildTargets,
 } from '../utils/approve-builds.ts';
 import { detectExistingEditors, selectEditors, writeEditorConfigs } from '../utils/editor.ts';
-import { initGitRepository } from '../utils/git.ts';
+import { findGitRoot, initGitRepository } from '../utils/git.ts';
 import { renderCliDoc } from '../utils/help.ts';
 import { readJsonFile } from '../utils/json.ts';
 import { displayRelative } from '../utils/path.ts';
 import {
+  cancelAndExit,
   type CommandRunSummary,
   defaultInteractive,
   downloadPackageManager,
@@ -51,7 +52,7 @@ import {
   runViteInstall,
   selectPackageManager,
 } from '../utils/prompts.ts';
-import { accent, muted, log, printHeader, success } from '../utils/terminal.ts';
+import { accent, formatDuration, muted, log, printHeader, success } from '../utils/terminal.ts';
 import {
   detectWorkspace,
   updatePackageJsonWithDeps,
@@ -68,7 +69,6 @@ import {
   resolveOrgManifestForCreate,
 } from './org-resolve.ts';
 import {
-  cancelAndExit,
   checkProjectDirExists,
   promptPackageNameAndTargetDir,
   promptTargetDir,
@@ -377,36 +377,11 @@ function formatTemplateName(templateName: string) {
   return `${frameworkName} + ${isTypeScript ? 'TypeScript' : 'JavaScript'}`;
 }
 
-function formatDuration(durationMs: number) {
-  if (durationMs < 1000) {
-    return `${Math.max(1, durationMs)}ms`;
-  }
-  const durationSeconds = durationMs / 1000;
-  if (durationSeconds < 10) {
-    return `${durationSeconds.toFixed(1)}s`;
-  }
-  return `${Math.round(durationSeconds)}s`;
-}
-
 function getNextCommand(projectDir: string, command: string) {
   if (!projectDir || projectDir === '.') {
     return command;
   }
   return `cd ${projectDir} && ${command}`;
-}
-
-function findGitRoot(startPath: string) {
-  let dir = startPath;
-  while (true) {
-    if (fs.existsSync(path.join(dir, '.git'))) {
-      return dir;
-    }
-    const parent = path.dirname(dir);
-    if (parent === dir) {
-      return undefined;
-    }
-    dir = parent;
-  }
 }
 
 function getCopilotSetupRoot(projectRoot: string, isExistingMonorepo: boolean) {

--- a/packages/cli/src/create/org-resolve.ts
+++ b/packages/cli/src/create/org-resolve.ts
@@ -1,6 +1,7 @@
 import * as prompts from '@voidzero-dev/vite-plus-prompts';
 
 import { findWorkspaceRoot, hasViteConfig, resolveViteConfig } from '../resolve-vite-config.ts';
+import { cancelAndExit } from '../utils/prompts.ts';
 import {
   CreateConfigSchemaError,
   type CreateTemplateEntry,
@@ -20,7 +21,6 @@ import {
   pickOrgTemplate,
 } from './org-picker.ts';
 import { ensureOrgPackageExtracted, resolveBundledPath } from './org-tarball.ts';
-import { cancelAndExit } from './prompts.ts';
 
 /**
  * Resolution outcome for an org template spec.

--- a/packages/cli/src/create/prompts.ts
+++ b/packages/cli/src/create/prompts.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import * as prompts from '@voidzero-dev/vite-plus-prompts';
 import validateNpmPackageName from 'validate-npm-package-name';
 
+import { cancelAndExit } from '../utils/prompts.ts';
 import { accent } from '../utils/terminal.ts';
 import { getRandomProjectName } from './random-name.ts';
 import { getProjectDirFromPackageName } from './utils.ts';
@@ -121,11 +122,6 @@ export async function checkProjectDirExists(projectDirFullPath: string, interact
     case 'no':
       cancelAndExit();
   }
-}
-
-export function cancelAndExit(message = 'Operation cancelled', exitCode = 0): never {
-  prompts.cancel(message);
-  process.exit(exitCode);
 }
 
 function isEmpty(path: string) {

--- a/packages/cli/src/create/templates/monorepo.ts
+++ b/packages/cli/src/create/templates/monorepo.ts
@@ -7,6 +7,7 @@ import * as prompts from '@voidzero-dev/vite-plus-prompts';
 import { rewriteMonorepoProject } from '../../migration/migrator.ts';
 import { PackageManager, type WorkspaceInfo } from '../../types/index.ts';
 import { editJsonFile } from '../../utils/json.ts';
+import { getScopeFromPackageName } from '../../utils/package.ts';
 import { templatesDir } from '../../utils/path.ts';
 import { editYamlFile, readYamlFile } from '../../utils/yaml.ts';
 import type { ExecutionWithProjectDir } from '../command.ts';
@@ -260,11 +261,4 @@ export function dropAliasedRuntimeDevDeps(
       return changed ? pkg : undefined;
     },
   );
-}
-
-function getScopeFromPackageName(packageName: string) {
-  if (packageName.startsWith('@')) {
-    return packageName.split('/')[0];
-  }
-  return '';
 }

--- a/packages/cli/src/migration/bin.ts
+++ b/packages/cli/src/migration/bin.ts
@@ -26,7 +26,7 @@ import {
   selectPackageManager,
   upgradeYarn,
 } from '../utils/prompts.ts';
-import { accent, log, muted, printHeader, warnMsg } from '../utils/terminal.ts';
+import { accent, formatDuration, log, muted, printHeader, warnMsg } from '../utils/terminal.ts';
 import {
   confirmBaseUrlFix,
   fixBaseUrlInTsconfig,
@@ -557,17 +557,6 @@ async function collectMigrationPlan(
   };
 
   return plan;
-}
-
-function formatDuration(durationMs: number) {
-  if (durationMs < 1000) {
-    return `${Math.max(1, durationMs)}ms`;
-  }
-  const durationSeconds = durationMs / 1000;
-  if (durationSeconds < 10) {
-    return `${durationSeconds.toFixed(1)}s`;
-  }
-  return `${Math.round(durationSeconds)}s`;
 }
 
 /**

--- a/packages/cli/src/migration/migrator/git-hooks.ts
+++ b/packages/cli/src/migration/migrator/git-hooks.ts
@@ -7,6 +7,7 @@ import spawn from 'cross-spawn';
 import { rewriteScripts } from '../../../binding/index.js';
 import { findUnsafeHookInstallPath, SUPPORTED_GIT_HOOK_NAMES } from '../../config/hooks.ts';
 import type { PackageManager, WorkspacePackage } from '../../types/index.ts';
+import { findGitRoot } from '../../utils/git.ts';
 import { editJsonFile, isJsonFile, readJsonFile } from '../../utils/json.ts';
 import {
   hasStagedConfigInViteConfig,
@@ -93,24 +94,6 @@ function findNonRegularViteHookPath(projectPath: string): string | null {
     }
   }
   return null;
-}
-
-/**
- * Walk up from `startPath` looking for `.git` (directory or file — submodules
- * use a `.git` file).  Returns the directory that contains `.git`, or `null`.
- */
-function findGitRoot(startPath: string): string | null {
-  let dir = startPath;
-  while (true) {
-    if (fs.existsSync(path.join(dir, '.git'))) {
-      return dir;
-    }
-    const parent = path.dirname(dir);
-    if (parent === dir) {
-      return null;
-    }
-    dir = parent;
-  }
 }
 
 function findWorkspacePackageHookPolicy(

--- a/packages/cli/src/utils/git.ts
+++ b/packages/cli/src/utils/git.ts
@@ -1,4 +1,25 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
 import { runCommandSilently } from './command.ts';
+
+/**
+ * Walk up from `startPath` looking for `.git` (directory or file — submodules
+ * use a `.git` file).  Returns the directory that contains `.git`, or `null`.
+ */
+export function findGitRoot(startPath: string): string | null {
+  let dir = startPath;
+  while (true) {
+    if (fs.existsSync(path.join(dir, '.git'))) {
+      return dir;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      return null;
+    }
+    dir = parent;
+  }
+}
 
 export async function initGitRepository(cwd: string): Promise<boolean> {
   const result = await runCommandSilently({

--- a/packages/cli/src/utils/terminal.ts
+++ b/packages/cli/src/utils/terminal.ts
@@ -36,6 +36,17 @@ export function error(text: string) {
   return styleText('red', text);
 }
 
+export function formatDuration(durationMs: number) {
+  if (durationMs < 1000) {
+    return `${Math.max(1, durationMs)}ms`;
+  }
+  const durationSeconds = durationMs / 1000;
+  if (durationSeconds < 10) {
+    return `${durationSeconds.toFixed(1)}s`;
+  }
+  return `${Math.round(durationSeconds)}s`;
+}
+
 // Standard message prefix functions matching the Rust CLI convention.
 // warn/error go to stderr (diagnostics).
 


### PR DESCRIPTION
## Description

Consolidates helpers that were defined identically in two places within
`packages/cli`, keeping a single copy under `src/utils/`:

- `formatDuration` (`create/bin.ts`, `migration/bin.ts`) → `utils/terminal.ts`
- `findGitRoot` (`create/bin.ts`, `migration/migrator/git-hooks.ts`) → `utils/git.ts`
- `cancelAndExit` (duplicate in `create/prompts.ts` removed) → `utils/prompts.ts`
- `getScopeFromPackageName` (duplicate in `create/templates/monorepo.ts` removed) → `utils/package.ts`