### PR TITLE
refactor(cli): deduplicate accent helpers into crate::help

### DIFF
--- a/crates/vp_global_cli/src/commands/env/current.rs
+++ b/crates/vp_global_cli/src/commands/env/current.rs
@@ -4,7 +4,6 @@
 
 use std::process::ExitStatus;
 
-use owo_colors::OwoColorize;
 use serde::Serialize;
 use vp_pm_cli::{
     PackageManagerResolution, package_manager_bin_path, package_manager_install_dir,
@@ -62,16 +61,12 @@ impl PackageManagerInfo {
     }
 }
 
-fn accent(text: &str) -> String {
-    if help::should_style_help() { text.bright_blue().to_string() } else { text.to_string() }
-}
-
 fn print_rows(title: &str, rows: &[(&str, String)]) {
     println!("{}", help::render_heading(title));
     let label_width = rows.iter().map(|(label, _)| label.chars().count()).max().unwrap_or(0);
     for (label, value) in rows {
         let padding = " ".repeat(label_width.saturating_sub(label.chars().count()));
-        println!("  {}{}  {value}", accent(label), padding);
+        println!("  {}{}  {value}", help::accent(label), padding);
     }
 }
 

--- a/crates/vp_global_cli/src/commands/env/off.rs
+++ b/crates/vp_global_cli/src/commands/env/off.rs
@@ -5,18 +5,8 @@
 
 use std::process::ExitStatus;
 
-use owo_colors::OwoColorize;
-
 use super::config::{ShimMode, load_config, save_config};
 use crate::{error::Error, help};
-
-fn accent_command(command: &str) -> String {
-    if help::should_style_help() {
-        format!("`{}`", command.bright_blue())
-    } else {
-        format!("`{command}`")
-    }
-}
 
 /// Execute the `vp env off` command.
 pub async fn execute() -> Result<ExitStatus, Error> {
@@ -39,7 +29,7 @@ pub async fn execute() -> Result<ExitStatus, Error> {
         "All vp commands and shims will now prefer system Node.js, falling back to managed if not found."
     );
     println!();
-    println!("Run {} to always use Vite+ managed Node.js.", accent_command("vp env on"));
+    println!("Run {} to always use Vite+ managed Node.js.", help::accent_command("vp env on"));
 
     Ok(ExitStatus::default())
 }

--- a/crates/vp_global_cli/src/commands/env/on.rs
+++ b/crates/vp_global_cli/src/commands/env/on.rs
@@ -4,18 +4,8 @@
 
 use std::process::ExitStatus;
 
-use owo_colors::OwoColorize;
-
 use super::config::{ShimMode, load_config, save_config};
 use crate::{error::Error, help};
