### PR TITLE
docs(ci): clarify setup-vp version pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,11 +181,13 @@ vp migrate
 Use the official [`setup-vp`](https://github.com/voidzero-dev/setup-vp) action to install Vite+ in GitHub Actions:
 
 ```yaml
-- uses: voidzero-dev/setup-vp@v1
+- uses: voidzero-dev/setup-vp@<setup-vp-version>
   with:
     node-version: '22'
     cache: true
 ```
+
+Replace `<setup-vp-version>` with the latest exact [`setup-vp` release tag](https://github.com/voidzero-dev/setup-vp/releases), or use a commit SHA. Do not use the `v1` tag: it is frozen and no longer receives updates.
 
 #### Manual Installation & Migration
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ Use the official [`setup-vp`](https://github.com/voidzero-dev/setup-vp) action t
 
 Set `<setup-vp-version>` to an exact version from the [`setup-vp` releases page](https://github.com/voidzero-dev/setup-vp/releases). You can use a commit SHA instead. Do not use the `v1` tag. The `v1` tag no longer receives updates.
 
+See [Automatic Version Updates](https://viteplus.dev/guide/ci#automatic-version-updates) to configure Dependabot or Renovate.
+
 #### Manual Installation & Migration
 
 If you are manually migrating a project to Vite+, install these dev dependencies first:

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Use the official [`setup-vp`](https://github.com/voidzero-dev/setup-vp) action t
     cache: true
 ```
 
-Replace `<setup-vp-version>` with the latest exact [`setup-vp` release tag](https://github.com/voidzero-dev/setup-vp/releases), or use a commit SHA. Do not use the `v1` tag: it is frozen and no longer receives updates.
+Set `<setup-vp-version>` to an exact version from the [`setup-vp` releases page](https://github.com/voidzero-dev/setup-vp/releases). You can use a commit SHA instead. Do not use the `v1` tag. The `v1` tag no longer receives updates.
 
 #### Manual Installation & Migration
 

--- a/docs/guide/ci.md
+++ b/docs/guide/ci.md
@@ -8,7 +8,34 @@ You can use `voidzero-dev/setup-vp` to use Vite+ in CI environments.
 
 ## setup-vp Versioning
 
-Set `<setup-vp-version>` in each example to an exact version from the [`setup-vp` releases page](https://github.com/voidzero-dev/setup-vp/releases). You can use a commit SHA instead. Do not use the `v1` tag. The `v1` tag no longer receives updates. Renovate and Dependabot can update exact versions.
+Set `<setup-vp-version>` in each example to an exact version from the [`setup-vp` releases page](https://github.com/voidzero-dev/setup-vp/releases). You can use a commit SHA instead. Do not use the `v1` tag. The `v1` tag no longer receives updates.
+
+### Automatic Version Updates
+
+Dependabot and Renovate can update exact versions in GitHub Actions workflows.
+
+To use [Dependabot version updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates), add a `github-actions` entry to `.github/dependabot.yml`:
+
+```yaml [.github/dependabot.yml]
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+```
+
+Dependabot checks `uses:` entries in `.github/workflows` each week.
+
+[Renovate's GitHub Actions manager](https://docs.renovatebot.com/modules/manager/github-actions/) detects `uses:` entries by default. You do not need a package rule for `setup-vp`.
+
+When you use a commit SHA, add the exact release tag in a comment. Renovate uses the comment to find updates:
+
+```yaml
+- uses: voidzero-dev/setup-vp@<commit-sha> # <setup-vp-version>
+```
+
+These settings apply only to GitHub Actions workflows. For GitLab CI/CD, update both version values together.
 
 ## GitHub Actions
 

--- a/docs/guide/ci.md
+++ b/docs/guide/ci.md
@@ -6,12 +6,16 @@ You can use `voidzero-dev/setup-vp` to use Vite+ in CI environments.
 
 [`voidzero-dev/setup-vp`](https://github.com/voidzero-dev/setup-vp) provides integrations for GitHub Actions and GitLab CI/CD. Both install Vite+ and can install project dependencies. The GitHub Action can also set up Node.js and cache package manager data automatically, while the GitLab CI/CD template uses the Node.js runtime and cache configuration provided by the job.
 
+## setup-vp Versioning
+
+Replace `<setup-vp-version>` in the examples below with the latest [exact release tag](https://github.com/voidzero-dev/setup-vp/releases), or use a commit SHA. Do not use the `v1` tag: it is frozen and no longer receives updates. Renovate and Dependabot can update pinned tags.
+
 ## GitHub Actions
 
 The GitHub Action sets up Vite+, the required Node.js version, and the package manager. This means you usually do not need separate `setup-node`, package-manager setup, or manual dependency caching steps in your workflow.
 
 ```yaml [.github/workflows/ci.yml]
-- uses: voidzero-dev/setup-vp@v1
+- uses: voidzero-dev/setup-vp@<setup-vp-version>
   with:
     node-version: '24'
     cache: true
@@ -29,11 +33,13 @@ With `cache: true`, `setup-vp` handles dependency caching for you automatically.
 
 ## GitLab CI/CD
 
-Use the reusable `setup-vp` remote template in your GitLab CI/CD configuration:
+Use the reusable `setup-vp` remote template in your GitLab CI/CD configuration. Pin the remote URL and `setup-ref` to the same exact release tag:
 
 ```yaml [.gitlab-ci.yml]
 include:
-  - remote: 'https://raw.githubusercontent.com/voidzero-dev/setup-vp/v1/gitlab/setup-vp.yml'
+  - remote: 'https://raw.githubusercontent.com/voidzero-dev/setup-vp/<setup-vp-version>/gitlab/setup-vp.yml'
+    inputs:
+      setup-ref: '<setup-vp-version>'
 
 test:
   extends: .setup-vp
@@ -76,7 +82,7 @@ If you are migrating an existing GitHub Actions workflow, you can often replace 
 #### After:
 
 ```yaml [.github/workflows/ci.yml]
-- uses: voidzero-dev/setup-vp@v1
+- uses: voidzero-dev/setup-vp@<setup-vp-version>
   with:
     node-version: '24'
     cache: true

--- a/docs/guide/ci.md
+++ b/docs/guide/ci.md
@@ -8,7 +8,7 @@ You can use `voidzero-dev/setup-vp` to use Vite+ in CI environments.
 
 ## setup-vp Versioning
 
-Replace `<setup-vp-version>` in the examples below with the latest [exact release tag](https://github.com/voidzero-dev/setup-vp/releases), or use a commit SHA. Do not use the `v1` tag: it is frozen and no longer receives updates. Renovate and Dependabot can update pinned tags.
+Set `<setup-vp-version>` in each example to an exact version from the [`setup-vp` releases page](https://github.com/voidzero-dev/setup-vp/releases). You can use a commit SHA instead. Do not use the `v1` tag. The `v1` tag no longer receives updates. Renovate and Dependabot can update exact versions.
 
 ## GitHub Actions
 
@@ -33,7 +33,7 @@ With `cache: true`, `setup-vp` handles dependency caching for you automatically.
 
 ## GitLab CI/CD
 
-Use the reusable `setup-vp` remote template in your GitLab CI/CD configuration. Pin the remote URL and `setup-ref` to the same exact release tag:
+Use the reusable `setup-vp` remote template in your GitLab CI/CD configuration. Set the remote URL and `setup-ref` to the same release tag or commit SHA:
 
 ```yaml [.gitlab-ci.yml]
 include:

--- a/docs/guide/github-actions-cache.md
+++ b/docs/guide/github-actions-cache.md
@@ -63,7 +63,7 @@ vp run lint # should print "cache hit"
 
 Restore `node_modules/.vite/task-cache` after `vp install`, because package installation can recreate or modify `node_modules`.
 
-Replace `<setup-vp-version>` below with the latest exact [`setup-vp` release tag](https://github.com/voidzero-dev/setup-vp/releases), or use a commit SHA.
+Set `<setup-vp-version>` below to an exact version from the [`setup-vp` releases page](https://github.com/voidzero-dev/setup-vp/releases). You can use a commit SHA instead.
 
 ```yaml [.github/workflows/ci.yml]
 name: CI

--- a/docs/guide/github-actions-cache.md
+++ b/docs/guide/github-actions-cache.md
@@ -65,6 +65,8 @@ Restore `node_modules/.vite/task-cache` after `vp install`, because package inst
 
 Set `<setup-vp-version>` below to an exact version from the [`setup-vp` releases page](https://github.com/voidzero-dev/setup-vp/releases). You can use a commit SHA instead.
 
+See [Automatic Version Updates](/guide/ci#automatic-version-updates) to configure Dependabot or Renovate.
+
 ```yaml [.github/workflows/ci.yml]
 name: CI
 

--- a/docs/guide/github-actions-cache.md
+++ b/docs/guide/github-actions-cache.md
@@ -63,6 +63,8 @@ vp run lint # should print "cache hit"
 
 Restore `node_modules/.vite/task-cache` after `vp install`, because package installation can recreate or modify `node_modules`.
 
+Replace `<setup-vp-version>` below with the latest exact [`setup-vp` release tag](https://github.com/voidzero-dev/setup-vp/releases), or use a commit SHA.
+
 ```yaml [.github/workflows/ci.yml]
 name: CI
 
@@ -80,7 +82,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@<setup-vp-version>
         with:
           node-version: '24'
           cache: true

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -175,11 +175,13 @@ vp migrate
 Use the official [`setup-vp`](https://github.com/voidzero-dev/setup-vp) action to install Vite+ in GitHub Actions:
 
 ```yaml
-- uses: voidzero-dev/setup-vp@v1
+- uses: voidzero-dev/setup-vp@<setup-vp-version>
   with:
     node-version: '22'
     cache: true
 ```
+
+Replace `<setup-vp-version>` with the latest exact [`setup-vp` release tag](https://github.com/voidzero-dev/setup-vp/releases), or use a commit SHA. Do not use the `v1` tag: it is frozen and no longer receives updates.
 
 #### Manual Installation & Migration
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -181,7 +181,7 @@ Use the official [`setup-vp`](https://github.com/voidzero-dev/setup-vp) action t
     cache: true
 ```
 
-Replace `<setup-vp-version>` with the latest exact [`setup-vp` release tag](https://github.com/voidzero-dev/setup-vp/releases), or use a commit SHA. Do not use the `v1` tag: it is frozen and no longer receives updates.
+Set `<setup-vp-version>` to an exact version from the [`setup-vp` releases page](https://github.com/voidzero-dev/setup-vp/releases). You can use a commit SHA instead. Do not use the `v1` tag. The `v1` tag no longer receives updates.
 
 #### Manual Installation & Migration
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -183,6 +183,8 @@ Use the official [`setup-vp`](https://github.com/voidzero-dev/setup-vp) action t
 
 Set `<setup-vp-version>` to an exact version from the [`setup-vp` releases page](https://github.com/voidzero-dev/setup-vp/releases). You can use a commit SHA instead. Do not use the `v1` tag. The `v1` tag no longer receives updates.
 
+See [Automatic Version Updates](https://viteplus.dev/guide/ci#automatic-version-updates) to configure Dependabot or Renovate.
+
 #### Manual Installation & Migration
 
 If you are manually migrating a project to Vite+, install these dev dependencies first:


### PR DESCRIPTION
The `v1` tag for `setup-vp` no longer receives updates. Users must select an exact release tag or commit SHA. The examples use a version placeholder, with update instructions for Dependabot and Renovate.

Related: https://github.com/voidzero-dev/setup-vp/pull/116