### PR TITLE
feat(pm): show download progress when fetching a package manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5824,7 +5824,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "append-only-vec",
@@ -6012,7 +6012,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_common"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6048,7 +6048,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_dev"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_dev_common"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "derive_more",
  "rolldown_common",
@@ -6081,7 +6081,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_devtools"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "blake3",
  "rolldown_devtools_action",
@@ -6094,7 +6094,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_devtools_action"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "serde",
  "ts-rs",
@@ -6102,7 +6102,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_ecmascript"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "arcstr",
  "oxc",
@@ -6114,7 +6114,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_ecmascript_utils"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "memchr",
  "oxc",
@@ -6124,7 +6124,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_error"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6141,7 +6141,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_fs"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "oxc_resolver",
  "vfs",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_fs_watcher"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "rolldown-notify",
  "rolldown-notify-debouncer-full",
@@ -6158,7 +6158,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6187,7 +6187,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_asset_module"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "rolldown_common",
@@ -6199,7 +6199,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_bundle_analyzer"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "arcstr",
  "rolldown_common",
@@ -6213,7 +6213,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_chunk_import_map"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "arcstr",
  "rolldown_common",
@@ -6226,7 +6226,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_copy_module"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6239,7 +6239,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_data_url"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "arcstr",
  "base64-simd",
@@ -6252,7 +6252,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_esm_external_require"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "nodejs-built-in-modules",
  "rolldown_common",
@@ -6263,7 +6263,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_hmr"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "rolldown_common",
  "rolldown_plugin",
@@ -6271,7 +6271,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_isolated_declaration"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "arcstr",
  "oxc",
@@ -6285,7 +6285,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_lazy_compilation"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6298,7 +6298,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_oxc_runtime"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "arcstr",
  "phf 0.14.0",
@@ -6309,7 +6309,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_replace"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "oxc",
@@ -6325,7 +6325,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_utils"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6478,7 +6478,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_vite_resolve"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_resolver"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6547,7 +6547,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_sourcemap"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "criterion2",
  "memchr",
@@ -6557,7 +6557,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_std_utils"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "regex",
  "sugar_path",
@@ -6603,7 +6603,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_tracing"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "tracing",
  "tracing-chrome",
@@ -6612,7 +6612,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_utils"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6650,7 +6650,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_watcher"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_workspace"
-version = "1.2.2"
+version = "1.2.3"
 
 [[package]]
 name = "ropey"
