### PR TITLE
refactor(cli): share Vite config file order

### DIFF
--- a/packages/cli/src/init-config.ts
+++ b/packages/cli/src/init-config.ts
@@ -5,7 +5,7 @@ import { hasConfigKey, mergeJsonConfig } from '../binding/index.js';
 import { createDefaultVitePlusLintConfig } from './oxlint-plugin-config.ts';
 import { fmt as resolveFmt } from './resolve-fmt.ts';
 import { runCommandSilently } from './utils/command.ts';
-import { BASEURL_TSCONFIG_WARNING, VITE_PLUS_NAME } from './utils/constants.ts';
+import { BASEURL_TSCONFIG_WARNING, VITE_CONFIG_FILES, VITE_PLUS_NAME } from './utils/constants.ts';
 import { warnMsg } from './utils/terminal.ts';
 import { fixBaseUrlInTsconfig, hasBaseUrlInTsconfig } from './utils/tsconfig.ts';
 
@@ -31,15 +31,6 @@ const INIT_COMMAND_SPECS: Record<string, InitCommandSpec> = {
 function normalizeInitCommand(command: string | undefined): string | undefined {
   return command === 'format' ? 'fmt' : command;
 }
-
-const VITE_CONFIG_FILES = [
-  'vite.config.ts',
-  'vite.config.mts',
-  'vite.config.cts',
-  'vite.config.js',
-  'vite.config.mjs',
-  'vite.config.cjs',
-] as const;
 
 export interface InitCommandInspection {
   handled: boolean;

--- a/packages/cli/src/migration/detector.ts
+++ b/packages/cli/src/migration/detector.ts
@@ -1,6 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { VITE_CONFIG_FILES } from '../utils/constants.ts';
+
 export interface ConfigFiles {
   viteConfig?: string;
   vitestConfig?: string;
@@ -44,17 +46,7 @@ export const PRETTIER_CONFIG_FILES = [
 export function detectConfigs(projectPath: string): ConfigFiles {
   const configs: ConfigFiles = {};
 
-  // Check for vite.config.*
-  // https://vite.dev/config/
-  const viteConfigs = [
-    'vite.config.ts',
-    'vite.config.mts',
-    'vite.config.cts',
-    'vite.config.js',
-    'vite.config.mjs',
-    'vite.config.cjs',
-  ];
-  for (const config of viteConfigs) {
+  for (const config of VITE_CONFIG_FILES) {
     if (fs.existsSync(path.join(projectPath, config))) {
       configs.viteConfig = config;
       break;

--- a/packages/cli/src/resolve-vite-config.ts
+++ b/packages/cli/src/resolve-vite-config.ts
@@ -2,20 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { withConfigMetadataResolution } from './define-config.ts';
-
-// Mirrors Vite's own DEFAULT_CONFIG_FILES order so finders here pick the same
-// file Vite loads when a directory contains more than one config (e.g. a
-// `vite.config.js` next to a stray `vite.config.ts`). Readers evaluate via
-// Vite's loader, so a different order would make read and write target
-// different files.
-const VITE_CONFIG_FILES = [
-  'vite.config.js',
-  'vite.config.mjs',
-  'vite.config.ts',
-  'vite.config.cjs',
-  'vite.config.mts',
-  'vite.config.cts',
-];
+import { VITE_CONFIG_FILES } from './utils/constants.ts';
 
 /**
  * Find a vite config file by walking up from `startDir` to `stopDir`.

--- a/packages/cli/src/utils/constants.ts
+++ b/packages/cli/src/utils/constants.ts
@@ -5,6 +5,16 @@ import cliPkg from '../../package.json' with { type: 'json' };
 export const VITE_PLUS_NAME = 'vite-plus';
 export const VITE_PLUS_VERSION = process.env.VP_VERSION || cliPkg.version;
 
+// Mirrors Vite's DEFAULT_CONFIG_FILES order so readers and writers target the same file.
+export const VITE_CONFIG_FILES = [
+  'vite.config.js',
+  'vite.config.mjs',
+  'vite.config.ts',
+  'vite.config.cjs',
+  'vite.config.mts',
+  'vite.config.cts',
+] as const;
+
 export const VITEST_VERSION = '4.1.10';
 
 export const VITE_PLUS_OVERRIDE_PACKAGES: Record<string, string> = process.env.VP_OVERRIDE_PACKAGES


### PR DESCRIPTION
## Summary

   Use one canonical Vite config filename order across config resolution, tool initialization, and migration detection.
 The shared order mirrors [Vite's `DEFAULT_CONFIG_FILES`](https://github.com/vitejs/vite/blob/v8.2.1/packages/vite/src/node/constants.ts#L98-L105), which  prevents duplicated lists from drifting.