### PR TITLE
docs(guide): document the vite-plus/test import surface

### DIFF
--- a/docs/guide/test.md
+++ b/docs/guide/test.md
@@ -6,6 +6,14 @@
 
 `vp test` is built on [Vitest](https://vitest.dev/), so you get a Vite-native test runner that reuses your Vite config and plugins, supports Jest-style expectations, snapshots, and coverage, and handles modern ESM, TypeScript, and JSX projects cleanly.
 
+Vitest APIs are available from `vite-plus/test`, so a single `vite-plus` install is enough — you do not need to install `vitest` directly:
+
+```ts [src/example.test.ts]
+import { describe, expect, it, vi } from 'vite-plus/test';
+```
+
+For the browser mode subpaths (`vite-plus/test/browser*`), see [Migrating Vitest](/guide/migrate#vitest).
+
 ::: info
 `vp test` always runs the built-in Vitest command. If your project also has a `test` script in `package.json`, run `vp run test` when you want to run that script instead. See [Built-in Commands vs Scripts](/guide/run#built-in-commands-vs-scripts).
 :::


### PR DESCRIPTION
## Summary
The test guide explains how to run and configure `vp test`, but it never shows where test APIs like `describe`, `it`, `expect`, and `vi` should be imported from. The `vite-plus/test` import surface is currently only documented in the migration guide, so a user who starts a new project and only reads the test guide may install `vitest` directly even though a single `vite-plus` install is enough.

This PR adds a short paragraph and an import example to the Overview section of `docs/guide/test.md`. The browser mode subpaths (`vite-plus/test/browser*`) are already covered in the migration guide, so the new section links to [Migrating Vitest](https://viteplus.dev/guide/migrate#vitest) instead of duplicating them.

Closes #2412