@@ -7468,7 +7468,7 @@ dependencies = [
 
 [[package]]
 name = "string_wizard"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "insta",
  "memchr",
@@ -8538,6 +8538,7 @@ dependencies = [
  "futures-util",
  "hex",
  "httpmock",
+ "indicatif",
  "indoc",
  "node-semver",
  "pathdiff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5824,7 +5824,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "append-only-vec",
@@ -6012,7 +6012,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_common"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6048,7 +6048,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_dev"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_dev_common"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "derive_more",
  "rolldown_common",
@@ -6081,7 +6081,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_devtools"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "blake3",
  "rolldown_devtools_action",
@@ -6094,7 +6094,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_devtools_action"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "serde",
  "ts-rs",
@@ -6102,7 +6102,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_ecmascript"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "arcstr",
  "oxc",
@@ -6114,7 +6114,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_ecmascript_utils"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "memchr",
  "oxc",
@@ -6124,7 +6124,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_error"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6141,7 +6141,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_fs"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "oxc_resolver",
  "vfs",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_fs_watcher"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "rolldown-notify",
  "rolldown-notify-debouncer-full",
@@ -6158,7 +6158,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6187,7 +6187,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_asset_module"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "rolldown_common",
@@ -6199,7 +6199,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_bundle_analyzer"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "arcstr",
  "rolldown_common",
@@ -6213,7 +6213,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_chunk_import_map"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "arcstr",
  "rolldown_common",
@@ -6226,7 +6226,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_copy_module"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6239,7 +6239,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_data_url"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "arcstr",
  "base64-simd",
@@ -6252,7 +6252,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_esm_external_require"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "nodejs-built-in-modules",
  "rolldown_common",
@@ -6263,7 +6263,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_hmr"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "rolldown_common",
  "rolldown_plugin",
@@ -6271,7 +6271,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_isolated_declaration"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "arcstr",
  "oxc",
@@ -6285,7 +6285,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_lazy_compilation"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6298,7 +6298,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_oxc_runtime"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "arcstr",
  "phf 0.14.0",
@@ -6309,7 +6309,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_replace"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "oxc",
@@ -6325,7 +6325,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_utils"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6478,7 +6478,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_plugin_vite_resolve"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_resolver"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6547,7 +6547,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_sourcemap"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "criterion2",
  "memchr",
@@ -6557,7 +6557,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_std_utils"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "regex",
  "sugar_path",
@@ -6603,7 +6603,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_tracing"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "tracing",
  "tracing-chrome",
@@ -6612,7 +6612,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_utils"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6650,7 +6650,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_watcher"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "rolldown_workspace"
-version = "1.2.3"
+version = "1.2.2"
 
 [[package]]
 name = "ropey"
@@ -7468,7 +7468,7 @@ dependencies = [
 
 [[package]]
 name = "string_wizard"
-version = "1.2.3"
+version = "1.2.2"
 dependencies = [
  "insta",
  "memchr",

--- a/crates/vp_pm_cli/Cargo.toml
+++ b/crates/vp_pm_cli/Cargo.toml
@@ -16,6 +16,7 @@ crossterm = { workspace = true }
 flate2 = { workspace = true }
 futures-util = { workspace = true }
 hex = { workspace = true }
+indicatif = { workspace = true }
 indoc = { workspace = true }
 node-semver = { workspace = true }
 pathdiff = { workspace = true }

--- a/crates/vp_pm_cli/src/package_manager.rs
+++ b/crates/vp_pm_cli/src/package_manager.rs
@@ -882,23 +882,29 @@ pub async fn download_package_manager(
     let tmp_dir = tempfile::tempdir_in(parent_dir)?;
     let target_dir_tmp = tmp_dir.path().to_path_buf();
 
-    download_and_extract_tgz_with_hash(&tgz_url, &target_dir_tmp, expected_hash).await.map_err(
-        |err| {
-            // status 404 means the version is not found, convert to PackageManagerVersionNotFound error
-            if let Error::Reqwest(e) = &err
-                && let Some(status) = e.status()
-                && status == reqwest::StatusCode::NOT_FOUND
-            {
-                Error::PackageManagerVersionNotFound {
-                    name: package_manager_type.to_string().into(),
-                    version: version.clone(),
-                    url: tgz_url.into(),
-                }
-            } else {
-                err
+    let download_message = format!("Downloading {package_manager_type} v{version}...");
+    download_and_extract_tgz_with_hash(
+        &tgz_url,
+        &target_dir_tmp,
+        expected_hash,
+        Some(&download_message),
+    )
+    .await
+    .map_err(|err| {
+        // status 404 means the version is not found, convert to PackageManagerVersionNotFound error
+        if let Error::Reqwest(e) = &err
+            && let Some(status) = e.status()
+            && status == reqwest::StatusCode::NOT_FOUND
+        {
+            Error::PackageManagerVersionNotFound {
+                name: package_manager_type.to_string().into(),
+                version: version.clone(),
+                url: tgz_url.into(),
             }
-        },
-    )?;
+        } else {
+            err
+        }
+    })?;
 
     // Normalize the package root to $target_dir_tmp/{bin_name}. Most npm
     // tarballs use `package/`, but the directory name is not guaranteed.
@@ -1019,10 +1025,12 @@ async fn download_bun_package_manager(
     let tmp_dir = tempfile::tempdir_in(parent_dir)?;
     let target_dir_tmp = tmp_dir.path().to_path_buf();
 
+    let download_message = format!("Downloading bun v{version}...");
     download_and_extract_tgz_with_hash(
         &platform_tgz_url,
         &target_dir_tmp,
         platform_hash.as_deref(),
+        Some(&download_message),
     )
     .await
     .map_err(|err| {
@@ -1191,8 +1199,14 @@ async fn download_pnpm_native_package_manager(
     if let Some(expected_hash) = expected_hash {
         let main_tgz_url = get_npm_package_tgz_url("pnpm", version);
         let verify_dir = tempfile::tempdir()?;
-        download_and_extract_tgz_with_hash(&main_tgz_url, verify_dir.path(), Some(expected_hash))
-            .await?;
+        let verify_message = format!("Verifying pnpm v{version}...");
+        download_and_extract_tgz_with_hash(
+            &main_tgz_url,
+            verify_dir.path(),
+            Some(expected_hash),
+            Some(&verify_message),
+        )
+        .await?;
     }
 
     // The declared hash never covers the platform tarball, so verify it
@@ -1208,10 +1222,12 @@ async fn download_pnpm_native_package_manager(
     let tmp_dir = tempfile::tempdir_in(parent_dir)?;
     let target_dir_tmp = tmp_dir.path().to_path_buf();
 
+    let download_message = format!("Downloading pnpm v{version}...");
     download_and_extract_tgz_with_hash(
         &platform_tgz_url,
         &target_dir_tmp,
         platform_hash.as_deref(),
+        Some(&download_message),
     )
     .await
     .map_err(|err| {

--- a/crates/vp_pm_cli/src/request.rs
+++ b/crates/vp_pm_cli/src/request.rs
@@ -3,6 +3,7 @@ use std::{path::Path, time::Duration};
 use backon::{ExponentialBuilder, Retryable};
 use flate2::read::GzDecoder;
 use futures_util::stream::StreamExt;
+use indicatif::{ProgressBar, ProgressStyle};
 use reqwest::{Response, StatusCode};
 use serde::de::DeserializeOwned;
 use sha1::Sha1;
@@ -136,10 +137,16 @@ impl HttpClient {
 
     /// Download a file to a specified path
     ///
+    /// The optional `message` is displayed above a progress bar (e.g. "Downloading
+    /// pnpm v10.0.0..."), shown only on a TTY and outside CI so piped/non-interactive
+    /// output stays clean. Pass `None` for downloads that shouldn't surface progress
+    /// (e.g. small metadata probes).
+    ///
     /// # Arguments
     ///
     /// * `url` - The URL of the file to download
     /// * `target_path` - The path where the file will be saved
+    /// * `message` - Optional message shown above the progress bar
     ///
     /// # Returns
     ///
@@ -149,19 +156,58 @@ impl HttpClient {
         &self,
         url: &str,
         target_path: impl AsRef<Path>,
+        message: Option<&str>,
     ) -> Result<(), Error> {
         let target_path = target_path.as_ref();
         tracing::debug!("Downloading {} to {:?}", url, target_path);
 
         let client = vp_shared::shared_http_client()?;
 
+        // Progress bar (only in TTY and not in CI). Built once and reused across
+        // retry attempts; its position is reset at the start of every attempt so
+        // a retried download doesn't double-count bytes.
+        let is_ci = vp_shared::EnvConfig::get().is_ci;
+        let progress = if let Some(message) = message
+            && vp_shared::is_stderr_terminal()
+            && !is_ci
+        {
+            let pb = ProgressBar::new_spinner();
+            pb.set_style(
+                ProgressStyle::default_spinner()
+                    .template(
+                        "{msg}\n{spinner:.green} [{elapsed_precise}] {bytes} ({bytes_per_sec})",
+                    )
+                    .expect("valid spinner template"),
+            );
+            pb.enable_steady_tick(Duration::from_millis(100));
+            pb.set_message(message.to_string());
+            Some(pb)
+        } else {
+            None
+        };
+
         // Make the request *and* the body stream a single retried unit. Doing
         // the request inline (instead of calling `self.get`) avoids a double
         // retry layer. A truncated download (bytes written != advertised
         // Content-Length) returns an error so the retry re-downloads.
-        (|| async {
+        let result = (|| async {
             let response = client.get(url).send().await?.error_for_status()?;
-            Self::write_response_to_file(response, target_path).await
+            if let Some(ref pb) = progress {
+                pb.set_position(0);
+                if let Some(size) = response.content_length() {
+                    pb.set_length(size);
+                    pb.set_style(
+                        ProgressStyle::default_bar()
+                            .template(
+                                "{msg}\n{spinner:.green} [{elapsed_precise}] [{bar:40.blue/white}] \
+                                 {bytes}/{total_bytes} ({bytes_per_sec}, {eta})",
+                            )
+                            .expect("valid progress bar template")
+                            .progress_chars("#>-"),
+                    );
+                }
+            }
+            Self::write_response_to_file(response, target_path, progress.as_ref()).await
         })
         .retry(
             ExponentialBuilder::default()
@@ -169,7 +215,12 @@ impl HttpClient {
                 .with_min_delay(Duration::from_millis(self.min_delay))
                 .with_max_times(self.max_times),
         )
-        .await?;
+        .await;
+
+        if let Some(pb) = progress {
+            pb.finish_and_clear();
+        }
+        result?;
 
         tracing::debug!("Download completed: {:?}", target_path);
         Ok(())
@@ -180,7 +231,11 @@ impl HttpClient {
     /// Captures the advertised `Content-Length` before streaming and verifies
     /// the number of bytes written matches it, so a truncated/short read
     /// surfaces as an error that the caller's retry can re-download.
-    async fn write_response_to_file(response: Response, target_path: &Path) -> Result<(), Error> {
+    async fn write_response_to_file(
+        response: Response,
+        target_path: &Path,
+        progress: Option<&ProgressBar>,
+    ) -> Result<(), Error> {
         let content_length = response.content_length();
 
         // Create the target file
@@ -192,6 +247,9 @@ impl HttpClient {
         while let Some(chunk_result) = stream.next().await {
             let chunk = chunk_result?;
             bytes_written += chunk.len() as u64;
+            if let Some(pb) = progress {
+                pb.inc(chunk.len() as u64);
+            }
             file.write_all(&chunk).await?;
         }
 
@@ -237,6 +295,7 @@ fn extract_tgz(tgz_file: impl AsRef<Path>, target_dir: impl AsRef<Path>) -> Resu
 /// * `url` - The URL of the tgz file to download.
 /// * `target_dir` - The directory to extract the tgz file to.
 /// * `expected_hash` - Optional expected hash, "algorithm.hex" or SRI "algorithm-base64" (see [`verify_file_hash`])
+/// * `message` - Optional message shown above a progress bar while downloading (see [`HttpClient::download_file`])
 ///
 /// # Returns
 /// * `Ok(())` - If the tgz file is downloaded, verified (if hash provided) and extracted successfully.
@@ -245,6 +304,7 @@ pub(crate) async fn download_and_extract_tgz_with_hash(
     url: &str,
     target_dir: impl AsRef<Path>,
     expected_hash: Option<&str>,
+    message: Option<&str>,
 ) -> Result<(), Error> {
     let target_dir = target_dir.as_ref().to_path_buf();
     tracing::debug!(
@@ -261,15 +321,17 @@ pub(crate) async fn download_and_extract_tgz_with_hash(
     // attempt. A 404 (version not found) and permanent config errors fail fast
     // and propagate unchanged so the caller in `package_manager.rs` can map a
     // 404 to `PackageManagerVersionNotFound`.
-    (|| async { download_and_extract_tgz_with_hash_once(url, &target_dir, expected_hash).await })
-        .retry(
-            ExponentialBuilder::default()
-                .with_jitter()
-                .with_min_delay(Duration::from_millis(500))
-                .with_max_times(3),
-        )
-        .when(is_retryable_download_error)
-        .await
+    (|| async {
+        download_and_extract_tgz_with_hash_once(url, &target_dir, expected_hash, message).await
+    })
+    .retry(
+        ExponentialBuilder::default()
+            .with_jitter()
+            .with_min_delay(Duration::from_millis(500))
+            .with_max_times(3),
+    )
+    .when(is_retryable_download_error)
+    .await
 }
 
 /// A single download → verify → extract attempt.
@@ -280,6 +342,7 @@ async fn download_and_extract_tgz_with_hash_once(
     url: &str,
     target_dir: &Path,
     expected_hash: Option<&str>,
+    message: Option<&str>,
 ) -> Result<(), Error> {
     // Reset target directory so a partial prior attempt can't interfere.
     if fs::try_exists(target_dir).await.unwrap_or(false) {
@@ -293,7 +356,7 @@ async fn download_and_extract_tgz_with_hash_once(
     // multiply attempts (up to N×M downloads) for a persistent failure.
     let tgz_file = target_dir.join("package.tgz");
     let client = HttpClient::with_config(0, 0);
-    client.download_file(url, &tgz_file).await?;
+    client.download_file(url, &tgz_file, message).await?;
 
     // Verify hash if provided
     if let Some(expected_hash) = expected_hash {
@@ -620,7 +683,7 @@ mod tests {
         let client = HttpClient::new();
         let url = vt_str::format!("{}/file.txt", server.base_url());
 
-        let result = client.download_file(&url, &target_file).await;
+        let result = client.download_file(&url, &target_file, None).await;
         assert!(result.is_ok(), "Failed to download file: {result:?}");
 
         // Verify file exists and has correct content
@@ -645,7 +708,7 @@ mod tests {
         let url = vt_str::format!("{}/server_error", server.base_url());
 
         // Should fail after retries
-        let result = client.download_file(&url, &target_file).await;
+        let result = client.download_file(&url, &target_file, None).await;
         // println!("result: {:?}", result);
         assert!(result.is_err(), "Expected download to fail with 500 after retries");
     }
@@ -665,7 +728,7 @@ mod tests {
         });
 
         let url = vt_str::format!("{}/test-package.tgz", server.base_url());
-        let result = download_and_extract_tgz_with_hash(&url, &target_dir, None).await;
+        let result = download_and_extract_tgz_with_hash(&url, &target_dir, None, None).await;
         assert!(result.is_ok(), "Failed to download and extract: {result:?}");
 
         assert!(target_dir.join("package/bin/yarn").exists());
@@ -697,7 +760,7 @@ mod tests {
         let target_dir = temp_dir.path().join("extracted");
         let url = vt_str::format!("{}/corrupt.tgz", server.base_url());
 
-        let result = download_and_extract_tgz_with_hash(&url, &target_dir, None).await;
+        let result = download_and_extract_tgz_with_hash(&url, &target_dir, None, None).await;
         assert!(result.is_err(), "corrupt archive should fail to extract: {result:?}");
         assert!(
             mock.hits() > 1,
@@ -724,7 +787,8 @@ mod tests {
         let wrong_hash = "sha512.0000000000000000000000000000000000000000000000000000000000000000\
              0000000000000000000000000000000000000000000000000000000000000000";
 
-        let result = download_and_extract_tgz_with_hash(&url, &target_dir, Some(wrong_hash)).await;
+        let result =
+            download_and_extract_tgz_with_hash(&url, &target_dir, Some(wrong_hash), None).await;
         assert!(result.is_err(), "hash mismatch should fail: {result:?}");
         assert!(
             mock.hits() > 1,
@@ -900,7 +964,7 @@ mod tests {
         let url = vt_str::format!("{}/nonexistent", server.base_url());
 
         // Should fail with 404
-        let result = client.download_file(&url, &target_file).await;
+        let result = client.download_file(&url, &target_file, None).await;
         assert!(result.is_err(), "Expected download to fail with 404");
 
         // Should try 4 times, 1 for first request, 3 for retries

--- a/crates/vp_pm_cli/src/request.rs
+++ b/crates/vp_pm_cli/src/request.rs
@@ -163,14 +163,14 @@ impl HttpClient {
 
         let client = vp_shared::shared_http_client()?;
 
-        // Progress bar (only when a message is given, on a TTY, and not in CI).
-        // Built once and reused across retry attempts; its position is reset at
-        // the start of every attempt so a retried download doesn't double-count
-        // bytes.
+        // Progress bar (only in TTY and not in CI). Built once and reused across
+        // retry attempts; its position is reset at the start of every attempt so
+        // a retried download doesn't double-count bytes.
         let is_ci = vp_shared::EnvConfig::get().is_ci;
-        let show_progress =
-            should_show_progress(message.is_some(), vp_shared::is_stderr_terminal(), is_ci);
-        let progress = if let Some(message) = message.filter(|_| show_progress) {
+        let progress = if let Some(message) = message
+            && vp_shared::is_stderr_terminal()
+            && !is_ci
+        {
             let pb = ProgressBar::new_spinner();
             pb.set_style(
                 ProgressStyle::default_spinner()
@@ -272,14 +272,6 @@ impl HttpClient {
 
         Ok(())
     }
-}
-
-/// Whether a download's progress bar should render: a caller opted in with a
-/// message, output is going to an interactive terminal, and we're not in CI
-/// (piped/non-interactive/CI output should stay log-only, not carry a
-/// spinner or bar).
-const fn should_show_progress(has_message: bool, is_terminal: bool, is_ci: bool) -> bool {
-    has_message && is_terminal && !is_ci
 }
 
 fn extract_tgz(tgz_file: impl AsRef<Path>, target_dir: impl AsRef<Path>) -> Result<(), Error> {
@@ -476,16 +468,6 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
-
-    #[test]
-    fn test_should_show_progress() {
-        // A message alone isn't enough: also needs a real terminal and no CI.
-        assert!(should_show_progress(true, true, false));
-        assert!(!should_show_progress(false, true, false), "no message -> no progress");
-        assert!(!should_show_progress(true, false, false), "non-terminal -> no progress");
-        assert!(!should_show_progress(true, true, true), "CI -> no progress, even with a TTY");
-        assert!(!should_show_progress(false, false, true));
-    }
 
     /// Helper function to create a mock package tar.gz that mimics npm package structure
     fn create_mock_package_tgz() -> Vec<u8> {
@@ -710,32 +692,6 @@ mod tests {
         assert_eq!(content, mock_content);
     }
 
-    /// Passing a progress `message` must not change the downloaded content —
-    /// the progress bar is a cosmetic side effect on stderr, not part of the
-    /// download contract. Whether the bar actually renders depends on
-    /// `should_show_progress` (covered separately below), which is false in
-    /// this non-interactive test run either way.
-    #[tokio::test]
-    async fn test_http_client_download_file_with_message() {
-        let server = MockServer::start();
-        let temp_dir = TempDir::new().unwrap();
-        let target_file = temp_dir.path().join("downloaded.txt");
-
-        let mock_content = b"Hello, World! This is test content.";
-
-        server.mock(|when, then| {
-            when.method(GET).path("/file.txt");
-            then.status(200).header("content-type", "text/plain").body(mock_content);
-        });
-
-        let client = HttpClient::new();
-        let url = vt_str::format!("{}/file.txt", server.base_url());
-
-        let result = client.download_file(&url, &target_file, Some("Downloading test...")).await;
-        assert!(result.is_ok(), "Failed to download file: {result:?}");
-        assert_eq!(fs::read(&target_file).unwrap(), mock_content);
-    }
-
     #[tokio::test]
     async fn test_http_client_retry_on_server_error() {
         // Test that the client correctly retries on server errors
@@ -779,35 +735,6 @@ mod tests {
         assert!(target_dir.join("package/bin/yarn.cmd").exists());
 
         // TempDir automatically cleans up when it goes out of scope
-    }
-
-    /// A download message (as passed by `package_manager.rs` call sites, e.g.
-    /// "Downloading pnpm v10.0.0...") must not affect the download/extract
-    /// result — the progress bar is cosmetic stderr output, not part of the
-    /// download contract.
-    #[tokio::test]
-    async fn test_download_and_extract_tgz_with_message() {
-        let server = MockServer::start();
-        let temp_dir = TempDir::new().unwrap();
-        let target_dir = temp_dir.path().join("extracted");
-
-        let mock_tgz = create_mock_package_tgz();
-        server.mock(|when, then| {
-            when.method(GET).path("/test-package.tgz");
-            then.status(200).header("content-type", "application/octet-stream").body(mock_tgz);
-        });
-
-        let url = vt_str::format!("{}/test-package.tgz", server.base_url());
-        let result = download_and_extract_tgz_with_hash(
-            &url,
-            &target_dir,
-            None,
-            Some("Downloading test-package..."),
-        )
-        .await;
-        assert!(result.is_ok(), "Failed to download and extract: {result:?}");
-        assert!(target_dir.join("package/bin/yarn").exists());
-        assert!(target_dir.join("package/bin/yarn.cmd").exists());
     }
 
     /// Regression test for flaky package-manager / node downloads.

--- a/crates/vp_pm_cli/src/request.rs
+++ b/crates/vp_pm_cli/src/request.rs
@@ -163,14 +163,14 @@ impl HttpClient {
 
         let client = vp_shared::shared_http_client()?;
 
-        // Progress bar (only in TTY and not in CI). Built once and reused across
-        // retry attempts; its position is reset at the start of every attempt so
-        // a retried download doesn't double-count bytes.
+        // Progress bar (only when a message is given, on a TTY, and not in CI).
+        // Built once and reused across retry attempts; its position is reset at
+        // the start of every attempt so a retried download doesn't double-count
+        // bytes.
         let is_ci = vp_shared::EnvConfig::get().is_ci;
-        let progress = if let Some(message) = message
-            && vp_shared::is_stderr_terminal()
-            && !is_ci
-        {
+        let show_progress =
+            should_show_progress(message.is_some(), vp_shared::is_stderr_terminal(), is_ci);
+        let progress = if let Some(message) = message.filter(|_| show_progress) {
             let pb = ProgressBar::new_spinner();
             pb.set_style(
                 ProgressStyle::default_spinner()
@@ -272,6 +272,14 @@ impl HttpClient {
 
         Ok(())
     }
+}
+
+/// Whether a download's progress bar should render: a caller opted in with a
+/// message, output is going to an interactive terminal, and we're not in CI
+/// (piped/non-interactive/CI output should stay log-only, not carry a
+/// spinner or bar).
+const fn should_show_progress(has_message: bool, is_terminal: bool, is_ci: bool) -> bool {
+    has_message && is_terminal && !is_ci
 }
 
 fn extract_tgz(tgz_file: impl AsRef<Path>, target_dir: impl AsRef<Path>) -> Result<(), Error> {
@@ -468,6 +476,16 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
+
+    #[test]
+    fn test_should_show_progress() {
+        // A message alone isn't enough: also needs a real terminal and no CI.
+        assert!(should_show_progress(true, true, false));
+        assert!(!should_show_progress(false, true, false), "no message -> no progress");
+        assert!(!should_show_progress(true, false, false), "non-terminal -> no progress");
+        assert!(!should_show_progress(true, true, true), "CI -> no progress, even with a TTY");
+        assert!(!should_show_progress(false, false, true));
+    }
 
     /// Helper function to create a mock package tar.gz that mimics npm package structure
     fn create_mock_package_tgz() -> Vec<u8> {
@@ -692,6 +710,32 @@ mod tests {
         assert_eq!(content, mock_content);
     }
 
+    /// Passing a progress `message` must not change the downloaded content —
+    /// the progress bar is a cosmetic side effect on stderr, not part of the
+    /// download contract. Whether the bar actually renders depends on
+    /// `should_show_progress` (covered separately below), which is false in
+    /// this non-interactive test run either way.
+    #[tokio::test]
+    async fn test_http_client_download_file_with_message() {
+        let server = MockServer::start();
+        let temp_dir = TempDir::new().unwrap();
+        let target_file = temp_dir.path().join("downloaded.txt");
+
+        let mock_content = b"Hello, World! This is test content.";
+
+        server.mock(|when, then| {
+            when.method(GET).path("/file.txt");
+            then.status(200).header("content-type", "text/plain").body(mock_content);
+        });
+
+        let client = HttpClient::new();
+        let url = vt_str::format!("{}/file.txt", server.base_url());
+
+        let result = client.download_file(&url, &target_file, Some("Downloading test...")).await;
+        assert!(result.is_ok(), "Failed to download file: {result:?}");
+        assert_eq!(fs::read(&target_file).unwrap(), mock_content);
+    }
+
     #[tokio::test]
     async fn test_http_client_retry_on_server_error() {
         // Test that the client correctly retries on server errors
@@ -735,6 +779,35 @@ mod tests {
         assert!(target_dir.join("package/bin/yarn.cmd").exists());
 
         // TempDir automatically cleans up when it goes out of scope
+    }
+
+    /// A download message (as passed by `package_manager.rs` call sites, e.g.
+    /// "Downloading pnpm v10.0.0...") must not affect the download/extract
+    /// result — the progress bar is cosmetic stderr output, not part of the
+    /// download contract.
+    #[tokio::test]
+    async fn test_download_and_extract_tgz_with_message() {
+        let server = MockServer::start();
+        let temp_dir = TempDir::new().unwrap();
+        let target_dir = temp_dir.path().join("extracted");
+
+        let mock_tgz = create_mock_package_tgz();
+        server.mock(|when, then| {
+            when.method(GET).path("/test-package.tgz");
+            then.status(200).header("content-type", "application/octet-stream").body(mock_tgz);
+        });
+
+        let url = vt_str::format!("{}/test-package.tgz", server.base_url());
+        let result = download_and_extract_tgz_with_hash(
+            &url,
+            &target_dir,
+            None,
+            Some("Downloading test-package..."),
+        )
+        .await;
+        assert!(result.is_ok(), "Failed to download and extract: {result:?}");
+        assert!(target_dir.join("package/bin/yarn").exists());
+        assert!(target_dir.join("package/bin/yarn.cmd").exists());
     }
 
     /// Regression test for flaky package-manager / node downloads.


### PR DESCRIPTION
Closes #2351

### Problem

When a project's workspace declares a package manager (`packageManager`, lockfile, `devEngines`, etc.) that isn't installed yet, `vp` downloads it silently. On a slow connection there's no way to tell whether the download is progressing or has hung — no log line, no progress indicator, nothing until it either succeeds or errors out.

### Root cause

The package-manager download path (`crates/vp_pm_cli/src/request.rs`: `HttpClient::download_file`, `download_and_extract_tgz_with_hash`) only emits `tracing::debug!` calls, which aren't shown at the default log level. This is unlike the Node.js runtime download path (`crates/vp_js_runtime/src/download.rs`), which already renders an `indicatif` progress bar.

### Fix

Mirror the existing `vp_js_runtime` pattern in `vp_pm_cli`:

- `HttpClient::download_file` takes an optional `message`, and shows a byte progress bar (speed, ETA) once `Content-Length` is known, gated on `stderr` being a TTY and not running in CI — non-interactive/piped output stays unchanged.
- `download_and_extract_tgz_with_hash` threads the message through.
- Each package-manager download call site (npm-style tgz for npm/pnpm<12/yarn, bun's platform binary, pnpm>=12's native binary, and the pnpm hash-verification download) now passes a message like `"Downloading pnpm v10.0.0..."`.

### Testing

- `cargo check -p vp_pm_cli`, `cargo clippy -p vp_pm_cli --all-targets`, `cargo fmt -p vp_pm_cli --check`
- `cargo test -p vp_pm_cli --lib`: all download-path tests pass (`request::tests::*`, `package_manager::tests::test_download_*`)