### PR TITLE
chore: remove unused build:src task

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -91,17 +91,4 @@ export default defineConfig({
       order: 'asc',
     },
   },
-  run: {
-    tasks: {
-      'build:src': {
-        command: [
-          'vp run rolldown#build-binding:release',
-          'vp run rolldown#build-node',
-          'vp run vite#build-types',
-          'vp run @voidzero-dev/vite-plus-core#build',
-          'vp run vite-plus#build',
-        ].join(' && '),
-      },
-    },
-  },
 });


### PR DESCRIPTION
## Summary

Removes the undocumented `build:src` task from the root Vite+ configuration. The existing `build` script already covers these source packages as part of the broader build flow.

The task appears to be unused. If the intended setup is for the root `build` script to delegate to this task, please let me know. I can keep the task and update the script to call `vpr build:src` instead.