### PR TITLE
docs: add View Prompt dialog for the setup prompt

### DIFF
--- a/docs/.vitepress/theme/components/CopyPrompt.vue
+++ b/docs/.vitepress/theme/components/CopyPrompt.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Icon } from '@iconify/vue';
-import { onBeforeUnmount, ref } from 'vue';
+import { computed, onBeforeUnmount, ref, useId } from 'vue';
 
 // Default getting-started prompt handed to an AI coding assistant. Every
 // command and URL here is verified against the Getting Started guide and the
@@ -26,11 +26,23 @@ const props = withDefaults(
   }>(),
   {
     prompt: DEFAULT_PROMPT,
-    label: 'Copy Prompt',
+    label: 'View Prompt',
   },
 );
 
+const titleId = useId();
+const dialogEl = ref<HTMLDialogElement | null>(null);
 const state = ref<'idle' | 'copied' | 'error'>('idle');
+const copyLabel = computed(() =>
+  state.value === 'copied' ? 'Copied!' : state.value === 'error' ? 'Could not copy' : 'Copy Prompt',
+);
+const copyIcon = computed(() =>
+  state.value === 'copied'
+    ? 'lucide:check'
+    : state.value === 'error'
+      ? 'lucide:x'
+      : 'lucide:clipboard',
+);
 let resetTimer: ReturnType<typeof setTimeout> | null = null;
 
 const flash = (next: 'copied' | 'error') => {
@@ -44,16 +56,20 @@ const flash = (next: 'copied' | 'error') => {
   }, 1600);
 };
 