-
-fn accent_command(command: &str) -> String {
-    if help::should_style_help() {
-        format!("`{}`", command.bright_blue())
-    } else {
-        format!("`{command}`")
-    }
-}
 
 /// Execute the `vp env on` command.
 pub async fn execute() -> Result<ExitStatus, Error> {
@@ -34,7 +24,7 @@ pub async fn execute() -> Result<ExitStatus, Error> {
     println!();
     println!("All vp commands and shims will now always use Vite+ managed Node.js.");
     println!();
-    println!("Run {} to prefer system Node.js instead.", accent_command("vp env off"));
+    println!("Run {} to prefer system Node.js instead.", help::accent_command("vp env off"));
 
     Ok(ExitStatus::default())
 }

--- a/crates/vp_global_cli/src/commands/env/setup.rs
+++ b/crates/vp_global_cli/src/commands/env/setup.rs
@@ -17,8 +17,6 @@
 
 use std::process::ExitStatus;
 
-use owo_colors::OwoColorize;
-
 use super::config::{get_bin_dir, get_vp_home};
 use crate::{error::Error, help};
 
@@ -46,14 +44,6 @@ impl EnvShell {
 /// Tools to create shims for (node, npm, npx, corepack, vpx, vpr)
 pub(crate) const SHIM_TOOLS: &[&str] = &["node", "npm", "npx", "corepack", "vpx", "vpr"];
 
-fn accent_command(command: &str) -> String {
-    if help::should_style_help() {
-        format!("`{}`", command.bright_blue())
-    } else {
-        format!("`{command}`")
-    }
-}
-
 /// Execute the setup command.
 pub async fn execute(refresh: bool, env_only: bool) -> Result<ExitStatus, Error> {
     let vite_plus_home = get_vp_home()?;
@@ -67,7 +57,7 @@ pub async fn execute(refresh: bool, env_only: bool) -> Result<ExitStatus, Error>
     if env_only {
         println!("{}", help::render_heading("Setup"));
         println!("  Updated shell environment files.");
-        println!("  Run {} to verify setup.", accent_command("vp env doctor"));
+        println!("  Run {} to verify setup.", help::accent_command("vp env doctor"));
         return Ok(ExitStatus::default());
     }
 
@@ -869,7 +859,7 @@ fn print_path_instructions(bin_dir: &vt_path::AbsolutePath) {
     println!();
     println!(
         "  Restart your terminal and IDE, then run {} to verify.",
-        accent_command("vp env doctor")
+        help::accent_command("vp env doctor")
     );
 }
 

--- a/crates/vp_global_cli/src/commands/version.rs
+++ b/crates/vp_global_cli/src/commands/version.rs
@@ -7,7 +7,6 @@ use std::{
     process::ExitStatus,
 };
 
-use owo_colors::OwoColorize;
 use serde::Deserialize;
 use vp_pm_cli::get_package_manager_type_and_version;
 use vt_path::AbsolutePathBuf;
@@ -107,16 +106,12 @@ fn resolve_tool_version(local: &LocalVitePlus, tool: ToolSpec) -> Option<String>
     Some(pkg.version)
 }
 
-fn accent(text: &str) -> String {
-    if help::should_style_help() { text.bright_blue().to_string() } else { text.to_string() }
-}
-
 fn print_rows(title: &str, rows: &[(&str, String)]) {
     println!("{}", help::render_heading(title));
     let label_width = rows.iter().map(|(label, _)| label.chars().count()).max().unwrap_or(0);
     for (label, value) in rows {
         let padding = " ".repeat(label_width.saturating_sub(label.chars().count()));
-        println!("  {}{}  {value}", accent(label), padding);
+        println!("  {}{}  {value}", help::accent(label), padding);
     }
 }
 

--- a/crates/vp_global_cli/src/help.rs
+++ b/crates/vp_global_cli/src/help.rs
@@ -79,6 +79,14 @@ fn write_documentation_footer(output: &mut String, documentation_url: &str) {
     let _ = writeln!(output, "{} {documentation_url}", render_heading("Documentation"));
 }
 
+pub fn accent(text: &str) -> String {
+    if should_style_help() { text.bright_blue().to_string() } else { text.to_string() }
+}
+
+pub fn accent_command(command: &str) -> String {
+    format!("`{}`", accent(command))
+}
+
 pub fn should_style_help() -> bool {
     vp_shared::is_stdout_terminal()
         && std::env::var_os("NO_COLOR").is_none()


### PR DESCRIPTION
## Description

The global CLI carried five copies of the same terminal-styling helpers:

- `accent` was duplicated in `commands/version.rs` and `commands/env/current.rs`.
- `accent_command` was duplicated in `commands/env/on.rs`, `commands/env/off.rs`, and `commands/env/setup.rs`.

All copies were byte-identical apart from the backtick wrapping in `accent_command`, and every one of them already depended on `help::should_style_help()`. This PR moves a single `accent` into `crate::help` next to the other styling helpers, reimplements `accent_command` as a one-line wrapper around it, and deletes the five local copies. The now-unused `owo_colors::OwoColorize` imports in the five call-site files are removed as well.

Output is byte-for-byte identical, so no PTY snapshots change.

## Changes

- Add `help::accent` and `help::accent_command` to `crates/vp_global_cli/src/help.rs`.
- Remove local duplicates and switch call sites to the shared helpers in `commands/version.rs`, `commands/env/current.rs`, `commands/env/on.rs`, `commands/env/off.rs`, and `commands/env/setup.rs`.