### PR TITLE
fix(test): emit NodeNext-compatible provider type specifiers

### DIFF
--- a/packages/cli/build.ts
+++ b/packages/cli/build.ts
@@ -842,7 +842,7 @@ async function writeInlinedProviderDts(
   const relToShim = (sub: string): string => {
     const r = relative(outDir, testDistDir).replaceAll('\\', '/');
     const prefix = r === '' ? '.' : r.startsWith('.') ? r : `./${r}`;
-    return `${prefix}/${sub}`;
+    return `${prefix}/${sub}.js`;
   };
   let result = upstream;
   for (const [bare, sub] of VITEST_TYPE_SPECIFIER_REWRITES) {

--- a/packages/cli/src/__tests__/exports-map.spec.ts
+++ b/packages/cli/src/__tests__/exports-map.spec.ts
@@ -91,6 +91,30 @@ describe('package.json exports map', () => {
     // vitest/config re-exports defineConfig / configDefaults — sanity-check one.
     expect(typeof cfg.defineConfig).toBe('function');
   });
+
+  it('browser-playwright declaration uses NodeNext-compatible relative specifiers', () => {
+    // Matches quoted relative module specifiers such as './node' and '../browser.js'.
+    const relativeModuleSpecifier = /(['"])(\.\.?\/[^'"]+)\1/g;
+    const pkg = JSON.parse(fs.readFileSync(cliPkgJsonPath, 'utf-8'));
+    const entry = (pkg.exports as Record<string, unknown>)['./test/browser-playwright'];
+    expect(isConditionObject(entry)).toBe(true);
+    const types = (entry as ExportConditions).types;
+    expect(types).toBeTypeOf('string');
+
+    const source = fs.readFileSync(path.resolve(cliPkgDir, types as string), 'utf-8');
+    const relativeSpecifiers = Array.from(
+      source.matchAll(relativeModuleSpecifier),
+      (match) => match[2],
+    );
+    expect(
+      relativeSpecifiers.length,
+      'declaration should contain relative specifiers',
+    ).toBeGreaterThan(0);
+    expect(
+      relativeSpecifiers.filter((specifier) => !specifier.endsWith('.js')),
+      'declaration contains NodeNext-incompatible relative specifiers',
+    ).toEqual([]);
+  });
 });
 
 /**


### PR DESCRIPTION
## Summary

- Emit `.js` extensions for relative shim specifiers in inlined browser-provider declarations so they resolve under NodeNext.
- Add regression coverage using the public `vite-plus/test/browser-playwright` types export.

Fixes #2354

## Validation

- `pnpm --filter vite-plus test src/__tests__/exports-map.spec.ts`
- `vp check`
- Verified `pnpm run check` and `pnpm run typecheck` in the public reproduction using a locally packed Vite+ build

![by](https://img.shields.io/badge/-by-grey?style=flat-square)![Codex](https://img.shields.io/badge/Codex-000000?logo=openai&logoColor=fff&style=flat-square)
