### PR TITLE
ci: run e2e migrate at the clone root

### DIFF
--- a/.claude/skills/add-ecosystem-ci/SKILL.md
+++ b/.claude/skills/add-ecosystem-ci/SKILL.md
@@ -66,7 +66,6 @@ Present the auto-detected configuration and ask user to confirm or modify:
        "repository": "https://github.com/owner/repo.git",
        "branch": "main",
        "hash": "full-commit-sha",
-       "directory": "web", // only if subdirectory is needed
        "forceFreshMigration": true // only if project already uses vite-plus
      }
    }
@@ -142,8 +141,7 @@ vp run build
 
 ## Important Notes
 
-- The `directory` field is optional - only add it if the package.json is not in the project root
-- If `directory` is specified in repo.json, it must also be specified in the workflow matrix
-- `patch-project.ts` automatically handles running `vp migrate` in the correct directory
+- The workflow matrix `directory` field is optional - only add it if the project commands must run in a subdirectory (like a workspace member)
+- `patch-project.ts` always runs `vp migrate` and `vp install` at the clone root; `vp migrate` rejects workspace member targets
 - `forceFreshMigration` is required for projects that already have `vite-plus` in their package.json — it sets `VP_FORCE_MIGRATE=1` so `vp migrate` forces full dependency rewriting instead of skipping
 - OS exclusions are added to the existing `exclude` section in the workflow matrix

--- a/ecosystem-ci/patch-project.ts
+++ b/ecosystem-ci/patch-project.ts
@@ -18,9 +18,10 @@ if (!projects.includes(project)) {
 
 const repoRoot = join(ecosystemCiDir, project);
 const repoConfig = repos[project as keyof typeof repos];
-const directory = 'directory' in repoConfig ? repoConfig.directory : undefined;
-const cwd = directory ? join(repoRoot, directory) : repoRoot;
-// run vp migrate
+// Migrate and install always run at the clone root: `vp migrate` rejects
+// workspace member targets (#2229). The workflow's `directory` matrix value
+// only steers where the later project commands run (e.g. dify's `vp run ...`
+// in web/).
 const cli = process.env.VP_CLI_BIN ?? 'vp';
 
 // The packed local build in tmp/tgz is served through a local npm registry
@@ -209,7 +210,7 @@ const migrateEnv: NodeJS.ProcessEnv = {
 };
 
 execSync(`${cli} migrate --no-agent --no-interactive`, {
-  cwd,
+  cwd: repoRoot,
   stdio: 'inherit',
   env: migrateEnv,
 });
@@ -218,7 +219,7 @@ execSync(`${cli} migrate --no-agent --no-interactive`, {
 // `vite-plus@<version>` in package.json exactly like a real migration, so no
 // manual package.json rewrite is needed.
 execSync(`${cli} install --no-frozen-lockfile`, {
-  cwd,
+  cwd: repoRoot,
   stdio: 'inherit',
   env: { ...process.env, ...registryInfo.env, ...releaseAgeEnv },
 });

--- a/ecosystem-ci/repo.json
+++ b/ecosystem-ci/repo.json
@@ -3,7 +3,6 @@
     "repository": "https://github.com/langgenius/dify.git",
     "branch": "main",
     "hash": "baf2191ee360c5f058a9e25c2c2c26cafea2bbe6",
-    "directory": "web",
     "forceFreshMigration": true
   },
   "skeleton": {


### PR DESCRIPTION
The dify e2e job fails since #2229 ([failed run](https://github.com/voidzero-dev/vite-plus/actions/runs/31460483166/job/93683227772)): `vp migrate` now rejects workspace member targets, and `patch-project.ts` ran it from `dify/web`, a member of dify's root pnpm workspace.

Before #2229 the member cwd only worked by accident. `detectWorkspace` corrected the target back to the workspace root, so migrate and install already operated there. This change makes the rig follow the product rule:

- `patch-project.ts` runs `vp migrate` and `vp install` at the clone root and no longer reads the `directory` key from `repo.json` (dify was its only user, key removed).
- The workflow matrix `directory: web` value is untouched and still runs the later dify commands (`verify-install.ts`, `vp run ...`) in `web/`.
- The add-ecosystem-ci skill notes now describe the new rule.
