### PR TITLE
test(global): remove no-op compile checks

### DIFF
--- a/crates/vp_global_cli/src/commands/delegate.rs
+++ b/crates/vp_global_cli/src/commands/delegate.rs
@@ -48,12 +48,3 @@ pub async fn execute_global(
     full_args.extend(args.iter().cloned());
     executor.delegate_to_global_cli(&cwd, &full_args).await
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn test_delegate_command_module_exists() {
-        // Basic test to ensure the module compiles
-        assert!(true);
-    }
-}

--- a/crates/vp_global_cli/src/commands/migrate.rs
+++ b/crates/vp_global_cli/src/commands/migrate.rs
@@ -17,12 +17,3 @@ pub async fn execute(cwd: AbsolutePathBuf, args: &[String]) -> Result<ExitStatus
     full_args.extend(args.iter().cloned());
     executor.delegate_migrate(&cwd, &full_args).await
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn test_migrate_command_module_exists() {
-        // Basic test to ensure the module compiles
-        assert!(true);
-    }
-}


### PR DESCRIPTION
## Summary
Removes no-op `assert!(true)` tests from the migrate and delegate command modules. Both modules already compile through production call sites, so these tests only inflated the test count.