### PR TITLE
refactor(pm): deduplicate command resolution tests

### DIFF
--- a/crates/vp_pm_cli/src/resolution/commands/add.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/add.rs
@@ -255,7 +255,7 @@ mod tests {
     use super::*;
     use crate::resolution::{
         resolve,
-        test_utils::{bun, npm, parse_args, pnpm, yarn},
+        test_utils::{bun, expect_run, npm, parse_args, pnpm, yarn},
     };
 
     fn add_args(packages: &[&str]) -> AddArgs {
@@ -268,9 +268,7 @@ mod tests {
     #[test]
     fn test_pnpm_basic_add() {
         let resolution = resolve(&pnpm("10.0.0"), add_args(&["react"]));
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["add", "react"]);
@@ -283,9 +281,7 @@ mod tests {
         options.pass_through_args =
             vec!["--registry".to_string(), "https://registry.example".to_string()];
         let resolution = resolve(&pnpm("10.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(
@@ -299,9 +295,7 @@ mod tests {
         let mut options = add_args(&["react"]);
         options.filter = vec!["app".to_string()];
         let resolution = resolve(&pnpm("10.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["--filter", "app", "add", "react"]);
@@ -313,9 +307,7 @@ mod tests {
         options.filter = vec!["app".to_string()];
         options.save_catalog_name = Some("react18".to_string());
         let resolution = resolve(&pnpm("10.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(
@@ -330,9 +322,7 @@ mod tests {
         options.filter = vec!["app".to_string()];
         options.save_catalog_name = Some(String::new());
         let resolution = resolve(&pnpm("10.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["--filter", "app", "add", "--save-catalog", "react"]);
@@ -344,9 +334,7 @@ mod tests {
         options.filter = vec!["app".to_string()];
         options.save_catalog = true;
         let resolution = resolve(&pnpm("10.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["--filter", "app", "add", "--save-catalog", "react"]);
@@ -358,9 +346,7 @@ mod tests {
         options.filter = vec!["app".to_string()];
         options.workspace_root = true;
         let resolution = resolve(&pnpm("10.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["--filter", "app", "add", "--workspace-root", "react"]);
@@ -372,9 +358,7 @@ mod tests {
         options.save_dependency = SaveDependencyArgs::dev();
         options.workspace_root = true;
         let resolution = resolve(&pnpm("10.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["add", "--workspace-root", "--save-dev", "typescript"]);
@@ -386,9 +370,7 @@ mod tests {
         options.filter = vec!["app".to_string()];
         options.workspace = true;
         let resolution = resolve(&pnpm("10.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["--filter", "app", "add", "--workspace", "@myorg/utils"]);
@@ -428,9 +410,7 @@ mod tests {
     #[test]
     fn test_yarn_basic_add() {
         let resolution = resolve(&yarn("1.22.22"), add_args(&["react"]));
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["add", "react"]);
@@ -441,9 +421,7 @@ mod tests {
         let mut options = add_args(&["react"]);
         options.filter = vec!["app".to_string()];
         let resolution = resolve(&yarn("1.22.22"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(
@@ -458,9 +436,7 @@ mod tests {
         options.save_dependency = SaveDependencyArgs::dev();
         options.workspace_root = true;
         let resolution = resolve(&yarn("1.22.22"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["add", "--dev", "typescript"]);
@@ -470,9 +446,7 @@ mod tests {
     #[test]
     fn test_npm_basic_add() {
         let resolution = resolve(&npm("11.0.0"), add_args(&["react"]));
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["install", "react"]);
@@ -483,9 +457,7 @@ mod tests {
         let mut options = add_args(&["react"]);
         options.filter = vec!["app".to_string()];
         let resolution = resolve(&npm("11.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["install", "--workspace", "app", "react"]);
@@ -496,9 +468,7 @@ mod tests {
         let mut options = add_args(&["typescript"]);
         options.workspace_root = true;
         let resolution = resolve(&npm("11.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["install", "--include-workspace-root", "typescript"]);
@@ -509,9 +479,7 @@ mod tests {
         let mut options = add_args(&["lodash"]);
         options.filter = vec!["app".to_string(), "web".to_string()];
         let resolution = resolve(&npm("11.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(
@@ -526,9 +494,7 @@ mod tests {
         options.filter = vec!["app".to_string(), "web".to_string()];
         options.workspace_root = true;
         let resolution = resolve(&npm("11.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(
@@ -550,9 +516,7 @@ mod tests {
         let mut options = add_args(&["react"]);
         options.allow_build = Some("react,napi".to_string());
         let resolution = resolve(&pnpm("10.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["add", "--allow-build=react,napi", "react"]);
@@ -561,9 +525,7 @@ mod tests {
     #[test]
     fn test_bun_basic_add() {
         let resolution = resolve(&bun("1.3.11"), add_args(&["react"]));
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["add", "react"]);
@@ -575,13 +537,9 @@ mod tests {
         args.workspace_root = true;
 
         let classic = resolve(&yarn("1.22.22"), args.clone());
-        let CommandResolution::Run(classic_command) = classic.outcome else {
-            panic!("expected command resolution");
-        };
+        let classic_command = expect_run(classic.outcome);
         let berry = resolve(&yarn("4.1.0"), args);
-        let CommandResolution::Run(berry_command) = berry.outcome else {
-            panic!("expected command resolution");
-        };
+        let berry_command = expect_run(berry.outcome);
 
         assert_eq!(classic_command.program, "yarn");
         assert_eq!(classic_command.args, vec!["add", "react"]);
@@ -600,9 +558,7 @@ mod tests {
         options.save_catalog = true;
         options.allow_build = Some("react".to_string());
         let resolution = resolve(&bun("1.3.11"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.args, vec!["add", "react"]);
         assert_eq!(

--- a/crates/vp_pm_cli/src/resolution/commands/approve_builds.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/approve_builds.rs
@@ -230,7 +230,7 @@ mod tests {
     use super::*;
     use crate::resolution::{
         resolve,
-        test_utils::{bun, npm, parse_args, pnpm, yarn},
+        test_utils::{bun, expect_run, npm, parse_args, pnpm, yarn},
     };
 
     #[test]
@@ -251,11 +251,7 @@ mod tests {
 
     #[test]
     fn pnpm_no_args_interactive() {
-        let CommandResolution::Run(command) =
-            resolve(&pnpm("10.32.0"), ApproveBuildsArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&pnpm("10.32.0"), ApproveBuildsArgs::default()).outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["approve-builds"]);
@@ -263,17 +259,16 @@ mod tests {
 
     #[test]
     fn pnpm_with_packages() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.32.0"),
-            ApproveBuildsArgs {
-                packages: vec!["esbuild".to_string(), "fsevents".to_string()],
-                ..Default::default()
-            },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.32.0"),
+                ApproveBuildsArgs {
+                    packages: vec!["esbuild".to_string(), "fsevents".to_string()],
+                    ..Default::default()
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["approve-builds", "esbuild", "fsevents"]);
@@ -281,17 +276,16 @@ mod tests {
 
     #[test]
     fn pnpm_v11_passes_deny_syntax_through() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("11.0.0"),
-            ApproveBuildsArgs {
-                packages: vec!["esbuild".to_string(), "!core-js".to_string()],
-                ..Default::default()
-            },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("11.0.0"),
+                ApproveBuildsArgs {
+                    packages: vec!["esbuild".to_string(), "!core-js".to_string()],
+                    ..Default::default()
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.args, vec!["approve-builds", "esbuild", "!core-js"]);
     }
@@ -324,12 +318,10 @@ mod tests {
 
     #[test]
     fn pnpm_all_flag() {
-        let CommandResolution::Run(command) =
+        let command = expect_run(
             resolve(&pnpm("10.32.0"), ApproveBuildsArgs { all: true, ..Default::default() })
-                .outcome
-        else {
-            panic!("expected command resolution");
-        };
+                .outcome,
+        );
 
         assert_eq!(command.args, vec!["approve-builds", "--all"]);
     }
@@ -358,30 +350,27 @@ mod tests {
 
     #[test]
     fn pnpm_all_accepts_newer_major_prerelease() {
-        let CommandResolution::Run(command) =
+        let command = expect_run(
             resolve(&pnpm("11.0.0-rc.0"), ApproveBuildsArgs { all: true, ..Default::default() })
-                .outcome
-        else {
-            panic!("expected command resolution");
-        };
+                .outcome,
+        );
 
         assert_eq!(command.args, vec!["approve-builds", "--all"]);
     }
 
     #[test]
     fn pnpm_appends_pass_through_args() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.32.0"),
-            ApproveBuildsArgs {
-                all: true,
-                pass_through_args: vec!["--workspace-root".to_string()],
-                ..Default::default()
-            },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.32.0"),
+                ApproveBuildsArgs {
+                    all: true,
+                    pass_through_args: vec!["--workspace-root".to_string()],
+                    ..Default::default()
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.args, vec!["approve-builds", "--all", "--workspace-root"]);
     }
@@ -405,14 +394,13 @@ mod tests {
 
     #[test]
     fn bun_trust_by_name() {
-        let CommandResolution::Run(command) = resolve(
-            &bun("1.3.0"),
-            ApproveBuildsArgs { packages: vec!["esbuild".to_string()], ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &bun("1.3.0"),
+                ApproveBuildsArgs { packages: vec!["esbuild".to_string()], ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["pm", "trust", "esbuild"]);
@@ -420,11 +408,9 @@ mod tests {
 
     #[test]
     fn bun_trust_all() {
-        let CommandResolution::Run(command) =
-            resolve(&bun("1.3.0"), ApproveBuildsArgs { all: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&bun("1.3.0"), ApproveBuildsArgs { all: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.args, vec!["pm", "trust", "--all"]);
     }
@@ -438,9 +424,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.args, vec!["pm", "trust", "esbuild"]);
         assert!(resolution.diagnostics[0].message.contains("Skipping: core-js"));
@@ -482,9 +466,7 @@ mod tests {
             &Npm::unknown_version(),
             ApproveBuildsArgs { packages: vec!["esbuild".to_string()], ..Default::default() },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.args, vec!["approve-scripts", "esbuild"]);
     }
@@ -509,9 +491,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["approve-scripts", "esbuild", "fsevents"]);
@@ -520,11 +500,9 @@ mod tests {
 
     #[test]
     fn npm_v11_16_all() {
-        let CommandResolution::Run(command) =
-            resolve(&npm("11.16.0"), ApproveBuildsArgs { all: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&npm("11.16.0"), ApproveBuildsArgs { all: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.args, vec!["approve-scripts", "--all"]);
     }
@@ -532,9 +510,7 @@ mod tests {
     #[test]
     fn npm_v11_16_no_args_lists_pending() {
         let resolution = resolve(&npm("11.16.0"), ApproveBuildsArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.args, vec!["approve-scripts", "--allow-scripts-pending"]);
         assert!(resolution.diagnostics.is_empty());
@@ -542,17 +518,16 @@ mod tests {
 
     #[test]
     fn npm_v11_16_pending_forwards_flags() {
-        let CommandResolution::Run(command) = resolve(
-            &npm("11.16.0"),
-            ApproveBuildsArgs {
-                pass_through_args: vec!["--json".to_string()],
-                ..Default::default()
-            },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &npm("11.16.0"),
+                ApproveBuildsArgs {
+                    pass_through_args: vec!["--json".to_string()],
+                    ..Default::default()
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.args, vec!["approve-scripts", "--allow-scripts-pending", "--json"]);
     }
@@ -579,9 +554,7 @@ mod tests {
             &npm("11.16.0"),
             ApproveBuildsArgs { packages: vec!["!core-js".to_string()], ..Default::default() },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.args, vec!["deny-scripts", "core-js"]);
         assert_eq!(resolution.diagnostics[0].message, NPM_ADVISORY_NOTE);

--- a/crates/vp_pm_cli/src/resolution/commands/audit.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/audit.rs
@@ -116,7 +116,7 @@ mod tests {
     use super::*;
     use crate::resolution::{
         CommandResolution, resolve,
-        test_utils::{bun, npm, parse_args, pnpm, yarn},
+        test_utils::{bun, expect_run, npm, parse_args, pnpm, yarn},
     };
 
     #[test]
@@ -142,9 +142,7 @@ mod tests {
     #[test]
     fn test_npm_audit() {
         let resolution = resolve(&npm("11.0.0"), AuditArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["audit"]);
@@ -153,9 +151,7 @@ mod tests {
     #[test]
     fn test_npm_audit_fix() {
         let resolution = resolve(&npm("11.0.0"), AuditArgs { fix: true, ..Default::default() });
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["audit", "fix"]);
@@ -164,9 +160,7 @@ mod tests {
     #[test]
     fn test_pnpm_audit_fix() {
         let resolution = resolve(&pnpm("10.0.0"), AuditArgs { fix: true, ..Default::default() });
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["audit", "--fix"]);
@@ -175,9 +169,7 @@ mod tests {
     #[test]
     fn test_yarn1_audit() {
         let resolution = resolve(&yarn("1.22.0"), AuditArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["audit"]);
@@ -194,9 +186,7 @@ mod tests {
     #[test]
     fn test_yarn2_audit() {
         let resolution = resolve(&yarn("4.0.0"), AuditArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["npm", "audit"]);
@@ -216,9 +206,7 @@ mod tests {
             &npm("11.0.0"),
             AuditArgs { level: Some("high".to_string()), ..Default::default() },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["audit", "--audit-level", "high"]);
@@ -230,9 +218,7 @@ mod tests {
             &yarn("1.22.0"),
             AuditArgs { level: Some("high".to_string()), ..Default::default() },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["audit", "--level", "high"]);
@@ -241,9 +227,7 @@ mod tests {
     #[test]
     fn test_bun_audit_basic() {
         let resolution = resolve(&bun("1.3.11"), AuditArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["audit"]);
@@ -255,9 +239,7 @@ mod tests {
             &bun("1.3.11"),
             AuditArgs { level: Some("high".to_string()), ..Default::default() },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["audit", "--audit-level", "high"]);
@@ -274,9 +256,7 @@ mod tests {
     #[test]
     fn test_bun_audit_json() {
         let resolution = resolve(&bun("1.3.11"), AuditArgs { json: true, ..Default::default() });
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["audit", "--json"]);
@@ -288,9 +268,7 @@ mod tests {
             &yarn("4.0.0"),
             AuditArgs { level: Some("high".to_string()), ..Default::default() },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["npm", "audit", "--severity", "high"]);
@@ -308,21 +286,11 @@ mod tests {
             resolve(&yarn("4.0.0"), AuditArgs { production: true, ..Default::default() });
         let bun_resolution =
             resolve(&bun("1.3.11"), AuditArgs { production: true, ..Default::default() });
-        let CommandResolution::Run(npm_command) = npm_resolution.outcome else {
-            panic!("expected command resolution");
-        };
-        let CommandResolution::Run(pnpm_command) = pnpm_resolution.outcome else {
-            panic!("expected command resolution");
-        };
-        let CommandResolution::Run(yarn_command) = yarn_resolution.outcome else {
-            panic!("expected command resolution");
-        };
-        let CommandResolution::Run(yarn_berry_command) = yarn_berry_resolution.outcome else {
-            panic!("expected command resolution");
-        };
-        let CommandResolution::Run(bun_command) = bun_resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let npm_command = expect_run(npm_resolution.outcome);
+        let pnpm_command = expect_run(pnpm_resolution.outcome);
+        let yarn_command = expect_run(yarn_resolution.outcome);
+        let yarn_berry_command = expect_run(yarn_berry_resolution.outcome);
+        let bun_command = expect_run(bun_resolution.outcome);
 
         assert_eq!(npm_command.program, "npm");
         assert_eq!(npm_command.args, vec!["audit", "--omit=dev"]);

--- a/crates/vp_pm_cli/src/resolution/commands/cache.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/cache.rs
@@ -81,7 +81,7 @@ mod tests {
     use super::*;
     use crate::resolution::{
         CommandResolution, resolve,
-        test_utils::{bun, npm, parse_args, pnpm, yarn},
+        test_utils::{bun, expect_run, npm, parse_args, pnpm, yarn},
     };
 
     fn cache(subcommand: &str) -> CacheArgs {
@@ -99,9 +99,7 @@ mod tests {
     #[test]
     fn test_pnpm_cache_dir() {
         let resolution = resolve(&pnpm("10.0.0"), cache("dir"));
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["store", "path"]);
@@ -110,9 +108,7 @@ mod tests {
     #[test]
     fn test_npm_cache_dir() {
         let resolution = resolve(&npm("11.0.0"), cache("dir"));
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["config", "get", "cache"]);
@@ -121,9 +117,7 @@ mod tests {
     #[test]
     fn test_yarn1_cache_dir() {
         let resolution = resolve(&yarn("1.22.0"), cache("dir"));
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["cache", "dir"]);
@@ -132,9 +126,7 @@ mod tests {
     #[test]
     fn test_yarn2_cache_dir() {
         let resolution = resolve(&yarn("4.0.0"), cache("dir"));
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["config", "get", "cacheFolder"]);
@@ -143,9 +135,7 @@ mod tests {
     #[test]
     fn test_pnpm_cache_clean() {
         let resolution = resolve(&pnpm("10.0.0"), cache("clean"));
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["store", "prune"]);
@@ -154,9 +144,7 @@ mod tests {
     #[test]
     fn test_npm_cache_clean() {
         let resolution = resolve(&npm("11.0.0"), cache("clean"));
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["cache", "clean"]);
@@ -165,9 +153,7 @@ mod tests {
     #[test]
     fn test_yarn1_cache_clean() {
         let resolution = resolve(&yarn("1.22.0"), cache("clean"));
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["cache", "clean"]);
@@ -176,9 +162,7 @@ mod tests {
     #[test]
     fn test_yarn2_cache_clean() {
         let resolution = resolve(&yarn("4.0.0"), cache("clean"));
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["cache", "clean"]);
@@ -187,9 +171,7 @@ mod tests {
     #[test]
     fn test_bun_cache_dir() {
         let resolution = resolve(&bun("1.3.11"), cache("path"));
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["pm", "cache"]);
@@ -198,9 +180,7 @@ mod tests {
     #[test]
     fn test_bun_cache_clean() {
         let resolution = resolve(&bun("1.3.11"), cache("clean"));
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["pm", "cache", "rm"]);
@@ -227,9 +207,7 @@ mod tests {
                 pass_through_args: vec!["--force".to_string()],
             },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["cache", "clean", "--force"]);

--- a/crates/vp_pm_cli/src/resolution/commands/ci.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/ci.rs
@@ -56,15 +56,13 @@ mod tests {
     use super::*;
     use crate::resolution::{
         resolve,
-        test_utils::{bun, npm, parse_args, pnpm, yarn},
+        test_utils::{bun, expect_run, npm, parse_args, pnpm, yarn},
     };
 
     fn resolved_args<D: Resolve<CiArgs>>(dialect: &D, args: CiArgs) -> Vec<String> {
         let resolution = resolve(dialect, args);
         assert!(resolution.diagnostics.is_empty());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
         command.args
     }
 

--- a/crates/vp_pm_cli/src/resolution/commands/config.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/config.rs
@@ -212,7 +212,7 @@ mod tests {
     use super::*;
     use crate::resolution::{
         Resolution, resolve,
-        test_utils::{bun, npm, parse_subcommand, pnpm, yarn},
+        test_utils::{bun, expect_run, npm, parse_subcommand, pnpm, yarn},
     };
 
     fn set_config(location: Option<&str>) -> ConfigCommand {
@@ -242,11 +242,7 @@ mod tests {
 
     #[test]
     fn test_pnpm_config_set() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } =
-            resolve(&pnpm("10.0.0"), set_config(None))
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&pnpm("10.0.0"), set_config(None)).outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["config", "set", "registry", "https://registry.npmjs.org"]);
@@ -254,11 +250,7 @@ mod tests {
 
     #[test]
     fn test_npm_config_set() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } =
-            resolve(&npm("11.0.0"), set_config(None))
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&npm("11.0.0"), set_config(None)).outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["config", "set", "registry", "https://registry.npmjs.org"]);
@@ -266,18 +258,19 @@ mod tests {
 
     #[test]
     fn test_config_set_with_json() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } = resolve(
-            &pnpm("10.0.0"),
-            ConfigCommand::Set {
-                key: "registry".to_string(),
-                value: "https://registry.npmjs.org".to_string(),
-                json: true,
-                global: false,
-                location: None,
-            },
-        ) else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                ConfigCommand::Set {
+                    key: "registry".to_string(),
+                    value: "https://registry.npmjs.org".to_string(),
+                    json: true,
+                    global: false,
+                    location: None,
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(
@@ -288,11 +281,7 @@ mod tests {
 
     #[test]
     fn test_config_set_with_location_global() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } =
-            resolve(&pnpm("10.0.0"), set_config(Some("global")))
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&pnpm("10.0.0"), set_config(Some("global"))).outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(
@@ -303,11 +292,7 @@ mod tests {
 
     #[test]
     fn test_yarn2_config_set_location_global() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } =
-            resolve(&yarn("4.0.0"), set_config(Some("global")))
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&yarn("4.0.0"), set_config(Some("global"))).outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(
@@ -318,11 +303,7 @@ mod tests {
 
     #[test]
     fn test_yarn1_config_set() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } =
-            resolve(&yarn("1.22.0"), set_config(None))
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&yarn("1.22.0"), set_config(None)).outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["config", "set", "registry", "https://registry.npmjs.org"]);
@@ -330,18 +311,19 @@ mod tests {
 
     #[test]
     fn test_pnpm_config_set_global() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } = resolve(
-            &pnpm("10.0.0"),
-            ConfigCommand::Set {
-                key: "registry".to_string(),
-                value: "https://registry.npmjs.org".to_string(),
-                json: false,
-                global: true,
-                location: None,
-            },
-        ) else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                ConfigCommand::Set {
+                    key: "registry".to_string(),
+                    value: "https://registry.npmjs.org".to_string(),
+                    json: false,
+                    global: true,
+                    location: None,
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(
@@ -352,11 +334,7 @@ mod tests {
 
     #[test]
     fn test_npm_config_set_global() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } =
-            resolve(&npm("11.0.0"), set_config(Some("global")))
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&npm("11.0.0"), set_config(Some("global"))).outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(
@@ -367,11 +345,7 @@ mod tests {
 
     #[test]
     fn test_yarn1_config_set_global() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } =
-            resolve(&yarn("1.22.0"), set_config(Some("global")))
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&yarn("1.22.0"), set_config(Some("global"))).outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(
@@ -382,17 +356,18 @@ mod tests {
 
     #[test]
     fn test_pnpm_config_get() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } = resolve(
-            &pnpm("10.0.0"),
-            ConfigCommand::Get {
-                key: "registry".to_string(),
-                json: false,
-                global: false,
-                location: None,
-            },
-        ) else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                ConfigCommand::Get {
+                    key: "registry".to_string(),
+                    json: false,
+                    global: false,
+                    location: None,
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["config", "get", "registry"]);
@@ -400,12 +375,17 @@ mod tests {
 
     #[test]
     fn test_npm_config_delete() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } = resolve(
-            &npm("11.0.0"),
-            ConfigCommand::Delete { key: "registry".to_string(), global: false, location: None },
-        ) else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &npm("11.0.0"),
+                ConfigCommand::Delete {
+                    key: "registry".to_string(),
+                    global: false,
+                    location: None,
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["config", "delete", "registry"]);
@@ -413,12 +393,17 @@ mod tests {
 
     #[test]
     fn test_yarn2_config_delete() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } = resolve(
-            &yarn("4.0.0"),
-            ConfigCommand::Delete { key: "registry".to_string(), global: false, location: None },
-        ) else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &yarn("4.0.0"),
+                ConfigCommand::Delete {
+                    key: "registry".to_string(),
+                    global: false,
+                    location: None,
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["config", "unset", "registry"]);
@@ -426,12 +411,13 @@ mod tests {
 
     #[test]
     fn test_yarn2_config_list() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } = resolve(
-            &yarn("4.0.0"),
-            ConfigCommand::List { json: false, global: false, location: None },
-        ) else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &yarn("4.0.0"),
+                ConfigCommand::List { json: false, global: false, location: None },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["config"]);
@@ -439,11 +425,9 @@ mod tests {
 
     #[test]
     fn test_yarn1_location_project_warns_and_drops() {
-        let Resolution { outcome: CommandResolution::Run(command), diagnostics } =
-            resolve(&yarn("1.22.0"), set_config(Some("project")))
-        else {
-            panic!("expected command resolution");
-        };
+        let Resolution { outcome, diagnostics } =
+            resolve(&yarn("1.22.0"), set_config(Some("project")));
+        let command = expect_run(outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["config", "set", "registry", "https://registry.npmjs.org"]);
@@ -452,11 +436,9 @@ mod tests {
 
     #[test]
     fn test_yarn2_location_project_is_silently_ignored() {
-        let Resolution { outcome: CommandResolution::Run(command), diagnostics } =
-            resolve(&yarn("4.0.0"), set_config(Some("project")))
-        else {
-            panic!("expected command resolution");
-        };
+        let Resolution { outcome, diagnostics } =
+            resolve(&yarn("4.0.0"), set_config(Some("project")));
+        let command = expect_run(outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["config", "set", "registry", "https://registry.npmjs.org"]);
@@ -465,11 +447,8 @@ mod tests {
 
     #[test]
     fn test_bun_config_fallback_keeps_bun_program() {
-        let Resolution { outcome: CommandResolution::Run(command), diagnostics } =
-            resolve(&bun("1.3.11"), set_config(None))
-        else {
-            panic!("expected command resolution");
-        };
+        let Resolution { outcome, diagnostics } = resolve(&bun("1.3.11"), set_config(None));
+        let command = expect_run(outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["config", "set", "registry", "https://registry.npmjs.org"]);

--- a/crates/vp_pm_cli/src/resolution/commands/dedupe.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/dedupe.rs
@@ -65,16 +65,14 @@ impl Resolve<DedupeArgs> for Bun {
 mod tests {
     use super::*;
     use crate::resolution::{
-        CommandResolution, resolve,
-        test_utils::{bun, npm, pnpm, yarn},
+        resolve,
+        test_utils::{bun, expect_run, npm, pnpm, yarn},
     };
 
     #[test]
     fn test_pnpm_dedupe_basic() {
         let resolution = resolve(&pnpm("10.0.0"), DedupeArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["dedupe"]);
@@ -83,9 +81,7 @@ mod tests {
     #[test]
     fn test_pnpm_dedupe_check() {
         let resolution = resolve(&pnpm("10.0.0"), DedupeArgs { check: true, ..Default::default() });
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["dedupe", "--check"]);
@@ -94,9 +90,7 @@ mod tests {
     #[test]
     fn test_npm_dedupe_basic() {
         let resolution = resolve(&npm("11.0.0"), DedupeArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["dedupe"]);
@@ -105,9 +99,7 @@ mod tests {
     #[test]
     fn test_npm_dedupe_check() {
         let resolution = resolve(&npm("11.0.0"), DedupeArgs { check: true, ..Default::default() });
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["dedupe", "--dry-run"]);
@@ -116,9 +108,7 @@ mod tests {
     #[test]
     fn test_yarn_dedupe_basic() {
         let resolution = resolve(&yarn("4.0.0"), DedupeArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["dedupe"]);
@@ -127,9 +117,7 @@ mod tests {
     #[test]
     fn test_yarn_dedupe_check() {
         let resolution = resolve(&yarn("4.0.0"), DedupeArgs { check: true, ..Default::default() });
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["dedupe", "--check"]);
@@ -138,9 +126,7 @@ mod tests {
     #[test]
     fn test_yarn_classic_dedupe_falls_back_to_install() {
         let resolution = resolve(&yarn("1.22.0"), DedupeArgs { check: true, ..Default::default() });
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["install"]);
@@ -155,9 +141,7 @@ mod tests {
     #[test]
     fn test_bun_dedupe_falls_back_to_install() {
         let resolution = resolve(&bun("1.3.11"), DedupeArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["install"]);
@@ -178,9 +162,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["dedupe", "--config.verify-store-integrity=false"]);

--- a/crates/vp_pm_cli/src/resolution/commands/deprecate.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/deprecate.rs
@@ -71,8 +71,8 @@ impl Resolve<DeprecateArgs> for Bun {
 mod tests {
     use super::*;
     use crate::resolution::{
-        CommandResolution, resolve,
-        test_utils::{bun, npm, parse_args, pnpm, yarn},
+        resolve,
+        test_utils::{bun, expect_run, npm, parse_args, pnpm, yarn},
     };
 
     fn deprecate(package: &str, message: &str) -> DeprecateArgs {
@@ -108,9 +108,7 @@ mod tests {
     fn test_deprecate_basic() {
         let resolution =
             resolve(&pnpm("10.0.0"), deprecate("my-package@1.0.0", "This version is deprecated"));
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(
@@ -130,9 +128,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(
@@ -152,9 +148,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(
@@ -172,9 +166,7 @@ mod tests {
     #[test]
     fn test_yarn_classic_deprecate_uses_npm() {
         let resolution = resolve(&yarn("1.22.0"), deprecate("my-package", "Deprecated"));
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["deprecate", "my-package", "Deprecated"]);
@@ -183,9 +175,7 @@ mod tests {
     #[test]
     fn test_bun_deprecate_falls_back_to_npm() {
         let resolution = resolve(&bun("1.3.11"), deprecate("my-package", "Deprecated"));
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["deprecate", "my-package", "Deprecated"]);

--- a/crates/vp_pm_cli/src/resolution/commands/dist_tag.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/dist_tag.rs
@@ -98,7 +98,7 @@ mod tests {
     use super::*;
     use crate::resolution::{
         Resolution, resolve,
-        test_utils::{bun, npm, parse_subcommand, pnpm, yarn},
+        test_utils::{bun, expect_run, npm, parse_subcommand, pnpm, yarn},
     };
 
     fn list(package: &str) -> DistTagCommand {
@@ -114,11 +114,7 @@ mod tests {
 
     #[test]
     fn test_npm_dist_tag_list() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } =
-            resolve(&npm("11.0.0"), list("my-package"))
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&npm("11.0.0"), list("my-package")).outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["dist-tag", "list", "my-package"]);
@@ -126,11 +122,7 @@ mod tests {
 
     #[test]
     fn test_pnpm_dist_tag_list() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } =
-            resolve(&pnpm("10.0.0"), list("my-package"))
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&pnpm("10.0.0"), list("my-package")).outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["dist-tag", "list", "my-package"]);
@@ -138,11 +130,7 @@ mod tests {
 
     #[test]
     fn test_yarn1_dist_tag_list() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } =
-            resolve(&yarn("1.22.0"), list("my-package"))
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&yarn("1.22.0"), list("my-package")).outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["tag", "list", "my-package"]);
@@ -150,11 +138,7 @@ mod tests {
 
     #[test]
     fn test_yarn2_dist_tag_list() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } =
-            resolve(&yarn("4.0.0"), list("my-package"))
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&yarn("4.0.0"), list("my-package")).outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["npm", "tag", "list", "my-package"]);
@@ -162,11 +146,8 @@ mod tests {
 
     #[test]
     fn test_bun_dist_tag_list_falls_back_to_npm() {
-        let Resolution { outcome: CommandResolution::Run(command), diagnostics } =
-            resolve(&bun("1.3.11"), list("my-package"))
-        else {
-            panic!("expected command resolution");
-        };
+        let Resolution { outcome, diagnostics } = resolve(&bun("1.3.11"), list("my-package"));
+        let command = expect_run(outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["dist-tag", "list", "my-package"]);
@@ -178,15 +159,16 @@ mod tests {
 
     #[test]
     fn test_dist_tag_add() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } = resolve(
-            &npm("11.0.0"),
-            DistTagCommand::Add {
-                package_at_version: "my-package@1.0.0".into(),
-                tag: "beta".into(),
-            },
-        ) else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &npm("11.0.0"),
+                DistTagCommand::Add {
+                    package_at_version: "my-package@1.0.0".into(),
+                    tag: "beta".into(),
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["dist-tag", "add", "my-package@1.0.0", "beta"]);
@@ -194,12 +176,13 @@ mod tests {
 
     #[test]
     fn test_dist_tag_rm() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } = resolve(
-            &npm("11.0.0"),
-            DistTagCommand::Rm { package: "my-package".into(), tag: "beta".into() },
-        ) else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &npm("11.0.0"),
+                DistTagCommand::Rm { package: "my-package".into(), tag: "beta".into() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["dist-tag", "rm", "my-package", "beta"]);

--- a/crates/vp_pm_cli/src/resolution/commands/dlx.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/dlx.rs
@@ -176,7 +176,7 @@ mod tests {
     use super::*;
     use crate::resolution::{
         resolve,
-        test_utils::{bun, npm, parse_args, pnpm, yarn},
+        test_utils::{bun, expect_run, npm, parse_args, pnpm, yarn},
     };
 
     fn dlx_args(package_spec: &str, args: &[&str]) -> DlxArgs {
@@ -198,11 +198,8 @@ mod tests {
 
     #[test]
     fn test_pnpm_dlx_basic() {
-        let CommandResolution::Run(command) =
-            resolve(&pnpm("10.0.0"), dlx_args("create-vue", &["my-app"])).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command =
+            expect_run(resolve(&pnpm("10.0.0"), dlx_args("create-vue", &["my-app"])).outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["dlx", "create-vue", "my-app"]);
@@ -210,11 +207,9 @@ mod tests {
 
     #[test]
     fn test_pnpm_dlx_with_version() {
-        let CommandResolution::Run(command) =
-            resolve(&pnpm("10.0.0"), dlx_args("typescript@5.5.4", &["tsc", "--version"])).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&pnpm("10.0.0"), dlx_args("typescript@5.5.4", &["tsc", "--version"])).outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["dlx", "typescript@5.5.4", "tsc", "--version"]);
@@ -224,9 +219,7 @@ mod tests {
     fn test_pnpm_dlx_with_packages() {
         let mut options = dlx_args("yo", &["webapp"]);
         options.package = vec!["yo".to_string(), "generator-webapp".to_string()];
-        let CommandResolution::Run(command) = resolve(&pnpm("10.0.0"), options).outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&pnpm("10.0.0"), options).outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(
@@ -240,9 +233,7 @@ mod tests {
         let mut options = dlx_args("echo hello | cowsay", &[]);
         options.package = vec!["cowsay".to_string()];
         options.shell_mode = true;
-        let CommandResolution::Run(command) = resolve(&pnpm("10.0.0"), options).outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&pnpm("10.0.0"), options).outcome);
 
         assert_eq!(command.program, "pnpm");
         assert!(command.args.contains(&"-c".to_string()));
@@ -253,9 +244,7 @@ mod tests {
     fn test_pnpm_dlx_with_silent() {
         let mut options = dlx_args("create-vue", &["my-app"]);
         options.silent = true;
-        let CommandResolution::Run(command) = resolve(&pnpm("10.0.0"), options).outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&pnpm("10.0.0"), options).outcome);
 
         assert_eq!(command.program, "pnpm");
         assert!(command.args.contains(&"--silent".to_string()));
@@ -263,11 +252,8 @@ mod tests {
 
     #[test]
     fn test_npm_exec_basic() {
-        let CommandResolution::Run(command) =
-            resolve(&npm("11.0.0"), dlx_args("create-vue", &["my-app"])).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command =
+            expect_run(resolve(&npm("11.0.0"), dlx_args("create-vue", &["my-app"])).outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["exec", "--yes", "--", "create-vue", "my-app"]);
@@ -275,11 +261,9 @@ mod tests {
 
     #[test]
     fn test_npm_exec_with_version() {
-        let CommandResolution::Run(command) =
-            resolve(&npm("11.0.0"), dlx_args("typescript@5.5.4", &["tsc", "--version"])).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&npm("11.0.0"), dlx_args("typescript@5.5.4", &["tsc", "--version"])).outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(
@@ -300,9 +284,7 @@ mod tests {
     fn test_npm_exec_with_packages() {
         let mut options = dlx_args("yo", &["webapp"]);
         options.package = vec!["yo".to_string(), "generator-webapp".to_string()];
-        let CommandResolution::Run(command) = resolve(&npm("11.0.0"), options).outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&npm("11.0.0"), options).outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(
@@ -324,9 +306,7 @@ mod tests {
     fn test_npm_exec_with_silent() {
         let mut options = dlx_args("create-vue", &["my-app"]);
         options.silent = true;
-        let CommandResolution::Run(command) = resolve(&npm("11.0.0"), options).outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&npm("11.0.0"), options).outcome);
 
         assert_eq!(command.program, "npm");
         assert!(command.args.contains(&"--loglevel".to_string()));
@@ -339,9 +319,7 @@ mod tests {
         let mut options = dlx_args("echo hello | cowsay | lolcatjs", &[]);
         options.package = vec!["cowsay".to_string(), "lolcatjs".to_string()];
         options.shell_mode = true;
-        let CommandResolution::Run(command) = resolve(&npm("11.0.0"), options).outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&npm("11.0.0"), options).outcome);
 
         assert_eq!(
             command.args,
@@ -361,9 +339,7 @@ mod tests {
         let mut options = dlx_args("echo", &["hello world"]);
         options.shell_mode = true;
         options.silent = true;
-        let CommandResolution::Run(command) = resolve(&npm("11.0.0"), options).outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&npm("11.0.0"), options).outcome);
 
         assert_eq!(
             command.args,
@@ -373,11 +349,9 @@ mod tests {
 
     #[test]
     fn test_npm_exec_scoped_package_with_version() {
-        let CommandResolution::Run(command) =
-            resolve(&npm("11.0.0"), dlx_args("@vue/cli@5.0.0", &["create", "my-app"])).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&npm("11.0.0"), dlx_args("@vue/cli@5.0.0", &["create", "my-app"])).outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(
@@ -388,11 +362,9 @@ mod tests {
 
     #[test]
     fn test_npm_exec_scoped_package_without_version() {
-        let CommandResolution::Run(command) =
-            resolve(&npm("11.0.0"), dlx_args("@vue/cli", &["create", "my-app"])).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&npm("11.0.0"), dlx_args("@vue/cli", &["create", "my-app"])).outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(
@@ -403,11 +375,8 @@ mod tests {
 
     #[test]
     fn test_npm_exec_version_requires_package_flag_and_extracted_command() {
-        let CommandResolution::Run(command) =
-            resolve(&npm("11.0.0"), dlx_args("create-vue@3.10.0", &["my-app"])).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command =
+            expect_run(resolve(&npm("11.0.0"), dlx_args("create-vue@3.10.0", &["my-app"])).outcome);
 
         assert!(command.args.contains(&"--package=create-vue@3.10.0".to_string()));
         let separator_pos = command.args.iter().position(|arg| arg == "--").unwrap();
@@ -417,9 +386,7 @@ mod tests {
     #[test]
     fn test_yarn_v1_fallback_to_npx() {
         let resolution = resolve(&yarn("1.22.19"), dlx_args("create-vue", &["my-app"]));
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npx");
         assert_eq!(command.args, vec!["--yes", "create-vue", "my-app"]);
@@ -429,9 +396,7 @@ mod tests {
     #[test]
     fn no_project_fallback_uses_npx_without_a_diagnostic() {
         let resolution = dlx_args("create-vue", &["my-app"]).resolve_npx_fallback();
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npx");
         assert_eq!(command.args, vec!["--yes", "create-vue", "my-app"]);
@@ -443,9 +408,7 @@ mod tests {
     fn test_yarn_v1_fallback_with_packages() {
         let mut options = dlx_args("yo", &["webapp"]);
         options.package = vec!["yo".to_string()];
-        let CommandResolution::Run(command) = resolve(&yarn("1.22.19"), options).outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&yarn("1.22.19"), options).outcome);
 
         assert_eq!(command.program, "npx");
         assert_eq!(command.args, vec!["--package", "yo", "--yes", "yo", "webapp"]);
@@ -457,9 +420,7 @@ mod tests {
         options.package = vec!["cowsay".to_string()];
         options.shell_mode = true;
         options.silent = true;
-        let CommandResolution::Run(command) = resolve(&yarn("1.22.19"), options).outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&yarn("1.22.19"), options).outcome);
 
         assert_eq!(
             command.args,
@@ -469,11 +430,8 @@ mod tests {
 
     #[test]
     fn test_yarn_v2_dlx_basic() {
-        let CommandResolution::Run(command) =
-            resolve(&yarn("4.0.0"), dlx_args("create-vue", &["my-app"])).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command =
+            expect_run(resolve(&yarn("4.0.0"), dlx_args("create-vue", &["my-app"])).outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["dlx", "create-vue", "my-app"]);
@@ -483,9 +441,7 @@ mod tests {
     fn test_yarn_v2_dlx_with_packages() {
         let mut options = dlx_args("yo", &["webapp"]);
         options.package = vec!["yo".to_string(), "generator-webapp".to_string()];
-        let CommandResolution::Run(command) = resolve(&yarn("4.0.0"), options).outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&yarn("4.0.0"), options).outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["dlx", "-p", "yo", "-p", "generator-webapp", "yo", "webapp"]);
@@ -495,9 +451,7 @@ mod tests {
     fn test_yarn_v2_dlx_with_quiet() {
         let mut options = dlx_args("create-vue", &["my-app"]);
         options.silent = true;
-        let CommandResolution::Run(command) = resolve(&yarn("4.0.0"), options).outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&yarn("4.0.0"), options).outcome);
 
         assert_eq!(command.program, "yarn");
         assert!(command.args.contains(&"--quiet".to_string()));
@@ -505,11 +459,8 @@ mod tests {
 
     #[test]
     fn test_yarn_v3_dlx() {
-        let CommandResolution::Run(command) =
-            resolve(&yarn("3.6.0"), dlx_args("create-vue", &["my-app"])).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command =
+            expect_run(resolve(&yarn("3.6.0"), dlx_args("create-vue", &["my-app"])).outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["dlx", "create-vue", "my-app"]);
@@ -517,11 +468,9 @@ mod tests {
 
     #[test]
     fn test_yarn_v2_dlx_with_version() {
-        let CommandResolution::Run(command) =
-            resolve(&yarn("4.0.0"), dlx_args("typescript@5.5.4", &["tsc", "--version"])).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&yarn("4.0.0"), dlx_args("typescript@5.5.4", &["tsc", "--version"])).outcome,
+        );
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["dlx", "typescript@5.5.4", "tsc", "--version"]);
@@ -532,9 +481,7 @@ mod tests {
         let mut options = dlx_args("echo", &["hello"]);
         options.shell_mode = true;
         let resolution = resolve(&yarn("4.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["dlx", "echo", "hello"]);
@@ -546,11 +493,8 @@ mod tests {
 
     #[test]
     fn test_bun_dlx_basic() {
-        let CommandResolution::Run(command) =
-            resolve(&bun("1.3.11"), dlx_args("create-vue", &["my-app"])).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command =
+            expect_run(resolve(&bun("1.3.11"), dlx_args("create-vue", &["my-app"])).outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["x", "create-vue", "my-app"]);
@@ -560,9 +504,7 @@ mod tests {
     fn test_bun_dlx_with_packages() {
         let mut options = dlx_args("yo", &["webapp"]);
         options.package = vec!["yo".to_string(), "generator-webapp".to_string()];
-        let CommandResolution::Run(command) = resolve(&bun("1.3.11"), options).outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&bun("1.3.11"), options).outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(
@@ -576,9 +518,7 @@ mod tests {
         let mut options = dlx_args("echo", &["hello"]);
         options.shell_mode = true;
         let resolution = resolve(&bun("1.3.11"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["x", "echo", "hello"]);

--- a/crates/vp_pm_cli/src/resolution/commands/fund.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/fund.rs
@@ -56,8 +56,8 @@ impl Resolve<FundArgs> for Bun {
 mod tests {
     use super::*;
     use crate::resolution::{
-        CommandResolution, resolve,
-        test_utils::{bun, npm, parse_args, pnpm, yarn},
+        resolve,
+        test_utils::{bun, expect_run, npm, parse_args, pnpm, yarn},
     };
 
     #[test]
@@ -71,9 +71,7 @@ mod tests {
     #[test]
     fn test_fund_basic() {
         let resolution = resolve(&pnpm("10.0.0"), FundArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["fund"]);
@@ -82,9 +80,7 @@ mod tests {
     #[test]
     fn test_fund_with_json() {
         let resolution = resolve(&npm("11.0.0"), FundArgs { json: true, ..Default::default() });
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["fund", "--json"]);
@@ -93,9 +89,7 @@ mod tests {
     #[test]
     fn test_yarn_fund_uses_npm() {
         let resolution = resolve(&yarn("4.0.0"), FundArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["fund"]);
@@ -104,9 +98,7 @@ mod tests {
     #[test]
     fn test_bun_fund_falls_back_to_npm() {
         let resolution = resolve(&bun("1.3.11"), FundArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["fund"]);

--- a/crates/vp_pm_cli/src/resolution/commands/install.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/install.rs
@@ -292,16 +292,12 @@ mod tests {
     use super::*;
     use crate::resolution::{
         resolve,
-        test_utils::{bun, npm, pnpm, yarn},
+        test_utils::{bun, expect_run, npm, pnpm, yarn},
     };
 
     #[test]
     fn test_pnpm_basic_install() {
-        let CommandResolution::Run(command) =
-            resolve(&pnpm("10.0.0"), InstallArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&pnpm("10.0.0"), InstallArgs::default()).outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["install"]);
@@ -309,11 +305,9 @@ mod tests {
 
     #[test]
     fn test_pnpm_prod_install() {
-        let CommandResolution::Run(command) =
-            resolve(&pnpm("10.0.0"), InstallArgs { prod: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&pnpm("10.0.0"), InstallArgs { prod: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["install", "--prod"]);
@@ -321,73 +315,60 @@ mod tests {
 
     #[test]
     fn test_pnpm_frozen_lockfile() {
-        let CommandResolution::Run(command) =
+        let command = expect_run(
             resolve(&pnpm("10.0.0"), InstallArgs { frozen_lockfile: true, ..Default::default() })
-                .outcome
-        else {
-            panic!("expected command resolution");
-        };
+                .outcome,
+        );
 
         assert_eq!(command.args, vec!["install", "--frozen-lockfile"]);
     }
 
     #[test]
     fn test_pnpm_filter() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.0.0"),
-            InstallArgs { filter: vec!["app".to_string()], ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                InstallArgs { filter: vec!["app".to_string()], ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.args, vec!["--filter", "app", "install"]);
     }
 
     #[test]
     fn test_pnpm_fix_lockfile() {
-        let CommandResolution::Run(command) =
+        let command = expect_run(
             resolve(&pnpm("10.0.0"), InstallArgs { fix_lockfile: true, ..Default::default() })
-                .outcome
-        else {
-            panic!("expected command resolution");
-        };
+                .outcome,
+        );
 
         assert_eq!(command.args, vec!["install", "--fix-lockfile"]);
     }
 
     #[test]
     fn test_pnpm_resolution_only() {
-        let CommandResolution::Run(command) =
+        let command = expect_run(
             resolve(&pnpm("10.0.0"), InstallArgs { resolution_only: true, ..Default::default() })
-                .outcome
-        else {
-            panic!("expected command resolution");
-        };
+                .outcome,
+        );
 
         assert_eq!(command.args, vec!["install", "--resolution-only"]);
     }
 
     #[test]
     fn test_pnpm_shamefully_hoist() {
-        let CommandResolution::Run(command) =
+        let command = expect_run(
             resolve(&pnpm("10.0.0"), InstallArgs { shamefully_hoist: true, ..Default::default() })
-                .outcome
-        else {
-            panic!("expected command resolution");
-        };
+                .outcome,
+        );
 
         assert_eq!(command.args, vec!["install", "--shamefully-hoist"]);
     }
 
     #[test]
     fn test_npm_basic_install() {
-        let CommandResolution::Run(command) =
-            resolve(&npm("11.0.0"), InstallArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&npm("11.0.0"), InstallArgs::default()).outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["install"]);
@@ -395,48 +376,39 @@ mod tests {
 
     #[test]
     fn test_npm_frozen_lockfile_uses_ci() {
-        let CommandResolution::Run(command) =
+        let command = expect_run(
             resolve(&npm("11.0.0"), InstallArgs { frozen_lockfile: true, ..Default::default() })
-                .outcome
-        else {
-            panic!("expected command resolution");
-        };
+                .outcome,
+        );
 
         assert_eq!(command.args, vec!["ci"]);
     }
 
     #[test]
     fn test_npm_prod_install() {
-        let CommandResolution::Run(command) =
-            resolve(&npm("11.0.0"), InstallArgs { prod: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&npm("11.0.0"), InstallArgs { prod: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.args, vec!["install", "--omit=dev"]);
     }
 
     #[test]
     fn test_npm_filter() {
-        let CommandResolution::Run(command) = resolve(
-            &npm("11.0.0"),
-            InstallArgs { filter: vec!["app".to_string()], ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &npm("11.0.0"),
+                InstallArgs { filter: vec!["app".to_string()], ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.args, vec!["install", "--workspace", "app"]);
     }
 
     #[test]
     fn test_yarn_classic_basic_install() {
-        let CommandResolution::Run(command) =
-            resolve(&yarn("1.22.0"), InstallArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&yarn("1.22.0"), InstallArgs::default()).outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["install"]);
@@ -444,34 +416,26 @@ mod tests {
 
     #[test]
     fn test_yarn_classic_frozen_lockfile() {
-        let CommandResolution::Run(command) =
+        let command = expect_run(
             resolve(&yarn("1.22.0"), InstallArgs { frozen_lockfile: true, ..Default::default() })
-                .outcome
-        else {
-            panic!("expected command resolution");
-        };
+                .outcome,
+        );
 
         assert_eq!(command.args, vec!["install", "--frozen-lockfile"]);
     }
 
     #[test]
     fn test_yarn_classic_prod_install() {
-        let CommandResolution::Run(command) =
-            resolve(&yarn("1.22.0"), InstallArgs { prod: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&yarn("1.22.0"), InstallArgs { prod: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.args, vec!["install", "--production"]);
     }
 
     #[test]
     fn test_yarn_berry_basic_install() {
-        let CommandResolution::Run(command) =
-            resolve(&yarn("4.0.0"), InstallArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&yarn("4.0.0"), InstallArgs::default()).outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["install"]);
@@ -479,12 +443,10 @@ mod tests {
 
     #[test]
     fn test_yarn_berry_frozen_lockfile() {
-        let CommandResolution::Run(command) =
+        let command = expect_run(
             resolve(&yarn("4.0.0"), InstallArgs { frozen_lockfile: true, ..Default::default() })
-                .outcome
-        else {
-            panic!("expected command resolution");
-        };
+                .outcome,
+        );
 
         assert_eq!(command.args, vec!["install", "--immutable"]);
     }
@@ -493,9 +455,7 @@ mod tests {
     fn test_yarn_berry_fix_lockfile() {
         let resolution =
             resolve(&yarn("4.0.0"), InstallArgs { fix_lockfile: true, ..Default::default() });
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.args, vec!["install", "--refresh-lockfile"]);
         assert!(resolution.diagnostics.is_empty());
@@ -503,12 +463,10 @@ mod tests {
 
     #[test]
     fn test_yarn_berry_ignore_scripts() {
-        let CommandResolution::Run(command) =
+        let command = expect_run(
             resolve(&yarn("4.0.0"), InstallArgs { ignore_scripts: true, ..Default::default() })
-                .outcome
-        else {
-            panic!("expected command resolution");
-        };
+                .outcome,
+        );
 
         assert_eq!(command.args, vec!["install", "--mode", "skip-build"]);
     }
@@ -519,9 +477,7 @@ mod tests {
             &yarn("4.0.0"),
             InstallArgs { lockfile_only: true, ignore_scripts: true, ..Default::default() },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.args, vec!["install", "--mode", "update-lockfile"]);
         assert_eq!(resolution.diagnostics.len(), 1);
@@ -533,14 +489,13 @@ mod tests {
 
     #[test]
     fn test_yarn_berry_filter() {
-        let CommandResolution::Run(command) = resolve(
-            &yarn("4.0.0"),
-            InstallArgs { filter: vec!["app".to_string()], ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &yarn("4.0.0"),
+                InstallArgs { filter: vec!["app".to_string()], ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(
             command.args,
@@ -550,23 +505,22 @@ mod tests {
 
     #[test]
     fn test_pnpm_all_options() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.0.0"),
-            InstallArgs {
-                prod: true,
-                no_optional: true,
-                prefer_offline: true,
-                ignore_scripts: true,
-                filter: vec!["app".to_string()],
-                workspace_root: true,
-                pass_through_args: vec!["--use-stderr".to_string()],
-                ..Default::default()
-            },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                InstallArgs {
+                    prod: true,
+                    no_optional: true,
+                    prefer_offline: true,
+                    ignore_scripts: true,
+                    filter: vec!["app".to_string()],
+                    workspace_root: true,
+                    pass_through_args: vec!["--use-stderr".to_string()],
+                    ..Default::default()
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(
             command.args,
@@ -586,33 +540,27 @@ mod tests {
 
     #[test]
     fn test_pnpm_silent() {
-        let CommandResolution::Run(command) =
-            resolve(&pnpm("10.0.0"), InstallArgs { silent: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&pnpm("10.0.0"), InstallArgs { silent: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.args, vec!["install", "--silent"]);
     }
 
     #[test]
     fn test_yarn_classic_silent() {
-        let CommandResolution::Run(command) =
-            resolve(&yarn("1.22.0"), InstallArgs { silent: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&yarn("1.22.0"), InstallArgs { silent: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.args, vec!["install", "--silent"]);
     }
 
     #[test]
     fn test_npm_silent() {
-        let CommandResolution::Run(command) =
-            resolve(&npm("11.0.0"), InstallArgs { silent: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&npm("11.0.0"), InstallArgs { silent: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.args, vec!["install", "--loglevel", "silent"]);
     }
@@ -621,9 +569,7 @@ mod tests {
     fn test_yarn_berry_silent_warns_and_drops() {
         let resolution =
             resolve(&yarn("4.0.0"), InstallArgs { silent: true, ..Default::default() });
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.args, vec!["install"]);
         assert_eq!(resolution.diagnostics[0].message, "yarn >=2 does not support --silent.");
@@ -631,105 +577,104 @@ mod tests {
 
     #[test]
     fn test_pnpm_no_frozen_lockfile() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.0.0"),
-            InstallArgs { no_frozen_lockfile: true, ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                InstallArgs { no_frozen_lockfile: true, ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.args, vec!["install", "--no-frozen-lockfile"]);
     }
 
     #[test]
     fn test_pnpm_no_frozen_lockfile_overrides_frozen_lockfile() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.0.0"),
-            InstallArgs { frozen_lockfile: true, no_frozen_lockfile: true, ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                InstallArgs {
+                    frozen_lockfile: true,
+                    no_frozen_lockfile: true,
+                    ..Default::default()
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.args, vec!["install", "--no-frozen-lockfile"]);
     }
 
     #[test]
     fn test_yarn_classic_no_frozen_lockfile() {
-        let CommandResolution::Run(command) = resolve(
-            &yarn("1.22.0"),
-            InstallArgs { no_frozen_lockfile: true, ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &yarn("1.22.0"),
+                InstallArgs { no_frozen_lockfile: true, ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.args, vec!["install", "--no-frozen-lockfile"]);
     }
 
     #[test]
     fn test_yarn_classic_no_frozen_lockfile_overrides_frozen_lockfile() {
-        let CommandResolution::Run(command) = resolve(
-            &yarn("1.22.0"),
-            InstallArgs { frozen_lockfile: true, no_frozen_lockfile: true, ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &yarn("1.22.0"),
+                InstallArgs {
+                    frozen_lockfile: true,
+                    no_frozen_lockfile: true,
+                    ..Default::default()
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.args, vec!["install", "--no-frozen-lockfile"]);
     }
 
     #[test]
     fn test_yarn_berry_no_frozen_lockfile() {
-        let CommandResolution::Run(command) =
+        let command = expect_run(
             resolve(&yarn("4.0.0"), InstallArgs { no_frozen_lockfile: true, ..Default::default() })
-                .outcome
-        else {
-            panic!("expected command resolution");
-        };
+                .outcome,
+        );
 
         assert_eq!(command.args, vec!["install", "--no-immutable"]);
     }
 
     #[test]
     fn test_yarn_berry_no_frozen_lockfile_overrides_frozen_lockfile() {
-        let CommandResolution::Run(command) = resolve(
-            &yarn("4.0.0"),
-            InstallArgs { frozen_lockfile: true, no_frozen_lockfile: true, ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &yarn("4.0.0"),
+                InstallArgs {
+                    frozen_lockfile: true,
+                    no_frozen_lockfile: true,
+                    ..Default::default()
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.args, vec!["install", "--no-immutable"]);
     }
 
     #[test]
     fn test_npm_no_frozen_lockfile_uses_install() {
-        let CommandResolution::Run(command) =
+        let command = expect_run(
             resolve(&npm("11.0.0"), InstallArgs { no_frozen_lockfile: true, ..Default::default() })
-                .outcome
-        else {
-            panic!("expected command resolution");
-        };
+                .outcome,
+        );
 
         assert_eq!(command.args, vec!["install"]);
     }
 
     #[test]
     fn test_bun_basic_install() {
-        let CommandResolution::Run(command) =
-            resolve(&bun("1.3.11"), InstallArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&bun("1.3.11"), InstallArgs::default()).outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["install"]);
@@ -737,36 +682,30 @@ mod tests {
 
     #[test]
     fn test_bun_frozen_lockfile() {
-        let CommandResolution::Run(command) =
+        let command = expect_run(
             resolve(&bun("1.3.11"), InstallArgs { frozen_lockfile: true, ..Default::default() })
-                .outcome
-        else {
-            panic!("expected command resolution");
-        };
+                .outcome,
+        );
 
         assert_eq!(command.args, vec!["install", "--frozen-lockfile"]);
     }
 
     #[test]
     fn test_bun_ignore_scripts() {
-        let CommandResolution::Run(command) =
+        let command = expect_run(
             resolve(&bun("1.3.11"), InstallArgs { ignore_scripts: true, ..Default::default() })
-                .outcome
-        else {
-            panic!("expected command resolution");
-        };
+                .outcome,
+        );
 
         assert!(command.args.contains(&"--ignore-scripts".to_string()));
     }
 
     #[test]
     fn test_bun_no_optional() {
-        let CommandResolution::Run(command) =
+        let command = expect_run(
             resolve(&bun("1.3.11"), InstallArgs { no_optional: true, ..Default::default() })
-                .outcome
-        else {
-            panic!("expected command resolution");
-        };
+                .outcome,
+        );
 
         assert!(command.args.contains(&"--omit".to_string()));
         assert!(command.args.contains(&"optional".to_string()));
@@ -774,46 +713,46 @@ mod tests {
 
     #[test]
     fn test_bun_prod_install() {
-        let CommandResolution::Run(command) =
-            resolve(&bun("1.3.11"), InstallArgs { prod: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&bun("1.3.11"), InstallArgs { prod: true, ..Default::default() }).outcome,
+        );
 
         assert!(command.args.contains(&"--production".to_string()));
     }
 
     #[test]
     fn test_npm_no_frozen_lockfile_overrides_frozen_lockfile() {
-        let CommandResolution::Run(command) = resolve(
-            &npm("11.0.0"),
-            InstallArgs { frozen_lockfile: true, no_frozen_lockfile: true, ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &npm("11.0.0"),
+                InstallArgs {
+                    frozen_lockfile: true,
+                    no_frozen_lockfile: true,
+                    ..Default::default()
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.args, vec!["install"]);
     }
 
     #[test]
     fn resolve_install_npm_uses_ci_for_frozen_lockfile() {
-        let CommandResolution::Run(command) = resolve(
-            &npm("11.0.0"),
-            InstallArgs {
-                frozen_lockfile: true,
-                dev: true,
-                force: true,
-                lockfile_only: true,
-                no_lockfile: true,
-                ..Default::default()
-            },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &npm("11.0.0"),
+                InstallArgs {
+                    frozen_lockfile: true,
+                    dev: true,
+                    force: true,
+                    lockfile_only: true,
+                    no_lockfile: true,
+                    ..Default::default()
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.args, vec!["ci"]);
     }
@@ -822,9 +761,7 @@ mod tests {
     fn drops_fix_lockfile_for_npm_with_warning() {
         let resolution =
             resolve(&npm("11.0.0"), InstallArgs { fix_lockfile: true, ..Default::default() });
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.args, vec!["install"]);
         assert_eq!(resolution.diagnostics.len(), 1);
@@ -837,9 +774,7 @@ mod tests {
             &yarn("4.1.0"),
             InstallArgs { prefer_offline: true, offline: true, ..Default::default() },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.args, vec!["install"]);
         assert!(resolution.diagnostics.is_empty());
@@ -848,9 +783,7 @@ mod tests {
     #[test]
     fn yarn_berry_prod_warns_without_dropping() {
         let resolution = resolve(&yarn("4.1.0"), InstallArgs { prod: true, ..Default::default() });
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.args, vec!["install"]);
         assert_eq!(
@@ -863,19 +796,13 @@ mod tests {
     fn resolution_only_warns_for_non_pnpm() {
         let npm_resolution =
             resolve(&npm("11.0.0"), InstallArgs { resolution_only: true, ..Default::default() });
-        let CommandResolution::Run(npm_command) = npm_resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let npm_command = expect_run(npm_resolution.outcome);
         let yarn_resolution =
             resolve(&yarn("1.22.0"), InstallArgs { resolution_only: true, ..Default::default() });
-        let CommandResolution::Run(yarn_command) = yarn_resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let yarn_command = expect_run(yarn_resolution.outcome);
         let berry_resolution =
             resolve(&yarn("4.1.0"), InstallArgs { resolution_only: true, ..Default::default() });
-        let CommandResolution::Run(berry_command) = berry_resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let berry_command = expect_run(berry_resolution.outcome);
 
         assert_eq!(npm_command.args, vec!["install"]);
         assert_eq!(
@@ -908,9 +835,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.args, vec!["install"]);
         assert_eq!(

--- a/crates/vp_pm_cli/src/resolution/commands/link.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/link.rs
@@ -54,16 +54,14 @@ fn resolve_link(program: &str, args: &LinkArgs) -> CommandResolution {
 mod tests {
     use super::*;
     use crate::resolution::{
-        CommandResolution, resolve,
-        test_utils::{bun, npm, parse_args, pnpm, yarn},
+        resolve,
+        test_utils::{bun, expect_run, npm, parse_args, pnpm, yarn},
     };
 
     #[test]
     fn test_pnpm_link_no_package() {
         let resolution = resolve(&pnpm("10.0.0"), LinkArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["link"]);
@@ -75,9 +73,7 @@ mod tests {
             &pnpm("10.0.0"),
             LinkArgs { package: Some("react".to_string()), ..Default::default() },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["link", "react"]);
@@ -89,9 +85,7 @@ mod tests {
             &pnpm("10.0.0"),
             LinkArgs { package: Some("./packages/utils".to_string()), ..Default::default() },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["link", "./packages/utils"]);
@@ -106,9 +100,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["link", "/absolute/path/to/package"]);
@@ -117,9 +109,7 @@ mod tests {
     #[test]
     fn test_yarn_link_basic() {
         let resolution = resolve(&yarn("4.0.0"), LinkArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["link"]);
@@ -131,9 +121,7 @@ mod tests {
             &yarn("4.0.0"),
             LinkArgs { package: Some("react".to_string()), ..Default::default() },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["link", "react"]);
@@ -145,9 +133,7 @@ mod tests {
             &yarn("1.22.0"),
             LinkArgs { package: Some("react".to_string()), ..Default::default() },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["link", "react"]);
@@ -156,9 +142,7 @@ mod tests {
     #[test]
     fn test_npm_link_basic() {
         let resolution = resolve(&npm("11.0.0"), LinkArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["link"]);
@@ -170,9 +154,7 @@ mod tests {
             &npm("11.0.0"),
             LinkArgs { package: Some("react".to_string()), ..Default::default() },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["link", "react"]);
@@ -184,9 +166,7 @@ mod tests {
             &bun("1.3.11"),
             LinkArgs { package: Some("react".to_string()), ..Default::default() },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["link", "react"]);
@@ -198,9 +178,7 @@ mod tests {
             &pnpm("10.0.0"),
             LinkArgs { package: Some("react".to_string()), args: vec!["--global".to_string()] },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["link", "react", "--global"]);

--- a/crates/vp_pm_cli/src/resolution/commands/list.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/list.rs
@@ -175,7 +175,7 @@ mod tests {
     use super::*;
     use crate::resolution::{
         resolve,
-        test_utils::{bun, npm, parse_args, pnpm, yarn},
+        test_utils::{bun, expect_run, npm, parse_args, pnpm, yarn},
     };
 
     fn list_args(pattern: Option<&str>) -> ListArgs {
@@ -193,10 +193,7 @@ mod tests {
 
     #[test]
     fn test_pnpm_list_basic() {
-        let CommandResolution::Run(command) = resolve(&pnpm("10.0.0"), ListArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&pnpm("10.0.0"), ListArgs::default()).outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["list"]);
@@ -204,11 +201,9 @@ mod tests {
 
     #[test]
     fn test_pnpm_list_recursive() {
-        let CommandResolution::Run(command) =
-            resolve(&pnpm("10.0.0"), ListArgs { recursive: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&pnpm("10.0.0"), ListArgs { recursive: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["list", "--recursive"]);
@@ -216,10 +211,7 @@ mod tests {
 
     #[test]
     fn test_npm_list_basic() {
-        let CommandResolution::Run(command) = resolve(&npm("11.0.0"), ListArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&npm("11.0.0"), ListArgs::default()).outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["list"]);
@@ -227,11 +219,9 @@ mod tests {
 
     #[test]
     fn test_npm_list_recursive() {
-        let CommandResolution::Run(command) =
-            resolve(&npm("11.0.0"), ListArgs { recursive: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&npm("11.0.0"), ListArgs { recursive: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["list", "--workspaces"]);
@@ -239,10 +229,7 @@ mod tests {
 
     #[test]
     fn test_yarn1_list_basic() {
-        let CommandResolution::Run(command) = resolve(&yarn("1.22.0"), ListArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&yarn("1.22.0"), ListArgs::default()).outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["list"]);
@@ -252,9 +239,7 @@ mod tests {
     fn test_yarn1_list_recursive_ignored() {
         let resolution =
             resolve(&yarn("1.22.0"), ListArgs { recursive: true, ..Default::default() });
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["list"]);
@@ -273,11 +258,9 @@ mod tests {
 
     #[test]
     fn test_pnpm_list_global_uses_npm() {
-        let CommandResolution::Run(command) =
-            resolve(&pnpm("10.0.0"), ListArgs { global: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&pnpm("10.0.0"), ListArgs { global: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["list", "-g"]);
@@ -285,11 +268,9 @@ mod tests {
 
     #[test]
     fn test_npm_list_global() {
-        let CommandResolution::Run(command) =
-            resolve(&npm("11.0.0"), ListArgs { global: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&npm("11.0.0"), ListArgs { global: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["list", "-g"]);
@@ -297,11 +278,9 @@ mod tests {
 
     #[test]
     fn test_yarn1_list_global_uses_npm() {
-        let CommandResolution::Run(command) =
-            resolve(&yarn("1.22.0"), ListArgs { global: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&yarn("1.22.0"), ListArgs { global: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["list", "-g"]);
@@ -316,11 +295,9 @@ mod tests {
 
     #[test]
     fn test_bun_list_global_uses_npm() {
-        let CommandResolution::Run(command) =
-            resolve(&bun("1.3.11"), ListArgs { global: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&bun("1.3.11"), ListArgs { global: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["list", "-g"]);
@@ -328,14 +305,13 @@ mod tests {
 
     #[test]
     fn test_global_list_with_depth() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.0.0"),
-            ListArgs { global: true, depth: Some(0), ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                ListArgs { global: true, depth: Some(0), ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["list", "--depth", "0", "-g"]);
@@ -343,14 +319,13 @@ mod tests {
 
     #[test]
     fn test_pnpm_list_with_filter() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.0.0"),
-            ListArgs { filter: vec!["app".to_string()], ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                ListArgs { filter: vec!["app".to_string()], ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["--filter", "app", "list"]);
@@ -358,14 +333,16 @@ mod tests {
 
     #[test]
     fn test_pnpm_list_with_multiple_filters() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.0.0"),
-            ListArgs { filter: vec!["app".to_string(), "web".to_string()], ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                ListArgs {
+                    filter: vec!["app".to_string(), "web".to_string()],
+                    ..Default::default()
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["--filter", "app", "--filter", "web", "list"]);
@@ -373,14 +350,13 @@ mod tests {
 
     #[test]
     fn test_npm_list_with_filter() {
-        let CommandResolution::Run(command) = resolve(
-            &npm("11.0.0"),
-            ListArgs { filter: vec!["app".to_string()], ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &npm("11.0.0"),
+                ListArgs { filter: vec!["app".to_string()], ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["list", "--workspace", "app"]);
@@ -392,9 +368,7 @@ mod tests {
             &yarn("1.22.0"),
             ListArgs { filter: vec!["app".to_string()], ..Default::default() },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["list"]);
@@ -403,11 +377,9 @@ mod tests {
 
     #[test]
     fn test_pnpm_list_prod() {
-        let CommandResolution::Run(command) =
-            resolve(&pnpm("10.0.0"), ListArgs { prod: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&pnpm("10.0.0"), ListArgs { prod: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["list", "--prod"]);
@@ -415,11 +387,9 @@ mod tests {
 
     #[test]
     fn test_npm_list_prod() {
-        let CommandResolution::Run(command) =
-            resolve(&npm("11.0.0"), ListArgs { prod: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&npm("11.0.0"), ListArgs { prod: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["list", "--include", "prod", "--include", "peer"]);
@@ -427,11 +397,9 @@ mod tests {
 
     #[test]
     fn test_yarn1_list_prod_ignored() {
-        let CommandResolution::Run(command) =
-            resolve(&yarn("1.22.0"), ListArgs { prod: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&yarn("1.22.0"), ListArgs { prod: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["list"]);
@@ -439,11 +407,9 @@ mod tests {
 
     #[test]
     fn test_pnpm_list_dev() {
-        let CommandResolution::Run(command) =
-            resolve(&pnpm("10.0.0"), ListArgs { dev: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&pnpm("10.0.0"), ListArgs { dev: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["list", "--dev"]);
@@ -451,11 +417,9 @@ mod tests {
 
     #[test]
     fn test_npm_list_dev() {
-        let CommandResolution::Run(command) =
-            resolve(&npm("11.0.0"), ListArgs { dev: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&npm("11.0.0"), ListArgs { dev: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["list", "--include", "dev"]);
@@ -463,11 +427,9 @@ mod tests {
 
     #[test]
     fn test_yarn1_list_dev_ignored() {
-        let CommandResolution::Run(command) =
-            resolve(&yarn("1.22.0"), ListArgs { dev: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&yarn("1.22.0"), ListArgs { dev: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["list"]);
@@ -475,11 +437,9 @@ mod tests {
 
     #[test]
     fn test_pnpm_list_no_optional() {
-        let CommandResolution::Run(command) =
-            resolve(&pnpm("10.0.0"), ListArgs { no_optional: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&pnpm("10.0.0"), ListArgs { no_optional: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["list", "--no-optional"]);
@@ -487,11 +447,9 @@ mod tests {
 
     #[test]
     fn test_npm_list_no_optional() {
-        let CommandResolution::Run(command) =
-            resolve(&npm("11.0.0"), ListArgs { no_optional: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&npm("11.0.0"), ListArgs { no_optional: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["list", "--omit", "optional"]);
@@ -499,11 +457,9 @@ mod tests {
 
     #[test]
     fn test_yarn1_list_no_optional_ignored() {
-        let CommandResolution::Run(command) =
-            resolve(&yarn("1.22.0"), ListArgs { no_optional: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&yarn("1.22.0"), ListArgs { no_optional: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["list"]);
@@ -511,12 +467,10 @@ mod tests {
 
     #[test]
     fn test_pnpm_list_only_projects() {
-        let CommandResolution::Run(command) =
+        let command = expect_run(
             resolve(&pnpm("10.0.0"), ListArgs { only_projects: true, ..Default::default() })
-                .outcome
-        else {
-            panic!("expected command resolution");
-        };
+                .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["list", "--only-projects"]);
@@ -526,9 +480,7 @@ mod tests {
     fn test_npm_list_only_projects_ignored() {
         let resolution =
             resolve(&npm("11.0.0"), ListArgs { only_projects: true, ..Default::default() });
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["list"]);
@@ -537,12 +489,10 @@ mod tests {
 
     #[test]
     fn test_yarn1_list_only_projects_ignored() {
-        let CommandResolution::Run(command) =
+        let command = expect_run(
             resolve(&yarn("1.22.0"), ListArgs { only_projects: true, ..Default::default() })
-                .outcome
-        else {
-            panic!("expected command resolution");
-        };
+                .outcome,
+        );
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["list"]);
@@ -550,12 +500,10 @@ mod tests {
 
     #[test]
     fn test_pnpm_list_exclude_peers() {
-        let CommandResolution::Run(command) =
+        let command = expect_run(
             resolve(&pnpm("10.0.0"), ListArgs { exclude_peers: true, ..Default::default() })
-                .outcome
-        else {
-            panic!("expected command resolution");
-        };
+                .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["list", "--exclude-peers"]);
@@ -563,11 +511,9 @@ mod tests {
 
     #[test]
     fn test_npm_list_exclude_peers() {
-        let CommandResolution::Run(command) =
-            resolve(&npm("11.0.0"), ListArgs { exclude_peers: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&npm("11.0.0"), ListArgs { exclude_peers: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["list", "--omit", "peer"]);
@@ -575,12 +521,10 @@ mod tests {
 
     #[test]
     fn test_yarn1_list_exclude_peers_ignored() {
-        let CommandResolution::Run(command) =
+        let command = expect_run(
             resolve(&yarn("1.22.0"), ListArgs { exclude_peers: true, ..Default::default() })
-                .outcome
-        else {
-            panic!("expected command resolution");
-        };
+                .outcome,
+        );
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["list"]);
@@ -588,14 +532,13 @@ mod tests {
 
     #[test]
     fn test_pnpm_list_find_by() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.0.0"),
-            ListArgs { find_by: Some("customFinder".to_string()), ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                ListArgs { find_by: Some("customFinder".to_string()), ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["list", "--find-by", "customFinder"]);
@@ -607,9 +550,7 @@ mod tests {
             &npm("11.0.0"),
             ListArgs { find_by: Some("customFinder".to_string()), ..Default::default() },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["list"]);
@@ -618,14 +559,13 @@ mod tests {
 
     #[test]
     fn test_yarn1_list_find_by_ignored() {
-        let CommandResolution::Run(command) = resolve(
-            &yarn("1.22.0"),
-            ListArgs { find_by: Some("customFinder".to_string()), ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &yarn("1.22.0"),
+                ListArgs { find_by: Some("customFinder".to_string()), ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["list"]);
@@ -633,10 +573,7 @@ mod tests {
 
     #[test]
     fn test_bun_list_basic() {
-        let CommandResolution::Run(command) = resolve(&bun("1.3.11"), ListArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&bun("1.3.11"), ListArgs::default()).outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["pm", "ls"]);
@@ -662,9 +599,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["pm", "ls"]);
@@ -675,21 +610,20 @@ mod tests {
 
     #[test]
     fn test_list_with_pattern_and_pass_through_args() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.0.0"),
-            ListArgs {
-                pattern: Some("react".to_string()),
-                pass_through_args: vec![
-                    "--registry".to_string(),
-                    "https://registry.npmjs.org".to_string(),
-                ],
-                ..Default::default()
-            },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                ListArgs {
+                    pattern: Some("react".to_string()),
+                    pass_through_args: vec![
+                        "--registry".to_string(),
+                        "https://registry.npmjs.org".to_string(),
+                    ],
+                    ..Default::default()
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["list", "react", "--registry", "https://registry.npmjs.org"]);
@@ -697,14 +631,13 @@ mod tests {
 
     #[test]
     fn test_list_with_long_parseable_and_json() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.0.0"),
-            ListArgs { json: true, long: true, parseable: true, ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                ListArgs { json: true, long: true, parseable: true, ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["list", "--json", "--long", "--parseable"]);

--- a/crates/vp_pm_cli/src/resolution/commands/login.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/login.rs
@@ -69,8 +69,8 @@ fn resolve_login(program: &str, base_args: &[&str], args: &LoginArgs) -> Command
 mod tests {
     use super::*;
     use crate::resolution::{
-        CommandResolution, resolve,
-        test_utils::{bun, npm, parse_args, pnpm, yarn},
+        resolve,
+        test_utils::{bun, expect_run, npm, parse_args, pnpm, yarn},
     };
 
     #[test]
@@ -94,9 +94,7 @@ mod tests {
     #[test]
     fn test_npm_login() {
         let resolution = resolve(&npm("11.0.0"), LoginArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["login"]);
@@ -105,9 +103,7 @@ mod tests {
     #[test]
     fn test_pnpm_login_uses_npm() {
         let resolution = resolve(&pnpm("10.0.0"), LoginArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["login"]);
@@ -116,9 +112,7 @@ mod tests {
     #[test]
     fn test_yarn1_login() {
         let resolution = resolve(&yarn("1.22.0"), LoginArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["login"]);
@@ -127,9 +121,7 @@ mod tests {
     #[test]
     fn test_yarn2_login() {
         let resolution = resolve(&yarn("4.0.0"), LoginArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["npm", "login"]);
@@ -138,9 +130,7 @@ mod tests {
     #[test]
     fn test_bun_login_uses_npm() {
         let resolution = resolve(&bun("1.3.11"), LoginArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["login"]);
@@ -155,9 +145,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["login", "--registry", "https://registry.example.com"]);
@@ -169,9 +157,7 @@ mod tests {
             &npm("11.0.0"),
             LoginArgs { scope: Some("@myorg".to_string()), ..Default::default() },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["login", "--scope", "@myorg"]);

--- a/crates/vp_pm_cli/src/resolution/commands/logout.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/logout.rs
@@ -69,8 +69,8 @@ fn resolve_logout(program: &str, base_args: &[&str], args: &LogoutArgs) -> Comma
 mod tests {
     use super::*;
     use crate::resolution::{
-        CommandResolution, resolve,
-        test_utils::{bun, npm, parse_args, pnpm, yarn},
+        resolve,
+        test_utils::{bun, expect_run, npm, parse_args, pnpm, yarn},
     };
 
     #[test]
@@ -94,9 +94,7 @@ mod tests {
     #[test]
     fn test_npm_logout() {
         let resolution = resolve(&npm("11.0.0"), LogoutArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["logout"]);
@@ -105,9 +103,7 @@ mod tests {
     #[test]
     fn test_pnpm_logout_uses_npm() {
         let resolution = resolve(&pnpm("10.0.0"), LogoutArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["logout"]);
@@ -116,9 +112,7 @@ mod tests {
     #[test]
     fn test_yarn1_logout() {
         let resolution = resolve(&yarn("1.22.0"), LogoutArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["logout"]);
@@ -127,9 +121,7 @@ mod tests {
     #[test]
     fn test_yarn2_logout() {
         let resolution = resolve(&yarn("4.0.0"), LogoutArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["npm", "logout"]);
@@ -138,9 +130,7 @@ mod tests {
     #[test]
     fn test_bun_logout_uses_npm() {
         let resolution = resolve(&bun("1.3.11"), LogoutArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["logout"]);
@@ -155,9 +145,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["logout", "--registry", "https://registry.example.com"]);
@@ -169,9 +157,7 @@ mod tests {
             &npm("11.0.0"),
             LogoutArgs { scope: Some("@myorg".to_string()), ..Default::default() },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["logout", "--scope", "@myorg"]);

--- a/crates/vp_pm_cli/src/resolution/commands/outdated.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/outdated.rs
@@ -233,7 +233,7 @@ mod tests {
     use super::*;
     use crate::resolution::{
         resolve,
-        test_utils::{bun, npm, parse_args, pnpm, yarn},
+        test_utils::{bun, expect_run, npm, parse_args, pnpm, yarn},
     };
 
     fn outdated_args(packages: &[&str]) -> OutdatedArgs {
@@ -273,11 +273,7 @@ mod tests {
 
     #[test]
     fn test_pnpm_outdated_basic() {
-        let CommandResolution::Run(command) =
-            resolve(&pnpm("10.0.0"), OutdatedArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&pnpm("10.0.0"), OutdatedArgs::default()).outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["outdated"]);
@@ -285,11 +281,8 @@ mod tests {
 
     #[test]
     fn test_pnpm_outdated_with_packages() {
-        let CommandResolution::Run(command) =
-            resolve(&pnpm("10.0.0"), outdated_args(&["*babel*", "eslint-*"])).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command =
+            expect_run(resolve(&pnpm("10.0.0"), outdated_args(&["*babel*", "eslint-*"])).outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["outdated", "*babel*", "eslint-*"]);
@@ -297,14 +290,13 @@ mod tests {
 
     #[test]
     fn test_pnpm_outdated_json() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.0.0"),
-            OutdatedArgs { format: Some(OutdatedFormat::Json), ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                OutdatedArgs { format: Some(OutdatedFormat::Json), ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["outdated", "--format", "json"]);
@@ -312,11 +304,7 @@ mod tests {
 
     #[test]
     fn test_npm_outdated_basic() {
-        let CommandResolution::Run(command) =
-            resolve(&npm("11.0.0"), OutdatedArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&npm("11.0.0"), OutdatedArgs::default()).outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["outdated"]);
@@ -324,14 +312,13 @@ mod tests {
 
     #[test]
     fn test_npm_outdated_json() {
-        let CommandResolution::Run(command) = resolve(
-            &npm("11.0.0"),
-            OutdatedArgs { format: Some(OutdatedFormat::Json), ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &npm("11.0.0"),
+                OutdatedArgs { format: Some(OutdatedFormat::Json), ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["outdated", "--json"]);
@@ -339,11 +326,7 @@ mod tests {
 
     #[test]
     fn test_yarn_outdated_basic() {
-        let CommandResolution::Run(command) =
-            resolve(&yarn("1.22.19"), OutdatedArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&yarn("1.22.19"), OutdatedArgs::default()).outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["outdated"]);
@@ -351,14 +334,17 @@ mod tests {
 
     #[test]
     fn test_pnpm_outdated_with_filter() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.0.0"),
-            OutdatedArgs { filter: vec!["app".to_string()], recursive: true, ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                OutdatedArgs {
+                    filter: vec!["app".to_string()],
+                    recursive: true,
+                    ..Default::default()
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["--filter", "app", "outdated", "--recursive"]);
@@ -366,11 +352,9 @@ mod tests {
 
     #[test]
     fn test_pnpm_outdated_prod_only() {
-        let CommandResolution::Run(command) =
-            resolve(&pnpm("10.0.0"), OutdatedArgs { prod: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&pnpm("10.0.0"), OutdatedArgs { prod: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["outdated", "--prod"]);
@@ -378,14 +362,13 @@ mod tests {
 
     #[test]
     fn test_npm_outdated_list_format() {
-        let CommandResolution::Run(command) = resolve(
-            &npm("11.0.0"),
-            OutdatedArgs { format: Some(OutdatedFormat::List), ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &npm("11.0.0"),
+                OutdatedArgs { format: Some(OutdatedFormat::List), ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["outdated", "--parseable"]);
@@ -393,11 +376,9 @@ mod tests {
 
     #[test]
     fn test_npm_outdated_recursive() {
-        let CommandResolution::Run(command) =
-            resolve(&npm("11.0.0"), OutdatedArgs { recursive: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&npm("11.0.0"), OutdatedArgs { recursive: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["outdated", "--all"]);
@@ -405,14 +386,13 @@ mod tests {
 
     #[test]
     fn test_npm_outdated_with_workspace() {
-        let CommandResolution::Run(command) = resolve(
-            &npm("11.0.0"),
-            OutdatedArgs { filter: vec!["app".to_string()], ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &npm("11.0.0"),
+                OutdatedArgs { filter: vec!["app".to_string()], ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["outdated", "--workspace", "app"]);
@@ -420,11 +400,9 @@ mod tests {
 
     #[test]
     fn test_global_outdated() {
-        let CommandResolution::Run(command) =
-            resolve(&pnpm("10.0.0"), OutdatedArgs { global: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&pnpm("10.0.0"), OutdatedArgs { global: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["outdated", "-g"]);
@@ -444,17 +422,13 @@ mod tests {
         };
 
         let yarn_resolution = resolve(&yarn("1.22.19"), args.clone());
-        let CommandResolution::Run(yarn_command) = yarn_resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let yarn_command = expect_run(yarn_resolution.outcome);
         assert_eq!(yarn_command.program, "npm");
         assert_eq!(yarn_command.args, vec!["outdated", "--parseable", "react", "-g"]);
         assert_eq!(yarn_resolution.diagnostics.len(), 4);
 
         let bun_resolution = resolve(&bun("1.3.11"), args);
-        let CommandResolution::Run(bun_command) = bun_resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let bun_command = expect_run(bun_resolution.outcome);
         assert_eq!(bun_command.program, "npm");
         assert_eq!(
             bun_command.args,
@@ -465,12 +439,10 @@ mod tests {
 
     #[test]
     fn test_pnpm_outdated_with_workspace_root() {
-        let CommandResolution::Run(command) =
+        let command = expect_run(
             resolve(&pnpm("10.0.0"), OutdatedArgs { workspace_root: true, ..Default::default() })
-                .outcome
-        else {
-            panic!("expected command resolution");
-        };
+                .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["outdated", "--workspace-root"]);
@@ -478,14 +450,13 @@ mod tests {
 
     #[test]
     fn test_pnpm_outdated_with_workspace_root_and_recursive() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.0.0"),
-            OutdatedArgs { workspace_root: true, recursive: true, ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                OutdatedArgs { workspace_root: true, recursive: true, ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["outdated", "--workspace-root", "--recursive"]);
@@ -493,25 +464,24 @@ mod tests {
 
     #[test]
     fn test_pnpm_outdated_with_all_flags() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.0.0"),
-            OutdatedArgs {
-                packages: vec!["react".to_string()],
-                long: true,
-                format: Some(OutdatedFormat::Json),
-                recursive: true,
-                filter: vec!["app".to_string()],
-                workspace_root: true,
-                prod: true,
-                compatible: true,
-                sort_by: Some("name".to_string()),
-                ..Default::default()
-            },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                OutdatedArgs {
+                    packages: vec!["react".to_string()],
+                    long: true,
+                    format: Some(OutdatedFormat::Json),
+                    recursive: true,
+                    filter: vec!["app".to_string()],
+                    workspace_root: true,
+                    prod: true,
+                    compatible: true,
+                    sort_by: Some("name".to_string()),
+                    ..Default::default()
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(
@@ -536,12 +506,10 @@ mod tests {
 
     #[test]
     fn test_npm_outdated_with_workspace_root() {
-        let CommandResolution::Run(command) =
+        let command = expect_run(
             resolve(&npm("11.0.0"), OutdatedArgs { workspace_root: true, ..Default::default() })
-                .outcome
-        else {
-            panic!("expected command resolution");
-        };
+                .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["outdated", "--include-workspace-root"]);
@@ -549,18 +517,17 @@ mod tests {
 
     #[test]
     fn test_npm_outdated_with_workspace_root_and_workspace() {
-        let CommandResolution::Run(command) = resolve(
-            &npm("11.0.0"),
-            OutdatedArgs {
-                filter: vec!["app".to_string()],
-                workspace_root: true,
-                ..Default::default()
-            },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &npm("11.0.0"),
+                OutdatedArgs {
+                    filter: vec!["app".to_string()],
+                    workspace_root: true,
+                    ..Default::default()
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(
@@ -575,9 +542,7 @@ mod tests {
             &yarn("1.22.19"),
             OutdatedArgs { format: Some(OutdatedFormat::List), ..Default::default() },
         );
-        let CommandResolution::Run(list_command) = list_resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let list_command = expect_run(list_resolution.outcome);
 
         assert_eq!(list_command.program, "yarn");
         assert_eq!(list_command.args, vec!["outdated"]);
@@ -587,9 +552,7 @@ mod tests {
             &yarn("1.22.19"),
             OutdatedArgs { format: Some(OutdatedFormat::Json), ..Default::default() },
         );
-        let CommandResolution::Run(json_command) = json_resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let json_command = expect_run(json_resolution.outcome);
         assert_eq!(json_command.args, vec!["outdated", "--json"]);
         assert!(json_resolution.diagnostics.is_empty());
     }
@@ -600,9 +563,7 @@ mod tests {
             &yarn("4.0.0"),
             OutdatedArgs { format: Some(OutdatedFormat::Json), ..Default::default() },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["upgrade-interactive"]);
@@ -627,9 +588,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(
@@ -668,9 +627,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        let CommandResolution::Run(yarn_command) = yarn_resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let yarn_command = expect_run(yarn_resolution.outcome);
         assert_eq!(yarn_command.args, vec!["outdated"]);
         assert_eq!(yarn_resolution.diagnostics.len(), 9);
 
@@ -685,9 +642,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        let CommandResolution::Run(bun_command) = bun_resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let bun_command = expect_run(bun_resolution.outcome);
         assert_eq!(bun_command.args, vec!["outdated"]);
         assert_eq!(bun_resolution.diagnostics.len(), 5);
     }

--- a/crates/vp_pm_cli/src/resolution/commands/owner.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/owner.rs
@@ -94,7 +94,7 @@ mod tests {
     use super::*;
     use crate::resolution::{
         Resolution, resolve,
-        test_utils::{bun, npm, parse_subcommand, pnpm, yarn},
+        test_utils::{bun, expect_run, npm, parse_subcommand, pnpm, yarn},
     };
 
     #[test]
@@ -113,12 +113,13 @@ mod tests {
 
     #[test]
     fn test_pnpm_owner_list_uses_npm() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } = resolve(
-            &pnpm("10.0.0"),
-            OwnerCommand::List { package: "my-package".to_string(), otp: None },
-        ) else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                OwnerCommand::List { package: "my-package".to_string(), otp: None },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["owner", "list", "my-package"]);
@@ -126,16 +127,17 @@ mod tests {
 
     #[test]
     fn test_npm_owner_add() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } = resolve(
-            &npm("11.0.0"),
-            OwnerCommand::Add {
-                user: "username".to_string(),
-                package: "my-package".to_string(),
-                otp: None,
-            },
-        ) else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &npm("11.0.0"),
+                OwnerCommand::Add {
+                    user: "username".to_string(),
+                    package: "my-package".to_string(),
+                    otp: None,
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["owner", "add", "username", "my-package"]);
@@ -143,16 +145,17 @@ mod tests {
 
     #[test]
     fn test_yarn_owner_rm_uses_npm() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } = resolve(
-            &yarn("4.0.0"),
-            OwnerCommand::Rm {
-                user: "username".to_string(),
-                package: "my-package".to_string(),
-                otp: None,
-            },
-        ) else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &yarn("4.0.0"),
+                OwnerCommand::Rm {
+                    user: "username".to_string(),
+                    package: "my-package".to_string(),
+                    otp: None,
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["owner", "rm", "username", "my-package"]);
@@ -160,12 +163,13 @@ mod tests {
 
     #[test]
     fn test_yarn_classic_owner_uses_npm() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } = resolve(
-            &yarn("1.22.0"),
-            OwnerCommand::List { package: "my-package".to_string(), otp: None },
-        ) else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &yarn("1.22.0"),
+                OwnerCommand::List { package: "my-package".to_string(), otp: None },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["owner", "list", "my-package"]);
@@ -173,12 +177,11 @@ mod tests {
 
     #[test]
     fn test_bun_owner_uses_npm() {
-        let Resolution { outcome: CommandResolution::Run(command), diagnostics } = resolve(
+        let Resolution { outcome, diagnostics } = resolve(
             &bun("1.3.11"),
             OwnerCommand::List { package: "my-package".to_string(), otp: None },
-        ) else {
-            panic!("expected command resolution");
-        };
+        );
+        let command = expect_run(outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["owner", "list", "my-package"]);
@@ -187,16 +190,17 @@ mod tests {
 
     #[test]
     fn test_owner_with_otp() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } = resolve(
-            &pnpm("10.0.0"),
-            OwnerCommand::Add {
-                user: "username".to_string(),
-                package: "my-package".to_string(),
-                otp: Some("123456".to_string()),
-            },
-        ) else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                OwnerCommand::Add {
+                    user: "username".to_string(),
+                    package: "my-package".to_string(),
+                    otp: Some("123456".to_string()),
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["owner", "add", "username", "my-package", "--otp", "123456"]);

--- a/crates/vp_pm_cli/src/resolution/commands/pack.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/pack.rs
@@ -115,15 +115,12 @@ mod tests {
         DiagnosticKind,
         command::PreRunAction,
         resolve,
-        test_utils::{bun, npm, parse_args, pnpm, yarn},
+        test_utils::{bun, expect_run, npm, parse_args, pnpm, yarn},
     };
 
     #[test]
     fn test_pnpm_pack_basic() {
-        let CommandResolution::Run(command) = resolve(&pnpm("10.0.0"), PackArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&pnpm("10.0.0"), PackArgs::default()).outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["pack"]);
@@ -131,39 +128,35 @@ mod tests {
 
     #[test]
     fn test_pnpm_pack_recursive() {
-        let CommandResolution::Run(command) =
-            resolve(&pnpm("10.0.0"), PackArgs { recursive: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&pnpm("10.0.0"), PackArgs { recursive: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.args, vec!["pack", "--recursive"]);
     }
 
     #[test]
     fn test_pnpm_pack_with_out() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.0.0"),
-            PackArgs { out: Some("./dist/package.tgz".to_string()), ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                PackArgs { out: Some("./dist/package.tgz".to_string()), ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.args, vec!["pack", "--out", "./dist/package.tgz"]);
     }
 
     #[test]
     fn test_pnpm_pack_with_destination() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.0.0"),
-            PackArgs { pack_destination: Some("./dist".to_string()), ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                PackArgs { pack_destination: Some("./dist".to_string()), ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.args, vec!["pack", "--pack-destination", "./dist"]);
     }
@@ -174,70 +167,62 @@ mod tests {
             &pnpm("10.0.0"),
             PackArgs { pack_destination: Some("./dist".to_string()), ..Default::default() },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert!(command.pre_run.is_empty());
     }
 
     #[test]
     fn test_pnpm_pack_with_gzip_level() {
-        let CommandResolution::Run(command) =
+        let command = expect_run(
             resolve(&pnpm("10.0.0"), PackArgs { pack_gzip_level: Some(9), ..Default::default() })
-                .outcome
-        else {
-            panic!("expected command resolution");
-        };
+                .outcome,
+        );
 
         assert_eq!(command.args, vec!["pack", "--pack-gzip-level", "9"]);
     }
 
     #[test]
     fn test_pnpm_pack_json() {
-        let CommandResolution::Run(command) =
-            resolve(&pnpm("10.0.0"), PackArgs { json: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&pnpm("10.0.0"), PackArgs { json: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.args, vec!["pack", "--json"]);
     }
 
     #[test]
     fn test_pnpm_pack_with_filter() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.0.0"),
-            PackArgs { filter: vec!["app".to_string()], ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                PackArgs { filter: vec!["app".to_string()], ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.args, vec!["--filter", "app", "pack"]);
     }
 
     #[test]
     fn test_pnpm_pack_with_multiple_filters() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.0.0"),
-            PackArgs { filter: vec!["app".to_string(), "web".to_string()], ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                PackArgs {
+                    filter: vec!["app".to_string(), "web".to_string()],
+                    ..Default::default()
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.args, vec!["--filter", "app", "--filter", "web", "pack"]);
     }
 
     #[test]
     fn test_npm_pack_basic() {
-        let CommandResolution::Run(command) = resolve(&npm("11.0.0"), PackArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&npm("11.0.0"), PackArgs::default()).outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["pack"]);
@@ -245,25 +230,22 @@ mod tests {
 
     #[test]
     fn test_npm_pack_recursive() {
-        let CommandResolution::Run(command) =
-            resolve(&npm("11.0.0"), PackArgs { recursive: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&npm("11.0.0"), PackArgs { recursive: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.args, vec!["pack", "--workspaces"]);
     }
 
     #[test]
     fn test_npm_pack_with_destination() {
-        let CommandResolution::Run(command) = resolve(
-            &npm("11.0.0"),
-            PackArgs { pack_destination: Some("./dist".to_string()), ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &npm("11.0.0"),
+                PackArgs { pack_destination: Some("./dist".to_string()), ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.args, vec!["pack", "--pack-destination", "./dist"]);
     }
@@ -274,48 +256,45 @@ mod tests {
             &npm("11.0.0"),
             PackArgs { pack_destination: Some("./dist".to_string()), ..Default::default() },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.pre_run, vec![PreRunAction::CreateDir { path: "./dist".to_string() }]);
     }
 
     #[test]
     fn test_npm_pack_json() {
-        let CommandResolution::Run(command) =
-            resolve(&npm("11.0.0"), PackArgs { json: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&npm("11.0.0"), PackArgs { json: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.args, vec!["pack", "--json"]);
     }
 
     #[test]
     fn test_npm_pack_with_filter() {
-        let CommandResolution::Run(command) = resolve(
-            &npm("11.0.0"),
-            PackArgs { filter: vec!["app".to_string()], ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &npm("11.0.0"),
+                PackArgs { filter: vec!["app".to_string()], ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.args, vec!["pack", "--workspace", "app"]);
     }
 
     #[test]
     fn test_npm_pack_with_multiple_filters() {
-        let CommandResolution::Run(command) = resolve(
-            &npm("11.0.0"),
-            PackArgs { filter: vec!["app".to_string(), "web".to_string()], ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &npm("11.0.0"),
+                PackArgs {
+                    filter: vec!["app".to_string(), "web".to_string()],
+                    ..Default::default()
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.args, vec!["pack", "--workspace", "app", "--workspace", "web"]);
     }
@@ -330,9 +309,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.args, vec!["pack"]);
         assert_eq!(resolution.diagnostics.len(), 2);
@@ -344,10 +321,7 @@ mod tests {
 
     #[test]
     fn test_yarn1_pack_basic() {
-        let CommandResolution::Run(command) = resolve(&yarn("1.22.0"), PackArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&yarn("1.22.0"), PackArgs::default()).outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["pack"]);
@@ -357,9 +331,7 @@ mod tests {
     fn test_yarn1_pack_recursive_ignored() {
         let resolution =
             resolve(&yarn("1.22.0"), PackArgs { recursive: true, ..Default::default() });
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.args, vec!["pack"]);
         assert_eq!(resolution.diagnostics.len(), 1);
@@ -367,25 +339,22 @@ mod tests {
 
     #[test]
     fn test_yarn1_pack_with_out() {
-        let CommandResolution::Run(command) = resolve(
-            &yarn("1.22.0"),
-            PackArgs { out: Some("./dist/package.tgz".to_string()), ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &yarn("1.22.0"),
+                PackArgs { out: Some("./dist/package.tgz".to_string()), ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.args, vec!["pack", "--filename", "./dist/package.tgz"]);
     }
 
     #[test]
     fn test_yarn1_pack_json() {
-        let CommandResolution::Run(command) =
-            resolve(&yarn("1.22.0"), PackArgs { json: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&yarn("1.22.0"), PackArgs { json: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.args, vec!["pack", "--json"]);
     }
@@ -396,9 +365,7 @@ mod tests {
             &yarn("1.22.0"),
             PackArgs { filter: vec!["app".to_string()], ..Default::default() },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.args, vec!["pack"]);
         assert_eq!(resolution.diagnostics.len(), 1);
@@ -406,10 +373,7 @@ mod tests {
 
     #[test]
     fn test_yarn2_pack_basic() {
-        let CommandResolution::Run(command) = resolve(&yarn("4.0.0"), PackArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&yarn("4.0.0"), PackArgs::default()).outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["pack"]);
@@ -417,50 +381,44 @@ mod tests {
 
     #[test]
     fn test_yarn2_pack_recursive() {
-        let CommandResolution::Run(command) =
-            resolve(&yarn("4.0.0"), PackArgs { recursive: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&yarn("4.0.0"), PackArgs { recursive: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.args, vec!["workspaces", "foreach", "--all", "pack"]);
     }
 
     #[test]
     fn test_yarn2_pack_with_out() {
-        let CommandResolution::Run(command) = resolve(
-            &yarn("4.0.0"),
-            PackArgs { out: Some("./dist/package.tgz".to_string()), ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &yarn("4.0.0"),
+                PackArgs { out: Some("./dist/package.tgz".to_string()), ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.args, vec!["pack", "--out", "./dist/package.tgz"]);
     }
 
     #[test]
     fn test_yarn2_pack_json() {
-        let CommandResolution::Run(command) =
-            resolve(&yarn("4.0.0"), PackArgs { json: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&yarn("4.0.0"), PackArgs { json: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.args, vec!["pack", "--json"]);
     }
 
     #[test]
     fn test_yarn2_pack_with_filter() {
-        let CommandResolution::Run(command) = resolve(
-            &yarn("4.0.0"),
-            PackArgs { filter: vec!["app".to_string()], ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &yarn("4.0.0"),
+                PackArgs { filter: vec!["app".to_string()], ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(
             command.args,
@@ -470,14 +428,16 @@ mod tests {
 
     #[test]
     fn test_yarn2_pack_with_multiple_filters() {
-        let CommandResolution::Run(command) = resolve(
-            &yarn("4.0.0"),
-            PackArgs { filter: vec!["app".to_string(), "web".to_string()], ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &yarn("4.0.0"),
+                PackArgs {
+                    filter: vec!["app".to_string(), "web".to_string()],
+                    ..Default::default()
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(
             command.args,
@@ -487,14 +447,13 @@ mod tests {
 
     #[test]
     fn test_yarn2_pack_with_filter_and_recursive() {
-        let CommandResolution::Run(command) = resolve(
-            &yarn("4.0.0"),
-            PackArgs { recursive: true, filter: vec!["app".to_string()], ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &yarn("4.0.0"),
+                PackArgs { recursive: true, filter: vec!["app".to_string()], ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(
             command.args,
@@ -512,9 +471,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.args, vec!["pack"]);
         assert_eq!(resolution.diagnostics.len(), 2);
@@ -526,10 +483,7 @@ mod tests {
 
     #[test]
     fn test_bun_pack_basic() {
-        let CommandResolution::Run(command) = resolve(&bun("1.3.11"), PackArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&bun("1.3.11"), PackArgs::default()).outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["pm", "pack"]);
@@ -537,40 +491,36 @@ mod tests {
 
     #[test]
     fn test_bun_pack_with_out_maps_to_filename() {
-        let CommandResolution::Run(command) = resolve(
-            &bun("1.3.11"),
-            PackArgs { out: Some("./dist/package.tgz".to_string()), ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &bun("1.3.11"),
+                PackArgs { out: Some("./dist/package.tgz".to_string()), ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.args, vec!["pm", "pack", "--filename", "./dist/package.tgz"]);
     }
 
     #[test]
     fn test_bun_pack_with_destination() {
-        let CommandResolution::Run(command) = resolve(
-            &bun("1.3.11"),
-            PackArgs { pack_destination: Some("./dist".to_string()), ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &bun("1.3.11"),
+                PackArgs { pack_destination: Some("./dist".to_string()), ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.args, vec!["pm", "pack", "--destination", "./dist"]);
     }
 
     #[test]
     fn test_bun_pack_with_gzip_level() {
-        let CommandResolution::Run(command) =
+        let command = expect_run(
             resolve(&bun("1.3.11"), PackArgs { pack_gzip_level: Some(5), ..Default::default() })
-                .outcome
-        else {
-            panic!("expected command resolution");
-        };
+                .outcome,
+        );
 
         assert_eq!(command.args, vec!["pm", "pack", "--gzip-level", "5"]);
     }
@@ -586,9 +536,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.args, vec!["pm", "pack"]);
         assert_eq!(resolution.diagnostics.len(), 3);
@@ -602,17 +550,16 @@ mod tests {
 
     #[test]
     fn test_pack_with_pass_through_args() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.0.0"),
-            PackArgs {
-                pass_through_args: vec!["--report-summary".to_string()],
-                ..Default::default()
-            },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                PackArgs {
+                    pass_through_args: vec!["--report-summary".to_string()],
+                    ..Default::default()
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.args, vec!["pack", "--report-summary"]);
     }

--- a/crates/vp_pm_cli/src/resolution/commands/patch.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/patch.rs
@@ -58,7 +58,7 @@ mod tests {
     use super::*;
     use crate::resolution::{
         resolve,
-        test_utils::{bun, npm, parse_args, pnpm, yarn},
+        test_utils::{bun, expect_run, npm, parse_args, pnpm, yarn},
     };
 
     fn patch_args(package: &str) -> PatchArgs {
@@ -67,11 +67,7 @@ mod tests {
 
     #[test]
     fn test_pnpm_patch() {
-        let CommandResolution::Run(command) =
-            resolve(&pnpm("10.0.0"), patch_args("left-pad")).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&pnpm("10.0.0"), patch_args("left-pad")).outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["patch", "left-pad"]);
@@ -79,11 +75,7 @@ mod tests {
 
     #[test]
     fn test_yarn_berry_patch() {
-        let CommandResolution::Run(command) =
-            resolve(&yarn("4.0.0"), patch_args("left-pad")).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&yarn("4.0.0"), patch_args("left-pad")).outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["patch", "left-pad"]);
@@ -91,11 +83,7 @@ mod tests {
 
     #[test]
     fn test_bun_patch() {
-        let CommandResolution::Run(command) =
-            resolve(&bun("1.3.11"), patch_args("left-pad")).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&bun("1.3.11"), patch_args("left-pad")).outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["patch", "left-pad"]);
@@ -123,17 +111,16 @@ mod tests {
 
     #[test]
     fn test_patch_with_pass_through_args() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.0.0"),
-            PatchArgs {
-                package: "left-pad".to_string(),
-                pass_through_args: vec!["--edit-dir".to_string(), ".patches".to_string()],
-            },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                PatchArgs {
+                    package: "left-pad".to_string(),
+                    pass_through_args: vec!["--edit-dir".to_string(), ".patches".to_string()],
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.args, vec!["patch", "left-pad", "--edit-dir", ".patches"]);
     }

--- a/crates/vp_pm_cli/src/resolution/commands/patch_commit.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/patch_commit.rs
@@ -65,7 +65,7 @@ mod tests {
     use super::*;
     use crate::resolution::{
         resolve,
-        test_utils::{bun, npm, parse_args, pnpm, yarn},
+        test_utils::{bun, expect_run, npm, parse_args, pnpm, yarn},
     };
 
     fn patch_commit_args(patch_dir: &str) -> PatchCommitArgs {
@@ -74,11 +74,8 @@ mod tests {
 
     #[test]
     fn test_pnpm_patch_commit() {
-        let CommandResolution::Run(command) =
-            resolve(&pnpm("10.0.0"), patch_commit_args("patches/left-pad")).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command =
+            expect_run(resolve(&pnpm("10.0.0"), patch_commit_args("patches/left-pad")).outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["patch-commit", "patches/left-pad"]);
@@ -86,11 +83,8 @@ mod tests {
 
     #[test]
     fn test_yarn_berry_patch_commit() {
-        let CommandResolution::Run(command) =
-            resolve(&yarn("4.0.0"), patch_commit_args("patches/left-pad")).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command =
+            expect_run(resolve(&yarn("4.0.0"), patch_commit_args("patches/left-pad")).outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["patch-commit", "--save", "patches/left-pad"]);
@@ -98,11 +92,8 @@ mod tests {
 
     #[test]
     fn test_bun_patch_commit_uses_flag() {
-        let CommandResolution::Run(command) =
-            resolve(&bun("1.3.11"), patch_commit_args("patches/left-pad")).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command =
+            expect_run(resolve(&bun("1.3.11"), patch_commit_args("patches/left-pad")).outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["patch", "--commit", "patches/left-pad"]);
@@ -133,17 +124,16 @@ mod tests {
 
     #[test]
     fn test_patch_commit_with_pass_through_args() {
-        let CommandResolution::Run(command) = resolve(
-            &bun("1.3.11"),
-            PatchCommitArgs {
-                patch_dir: "patches/left-pad".to_string(),
-                pass_through_args: vec!["--patches-dir".to_string(), ".patches".to_string()],
-            },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &bun("1.3.11"),
+                PatchCommitArgs {
+                    patch_dir: "patches/left-pad".to_string(),
+                    pass_through_args: vec!["--patches-dir".to_string(), ".patches".to_string()],
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(
             command.args,

--- a/crates/vp_pm_cli/src/resolution/commands/ping.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/ping.rs
@@ -54,8 +54,8 @@ impl Resolve<PingArgs> for Npm {
 mod tests {
     use super::*;
     use crate::resolution::{
-        CommandResolution, resolve,
-        test_utils::{bun, npm, parse_args, pnpm, yarn},
+        resolve,
+        test_utils::{bun, expect_run, npm, parse_args, pnpm, yarn},
     };
 
     #[test]
@@ -71,9 +71,7 @@ mod tests {
     #[test]
     fn test_ping_basic() {
         let resolution = resolve(&pnpm("10.0.0"), PingArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["ping"]);
@@ -88,9 +86,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["ping", "--registry", "https://registry.npmjs.org"]);
@@ -99,9 +95,7 @@ mod tests {
     #[test]
     fn test_bun_ping_uses_npm_without_warning() {
         let resolution = resolve(&bun("1.3.11"), PingArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["ping"]);
@@ -111,9 +105,7 @@ mod tests {
     #[test]
     fn test_yarn_ping_uses_npm() {
         let resolution = resolve(&yarn("4.0.0"), PingArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["ping"]);
@@ -122,9 +114,7 @@ mod tests {
     #[test]
     fn test_yarn_classic_ping_uses_npm() {
         let resolution = resolve(&yarn("1.22.0"), PingArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["ping"]);

--- a/crates/vp_pm_cli/src/resolution/commands/prune.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/prune.rs
@@ -71,16 +71,12 @@ mod tests {
     use super::*;
     use crate::resolution::{
         resolve,
-        test_utils::{bun, npm, parse_args, pnpm, yarn},
+        test_utils::{bun, expect_run, npm, parse_args, pnpm, yarn},
     };
 
     #[test]
     fn test_pnpm_prune() {
-        let CommandResolution::Run(command) =
-            resolve(&pnpm("10.0.0"), PruneArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&pnpm("10.0.0"), PruneArgs::default()).outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["prune"]);
@@ -88,11 +84,9 @@ mod tests {
 
     #[test]
     fn test_pnpm_prune_prod() {
-        let CommandResolution::Run(command) =
-            resolve(&pnpm("10.0.0"), PruneArgs { prod: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&pnpm("10.0.0"), PruneArgs { prod: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["prune", "--prod"]);
@@ -100,10 +94,7 @@ mod tests {
 
     #[test]
     fn test_npm_prune() {
-        let CommandResolution::Run(command) = resolve(&npm("11.0.0"), PruneArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&npm("11.0.0"), PruneArgs::default()).outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["prune"]);
@@ -111,11 +102,9 @@ mod tests {
 
     #[test]
     fn test_npm_prune_prod() {
-        let CommandResolution::Run(command) =
-            resolve(&npm("11.0.0"), PruneArgs { prod: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&npm("11.0.0"), PruneArgs { prod: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["prune", "--omit=dev"]);
@@ -123,11 +112,9 @@ mod tests {
 
     #[test]
     fn test_npm_prune_no_optional() {
-        let CommandResolution::Run(command) =
-            resolve(&npm("11.0.0"), PruneArgs { no_optional: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&npm("11.0.0"), PruneArgs { no_optional: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["prune", "--omit=optional"]);
@@ -135,14 +122,13 @@ mod tests {
 
     #[test]
     fn test_npm_prune_both_flags() {
-        let CommandResolution::Run(command) = resolve(
-            &npm("11.0.0"),
-            PruneArgs { prod: true, no_optional: true, ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &npm("11.0.0"),
+                PruneArgs { prod: true, no_optional: true, ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["prune", "--omit=dev", "--omit=optional"]);
@@ -150,18 +136,17 @@ mod tests {
 
     #[test]
     fn test_npm_prune_with_pass_through_args() {
-        let CommandResolution::Run(command) = resolve(
-            &npm("11.0.0"),
-            PruneArgs {
-                prod: true,
-                pass_through_args: vec!["--registry".to_string(), "x".to_string()],
-                ..Default::default()
-            },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &npm("11.0.0"),
+                PruneArgs {
+                    prod: true,
+                    pass_through_args: vec!["--registry".to_string(), "x".to_string()],
+                    ..Default::default()
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["prune", "--omit=dev", "--registry", "x"]);
@@ -204,17 +189,16 @@ mod tests {
 
     #[test]
     fn test_prune_with_pass_through_args() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.0.0"),
-            PruneArgs {
-                pass_through_args: vec!["--workspace-root".to_string()],
-                ..Default::default()
-            },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                PruneArgs {
+                    pass_through_args: vec!["--workspace-root".to_string()],
+                    ..Default::default()
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["prune", "--workspace-root"]);

--- a/crates/vp_pm_cli/src/resolution/commands/publish.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/publish.rs
@@ -135,7 +135,7 @@ mod tests {
     use super::*;
     use crate::resolution::{
         resolve,
-        test_utils::{bun, npm, parse_args, pnpm, yarn},
+        test_utils::{bun, expect_run, npm, parse_args, pnpm, yarn},
     };
 
     #[test]
@@ -160,11 +160,7 @@ mod tests {
 
     #[test]
     fn test_pnpm_publish() {
-        let CommandResolution::Run(command) =
-            resolve(&pnpm("10.0.0"), PublishArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&pnpm("10.0.0"), PublishArgs::default()).outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["publish"]);
@@ -172,11 +168,7 @@ mod tests {
 
     #[test]
     fn test_npm_publish() {
-        let CommandResolution::Run(command) =
-            resolve(&npm("11.0.0"), PublishArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&npm("11.0.0"), PublishArgs::default()).outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["publish"]);
@@ -184,11 +176,7 @@ mod tests {
 
     #[test]
     fn test_yarn1_publish_uses_npm() {
-        let CommandResolution::Run(command) =
-            resolve(&yarn("1.22.0"), PublishArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&yarn("1.22.0"), PublishArgs::default()).outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["publish"]);
@@ -196,11 +184,7 @@ mod tests {
 
     #[test]
     fn test_yarn2_publish_uses_npm() {
-        let CommandResolution::Run(command) =
-            resolve(&yarn("4.0.0"), PublishArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&yarn("4.0.0"), PublishArgs::default()).outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["publish"]);
@@ -208,14 +192,13 @@ mod tests {
 
     #[test]
     fn test_yarn_publish_with_tag() {
-        let CommandResolution::Run(command) = resolve(
-            &yarn("4.0.0"),
-            PublishArgs { tag: Some("beta".to_string()), ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &yarn("4.0.0"),
+                PublishArgs { tag: Some("beta".to_string()), ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["publish", "--tag", "beta"]);
@@ -223,11 +206,9 @@ mod tests {
 
     #[test]
     fn test_pnpm_publish_recursive() {
-        let CommandResolution::Run(command) =
-            resolve(&pnpm("10.0.0"), PublishArgs { recursive: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&pnpm("10.0.0"), PublishArgs { recursive: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["publish", "--recursive"]);
@@ -235,11 +216,9 @@ mod tests {
 
     #[test]
     fn test_npm_publish_recursive() {
-        let CommandResolution::Run(command) =
-            resolve(&npm("11.0.0"), PublishArgs { recursive: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&npm("11.0.0"), PublishArgs { recursive: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["publish", "--workspaces"]);
@@ -247,14 +226,13 @@ mod tests {
 
     #[test]
     fn test_pnpm_publish_with_filter() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.0.0"),
-            PublishArgs { filter: Some(vec!["app".to_string()]), ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                PublishArgs { filter: Some(vec!["app".to_string()]), ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["--filter", "app", "publish"]);
@@ -262,14 +240,13 @@ mod tests {
 
     #[test]
     fn test_npm_publish_with_filter() {
-        let CommandResolution::Run(command) = resolve(
-            &npm("11.0.0"),
-            PublishArgs { filter: Some(vec!["app".to_string()]), ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &npm("11.0.0"),
+                PublishArgs { filter: Some(vec!["app".to_string()]), ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["publish", "--workspace", "app"]);
@@ -277,14 +254,13 @@ mod tests {
 
     #[test]
     fn test_yarn_publish_with_filter() {
-        let CommandResolution::Run(command) = resolve(
-            &yarn("1.22.0"),
-            PublishArgs { filter: Some(vec!["app".to_string()]), ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &yarn("1.22.0"),
+                PublishArgs { filter: Some(vec!["app".to_string()]), ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["publish", "--workspace", "app"]);
@@ -292,11 +268,9 @@ mod tests {
 
     #[test]
     fn test_pnpm_publish_json() {
-        let CommandResolution::Run(command) =
-            resolve(&pnpm("10.0.0"), PublishArgs { json: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&pnpm("10.0.0"), PublishArgs { json: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["publish", "--json"]);
@@ -305,9 +279,7 @@ mod tests {
     #[test]
     fn test_npm_publish_json_ignored() {
         let resolution = resolve(&npm("11.0.0"), PublishArgs { json: true, ..Default::default() });
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["publish"]);
@@ -317,9 +289,7 @@ mod tests {
     #[test]
     fn test_yarn_publish_json_is_checked_against_current_dialect() {
         let resolution = resolve(&yarn("4.0.0"), PublishArgs { json: true, ..Default::default() });
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["publish"]);
@@ -328,14 +298,13 @@ mod tests {
 
     #[test]
     fn test_pnpm_publish_branch() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.0.0"),
-            PublishArgs { publish_branch: Some("main".to_string()), ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                PublishArgs { publish_branch: Some("main".to_string()), ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["publish", "--publish-branch", "main"]);
@@ -347,9 +316,7 @@ mod tests {
             &npm("11.0.0"),
             PublishArgs { publish_branch: Some("main".to_string()), ..Default::default() },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["publish"]);
@@ -358,12 +325,10 @@ mod tests {
 
     #[test]
     fn test_pnpm_publish_report_summary() {
-        let CommandResolution::Run(command) =
+        let command = expect_run(
             resolve(&pnpm("10.0.0"), PublishArgs { report_summary: true, ..Default::default() })
-                .outcome
-        else {
-            panic!("expected command resolution");
-        };
+                .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["publish", "--report-summary"]);
@@ -373,9 +338,7 @@ mod tests {
     fn test_npm_publish_report_summary_ignored() {
         let resolution =
             resolve(&npm("11.0.0"), PublishArgs { report_summary: true, ..Default::default() });
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["publish"]);
@@ -384,12 +347,10 @@ mod tests {
 
     #[test]
     fn test_pnpm_publish_provenance() {
-        let CommandResolution::Run(command) =
+        let command = expect_run(
             resolve(&pnpm("10.0.0"), PublishArgs { provenance: true, ..Default::default() })
-                .outcome
-        else {
-            panic!("expected command resolution");
-        };
+                .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["publish", "--provenance"]);
@@ -397,11 +358,9 @@ mod tests {
 
     #[test]
     fn test_npm_publish_provenance() {
-        let CommandResolution::Run(command) =
-            resolve(&npm("11.0.0"), PublishArgs { provenance: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&npm("11.0.0"), PublishArgs { provenance: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["publish", "--provenance"]);
@@ -409,11 +368,9 @@ mod tests {
 
     #[test]
     fn test_yarn_publish_provenance() {
-        let CommandResolution::Run(command) =
-            resolve(&yarn("4.0.0"), PublishArgs { provenance: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&yarn("4.0.0"), PublishArgs { provenance: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["publish", "--provenance"]);
@@ -423,9 +380,7 @@ mod tests {
     fn test_bun_publish_provenance_ignored() {
         let resolution =
             resolve(&bun("1.2.0"), PublishArgs { provenance: true, ..Default::default() });
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["publish"]);
@@ -434,14 +389,13 @@ mod tests {
 
     #[test]
     fn test_pnpm_publish_otp() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.0.0"),
-            PublishArgs { otp: Some("123456".to_string()), ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                PublishArgs { otp: Some("123456".to_string()), ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["publish", "--otp", "123456"]);
@@ -449,14 +403,13 @@ mod tests {
 
     #[test]
     fn test_npm_publish_otp() {
-        let CommandResolution::Run(command) = resolve(
-            &npm("11.0.0"),
-            PublishArgs { otp: Some("654321".to_string()), ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &npm("11.0.0"),
+                PublishArgs { otp: Some("654321".to_string()), ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["publish", "--otp", "654321"]);
@@ -464,14 +417,13 @@ mod tests {
 
     #[test]
     fn test_yarn_publish_otp() {
-        let CommandResolution::Run(command) = resolve(
-            &yarn("1.22.0"),
-            PublishArgs { otp: Some("999999".to_string()), ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &yarn("1.22.0"),
+                PublishArgs { otp: Some("999999".to_string()), ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["publish", "--otp", "999999"]);
@@ -479,25 +431,24 @@ mod tests {
 
     #[test]
     fn test_publish_common_options() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.0.0"),
-            PublishArgs {
-                target: Some("pkg.tgz".to_string()),
-                dry_run: true,
-                tag: Some("next".to_string()),
-                access: Some("public".to_string()),
-                force: true,
-                pass_through_args: vec![
-                    "--registry".to_string(),
-                    "https://registry.npmjs.org".to_string(),
-                ],
-                ..Default::default()
-            },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                PublishArgs {
+                    target: Some("pkg.tgz".to_string()),
+                    dry_run: true,
+                    tag: Some("next".to_string()),
+                    access: Some("public".to_string()),
+                    force: true,
+                    pass_through_args: vec![
+                        "--registry".to_string(),
+                        "https://registry.npmjs.org".to_string(),
+                    ],
+                    ..Default::default()
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(
@@ -521,9 +472,7 @@ mod tests {
     fn test_npm_silently_ignores_no_git_checks() {
         let resolution =
             resolve(&npm("11.0.0"), PublishArgs { no_git_checks: true, ..Default::default() });
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["publish"]);
@@ -546,9 +495,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["publish"]);

--- a/crates/vp_pm_cli/src/resolution/commands/rebuild.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/rebuild.rs
@@ -60,7 +60,7 @@ mod tests {
     use super::*;
     use crate::resolution::{
         resolve,
-        test_utils::{bun, npm, parse_args, pnpm, yarn},
+        test_utils::{bun, expect_run, npm, parse_args, pnpm, yarn},
     };
 
     #[test]
@@ -73,11 +73,7 @@ mod tests {
 
     #[test]
     fn test_npm_rebuild() {
-        let CommandResolution::Run(command) =
-            resolve(&npm("11.0.0"), RebuildArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&npm("11.0.0"), RebuildArgs::default()).outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["rebuild"]);
@@ -85,11 +81,7 @@ mod tests {
 
     #[test]
     fn test_pnpm_rebuild() {
-        let CommandResolution::Run(command) =
-            resolve(&pnpm("10.0.0"), RebuildArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&pnpm("10.0.0"), RebuildArgs::default()).outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["rebuild"]);
@@ -124,17 +116,16 @@ mod tests {
 
     #[test]
     fn test_npm_rebuild_with_packages() {
-        let CommandResolution::Run(command) = resolve(
-            &npm("11.0.0"),
-            RebuildArgs {
-                packages: vec!["better-sqlite3".to_string(), "sharp".to_string()],
-                ..Default::default()
-            },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &npm("11.0.0"),
+                RebuildArgs {
+                    packages: vec!["better-sqlite3".to_string(), "sharp".to_string()],
+                    ..Default::default()
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["rebuild", "better-sqlite3", "sharp"]);
@@ -142,14 +133,13 @@ mod tests {
 
     #[test]
     fn test_pnpm_rebuild_with_packages() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.0.0"),
-            RebuildArgs { packages: vec!["better-sqlite3".to_string()], ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                RebuildArgs { packages: vec!["better-sqlite3".to_string()], ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["rebuild", "better-sqlite3"]);
@@ -157,17 +147,16 @@ mod tests {
 
     #[test]
     fn test_pnpm_rebuild_with_packages_and_pass_through() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("11.0.6"),
-            RebuildArgs {
-                packages: vec!["better-sqlite3".to_string()],
-                pass_through_args: vec!["--recursive".to_string()],
-            },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("11.0.6"),
+                RebuildArgs {
+                    packages: vec!["better-sqlite3".to_string()],
+                    pass_through_args: vec!["--recursive".to_string()],
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["rebuild", "--recursive", "better-sqlite3"]);

--- a/crates/vp_pm_cli/src/resolution/commands/remove.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/remove.rs
@@ -131,8 +131,8 @@ impl Resolve<RemoveArgs> for Bun {
 mod tests {
     use super::*;
     use crate::resolution::{
-        CommandResolution, resolve,
-        test_utils::{bun, npm, parse_args, pnpm, yarn},
+        resolve,
+        test_utils::{bun, expect_run, npm, parse_args, pnpm, yarn},
     };
 
     fn remove_args(packages: &[&str]) -> RemoveArgs {
@@ -161,9 +161,7 @@ mod tests {
     #[test]
     fn test_pnpm_basic_remove() {
         let resolution = resolve(&pnpm("1.0.0"), remove_args(&["lodash"]));
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["remove", "lodash"]);
@@ -174,9 +172,7 @@ mod tests {
         let mut options = remove_args(&["lodash"]);
         options.filter = vec!["app".to_string()];
         let resolution = resolve(&pnpm("1.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["--filter", "app", "remove", "lodash"]);
@@ -187,9 +183,7 @@ mod tests {
         let mut options = remove_args(&["typescript"]);
         options.workspace_root = true;
         let resolution = resolve(&pnpm("1.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["remove", "--workspace-root", "typescript"]);
@@ -200,9 +194,7 @@ mod tests {
         let mut options = remove_args(&["lodash"]);
         options.recursive = true;
         let resolution = resolve(&pnpm("1.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["remove", "--recursive", "lodash"]);
@@ -213,9 +205,7 @@ mod tests {
         let mut options = remove_args(&["axios"]);
         options.filter = vec!["app".to_string(), "web".to_string()];
         let resolution = resolve(&pnpm("1.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["--filter", "app", "--filter", "web", "remove", "axios"]);
@@ -224,9 +214,7 @@ mod tests {
     #[test]
     fn test_yarn_basic_remove() {
         let resolution = resolve(&yarn("1.22.0"), remove_args(&["lodash"]));
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["remove", "lodash"]);
@@ -237,9 +225,7 @@ mod tests {
         let mut options = remove_args(&["lodash"]);
         options.filter = vec!["app".to_string()];
         let resolution = resolve(&yarn("1.22.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(
@@ -253,9 +239,7 @@ mod tests {
         let mut options = remove_args(&["lodash"]);
         options.recursive = true;
         let resolution = resolve(&yarn("1.22.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["remove", "--all", "lodash"]);
@@ -266,9 +250,7 @@ mod tests {
         let mut options = remove_args(&["lodash"]);
         options.filter = vec!["app".to_string()];
         let resolution = resolve(&yarn("4.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(
@@ -280,9 +262,7 @@ mod tests {
     #[test]
     fn test_npm_basic_remove() {
         let resolution = resolve(&npm("1.0.0"), remove_args(&["lodash"]));
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["uninstall", "lodash"]);
@@ -293,9 +273,7 @@ mod tests {
         let mut options = remove_args(&["lodash"]);
         options.filter = vec!["app".to_string()];
         let resolution = resolve(&npm("1.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["uninstall", "--workspace", "app", "lodash"]);
@@ -306,9 +284,7 @@ mod tests {
         let mut options = remove_args(&["typescript"]);
         options.workspace_root = true;
         let resolution = resolve(&npm("1.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["uninstall", "--include-workspace-root", "typescript"]);
@@ -319,9 +295,7 @@ mod tests {
         let mut options = remove_args(&["lodash"]);
         options.recursive = true;
         let resolution = resolve(&npm("1.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(
@@ -335,9 +309,7 @@ mod tests {
         let mut options = remove_args(&["lodash"]);
         options.filter = vec!["app".to_string(), "web".to_string()];
         let resolution = resolve(&npm("1.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(
@@ -349,9 +321,7 @@ mod tests {
     #[test]
     fn test_bun_basic_remove() {
         let resolution = resolve(&bun("1.0.0"), remove_args(&["lodash"]));
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["remove", "lodash"]);
@@ -362,9 +332,7 @@ mod tests {
         let mut options = remove_args(&["typescript"]);
         options.global = true;
         let resolution = resolve(&pnpm("1.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["uninstall", "--global", "typescript"]);
@@ -373,9 +341,7 @@ mod tests {
     #[test]
     fn test_remove_multiple_packages() {
         let resolution = resolve(&pnpm("1.0.0"), remove_args(&["lodash", "axios", "underscore"]));
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["remove", "lodash", "axios", "underscore"]);
@@ -386,9 +352,7 @@ mod tests {
         let mut options = remove_args(&["lodash"]);
         options.pass_through_args = vec!["--use-stderr".to_string()];
         let resolution = resolve(&pnpm("1.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["remove", "--use-stderr", "lodash"]);
@@ -400,9 +364,7 @@ mod tests {
         options.global = true;
         options.pass_through_args = vec!["--foreground-scripts".to_string()];
         let resolution = resolve(&pnpm("1.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(
@@ -416,9 +378,7 @@ mod tests {
         let mut options = remove_args(&["typescript"]);
         options.save_dev = true;
         let resolution = resolve(&pnpm("1.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["remove", "--save-dev", "typescript"]);
@@ -429,9 +389,7 @@ mod tests {
         let mut options = remove_args(&["sharp"]);
         options.save_optional = true;
         let resolution = resolve(&pnpm("1.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["remove", "--save-optional", "sharp"]);
@@ -442,9 +400,7 @@ mod tests {
         let mut options = remove_args(&["react"]);
         options.save_prod = true;
         let resolution = resolve(&pnpm("1.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["remove", "--save-prod", "react"]);
@@ -455,9 +411,7 @@ mod tests {
         let mut options = remove_args(&["typescript"]);
         options.save_dev = true;
         let resolution = resolve(&npm("1.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["uninstall", "typescript"]);
@@ -468,9 +422,7 @@ mod tests {
         let mut options = remove_args(&["sharp"]);
         options.save_optional = true;
         let resolution = resolve(&npm("1.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["uninstall", "sharp"]);
@@ -481,9 +433,7 @@ mod tests {
         let mut options = remove_args(&["react"]);
         options.save_prod = true;
         let resolution = resolve(&npm("1.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["uninstall", "react"]);
@@ -496,9 +446,7 @@ mod tests {
         options.save_optional = true;
         options.save_prod = true;
         let resolution = resolve(&yarn("1.22.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["remove", "lodash"]);
@@ -509,9 +457,7 @@ mod tests {
         let mut options = remove_args(&["lodash"]);
         options.filter = vec!["app".to_string(), "web".to_string()];
         let resolution = resolve(&yarn("1.22.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(
@@ -536,9 +482,7 @@ mod tests {
         options.filter = vec!["app".to_string(), "web".to_string()];
         options.recursive = true;
         let resolution = resolve(&yarn("1.22.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["remove", "--all", "lodash"]);
@@ -550,9 +494,7 @@ mod tests {
         options.filter = vec!["app".to_string()];
         options.workspace_root = true;
         let resolution = resolve(&bun("1.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["remove", "lodash"]);

--- a/crates/vp_pm_cli/src/resolution/commands/search.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/search.rs
@@ -70,7 +70,7 @@ mod tests {
     use super::*;
     use crate::resolution::{
         resolve,
-        test_utils::{bun, npm, parse_args, pnpm, yarn},
+        test_utils::{bun, expect_run, npm, parse_args, pnpm, yarn},
     };
 
     #[test]
@@ -83,14 +83,13 @@ mod tests {
 
     #[test]
     fn test_search_basic() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.0.0"),
-            SearchArgs { terms: vec!["react".to_string()], ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                SearchArgs { terms: vec!["react".to_string()], ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["search", "react"]);
@@ -98,14 +97,13 @@ mod tests {
 
     #[test]
     fn test_search_with_json() {
-        let CommandResolution::Run(command) = resolve(
-            &npm("11.0.0"),
-            SearchArgs { terms: vec!["lodash".to_string()], json: true, ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &npm("11.0.0"),
+                SearchArgs { terms: vec!["lodash".to_string()], json: true, ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["search", "lodash", "--json"]);
@@ -113,19 +111,18 @@ mod tests {
 
     #[test]
     fn test_search_multiple_terms() {
-        let CommandResolution::Run(command) = resolve(
-            &yarn("4.0.0"),
-            SearchArgs {
-                terms: vec!["react".to_string(), "hooks".to_string(), "state".to_string()],
-                long: true,
-                registry: Some("https://registry.npmjs.org".to_string()),
-                ..Default::default()
-            },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &yarn("4.0.0"),
+                SearchArgs {
+                    terms: vec!["react".to_string(), "hooks".to_string(), "state".to_string()],
+                    long: true,
+                    registry: Some("https://registry.npmjs.org".to_string()),
+                    ..Default::default()
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(
@@ -148,9 +145,7 @@ mod tests {
             &bun("1.3.11"),
             SearchArgs { terms: vec!["react".to_string()], ..Default::default() },
         );
-        let CommandResolution::Run(command) = result.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(result.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["search", "react"]);
@@ -159,14 +154,13 @@ mod tests {
 
     #[test]
     fn test_yarn_classic_search_uses_npm() {
-        let CommandResolution::Run(command) = resolve(
-            &yarn("1.22.0"),
-            SearchArgs { terms: vec!["react".to_string()], ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &yarn("1.22.0"),
+                SearchArgs { terms: vec!["react".to_string()], ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["search", "react"]);

--- a/crates/vp_pm_cli/src/resolution/commands/stage.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/stage.rs
@@ -401,7 +401,7 @@ mod tests {
     use super::*;
     use crate::resolution::{
         Resolution, resolve,
-        test_utils::{bun, npm, parse_subcommand, pnpm, yarn},
+        test_utils::{bun, expect_run, npm, parse_subcommand, pnpm, yarn},
     };
 
     fn publish_sub_full(
@@ -464,11 +464,7 @@ mod tests {
 
     #[test]
     fn test_pnpm_stage_publish() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } =
-            resolve(&pnpm("11.3.0"), publish_sub())
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&pnpm("11.3.0"), publish_sub()).outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["stage", "publish"]);
@@ -476,12 +472,13 @@ mod tests {
 
     #[test]
     fn test_pnpm_stage_publish_with_tag_access() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } = resolve(
-            &pnpm("11.3.0"),
-            publish_sub_full(Some("next"), Some("public"), false, None, false),
-        ) else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("11.3.0"),
+                publish_sub_full(Some("next"), Some("public"), false, None, false),
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["stage", "publish", "--tag", "next", "--access", "public"]);
@@ -489,12 +486,13 @@ mod tests {
 
     #[test]
     fn test_pnpm_stage_publish_recursive_filter() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } = resolve(
-            &pnpm("11.3.0"),
-            publish_sub_full(None, None, true, Some(vec!["app".into()]), false),
-        ) else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("11.3.0"),
+                publish_sub_full(None, None, true, Some(vec!["app".into()]), false),
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["--filter", "app", "stage", "publish", "--recursive"]);
@@ -502,11 +500,7 @@ mod tests {
 
     #[test]
     fn test_npm_stage_publish() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } =
-            resolve(&npm("11.15.0"), publish_sub())
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&npm("11.15.0"), publish_sub()).outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["stage", "publish"]);
@@ -514,12 +508,11 @@ mod tests {
 
     #[test]
     fn test_npm_stage_publish_recursive_ignored() {
-        let Resolution { outcome: CommandResolution::Run(command), diagnostics } = resolve(
+        let Resolution { outcome, diagnostics } = resolve(
             &npm("11.15.0"),
             publish_sub_full(None, None, true, Some(vec!["app".into()]), false),
-        ) else {
-            panic!("expected command resolution");
-        };
+        );
+        let command = expect_run(outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["stage", "publish"]);
@@ -536,17 +529,18 @@ mod tests {
 
     #[test]
     fn test_npm_stage_list_with_package_json() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } = resolve(
-            &npm("11.15.0"),
-            StageCommand::List {
-                package: Some("my-pkg".into()),
-                json: true,
-                registry: None,
-                pass_through_args: Vec::new(),
-            },
-        ) else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &npm("11.15.0"),
+                StageCommand::List {
+                    package: Some("my-pkg".into()),
+                    json: true,
+                    registry: None,
+                    pass_through_args: Vec::new(),
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["stage", "list", "my-pkg", "--json"]);
@@ -554,17 +548,18 @@ mod tests {
 
     #[test]
     fn test_npm_stage_view() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } = resolve(
-            &npm("11.15.0"),
-            StageCommand::View {
-                stage_id: "abc123".into(),
-                json: false,
-                registry: None,
-                pass_through_args: Vec::new(),
-            },
-        ) else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &npm("11.15.0"),
+                StageCommand::View {
+                    stage_id: "abc123".into(),
+                    json: false,
+                    registry: None,
+                    pass_through_args: Vec::new(),
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["stage", "view", "abc123"]);
@@ -572,16 +567,17 @@ mod tests {
 
     #[test]
     fn test_npm_stage_download() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } = resolve(
-            &npm("11.15.0"),
-            StageCommand::Download {
-                stage_id: "abc123".into(),
-                registry: None,
-                pass_through_args: Vec::new(),
-            },
-        ) else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &npm("11.15.0"),
+                StageCommand::Download {
+                    stage_id: "abc123".into(),
+                    registry: None,
+                    pass_through_args: Vec::new(),
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["stage", "download", "abc123"]);
@@ -589,17 +585,18 @@ mod tests {
 
     #[test]
     fn test_stage_approve_with_otp() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } = resolve(
-            &pnpm("11.3.0"),
-            StageCommand::Approve {
-                stage_id: "abc123".into(),
-                otp: Some("123456".into()),
-                registry: None,
-                pass_through_args: Vec::new(),
-            },
-        ) else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("11.3.0"),
+                StageCommand::Approve {
+                    stage_id: "abc123".into(),
+                    otp: Some("123456".into()),
+                    registry: None,
+                    pass_through_args: Vec::new(),
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["stage", "approve", "abc123", "--otp", "123456"]);
@@ -607,17 +604,18 @@ mod tests {
 
     #[test]
     fn test_stage_reject() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } = resolve(
-            &npm("11.15.0"),
-            StageCommand::Reject {
-                stage_id: "abc123".into(),
-                otp: None,
-                registry: None,
-                pass_through_args: Vec::new(),
-            },
-        ) else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &npm("11.15.0"),
+                StageCommand::Reject {
+                    stage_id: "abc123".into(),
+                    otp: None,
+                    registry: None,
+                    pass_through_args: Vec::new(),
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["stage", "reject", "abc123"]);
@@ -625,11 +623,10 @@ mod tests {
 
     #[test]
     fn test_yarn_berry_stage_publish_uses_npm_plugin() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } =
+        let command = expect_run(
             resolve(&yarn("4.0.0"), publish_sub_full(Some("next"), None, false, None, false))
-        else {
-            panic!("expected command resolution");
-        };
+                .outcome,
+        );
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["npm", "publish", "--staged", "--tag", "next"]);
@@ -637,24 +634,25 @@ mod tests {
 
     #[test]
     fn test_yarn_berry_stage_publish_forwards_dry_run_json_provenance() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } = resolve(
-            &yarn("4.0.0"),
-            StageCommand::Publish {
-                target: None,
-                tag: None,
-                access: None,
-                otp: None,
-                dry_run: true,
-                json: true,
-                recursive: false,
-                filter: None,
-                provenance: true,
-                registry: None,
-                pass_through_args: Vec::new(),
-            },
-        ) else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &yarn("4.0.0"),
+                StageCommand::Publish {
+                    target: None,
+                    tag: None,
+                    access: None,
+                    otp: None,
+                    dry_run: true,
+                    json: true,
+                    recursive: false,
+                    filter: None,
+                    provenance: true,
+                    registry: None,
+                    pass_through_args: Vec::new(),
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "yarn");
         assert_eq!(
@@ -665,7 +663,7 @@ mod tests {
 
     #[test]
     fn test_yarn_berry_stage_publish_with_target_falls_back_to_npm() {
-        let Resolution { outcome: CommandResolution::Run(command), diagnostics } = resolve(
+        let Resolution { outcome, diagnostics } = resolve(
             &yarn("4.0.0"),
             StageCommand::Publish {
                 target: Some("./pkg.tgz".into()),
@@ -680,9 +678,8 @@ mod tests {
                 registry: None,
                 pass_through_args: Vec::new(),
             },
-        ) else {
-            panic!("expected command resolution");
-        };
+        );
+        let command = expect_run(outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["stage", "publish", "./pkg.tgz"]);
@@ -694,7 +691,7 @@ mod tests {
 
     #[test]
     fn test_yarn_berry_stage_registry_dropped() {
-        let Resolution { outcome: CommandResolution::Run(command), diagnostics } = resolve(
+        let Resolution { outcome, diagnostics } = resolve(
             &yarn("4.0.0"),
             StageCommand::List {
                 package: None,
@@ -702,9 +699,8 @@ mod tests {
                 registry: Some("https://registry.example.com".into()),
                 pass_through_args: Vec::new(),
             },
-        ) else {
-            panic!("expected command resolution");
-        };
+        );
+        let command = expect_run(outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["npm", "stage", "list"]);
@@ -716,17 +712,18 @@ mod tests {
 
     #[test]
     fn test_yarn_berry_stage_list() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } = resolve(
-            &yarn("4.0.0"),
-            StageCommand::List {
-                package: None,
-                json: false,
-                registry: None,
-                pass_through_args: Vec::new(),
-            },
-        ) else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &yarn("4.0.0"),
+                StageCommand::List {
+                    package: None,
+                    json: false,
+                    registry: None,
+                    pass_through_args: Vec::new(),
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["npm", "stage", "list"]);
@@ -734,17 +731,18 @@ mod tests {
 
     #[test]
     fn test_yarn_berry_stage_approve() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } = resolve(
-            &yarn("4.0.0"),
-            StageCommand::Approve {
-                stage_id: "abc123".into(),
-                otp: None,
-                registry: None,
-                pass_through_args: Vec::new(),
-            },
-        ) else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &yarn("4.0.0"),
+                StageCommand::Approve {
+                    stage_id: "abc123".into(),
+                    otp: None,
+                    registry: None,
+                    pass_through_args: Vec::new(),
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["npm", "stage", "approve", "abc123"]);
@@ -752,7 +750,7 @@ mod tests {
 
     #[test]
     fn test_yarn_berry_stage_view_falls_back_to_npm() {
-        let Resolution { outcome: CommandResolution::Run(command), diagnostics } = resolve(
+        let Resolution { outcome, diagnostics } = resolve(
             &yarn("4.0.0"),
             StageCommand::View {
                 stage_id: "abc123".into(),
@@ -760,9 +758,8 @@ mod tests {
                 registry: None,
                 pass_through_args: Vec::new(),
             },
-        ) else {
-            panic!("expected command resolution");
-        };
+        );
+        let command = expect_run(outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["stage", "view", "abc123"]);
@@ -774,11 +771,8 @@ mod tests {
 
     #[test]
     fn test_yarn1_stage_falls_back_to_npm() {
-        let Resolution { outcome: CommandResolution::Run(command), diagnostics } =
-            resolve(&yarn("1.22.0"), publish_sub())
-        else {
-            panic!("expected command resolution");
-        };
+        let Resolution { outcome, diagnostics } = resolve(&yarn("1.22.0"), publish_sub());
+        let command = expect_run(outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["stage", "publish"]);
@@ -790,11 +784,8 @@ mod tests {
 
     #[test]
     fn test_bun_stage_falls_back_to_npm() {
-        let Resolution { outcome: CommandResolution::Run(command), diagnostics } =
-            resolve(&bun("1.2.0"), publish_sub())
-        else {
-            panic!("expected command resolution");
-        };
+        let Resolution { outcome, diagnostics } = resolve(&bun("1.2.0"), publish_sub());
+        let command = expect_run(outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["stage", "publish"]);
@@ -806,17 +797,18 @@ mod tests {
 
     #[test]
     fn test_stage_registry_appended() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } = resolve(
-            &pnpm("11.3.0"),
-            StageCommand::List {
-                package: None,
-                json: false,
-                registry: Some("https://registry.example.com".into()),
-                pass_through_args: Vec::new(),
-            },
-        ) else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("11.3.0"),
+                StageCommand::List {
+                    package: None,
+                    json: false,
+                    registry: Some("https://registry.example.com".into()),
+                    pass_through_args: Vec::new(),
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(
@@ -827,24 +819,25 @@ mod tests {
 
     #[test]
     fn test_stage_pass_through_args() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } = resolve(
-            &pnpm("11.3.0"),
-            StageCommand::Publish {
-                target: None,
-                tag: None,
-                access: None,
-                otp: None,
-                dry_run: false,
-                json: false,
-                recursive: false,
-                filter: None,
-                provenance: false,
-                registry: None,
-                pass_through_args: vec!["--foo".to_string()],
-            },
-        ) else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("11.3.0"),
+                StageCommand::Publish {
+                    target: None,
+                    tag: None,
+                    access: None,
+                    otp: None,
+                    dry_run: false,
+                    json: false,
+                    recursive: false,
+                    filter: None,
+                    provenance: false,
+                    registry: None,
+                    pass_through_args: vec!["--foo".to_string()],
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["stage", "publish", "--foo"]);

--- a/crates/vp_pm_cli/src/resolution/commands/token.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/token.rs
@@ -120,7 +120,7 @@ mod tests {
     use super::*;
     use crate::resolution::{
         Resolution, resolve,
-        test_utils::{bun, npm, parse_subcommand, pnpm, yarn},
+        test_utils::{bun, expect_run, npm, parse_subcommand, pnpm, yarn},
     };
 
     #[test]
@@ -139,12 +139,13 @@ mod tests {
 
     #[test]
     fn test_token_list() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } = resolve(
-            &pnpm("10.0.0"),
-            TokenCommand::List { json: false, registry: None, pass_through_args: Vec::new() },
-        ) else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                TokenCommand::List { json: false, registry: None, pass_through_args: Vec::new() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["token", "list"]);
@@ -152,18 +153,19 @@ mod tests {
 
     #[test]
     fn test_token_create() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } = resolve(
-            &npm("11.0.0"),
-            TokenCommand::Create {
-                json: false,
-                registry: None,
-                cidr: None,
-                readonly: false,
-                pass_through_args: Vec::new(),
-            },
-        ) else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &npm("11.0.0"),
+                TokenCommand::Create {
+                    json: false,
+                    registry: None,
+                    cidr: None,
+                    readonly: false,
+                    pass_through_args: Vec::new(),
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["token", "create"]);
@@ -171,18 +173,19 @@ mod tests {
 
     #[test]
     fn test_token_create_with_flags() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } = resolve(
-            &pnpm("10.0.0"),
-            TokenCommand::Create {
-                json: true,
-                registry: Some("https://registry.npmjs.org".to_string()),
-                cidr: Some(vec!["192.168.1.0/24".to_string(), "10.0.0.0/8".to_string()]),
-                readonly: true,
-                pass_through_args: Vec::new(),
-            },
-        ) else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                TokenCommand::Create {
+                    json: true,
+                    registry: Some("https://registry.npmjs.org".to_string()),
+                    cidr: Some(vec!["192.168.1.0/24".to_string(), "10.0.0.0/8".to_string()]),
+                    readonly: true,
+                    pass_through_args: Vec::new(),
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(
@@ -204,16 +207,17 @@ mod tests {
 
     #[test]
     fn test_token_revoke() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } = resolve(
-            &yarn("4.0.0"),
-            TokenCommand::Revoke {
-                token: "abc123".to_string(),
-                registry: None,
-                pass_through_args: Vec::new(),
-            },
-        ) else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &yarn("4.0.0"),
+                TokenCommand::Revoke {
+                    token: "abc123".to_string(),
+                    registry: None,
+                    pass_through_args: Vec::new(),
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["token", "revoke", "abc123"]);
@@ -221,12 +225,11 @@ mod tests {
 
     #[test]
     fn test_bun_token_uses_npm_without_warning() {
-        let Resolution { outcome: CommandResolution::Run(command), diagnostics } = resolve(
+        let Resolution { outcome, diagnostics } = resolve(
             &bun("1.3.11"),
             TokenCommand::List { json: false, registry: None, pass_through_args: Vec::new() },
-        ) else {
-            panic!("expected command resolution");
-        };
+        );
+        let command = expect_run(outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["token", "list"]);
@@ -235,16 +238,17 @@ mod tests {
 
     #[test]
     fn test_token_revoke_with_registry_and_pass_through_args() {
-        let Resolution { outcome: CommandResolution::Run(command), .. } = resolve(
-            &npm("11.0.0"),
-            TokenCommand::Revoke {
-                token: "abc123".to_string(),
-                registry: Some("https://registry.npmjs.org".to_string()),
-                pass_through_args: vec!["--otp".to_string(), "123456".to_string()],
-            },
-        ) else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &npm("11.0.0"),
+                TokenCommand::Revoke {
+                    token: "abc123".to_string(),
+                    registry: Some("https://registry.npmjs.org".to_string()),
+                    pass_through_args: vec!["--otp".to_string(), "123456".to_string()],
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(

--- a/crates/vp_pm_cli/src/resolution/commands/unlink.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/unlink.rs
@@ -68,16 +68,12 @@ mod tests {
     use super::*;
     use crate::resolution::{
         resolve,
-        test_utils::{bun, npm, parse_args, pnpm, yarn},
+        test_utils::{bun, expect_run, npm, parse_args, pnpm, yarn},
     };
 
     #[test]
     fn test_pnpm_unlink_no_package() {
-        let CommandResolution::Run(command) =
-            resolve(&pnpm("10.0.0"), UnlinkArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&pnpm("10.0.0"), UnlinkArgs::default()).outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["unlink"]);
@@ -85,14 +81,13 @@ mod tests {
 
     #[test]
     fn test_pnpm_unlink_package() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.0.0"),
-            UnlinkArgs { package: Some("react".to_string()), ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                UnlinkArgs { package: Some("react".to_string()), ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["unlink", "react"]);
@@ -100,11 +95,9 @@ mod tests {
 
     #[test]
     fn test_pnpm_unlink_recursive() {
-        let CommandResolution::Run(command) =
-            resolve(&pnpm("10.0.0"), UnlinkArgs { recursive: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&pnpm("10.0.0"), UnlinkArgs { recursive: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["unlink", "--recursive"]);
@@ -112,18 +105,17 @@ mod tests {
 
     #[test]
     fn test_pnpm_unlink_package_recursive() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.0.0"),
-            UnlinkArgs {
-                package: Some("react".to_string()),
-                recursive: true,
-                ..Default::default()
-            },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                UnlinkArgs {
+                    package: Some("react".to_string()),
+                    recursive: true,
+                    ..Default::default()
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["unlink", "--recursive", "react"]);
@@ -131,11 +123,7 @@ mod tests {
 
     #[test]
     fn test_yarn_unlink_basic() {
-        let CommandResolution::Run(command) =
-            resolve(&yarn("4.0.0"), UnlinkArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&yarn("4.0.0"), UnlinkArgs::default()).outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["unlink"]);
@@ -143,14 +131,13 @@ mod tests {
 
     #[test]
     fn test_yarn_unlink_package() {
-        let CommandResolution::Run(command) = resolve(
-            &yarn("4.0.0"),
-            UnlinkArgs { package: Some("react".to_string()), ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &yarn("4.0.0"),
+                UnlinkArgs { package: Some("react".to_string()), ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["unlink", "react"]);
@@ -158,14 +145,13 @@ mod tests {
 
     #[test]
     fn test_yarn_classic_unlink_package() {
-        let CommandResolution::Run(command) = resolve(
-            &yarn("1.22.0"),
-            UnlinkArgs { package: Some("react".to_string()), ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &yarn("1.22.0"),
+                UnlinkArgs { package: Some("react".to_string()), ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["unlink", "react"]);
@@ -173,11 +159,9 @@ mod tests {
 
     #[test]
     fn test_yarn_unlink_recursive() {
-        let CommandResolution::Run(command) =
-            resolve(&yarn("4.0.0"), UnlinkArgs { recursive: true, ..Default::default() }).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(&yarn("4.0.0"), UnlinkArgs { recursive: true, ..Default::default() }).outcome,
+        );
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["unlink", "--all"]);
@@ -185,11 +169,7 @@ mod tests {
 
     #[test]
     fn test_npm_unlink_basic() {
-        let CommandResolution::Run(command) =
-            resolve(&npm("11.0.0"), UnlinkArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&npm("11.0.0"), UnlinkArgs::default()).outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["unlink"]);
@@ -197,14 +177,13 @@ mod tests {
 
     #[test]
     fn test_npm_unlink_package() {
-        let CommandResolution::Run(command) = resolve(
-            &npm("11.0.0"),
-            UnlinkArgs { package: Some("react".to_string()), ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &npm("11.0.0"),
+                UnlinkArgs { package: Some("react".to_string()), ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["unlink", "react"]);
@@ -213,9 +192,7 @@ mod tests {
     #[test]
     fn test_npm_unlink_recursive_warns_and_drops_flag() {
         let result = resolve(&npm("11.0.0"), UnlinkArgs { recursive: true, ..Default::default() });
-        let CommandResolution::Run(command) = result.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(result.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["unlink"]);
@@ -224,14 +201,13 @@ mod tests {
 
     #[test]
     fn test_bun_unlink_package() {
-        let CommandResolution::Run(command) = resolve(
-            &bun("1.3.11"),
-            UnlinkArgs { package: Some("react".to_string()), ..Default::default() },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &bun("1.3.11"),
+                UnlinkArgs { package: Some("react".to_string()), ..Default::default() },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["unlink", "react"]);
@@ -240,9 +216,7 @@ mod tests {
     #[test]
     fn test_bun_unlink_recursive_warns_and_drops_flag() {
         let result = resolve(&bun("1.3.11"), UnlinkArgs { recursive: true, ..Default::default() });
-        let CommandResolution::Run(command) = result.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(result.outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["unlink"]);
@@ -251,18 +225,17 @@ mod tests {
 
     #[test]
     fn test_unlink_with_pass_through_args() {
-        let CommandResolution::Run(command) = resolve(
-            &pnpm("10.0.0"),
-            UnlinkArgs {
-                package: Some("react".to_string()),
-                args: vec!["--global".to_string()],
-                ..Default::default()
-            },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &pnpm("10.0.0"),
+                UnlinkArgs {
+                    package: Some("react".to_string()),
+                    args: vec!["--global".to_string()],
+                    ..Default::default()
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["unlink", "react", "--global"]);

--- a/crates/vp_pm_cli/src/resolution/commands/update.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/update.rs
@@ -170,8 +170,8 @@ impl Resolve<UpdateArgs> for Bun {
 mod tests {
     use super::*;
     use crate::resolution::{
-        CommandResolution, resolve,
-        test_utils::{bun, npm, parse_args, pnpm, yarn},
+        resolve,
+        test_utils::{bun, expect_run, npm, parse_args, pnpm, yarn},
     };
 
     fn update_args(packages: &[&str]) -> UpdateArgs {
@@ -215,9 +215,7 @@ mod tests {
     #[test]
     fn test_pnpm_basic_update() {
         let resolution = resolve(&pnpm("10.0.0"), update_args(&["react"]));
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["update", "react"]);
@@ -228,9 +226,7 @@ mod tests {
         let mut options = update_args(&["react"]);
         options.latest = true;
         let resolution = resolve(&pnpm("10.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["update", "--latest", "react"]);
@@ -239,9 +235,7 @@ mod tests {
     #[test]
     fn test_pnpm_update_all() {
         let resolution = resolve(&pnpm("10.0.0"), UpdateArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["update"]);
@@ -252,9 +246,7 @@ mod tests {
         let mut options = update_args(&["react"]);
         options.filter = vec!["app".to_string()];
         let resolution = resolve(&pnpm("10.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["--filter", "app", "update", "react"]);
@@ -264,9 +256,7 @@ mod tests {
     fn test_pnpm_update_recursive() {
         let options = UpdateArgs { recursive: true, ..Default::default() };
         let resolution = resolve(&pnpm("10.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["update", "--recursive"]);
@@ -276,9 +266,7 @@ mod tests {
     fn test_pnpm_update_interactive() {
         let options = UpdateArgs { interactive: true, ..Default::default() };
         let resolution = resolve(&pnpm("10.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["update", "--interactive"]);
@@ -288,9 +276,7 @@ mod tests {
     fn test_pnpm_update_dev_only() {
         let options = UpdateArgs { dev: true, ..Default::default() };
         let resolution = resolve(&pnpm("10.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["update", "--dev"]);
@@ -300,9 +286,7 @@ mod tests {
     fn test_pnpm_update_no_optional() {
         let options = UpdateArgs { no_optional: true, ..Default::default() };
         let resolution = resolve(&pnpm("10.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["update", "--no-optional"]);
@@ -313,9 +297,7 @@ mod tests {
         let mut options = update_args(&["react"]);
         options.no_save = true;
         let resolution = resolve(&pnpm("10.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["update", "--no-save", "react"]);
@@ -327,9 +309,7 @@ mod tests {
         options.workspace = true;
         options.filter = vec!["app".to_string()];
         let resolution = resolve(&pnpm("10.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["--filter", "app", "update", "--workspace", "@myorg/utils"]);
@@ -338,9 +318,7 @@ mod tests {
     #[test]
     fn test_yarn_v1_basic_update() {
         let resolution = resolve(&yarn("1.22.0"), update_args(&["react"]));
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["upgrade", "react"]);
@@ -351,9 +329,7 @@ mod tests {
         let mut options = update_args(&["react"]);
         options.latest = true;
         let resolution = resolve(&yarn("1.22.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["upgrade", "--latest", "react"]);
@@ -364,9 +340,7 @@ mod tests {
         let mut options = update_args(&["react"]);
         options.filter = vec!["app".to_string()];
         let resolution = resolve(&yarn("1.22.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["workspace", "app", "upgrade", "react"]);
@@ -375,9 +349,7 @@ mod tests {
     #[test]
     fn test_yarn_v4_basic_update() {
         let resolution = resolve(&yarn("4.0.0"), update_args(&["react"]));
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["up", "react"]);
@@ -387,9 +359,7 @@ mod tests {
     fn test_yarn_v4_update_interactive() {
         let options = UpdateArgs { interactive: true, ..Default::default() };
         let resolution = resolve(&yarn("4.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["up", "--interactive"]);
@@ -400,9 +370,7 @@ mod tests {
         let mut options = update_args(&["react"]);
         options.filter = vec!["app".to_string()];
         let resolution = resolve(&yarn("4.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(
@@ -415,9 +383,7 @@ mod tests {
     fn test_yarn_v4_update_recursive() {
         let options = UpdateArgs { recursive: true, ..Default::default() };
         let resolution = resolve(&yarn("4.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["up", "--recursive"]);
@@ -426,9 +392,7 @@ mod tests {
     #[test]
     fn test_npm_basic_update() {
         let resolution = resolve(&npm("11.0.0"), update_args(&["react"]));
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["update", "react"]);
@@ -437,9 +401,7 @@ mod tests {
     #[test]
     fn test_npm_update_all() {
         let resolution = resolve(&npm("11.0.0"), UpdateArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["update"]);
@@ -450,9 +412,7 @@ mod tests {
         let mut options = update_args(&["react"]);
         options.filter = vec!["app".to_string()];
         let resolution = resolve(&npm("11.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["update", "--workspace", "app", "react"]);
@@ -462,9 +422,7 @@ mod tests {
     fn test_npm_update_recursive() {
         let options = UpdateArgs { recursive: true, ..Default::default() };
         let resolution = resolve(&npm("11.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["update", "--include-workspace-root", "--workspaces"]);
@@ -474,9 +432,7 @@ mod tests {
     fn test_npm_update_dev_only() {
         let options = UpdateArgs { dev: true, ..Default::default() };
         let resolution = resolve(&npm("11.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["update", "--include=dev"]);
@@ -486,9 +442,7 @@ mod tests {
     fn test_npm_update_no_optional() {
         let options = UpdateArgs { no_optional: true, ..Default::default() };
         let resolution = resolve(&npm("11.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["update", "--no-optional"]);
@@ -499,9 +453,7 @@ mod tests {
         let mut options = update_args(&["react"]);
         options.no_save = true;
         let resolution = resolve(&npm("11.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["update", "--no-save", "react"]);
@@ -513,9 +465,7 @@ mod tests {
         options.latest = true;
         options.interactive = true;
         let resolution = resolve(&npm("11.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["update", "react"]);
@@ -532,9 +482,7 @@ mod tests {
         let mut options = update_args(&["react", "react-dom", "vite"]);
         options.latest = true;
         let resolution = resolve(&pnpm("10.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["update", "--latest", "react", "react-dom", "vite"]);
@@ -549,9 +497,7 @@ mod tests {
         options.dev = true;
         options.interactive = true;
         let resolution = resolve(&pnpm("10.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(
@@ -576,9 +522,7 @@ mod tests {
         let mut options = update_args(&["lodash"]);
         options.filter = vec!["app".to_string(), "web".to_string()];
         let resolution = resolve(&yarn("4.0.0"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(
@@ -600,9 +544,7 @@ mod tests {
     #[test]
     fn test_bun_basic_update() {
         let resolution = resolve(&bun("1.3.11"), UpdateArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["update"]);
@@ -612,9 +554,7 @@ mod tests {
     fn test_bun_update_latest() {
         let options = UpdateArgs { latest: true, ..Default::default() };
         let resolution = resolve(&bun("1.3.11"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["update", "--latest"]);
@@ -624,9 +564,7 @@ mod tests {
     fn test_bun_update_prod() {
         let options = UpdateArgs { prod: true, ..Default::default() };
         let resolution = resolve(&bun("1.3.11"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["update", "--production"]);
@@ -636,9 +574,7 @@ mod tests {
     fn test_bun_update_no_optional() {
         let options = UpdateArgs { no_optional: true, ..Default::default() };
         let resolution = resolve(&bun("1.3.11"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["update", "--omit", "optional"]);
@@ -648,9 +584,7 @@ mod tests {
     fn test_bun_update_no_save() {
         let options = UpdateArgs { no_save: true, ..Default::default() };
         let resolution = resolve(&bun("1.3.11"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["update", "--no-save"]);
@@ -660,9 +594,7 @@ mod tests {
     fn test_bun_update_recursive() {
         let options = UpdateArgs { recursive: true, ..Default::default() };
         let resolution = resolve(&bun("1.3.11"), options);
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["update", "--recursive"]);

--- a/crates/vp_pm_cli/src/resolution/commands/version.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/version.rs
@@ -114,7 +114,7 @@ mod tests {
     use super::*;
     use crate::resolution::{
         PackageManagerDialect, resolve,
-        test_utils::{bun, npm, parse_args, pnpm, yarn},
+        test_utils::{bun, expect_run, npm, parse_args, pnpm, yarn},
     };
 
     #[test]
@@ -135,15 +135,11 @@ mod tests {
             ..Default::default()
         };
 
-        let CommandResolution::Run(command) = resolve(&npm("11.0.0"), args.clone()).outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&npm("11.0.0"), args.clone()).outcome);
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, ["version", "prerelease", "--preid", "beta"]);
 
-        let CommandResolution::Run(command) = resolve(&pnpm("10.0.0"), args).outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&pnpm("10.0.0"), args).outcome);
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, ["version", "prerelease", "--preid", "beta"]);
     }
@@ -154,18 +150,14 @@ mod tests {
             &yarn("1.22.22"),
             VersionArgs { new_version: Some("patch".to_string()), ..Default::default() },
         );
-        let CommandResolution::Run(patch) = patch.outcome else {
-            panic!("expected command resolution");
-        };
+        let patch = expect_run(patch.outcome);
         assert_eq!(patch.args, ["version", "--patch"]);
 
         let explicit = resolve(
             &yarn("1.22.22"),
             VersionArgs { new_version: Some("2.0.0".to_string()), ..Default::default() },
         );
-        let CommandResolution::Run(explicit) = explicit.outcome else {
-            panic!("expected command resolution");
-        };
+        let explicit = expect_run(explicit.outcome);
         assert_eq!(explicit.args, ["version", "--new-version", "2.0.0"]);
     }
 
@@ -175,9 +167,7 @@ mod tests {
             &yarn("4.0.0"),
             VersionArgs { new_version: Some("patch".to_string()), ..Default::default() },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.args, ["version", "patch"]);
     }
@@ -188,9 +178,7 @@ mod tests {
             &bun("1.3.11"),
             VersionArgs { new_version: Some("patch".to_string()), ..Default::default() },
         );
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, ["pm", "version", "patch"]);
@@ -221,9 +209,7 @@ mod tests {
         let dialect = bun("1.2.17");
         assert_eq!(dialect.version(), Some(&Version::new(1, 2, 17)));
         let resolution = resolve(&dialect, VersionArgs::default());
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.args, ["pm", "version"]);
         assert_eq!(resolution.diagnostics.len(), 1);

--- a/crates/vp_pm_cli/src/resolution/commands/view.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/view.rs
@@ -72,7 +72,7 @@ mod tests {
     use super::*;
     use crate::resolution::{
         resolve,
-        test_utils::{bun, npm, pnpm, yarn},
+        test_utils::{bun, expect_run, npm, pnpm, yarn},
     };
 
     fn view_args(package: &str) -> ViewArgs {
@@ -81,10 +81,7 @@ mod tests {
 
     #[test]
     fn test_pnpm_view_uses_pnpm() {
-        let CommandResolution::Run(command) = resolve(&pnpm("10.0.0"), view_args("react")).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&pnpm("10.0.0"), view_args("react")).outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["view", "react"]);
@@ -94,9 +91,7 @@ mod tests {
     fn test_npm_view() {
         let mut options = view_args("react");
         options.field = Some("version".to_string());
-        let CommandResolution::Run(command) = resolve(&npm("11.0.0"), options).outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&npm("11.0.0"), options).outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["view", "react", "version"]);
@@ -106,9 +101,7 @@ mod tests {
     fn test_yarn_view_uses_info() {
         let mut options = view_args("lodash");
         options.json = true;
-        let CommandResolution::Run(command) = resolve(&yarn("1.22.0"), options).outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&yarn("1.22.0"), options).outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["info", "lodash", "--json"]);
@@ -118,9 +111,7 @@ mod tests {
     fn test_yarn_berry_view_uses_yarn_npm_info() {
         let mut options = view_args("lodash");
         options.json = true;
-        let CommandResolution::Run(command) = resolve(&yarn("4.0.0"), options).outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&yarn("4.0.0"), options).outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["npm", "info", "lodash", "--json"]);
@@ -130,9 +121,7 @@ mod tests {
     fn test_yarn_berry_view_uses_fields_option_for_view_field() {
         let mut options = view_args("lodash");
         options.field = Some("dist.tarball".to_string());
-        let CommandResolution::Run(command) = resolve(&yarn("4.0.0"), options).outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&yarn("4.0.0"), options).outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["npm", "info", "lodash", "--fields", "dist.tarball"]);
@@ -142,9 +131,7 @@ mod tests {
     fn test_view_with_nested_field() {
         let mut options = view_args("react");
         options.field = Some("dist.tarball".to_string());
-        let CommandResolution::Run(command) = resolve(&pnpm("10.0.0"), options).outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&pnpm("10.0.0"), options).outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["view", "react", "dist.tarball"]);
@@ -155,9 +142,7 @@ mod tests {
         let mut options = view_args("react");
         options.field = Some("version".to_string());
         options.json = true;
-        let CommandResolution::Run(command) = resolve(&bun("1.3.11"), options).outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&bun("1.3.11"), options).outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["info", "react", "version", "--json"]);
@@ -168,9 +153,7 @@ mod tests {
         let mut options = view_args("react");
         options.pass_through_args =
             vec!["--registry".to_string(), "https://registry.npmjs.org".to_string()];
-        let CommandResolution::Run(command) = resolve(&npm("11.0.0"), options).outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&npm("11.0.0"), options).outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["view", "react", "--registry", "https://registry.npmjs.org"]);

--- a/crates/vp_pm_cli/src/resolution/commands/whoami.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/whoami.rs
@@ -68,7 +68,7 @@ mod tests {
     use super::*;
     use crate::resolution::{
         resolve,
-        test_utils::{bun, npm, parse_args, pnpm, yarn},
+        test_utils::{bun, expect_run, npm, parse_args, pnpm, yarn},
     };
 
     #[test]
@@ -87,11 +87,7 @@ mod tests {
 
     #[test]
     fn test_npm_whoami() {
-        let CommandResolution::Run(command) =
-            resolve(&npm("11.0.0"), WhoamiArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&npm("11.0.0"), WhoamiArgs::default()).outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["whoami"]);
@@ -99,11 +95,7 @@ mod tests {
 
     #[test]
     fn test_pnpm_whoami_uses_npm() {
-        let CommandResolution::Run(command) =
-            resolve(&pnpm("10.0.0"), WhoamiArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&pnpm("10.0.0"), WhoamiArgs::default()).outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["whoami"]);
@@ -120,11 +112,7 @@ mod tests {
 
     #[test]
     fn test_yarn2_whoami() {
-        let CommandResolution::Run(command) =
-            resolve(&yarn("4.0.0"), WhoamiArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&yarn("4.0.0"), WhoamiArgs::default()).outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["npm", "whoami"]);
@@ -132,11 +120,7 @@ mod tests {
 
     #[test]
     fn test_bun_whoami() {
-        let CommandResolution::Run(command) =
-            resolve(&bun("1.3.11"), WhoamiArgs::default()).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&bun("1.3.11"), WhoamiArgs::default()).outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["pm", "whoami"]);
@@ -144,17 +128,16 @@ mod tests {
 
     #[test]
     fn test_whoami_with_registry() {
-        let CommandResolution::Run(command) = resolve(
-            &npm("11.0.0"),
-            WhoamiArgs {
-                registry: Some("https://registry.example.com".to_string()),
-                ..Default::default()
-            },
-        )
-        .outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(
+            resolve(
+                &npm("11.0.0"),
+                WhoamiArgs {
+                    registry: Some("https://registry.example.com".to_string()),
+                    ..Default::default()
+                },
+            )
+            .outcome,
+        );
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["whoami", "--registry", "https://registry.example.com"]);

--- a/crates/vp_pm_cli/src/resolution/commands/why.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/why.rs
@@ -131,7 +131,7 @@ mod tests {
     use super::*;
     use crate::resolution::{
         resolve,
-        test_utils::{bun, npm, pnpm, yarn},
+        test_utils::{bun, expect_run, npm, pnpm, yarn},
     };
 
     fn why_args(packages: &[&str]) -> WhyArgs {
@@ -143,11 +143,7 @@ mod tests {
 
     #[test]
     fn test_pnpm_why_basic() {
-        let CommandResolution::Run(command) =
-            resolve(&pnpm("10.0.0"), why_args(&["react"])).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&pnpm("10.0.0"), why_args(&["react"])).outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["why", "react"]);
@@ -155,11 +151,7 @@ mod tests {
 
     #[test]
     fn test_pnpm_why_multiple_packages() {
-        let CommandResolution::Run(command) =
-            resolve(&pnpm("10.0.0"), why_args(&["react", "lodash"])).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&pnpm("10.0.0"), why_args(&["react", "lodash"])).outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["why", "react", "lodash"]);
@@ -169,9 +161,7 @@ mod tests {
     fn test_pnpm_why_json() {
         let mut options = why_args(&["react"]);
         options.json = true;
-        let CommandResolution::Run(command) = resolve(&pnpm("10.0.0"), options).outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&pnpm("10.0.0"), options).outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["why", "--json", "react"]);
@@ -179,10 +169,7 @@ mod tests {
 
     #[test]
     fn test_npm_explain_basic() {
-        let CommandResolution::Run(command) = resolve(&npm("11.0.0"), why_args(&["react"])).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&npm("11.0.0"), why_args(&["react"])).outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["explain", "react"]);
@@ -190,11 +177,7 @@ mod tests {
 
     #[test]
     fn test_npm_explain_multiple_packages() {
-        let CommandResolution::Run(command) =
-            resolve(&npm("11.0.0"), why_args(&["react", "lodash"])).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&npm("11.0.0"), why_args(&["react", "lodash"])).outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["explain", "react", "lodash"]);
@@ -204,9 +187,7 @@ mod tests {
     fn test_npm_explain_with_workspace() {
         let mut options = why_args(&["react"]);
         options.filter = vec!["app".to_string()];
-        let CommandResolution::Run(command) = resolve(&npm("11.0.0"), options).outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&npm("11.0.0"), options).outcome);
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["explain", "--workspace", "app", "react"]);
@@ -214,10 +195,7 @@ mod tests {
 
     #[test]
     fn test_yarn_why_basic() {
-        let CommandResolution::Run(command) = resolve(&yarn("4.0.0"), why_args(&["react"])).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&yarn("4.0.0"), why_args(&["react"])).outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["why", "react", "--peers"]);
@@ -227,9 +205,7 @@ mod tests {
     fn test_yarn_why_with_exclude_peers() {
         let mut options = why_args(&["react"]);
         options.exclude_peers = true;
-        let CommandResolution::Run(command) = resolve(&yarn("4.0.0"), options).outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&yarn("4.0.0"), options).outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["why", "react"]);
@@ -237,11 +213,7 @@ mod tests {
 
     #[test]
     fn test_yarn1_why_no_peers() {
-        let CommandResolution::Run(command) =
-            resolve(&yarn("1.22.0"), why_args(&["react"])).outcome
-        else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&yarn("1.22.0"), why_args(&["react"])).outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["why", "react"]);
@@ -250,9 +222,7 @@ mod tests {
     #[test]
     fn test_yarn_why_multiple_packages_warns_and_uses_first_package() {
         let resolution = resolve(&yarn("4.0.0"), why_args(&["react", "lodash"]));
-        let CommandResolution::Run(command) = resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolution.outcome);
 
         assert_eq!(command.program, "yarn");
         assert_eq!(command.args, vec!["why", "react", "--peers"]);
@@ -266,9 +236,7 @@ mod tests {
     fn test_pnpm_why_with_filter() {
         let mut options = why_args(&["react"]);
         options.filter = vec!["app".to_string()];
-        let CommandResolution::Run(command) = resolve(&pnpm("10.0.0"), options).outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&pnpm("10.0.0"), options).outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["--filter", "app", "why", "react"]);
@@ -278,9 +246,7 @@ mod tests {
     fn test_pnpm_why_with_depth() {
         let mut options = why_args(&["react"]);
         options.depth = Some(3);
-        let CommandResolution::Run(command) = resolve(&pnpm("10.0.0"), options).outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&pnpm("10.0.0"), options).outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["why", "--depth", "3", "react"]);
@@ -290,9 +256,7 @@ mod tests {
     fn test_pnpm_why_with_find_by() {
         let mut options = why_args(&["react"]);
         options.find_by = Some("customFinder".to_string());
-        let CommandResolution::Run(command) = resolve(&pnpm("10.0.0"), options).outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&pnpm("10.0.0"), options).outcome);
 
         assert_eq!(command.program, "pnpm");
         assert_eq!(command.args, vec!["why", "--find-by", "customFinder", "react"]);
@@ -302,9 +266,7 @@ mod tests {
     fn test_bun_why_with_depth() {
         let mut options = why_args(&["testnpm2"]);
         options.depth = Some(2);
-        let CommandResolution::Run(command) = resolve(&bun("1.3.11"), options).outcome else {
-            panic!("expected command resolution");
-        };
+        let command = expect_run(resolve(&bun("1.3.11"), options).outcome);
 
         assert_eq!(command.program, "bun");
         assert_eq!(command.args, vec!["why", "testnpm2", "--depth", "2"]);
@@ -321,9 +283,7 @@ mod tests {
         yarn_options.dev = true;
         yarn_options.find_by = Some("customFinder".to_string());
         let yarn_resolution = resolve(&yarn("1.22.0"), yarn_options);
-        let CommandResolution::Run(yarn_command) = yarn_resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let yarn_command = expect_run(yarn_resolution.outcome);
 
         assert_eq!(yarn_command.args, vec!["why", "react"]);
         assert_eq!(yarn_resolution.diagnostics.len(), 7);
@@ -336,9 +296,7 @@ mod tests {
         npm_options.depth = Some(2);
         npm_options.find_by = Some("customFinder".to_string());
         let npm_resolution = resolve(&npm("11.0.0"), npm_options);
-        let CommandResolution::Run(npm_command) = npm_resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let npm_command = expect_run(npm_resolution.outcome);
 
         assert_eq!(npm_command.args, vec!["explain", "react"]);
         assert_eq!(npm_resolution.diagnostics.len(), 6);
@@ -356,9 +314,7 @@ mod tests {
         bun_options.exclude_peers = true;
         bun_options.find_by = Some("customFinder".to_string());
         let bun_resolution = resolve(&bun("1.3.11"), bun_options);
-        let CommandResolution::Run(bun_command) = bun_resolution.outcome else {
-            panic!("expected command resolution");
-        };
+        let bun_command = expect_run(bun_resolution.outcome);
 
         assert_eq!(bun_command.args, vec!["why", "react"]);
         assert_eq!(bun_resolution.diagnostics.len(), 11);

--- a/crates/vp_pm_cli/src/resolution/test_utils.rs
+++ b/crates/vp_pm_cli/src/resolution/test_utils.rs
@@ -2,7 +2,15 @@ use std::ffi::OsString;
 
 use semver::Version;
 
-use crate::resolution::{Bun, Npm, Pnpm, Yarn};
+use crate::resolution::{Bun, CommandResolution, Npm, Pnpm, Yarn, command::ResolvedCommand};
+
+#[track_caller]
+pub(crate) fn expect_run(outcome: CommandResolution) -> ResolvedCommand {
+    match outcome {
+        CommandResolution::Run(command) => command,
+        other => panic!("expected command resolution, got {other:?}"),
+    }
+}
 
 pub(crate) fn npm(version: &str) -> Npm {
     Npm::new(parse_version(version))


### PR DESCRIPTION
## Summary

Consolidate repeated `CommandResolution::Run` extraction in the `vp_pm_cli` command resolution tests into a shared `expect_run` helper.

- Removes repeated extraction and panic blocks.
- Uses `#[track_caller]` and reports the actual outcome to improve failure diagnostics.