### PR TITLE
chore(core): expose pluginutils export types

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -89,8 +89,14 @@
       "default": "./dist/rolldown/plugins-index.mjs",
       "types": "./dist/rolldown/plugins-index.d.mts"
     },
-    "./rolldown/pluginutils": "./dist/pluginutils/index.mjs",
-    "./rolldown/pluginutils/filter": "./dist/pluginutils/filter/index.mjs",
+    "./rolldown/pluginutils": {
+      "default": "./dist/pluginutils/index.mjs",
+      "types": "./dist/pluginutils/index.d.mts"
+    },
+    "./rolldown/pluginutils/filter": {
+      "default": "./dist/pluginutils/filter/index.mjs",
+      "types": "./dist/pluginutils/filter/index.d.mts"
+    },
     "./rolldown/utils": {
       "default": "./dist/rolldown/utils-index.mjs",
       "types": "./dist/rolldown/utils-index.d.mts"


### PR DESCRIPTION
## Summary

Follow-up PR to #2358.

That PR taught the sync tool to apply the `.mjs` declaration mapping to pluginutils exports, but only changed the tool itself. This PR commits the regenerated `packages/core/package.json`, so the `./rolldown/pluginutils`
and `./rolldown/pluginutils/filter` exports regain their explicit `types` conditions.

The `types` conditions were originally present but were dropped in #1646 when upstream `@rolldown/pluginutils` moved from `.js` to `.mjs`, because the transformer at the time only mapped `.js` declarations. Type resolution
still worked in the meantime through TypeScript's adjacent-file lookup, since `index.d.mts` ships next to `index.mjs` in `dist/pluginutils`, so this restores the explicit mapping rather than changing runtime behavior.