-const copyPrompt = async (event: MouseEvent) => {
-  // The theme draws the `.button` border with an `outline`, but a global reset
-  // (`button:focus:not(:focus-visible) { outline: none !important }`) strips it
-  // after a mouse click. The theme only ever uses `.button` on <a> tags, so this
-  // bites only real <button> elements. For pointer activation (event.detail > 0)
-  // drop focus so the button returns to its resting state and keeps its border;
-  // keyboard activation (detail === 0) keeps focus so the a11y focus ring shows.
+// The theme draws the `.button` border with an `outline`, but a global reset
+// (`button:focus:not(:focus-visible) { outline: none !important }`) strips it
+// after a mouse click. The theme only ever uses `.button` on <a> tags, so this
+// bites only real <button> elements. For pointer activation (event.detail > 0)
+// drop focus so the button returns to its resting state and keeps its border;
+// keyboard activation (detail === 0) keeps focus so the a11y focus ring shows.
+const blurPointerTarget = (event: MouseEvent) => {
   if (event.detail > 0) {
     (event.currentTarget as HTMLElement | null)?.blur();
   }
+};
+
+const copyPrompt = async (event: MouseEvent) => {
+  blurPointerTarget(event);
   try {
     await navigator.clipboard.writeText(props.prompt);
     flash('copied');
@@ -62,10 +78,26 @@ const copyPrompt = async (event: MouseEvent) => {
   }
 };
 
+const openView = (event: MouseEvent) => {
+  blurPointerTarget(event);
+  dialogEl.value?.showModal();
+};
+
+const closeView = () => {
+  dialogEl.value?.close();
+};
+
+const onDialogClick = (event: MouseEvent) => {
+  if (event.target === dialogEl.value) {
+    closeView();
+  }
+};
+
 onBeforeUnmount(() => {
   if (resetTimer) {
     clearTimeout(resetTimer);
   }
+  dialogEl.value?.close();
 });
 </script>
 
@@ -74,23 +106,40 @@ onBeforeUnmount(() => {
     type="button"
     class="button"
     :aria-label="`${label} for setting up Vite+ with an AI assistant`"
-    @click="copyPrompt"
+    @click="openView"
   >
-    <Icon
-      :icon="
-        state === 'copied' ? 'lucide:check' : state === 'error' ? 'lucide:x' : 'lucide:clipboard'
-      "
-      class="size-4"
-      aria-hidden="true"
-    />
-    <span>{{ state === 'copied' ? 'Copied!' : state === 'error' ? 'Could not copy' : label }}</span>
+    <Icon icon="lucide:eye" class="size-4" aria-hidden="true" />
+    <span>{{ label }}</span>
   </button>
-</template>
 
-<style scoped>
-.button {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-</style>
+  <Teleport to="body">
+    <dialog
+      ref="dialogEl"
+      class="m-auto w-[min(40rem,calc(100vw-2rem))] max-h-[min(80vh,36rem)] rounded-xl border border-stroke bg-white p-0 text-primary shadow-xl backdrop:bg-black/40 dark:border-nickel dark:bg-slate dark:text-white"
+      :aria-labelledby="titleId"
+      @click="onDialogClick"
+    >
+      <form class="flex max-h-[min(80vh,36rem)] flex-col" method="dialog">
+        <header class="flex items-center justify-between gap-4 px-5 pt-4 pb-3">
+          <h2 :id="titleId" class="m-0 text-base font-medium">Setup prompt</h2>
+          <button
+            type="submit"
+            class="inline-flex size-8 items-center justify-center rounded-md text-grey hover:bg-beige hover:text-primary dark:text-white dark:hover:bg-slate dark:hover:text-white"
+            aria-label="Close"
+          >
+            <Icon icon="lucide:x" class="size-4" aria-hidden="true" />
+          </button>
+        </header>
+        <pre
+          class="m-0 overflow-auto px-5 pb-4 font-mono text-sm leading-relaxed break-words whitespace-pre-wrap"
+          >{{ prompt }}</pre>
+        <footer class="flex justify-end border-t border-stroke px-5 py-3 dark:border-nickel">
+          <button type="button" class="button" @click="copyPrompt">
+            <Icon :icon="copyIcon" class="size-4" aria-hidden="true" />
+            <span>{{ copyLabel }}</span>
+          </button>
+        </footer>
+      </form>
+    </dialog>
+  </Teleport>
+</template>

--- a/docs/.vitepress/theme/components/CopyPrompt.vue
+++ b/docs/.vitepress/theme/components/CopyPrompt.vue
@@ -115,7 +115,7 @@ onBeforeUnmount(() => {
   <Teleport to="body">
     <dialog
       ref="dialogEl"
-      class="m-auto w-[min(40rem,calc(100vw-2rem))] max-h-[min(80vh,36rem)] rounded-xl border border-stroke bg-white p-0 text-primary shadow-xl backdrop:bg-black/40 dark:border-nickel dark:bg-slate dark:text-white"
+      class="m-auto w-[min(48rem,calc(100vw-2rem))] max-h-[min(80vh,36rem)] rounded-xl border border-stroke bg-white p-0 text-primary shadow-xl backdrop:bg-black/40 dark:border-nickel dark:bg-slate dark:text-white"
       :aria-labelledby="titleId"
       @click="onDialogClick"
     >

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -4,7 +4,7 @@ Vite+ is the unified toolchain and entry point for web development. It manages y
 
 Vite+ ships in two parts: `vp`, the global command-line tool, and `vite-plus`, the local package installed in each project. If you already have a Vite project, use [`vp migrate`](/guide/migrate) to migrate it to Vite+, or paste our [migration prompt](/guide/migrate#migration-prompt) into your coding agent.
 
-Building with an AI assistant? Copy a ready-made setup prompt:
+Building with an AI assistant? View and copy a ready-made setup prompt:
 
 <CopyPrompt />
 


### PR DESCRIPTION
## Summary

The homepage Copy Prompt button copied text you couldn't read first (#2383). This replaces that one-click CTA with a single **View Prompt** button that opens the full setup prompt in a native dialog; copy stays inside the modal.

Also used on `/guide`. Maintainers preferred one hero-aligned button over a Copy control plus a View prompt link underneath.

Closes #2383

## Test plan

- [ ] On `/`, the hero CTA reads **View Prompt** (eye icon) and sits in line with Get started / Announcement
- [ ] Clicking it opens a dialog with the full prompt; clicking **Copy Prompt** copies and flashes Copied!
- [ ] Close via X, Escape, and backdrop click
- [ ] Same control on `/guide` works and is not restyled by `.vp-doc`