### PR TITLE
refactor(core): remove redundant Vite reporter patch

### DIFF
--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -201,49 +201,6 @@ async function buildVite() {
             return undefined;
           },
         },
-        {
-          name: 'suppress-vite-version-only-reporter-line',
-          transform(code, id) {
-            if (!id.endsWith(join('vite', 'src', 'node', 'plugins', 'reporter.ts'))) {
-              return undefined;
-            }
-
-            // Upstream native reporter can emit a redundant standalone "vite vX.Y.Z" line.
-            // Filter it at source so snapshots and CLI output remain stable.
-            if (code.includes('VITE_VERSION_ONLY_LINE_RE')) {
-              return undefined;
-            }
-
-            const constLine =
-              'const COMPRESSIBLE_ASSETS_RE = /\\.(?:html|json|svg|txt|xml|xhtml|wasm)$/';
-            const logInfoLine =
-              '        logInfo: shouldLogInfo ? (msg) => env.logger.info(msg) : undefined,';
-
-            if (!code.includes(constLine) || !code.includes(logInfoLine)) {
-              return undefined;
-            }
-
-            return {
-              code: code
-                .replace(
-                  constLine,
-                  `${constLine}\nconst VITE_VERSION_ONLY_LINE_RE = /^vite v\\S+$/`,
-                )
-                .replace(
-                  logInfoLine,
-                  `        logInfo: shouldLogInfo
-          ? (msg) => {
-              // Keep transformed/chunk/gzip logs but suppress redundant version-only line.
-              if (VITE_VERSION_ONLY_LINE_RE.test(msg.trim())) {
-                return
-              }
-              env.logger.info(msg)
-            }
-          : undefined,`,
-                ),
-            };
-          },
-        },
         ...config.plugins.filter((plugin) => {
           return !(
             typeof plugin === 'object' &&


### PR DESCRIPTION
## Summary

Make `brandVite()` the single source of truth for suppressing Vite's standalone version reporter line.

The removed build-time transform was a no-op for branded sources. It also could not patch the current unbranded upstream source because its anchor was stale