### PR TITLE
test(snapshots): stop Windows network stalls from timing out PTY cases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -970,6 +970,12 @@ jobs:
         run: |
           "$HOME/.vite-plus/bin/vp" node --version \
             || echo "prewarm failed; cases will download the runtime on demand"
+          # Warm the Node.js version index cache (~1h TTL) into the runtime
+          # seed. Cases without a version pin resolve "latest LTS" before
+          # their first output, and a stalled nodejs.org fetch there times
+          # out the 60s step budget (same stall class as #2390).
+          "$HOME/.vite-plus/bin/vp" env list-remote > /dev/null \
+            || echo "index prewarm failed; cases will fetch the version index on demand"
 
       - name: Install Playwright Chromium
         run: pnpm exec playwright install chromium
@@ -1059,6 +1065,12 @@ jobs:
         run: |
           "$USERPROFILE/.vite-plus/bin/vp.exe" node --version \
             || echo "prewarm failed; cases will download the runtime on demand"
+          # Warm the Node.js version index cache (~1h TTL) into the runtime
+          # seed. Cases without a version pin resolve "latest LTS" before
+          # their first output, and a stalled nodejs.org fetch there times
+          # out the 60s step budget (same stall class as #2390).
+          "$USERPROFILE/.vite-plus/bin/vp.exe" env list-remote > /dev/null \
+            || echo "index prewarm failed; cases will fetch the version index on demand"
 
       - name: Install Playwright Chromium
         shell: bash

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/main.rs
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/main.rs
@@ -653,6 +653,12 @@ impl CaseHome {
         env.insert("TERM".into(), "xterm-256color".into());
         env.insert("VP_CLI_TEST".into(), "1".into());
         env.insert("NODE_NO_WARNINGS".into(), "1".into());
+        // Cap download attempts far below vp's 10-minute default: a stalled
+        // runtime or package-manager download must fail fast enough for vp's
+        // retry (3 attempts, exponential backoff) to finish inside the 60s
+        // step budget. Healthy CI downloads take ~1s; Windows runners stall
+        // intermittently (see command_cache_bun in the #2390 stall class).
+        env.insert("VP_DOWNLOAD_TIMEOUT".into(), "30".into());
         env.insert("VP_HOME".into(), self.vp_home().into_os_string());
         if cfg!(windows) {
             env.insert("USERPROFILE".into(), self.home.clone().into_os_string());


### PR DESCRIPTION
Two PTY snapshot cases intermittently fail the Windows leg with "timed out after 60s" and empty partial output: `migration_eslint` and `command_cache_bun` (run [31453833634](https://github.com/voidzero-dev/vite-plus/actions/runs/31453833634), attempts 2 and 4 red, attempt 5 green with no code change). This is the stall class from #2390: the Windows runner's connections to external hosts stall intermittently, and any step that must fetch from the network inside its 60s budget dies with no output.

Where each case stalls:

- `migration_eslint` has no Node version pin, so the global vp resolves "latest LTS" through a `nodejs.org/dist/index.json` fetch before it spawns node and prints anything. Each case runs in a fresh `VP_HOME` and the CI runtime seed carries no index cache, so every unpinned case fetches the index. A stall there spends the whole step budget before the first byte of output.
- `command_cache_bun` provisions `bun@1.3.11` into its fresh `VP_HOME`. A stalled tarball download holds the request for vp's full download timeout (10 minutes since #2386), so the in-request retry never fires inside the step budget.

Two fixes:

- Warm the version index cache in the snapshot jobs' prewarm step with `vp env list-remote`, so `node/index_cache.json` lands in the seeded `js_runtime` dir. nodejs.org serves the index with a one-hour max-age, which covers the whole suite, and vp falls back to an existing cache when a later fetch fails.
- Set `VP_DOWNLOAD_TIMEOUT=30` (the #2386 knob) in every case's env in the runner, so a stalled runtime or package-manager download fails fast enough for vp's retry (3 attempts) to finish inside the 60s step budget. Healthy CI downloads take about a second.

Verification: `cargo check -p vp_cli_snapshots --tests` and `cargo fmt --check` pass; `command_cache_bun` and `dev_engines_runtime_pnpm10` pass through the runner locally with the new env (the installed vp 0.2.8 ignores the unknown variable; CI builds vp from HEAD where the cap is active). `migration_eslint` needs the JS dist build a fresh worktree lacks, so CI covers it. `vp env list-remote` was verified to write `js_runtime/node/index_cache.json` with a ~3600s TTL from the real nodejs.org response.
