### PR TITLE
fix(editor): Remove overrides from default config

### DIFF
--- a/packages/cli/src/utils/editor.ts
+++ b/packages/cli/src/utils/editor.ts
@@ -46,8 +46,6 @@ const ZED_SETTINGS = {
         settings: {
           run: 'onType',
           fixKind: 'safe_fix',
-          typeAware: true,
-          unusedDisableDirectives: 'deny',
         },
       },
     },


### PR DESCRIPTION
Do not set the options in the `.zed/settings.json`, to prevent a mismatch between `vp lint` and the language server.

These options are also not set in the vscode settings.

