### PR TITLE
ci: format-check docs PRs with the vp built from the checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,25 +76,36 @@ jobs:
     # them (code changes get `vp check` in cli-e2e-test). Non-blocking:
     # intentionally not listed in the `done` job's needs.
     if: needs.detect-changes.outputs.code-changed == 'false'
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-linux-x64-default
+    permissions:
+      contents: read
+      packages: read
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+      - uses: ./.github/actions/clone
 
-      - uses: voidzero-dev/setup-vp@13e7afb99c66525824db54e107d667216e795d37 # v1.14.0
+      - uses: oxc-project/setup-rust@68c3199c5339f965e6e163924c3c450773eba42b # main (pending v1.0.17 — Swatinem/rust-cache v2.9.1 for node24)
         with:
-          # The workspace `vite-plus` version can be ahead of the registry, so
-          # pin the released build instead of auto-detecting from package.json.
-          version: latest
-          run-install: false
+          # Shares the cargo cache with the Linux leg of cli-e2e-test, which
+          # builds the same target. Only that job saves it.
+          save-cache: false
+          cache-key: cli-e2e-test-x86_64-unknown-linux-gnu
+
+      - uses: oxc-project/setup-node@4c588e9266bd930b6ddc34307df0659ed511d187 # v1.3.1
+
+      # Format-check with the oxfmt of this commit instead of the released one.
+      # A release carries the oxfmt it shipped with, which trails the catalog
+      # pin the repo is formatted with, and then flags files the workspace
+      # formatter accepts. build-upstream restores the NAPI binding cache the
+      # code jobs fill, so a docs-only run reuses their binaries instead of
+      # compiling Rust.
+      - name: Build with upstream
+        uses: ./.github/actions/build-upstream
+        with:
+          target: x86_64-unknown-linux-gnu
 
       - name: Run vp fmt --check
-        run: |
-          # `vp fmt` loads the root vite.config.ts, whose `import ... from 'vite-plus'`
-          # must resolve at runtime. Link the released package out of the global
-          # install instead of installing the whole workspace.
-          mkdir -p node_modules
-          ln -s "$HOME/.vite-plus/current/node_modules/vite-plus" node_modules/vite-plus
-          vp fmt --check
+        run: pnpm vp fmt --check
 
   download-previous-rolldown-binaries:
     needs: detect-changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,9 @@ jobs:
     # Docs-only changes skip the full CI matrix, so nothing else format-checks
     # them (code changes get `vp check` in cli-e2e-test). Non-blocking:
     # intentionally not listed in the `done` job's needs.
-    if: needs.detect-changes.outputs.code-changed == 'false'
+    # TEMPORARY, revert before merge: lifted so this PR runs the job. ci.yml is
+    # a code change, so detect-changes reports code-changed == 'true' here.
+    # if: needs.detect-changes.outputs.code-changed == 'false'
     runs-on: namespace-profile-linux-x64-default
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,9 +75,7 @@ jobs:
     # Docs-only changes skip the full CI matrix, so nothing else format-checks
     # them (code changes get `vp check` in cli-e2e-test). Non-blocking:
     # intentionally not listed in the `done` job's needs.
-    # TEMPORARY, revert before merge: lifted so this PR runs the job. ci.yml is
-    # a code change, so detect-changes reports code-changed == 'true' here.
-    # if: needs.detect-changes.outputs.code-changed == 'false'
+    if: needs.detect-changes.outputs.code-changed == 'false'
     runs-on: namespace-profile-linux-x64-default
     permissions:
       contents: read


### PR DESCRIPTION
`vp fmt --check` in the `docs-fmt` job ran the released Vite+, which carries the oxfmt of its own release. That version trails the catalog pin the repo is formatted with, so it flagged a file the workspace formatter accepts.

- `vp v0.2.8` ships oxfmt `0.61.0`, `pnpm-workspace.yaml` pins `0.62.0`.
- e088f5465 reformatted `packages/cli/rules/vite-tools.yml` with `0.62.0`, dropping duplicate blank lines that `0.61.0` keeps.
- Every docs-only PR since then failed on that file, for example [#2381](https://github.com/voidzero-dev/vite-plus/actions/runs/31302760382/job/93218108501).

## Change

Build vp through `.github/actions/build-upstream` and run the compiled CLI (`pnpm vp fmt --check`) instead of installing a release.

The job reuses what the code jobs already built:

- `build-upstream` restores the NAPI binding cache, so a cache hit skips every cargo and napi build.
- `setup-rust` uses `cache-key: cli-e2e-test-x86_64-unknown-linux-gnu`, which maps to the rust-cache `shared-key`, so the cargo cache of that job restores here. This job never saves.
- The rolldown binding comes from `build-upstream`'s own `download-rolldown-binaries` step, so no dependency on `download-previous-rolldown-binaries` (skipped on docs-only PRs).

## Verification

The middle commit lifted the `code-changed == 'false'` guard so this PR ran the job; the last commit reverts it, so the net change is the first commit alone.

[Green run](https://github.com/voidzero-dev/vite-plus/actions/runs/31304482231/job/93222541651), 61s end to end:

| Step | Time |
| --- | --- |
| clone (rolldown + vite) | 3s |
| setup-rust | 10s |
| setup-node | 16s |
| Build with upstream | 23s (NAPI cache hit) |
| `pnpm vp fmt --check` | 4s |

Output: `All matched files use the correct format. Finished in 2216ms on 441 files`, the same file count the failing run reported.