### PR TITLE
fix(migrate): keep `catalog:` specs intact through `vp up` under pnpm

### DIFF
--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_update_catalog_protocol_legacy_key/.gitignore
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_update_catalog_protocol_legacy_key/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_update_catalog_protocol_legacy_key/package.json
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_update_catalog_protocol_legacy_key/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "command-update-catalog-protocol-legacy-key",
+  "private": true,
+  "devDependencies": {
+    "vite": "^7.0.0"
+  },
+  "packageManager": "pnpm@11.20.0"
+}

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_update_catalog_protocol_legacy_key/snapshots.toml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_update_catalog_protocol_legacy_key/snapshots.toml
@@ -1,0 +1,58 @@
+[[case]]
+name = "command_update_catalog_protocol_legacy_key"
+vp = "global"
+skip-platforms = ["windows"]
+unset-env = ["CI", "VP_SKIP_INSTALL"]
+local-registry = true
+comment = "#2309 repair path. Migrate first so the catalog holds a real PINNED toolchain version (the reporter's shape), then downgrade the override key to the pre-fix bare spelling a project migrated by an older Vite+ still carries."
+steps = [
+  { argv = [
+    "vp",
+    "migrate",
+    "--no-interactive",
+    "--no-hooks",
+    "--package-manager",
+    "pnpm",
+  ], comment = "migrate pins the toolchain through the workspace catalog", continue-on-failure = true },
+  { argv = [
+    "vpt",
+    "replace-file-content",
+    "pnpm-workspace.yaml",
+    "vite@*:",
+    "vite:",
+  ], comment = "rewind the override key to the pre-#2309 bare spelling (fails if migrate stopped writing the ranged key)", snapshot = false, continue-on-failure = true },
+  { argv = [
+    "vpt",
+    "print-file",
+    "pnpm-workspace.yaml",
+  ], comment = "the pre-fix shape: bare override key over an exactly pinned catalog alias", continue-on-failure = true },
+  { argv = [
+    "vp",
+    "up",
+  ], comment = "nothing to update, yet the bare key still resolves the catalog reference away", continue-on-failure = true },
+  { argv = [
+    "vpt",
+    "print-file",
+    "package.json",
+  ], comment = "`vite` lost `catalog:` for the pinned alias; `vite-plus` (no override) kept it", continue-on-failure = true },
+  { argv = [
+    "vp",
+    "migrate",
+    "--no-interactive",
+    "--no-hooks",
+  ], comment = "the bare key reads as pending, so one migrate repairs it", continue-on-failure = true },
+  { argv = [
+    "vpt",
+    "print-file",
+    "pnpm-workspace.yaml",
+  ], comment = "the bare key is replaced by the range-qualified one", continue-on-failure = true },
+  { argv = [
+    "vp",
+    "up",
+  ], comment = "update is now a no-op on the catalog reference", continue-on-failure = true },
+  { argv = [
+    "vpt",
+    "print-file",
+    "package.json",
+  ], comment = "`vite` stays `catalog:` across the update", continue-on-failure = true },
+]

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_update_catalog_protocol_legacy_key/snapshots/command_update_catalog_protocol_legacy_key.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_update_catalog_protocol_legacy_key/snapshots/command_update_catalog_protocol_legacy_key.md
@@ -1,0 +1,128 @@
+# command_update_catalog_protocol_legacy_key
+
+#2309 repair path. Migrate first so the catalog holds a real PINNED toolchain version (the reporter's shape), then downgrade the override key to the pre-fix bare spelling a project migrated by an older Vite+ still carries.
+
+## `vp migrate --no-interactive --no-hooks --package-manager pnpm`
+
+migrate pins the toolchain through the workspace catalog
+
+```
+VITE+ - The Unified Toolchain for the Web
+
+Formatting code...
+
+Code formatted
+◇ Migrated . to Vite+ <version>
+• Node <version>  pnpm <version>
+✓ Dependencies installed in <duration>
+• 1 config update applied
+```
+
+## `vpt replace-file-content pnpm-workspace.yaml vite@*: vite:`
+
+rewind the override key to the pre-#2309 bare spelling (fails if migrate stopped writing the ranged key)
+
+
+## `vpt print-file pnpm-workspace.yaml`
+
+the pre-fix shape: bare override key over an exactly pinned catalog alias
+
+```
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@<version>
+  vite-plus: <version>
+overrides:
+  vite: "catalog:"
+peerDependencyRules:
+  allowAny:
+    - vite
+  allowedVersions:
+    vite: "*"
+```
+
+## `vp up`
+
+nothing to update, yet the bare key still resolves the catalog reference away
+
+```
+✓ Lockfile passes supply-chain policies (verified <duration> ago)
+Already up to date
+
+Done in <duration> using pnpm <version>
+```
+
+## `vpt print-file package.json`
+
+`vite` lost `catalog:` for the pinned alias; `vite-plus` (no override) kept it
+
+```
+{
+  "name": "command-update-catalog-protocol-legacy-key",
+  "private": true,
+  "devDependencies": {
+    "vite": "npm:@voidzero-dev/vite-plus-core@<version>",
+    "vite-plus": "catalog:"
+  },
+  "packageManager": "pnpm@11.20.0"
+}
+```
+
+## `vp migrate --no-interactive --no-hooks`
+
+the bare key reads as pending, so one migrate repairs it
+
+```
+VITE+ - The Unified Toolchain for the Web
+
+Formatting code...
+
+Code formatted
+◇ Updated . to Vite+ <version>
+• Node <version>  pnpm <version>
+✓ Dependencies installed in <duration>
+• Package manager settings configured
+```
+
+## `vpt print-file pnpm-workspace.yaml`
+
+the bare key is replaced by the range-qualified one
+
+```
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@<version>
+  vite-plus: <version>
+overrides:
+  vite@*: "catalog:"
+peerDependencyRules:
+  allowAny:
+    - vite
+  allowedVersions:
+    vite: "*"
+```
+
+## `vp up`
+
+update is now a no-op on the catalog reference
+
+```
+✓ Lockfile passes supply-chain policies (verified <duration> ago)
+Already up to date
+
+Done in <duration> using pnpm <version>
+```
+
+## `vpt print-file package.json`
+
+`vite` stays `catalog:` across the update
+
+```
+{
+  "name": "command-update-catalog-protocol-legacy-key",
+  "private": true,
+  "devDependencies": {
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
+  },
+  "packageManager": "pnpm@11.20.0"
+}
+```

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_update_catalog_protocol_pnpm/.gitignore
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_update_catalog_protocol_pnpm/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_update_catalog_protocol_pnpm/package.json
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_update_catalog_protocol_pnpm/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "command-update-catalog-protocol-pnpm",
+  "devDependencies": {
+    "vite": "^7.0.0"
+  },
+  "packageManager": "pnpm@11.20.0"
+}

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_update_catalog_protocol_pnpm/snapshots.toml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_update_catalog_protocol_pnpm/snapshots.toml
@@ -1,0 +1,35 @@
+[[case]]
+name = "command_update_catalog_protocol_pnpm"
+vp = "global"
+skip-platforms = ["windows"]
+unset-env = ["CI", "VP_SKIP_INSTALL"]
+local-registry = true
+steps = [
+  { argv = [
+    "vp",
+    "migrate",
+    "--no-interactive",
+    "--no-hooks",
+    "--package-manager",
+    "pnpm",
+  ], comment = "migrate pins the toolchain through the workspace catalog", continue-on-failure = true },
+  { argv = [
+    "vpt",
+    "print-file",
+    "package.json",
+  ], comment = "the migrated project references the catalog", continue-on-failure = true },
+  { argv = [
+    "vp",
+    "up",
+  ], comment = "#2309: update must not resolve the catalog reference away", continue-on-failure = true },
+  { argv = [
+    "vpt",
+    "print-file",
+    "package.json",
+  ], comment = "`vite` stays `catalog:` instead of the concrete core alias", continue-on-failure = true },
+  { argv = [
+    "vpt",
+    "print-file",
+    "pnpm-workspace.yaml",
+  ], comment = "the catalog keeps owning the resolved toolchain version", continue-on-failure = true },
+]

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_update_catalog_protocol_pnpm/snapshots/command_update_catalog_protocol_pnpm.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_update_catalog_protocol_pnpm/snapshots/command_update_catalog_protocol_pnpm.md
@@ -1,0 +1,75 @@
+# command_update_catalog_protocol_pnpm
+
+## `vp migrate --no-interactive --no-hooks --package-manager pnpm`
+
+migrate pins the toolchain through the workspace catalog
+
+```
+VITE+ - The Unified Toolchain for the Web
+
+Formatting code...
+
+Code formatted
+◇ Migrated . to Vite+ <version>
+• Node <version>  pnpm <version>
+✓ Dependencies installed in <duration>
+• 1 config update applied
+```
+
+## `vpt print-file package.json`
+
+the migrated project references the catalog
+
+```
+{
+  "name": "command-update-catalog-protocol-pnpm",
+  "devDependencies": {
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
+  },
+  "packageManager": "pnpm@11.20.0"
+}
+```
+
+## `vp up`
+
+#2309: update must not resolve the catalog reference away
+
+```
+✓ Lockfile passes supply-chain policies (verified <duration> ago)
+Already up to date
+
+Done in <duration> using pnpm <version>
+```
+
+## `vpt print-file package.json`
+
+`vite` stays `catalog:` instead of the concrete core alias
+
+```
+{
+  "name": "command-update-catalog-protocol-pnpm",
+  "devDependencies": {
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
+  },
+  "packageManager": "pnpm@11.20.0"
+}
+```
+
+## `vpt print-file pnpm-workspace.yaml`
+
+the catalog keeps owning the resolved toolchain version
+
+```
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@<version>
+  vite-plus: <version>
+overrides:
+  vite@*: "catalog:"
+peerDependencyRules:
+  allowAny:
+    - vite
+  allowedVersions:
+    vite: "*"
+```

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/create_approve_builds_migrate_pnpm11/snapshots/create_approve_builds_migrate_pnpm11.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/create_approve_builds_migrate_pnpm11/snapshots/create_approve_builds_migrate_pnpm11.md
@@ -24,7 +24,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: "catalog:"
+  vite@*: "catalog:"
 peerDependencyRules:
   allowAny:
     - vite
@@ -60,7 +60,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: "catalog:"
+  vite@*: "catalog:"
 peerDependencyRules:
   allowAny:
     - vite
@@ -87,7 +87,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: "catalog:"
+  vite@*: "catalog:"
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/create_approve_builds_pnpm11/snapshots/create_approve_builds_pnpm11.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/create_approve_builds_pnpm11/snapshots/create_approve_builds_pnpm11.md
@@ -22,7 +22,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: "catalog:"
+  vite@*: "catalog:"
 peerDependencyRules:
   allowAny:
     - vite
@@ -56,7 +56,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: "catalog:"
+  vite@*: "catalog:"
 peerDependencyRules:
   allowAny:
     - vite
@@ -83,7 +83,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: "catalog:"
+  vite@*: "catalog:"
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/create_org_bundled_monorepo/snapshots/create_org_bundled_monorepo.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/create_org_bundled_monorepo/snapshots/create_org_bundled_monorepo.md
@@ -44,7 +44,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: "catalog:"
+  vite@*: "catalog:"
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_add_git_hooks/snapshots/migration_add_git_hooks.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_add_git_hooks/snapshots/migration_add_git_hooks.md
@@ -49,7 +49,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_auto_create_vite_config/snapshots/migration_auto_create_vite_config.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_auto_create_vite_config/snapshots/migration_auto_create_vite_config.md
@@ -97,7 +97,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_baseurl_tsconfig/snapshots/migration_baseurl_tsconfig.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_baseurl_tsconfig/snapshots/migration_baseurl_tsconfig.md
@@ -104,7 +104,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_chained_lint_staged_pre_commit/snapshots/migration_chained_lint_staged_pre_commit.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_chained_lint_staged_pre_commit/snapshots/migration_chained_lint_staged_pre_commit.md
@@ -54,7 +54,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_composed_husky_custom_dir/snapshots/migration_composed_husky_custom_dir.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_composed_husky_custom_dir/snapshots/migration_composed_husky_custom_dir.md
@@ -63,7 +63,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_composed_husky_prepare/snapshots/migration_composed_husky_prepare.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_composed_husky_prepare/snapshots/migration_composed_husky_prepare.md
@@ -50,7 +50,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_env_prefix_lint_staged/snapshots/migration_env_prefix_lint_staged.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_env_prefix_lint_staged/snapshots/migration_env_prefix_lint_staged.md
@@ -54,7 +54,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_eslint/snapshots/migration_eslint.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_eslint/snapshots/migration_eslint.md
@@ -50,7 +50,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_eslint_lint_staged/snapshots/migration_eslint_lint_staged.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_eslint_lint_staged/snapshots/migration_eslint_lint_staged.md
@@ -47,7 +47,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_eslint_lintstagedrc/snapshots/migration_eslint_lintstagedrc.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_eslint_lintstagedrc/snapshots/migration_eslint_lintstagedrc.md
@@ -47,7 +47,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_eslint_npx_wrapper/snapshots/migration_eslint_npx_wrapper.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_eslint_npx_wrapper/snapshots/migration_eslint_npx_wrapper.md
@@ -52,7 +52,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_existing_husky/snapshots/migration_existing_husky.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_existing_husky/snapshots/migration_existing_husky.md
@@ -50,7 +50,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_existing_husky_lint_staged/snapshots/migration_existing_husky_lint_staged.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_existing_husky_lint_staged/snapshots/migration_existing_husky_lint_staged.md
@@ -54,7 +54,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_existing_husky_v8_hooks/snapshots/migration_existing_husky_v8_hooks.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_existing_husky_v8_hooks/snapshots/migration_existing_husky_v8_hooks.md
@@ -51,7 +51,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_existing_husky_v8_multi_hooks/snapshots/migration_existing_husky_v8_multi_hooks.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_existing_husky_v8_multi_hooks/snapshots/migration_existing_husky_v8_multi_hooks.md
@@ -51,7 +51,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_existing_lint_staged_config/snapshots/migration_existing_lint_staged_config.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_existing_lint_staged_config/snapshots/migration_existing_lint_staged_config.md
@@ -49,7 +49,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_existing_pnpm_exec_lint_staged/snapshots/migration_existing_pnpm_exec_lint_staged.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_existing_pnpm_exec_lint_staged/snapshots/migration_existing_pnpm_exec_lint_staged.md
@@ -54,7 +54,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_existing_prepare_script/snapshots/migration_existing_prepare_script.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_existing_prepare_script/snapshots/migration_existing_prepare_script.md
@@ -50,7 +50,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_from_tsdown/snapshots/migration_from_tsdown.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_from_tsdown/snapshots/migration_from_tsdown.md
@@ -84,7 +84,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_from_tsdown_json_config/snapshots/migration_from_tsdown_json_config.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_from_tsdown_json_config/snapshots/migration_from_tsdown_json_config.md
@@ -84,7 +84,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_from_vitest_config/snapshots/migration_from_vitest_config.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_from_vitest_config/snapshots/migration_from_vitest_config.md
@@ -93,8 +93,8 @@ allowBuilds:
   edgedriver: true
   geckodriver: true
 overrides:
-  vite: 'catalog:'
-  vitest: 'catalog:'
+  vite@*: 'catalog:'
+  vitest@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_from_vitest_files/snapshots/migration_from_vitest_files.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_from_vitest_files/snapshots/migration_from_vitest_files.md
@@ -55,8 +55,8 @@ catalog:
   vite-plus: <version>
   '@vitest/browser-playwright': <version>
 overrides:
-  vite: 'catalog:'
-  vitest: 'catalog:'
+  vite@*: 'catalog:'
+  vitest@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_hooks_skip_on_existing_hookspath/snapshots/migration_hooks_skip_on_existing_hookspath.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_hooks_skip_on_existing_hookspath/snapshots/migration_hooks_skip_on_existing_hookspath.md
@@ -49,7 +49,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_husky_catalog_version/snapshots/migration_husky_catalog_version.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_husky_catalog_version/snapshots/migration_husky_catalog_version.md
@@ -59,7 +59,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_husky_latest_dist_tag/snapshots/migration_husky_latest_dist_tag.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_husky_latest_dist_tag/snapshots/migration_husky_latest_dist_tag.md
@@ -50,7 +50,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_husky_latest_dist_tag_v9_installed/snapshots/migration_husky_latest_dist_tag_v9_installed.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_husky_latest_dist_tag_v9_installed/snapshots/migration_husky_latest_dist_tag_v9_installed.md
@@ -54,7 +54,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_husky_or_prepare/snapshots/migration_husky_or_prepare.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_husky_or_prepare/snapshots/migration_husky_or_prepare.md
@@ -54,7 +54,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_husky_semicolon_prepare/snapshots/migration_husky_semicolon_prepare.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_husky_semicolon_prepare/snapshots/migration_husky_semicolon_prepare.md
@@ -54,7 +54,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_husky_v8_preserves_lint_staged/snapshots/migration_husky_v8_preserves_lint_staged.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_husky_v8_preserves_lint_staged/snapshots/migration_husky_v8_preserves_lint_staged.md
@@ -54,7 +54,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_lazy_plugins_await/snapshots/migration_lazy_plugins_await.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_lazy_plugins_await/snapshots/migration_lazy_plugins_await.md
@@ -61,7 +61,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_lint_staged_in_scripts/snapshots/migration_lint_staged_in_scripts.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_lint_staged_in_scripts/snapshots/migration_lint_staged_in_scripts.md
@@ -55,7 +55,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_lint_staged_merge_fail/snapshots/migration_lint_staged_merge_fail.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_lint_staged_merge_fail/snapshots/migration_lint_staged_merge_fail.md
@@ -56,7 +56,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_lint_staged_ts_config/snapshots/migration_lint_staged_ts_config.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_lint_staged_ts_config/snapshots/migration_lint_staged_ts_config.md
@@ -52,7 +52,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_lintstagedrc_json/snapshots/migration_lintstagedrc_json.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_lintstagedrc_json/snapshots/migration_lintstagedrc_json.md
@@ -133,7 +133,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_lintstagedrc_merge_fail/snapshots/migration_lintstagedrc_merge_fail.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_lintstagedrc_merge_fail/snapshots/migration_lintstagedrc_merge_fail.md
@@ -53,7 +53,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_lintstagedrc_not_support/snapshots/migration_lintstagedrc_not_support.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_lintstagedrc_not_support/snapshots/migration_lintstagedrc_not_support.md
@@ -81,7 +81,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_lintstagedrc_staged_exists/snapshots/migration_lintstagedrc_staged_exists.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_lintstagedrc_staged_exists/snapshots/migration_lintstagedrc_staged_exists.md
@@ -50,7 +50,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_merge_vite_config_js/snapshots/migration_merge_vite_config_js.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_merge_vite_config_js/snapshots/migration_merge_vite_config_js.md
@@ -90,7 +90,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_merge_vite_config_ts/snapshots/migration_merge_vite_config_ts.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_merge_vite_config_ts/snapshots/migration_merge_vite_config_ts.md
@@ -133,8 +133,8 @@ catalog:
   vite-plus: <version>
   '@vitest/browser-playwright': <version>
 overrides:
-  vite: 'catalog:'
-  vitest: 'catalog:'
+  vite@*: 'catalog:'
+  vitest@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_monorepo_pnpm/snapshots/migration_monorepo_pnpm.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_monorepo_pnpm/snapshots/migration_monorepo_pnpm.md
@@ -124,8 +124,8 @@ catalog:
 
 minimumReleaseAge: 1440
 overrides:
-  vite: 'catalog:'
-  vitest: 'catalog:'
+  vite@*: 'catalog:'
+  vitest@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_monorepo_pnpm_overrides_dependency_selector/snapshots/migration_monorepo_pnpm_overrides_dependency_selector.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_monorepo_pnpm_overrides_dependency_selector/snapshots/migration_monorepo_pnpm_overrides_dependency_selector.md
@@ -67,7 +67,7 @@ catalog:
 overrides:
   supertest>superagent: 9.0.2
   react-click-away-listener>react: 0.0.0-experimental-7dc903cd-20251203
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_no_git_repo/snapshots/migration_no_git_repo.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_no_git_repo/snapshots/migration_no_git_repo.md
@@ -45,7 +45,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_no_hooks/snapshots/migration_no_hooks.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_no_hooks/snapshots/migration_no_hooks.md
@@ -45,7 +45,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_no_hooks_with_husky/snapshots/migration_no_hooks_with_husky.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_no_hooks_with_husky/snapshots/migration_no_hooks_with_husky.md
@@ -54,7 +54,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_npmx_dev/snapshots/migration_npmx_dev.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_npmx_dev/snapshots/migration_npmx_dev.md
@@ -55,8 +55,8 @@ catalog:
   '@vitest/browser-playwright': <version>
   '@vitest/coverage-v8': <version>
 overrides:
-  vite: 'catalog:'
-  vitest: 'catalog:'
+  vite@*: 'catalog:'
+  vitest@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_other_hook_tool/snapshots/migration_other_hook_tool.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_other_hook_tool/snapshots/migration_other_hook_tool.md
@@ -54,7 +54,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlintrc_json_with_comments/snapshots/migration_oxlintrc_json_with_comments.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlintrc_json_with_comments/snapshots/migration_oxlintrc_json_with_comments.md
@@ -88,7 +88,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlintrc_jsonc/snapshots/migration_oxlintrc_jsonc.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_oxlintrc_jsonc/snapshots/migration_oxlintrc_jsonc.md
@@ -97,7 +97,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_partially_installed_vite_plus/snapshots/migration_partially_installed_vite_plus.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_partially_installed_vite_plus/snapshots/migration_partially_installed_vite_plus.md
@@ -65,7 +65,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_partially_migrated_pre_commit/snapshots/migration_partially_migrated_pre_commit.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_partially_migrated_pre_commit/snapshots/migration_partially_migrated_pre_commit.md
@@ -51,7 +51,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_preserve_below_policy_node_pins/snapshots/migration_preserve_below_policy_node_pins.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_preserve_below_policy_node_pins/snapshots/migration_preserve_below_policy_node_pins.md
@@ -66,7 +66,7 @@ catalogs:
     vite: npm:@voidzero-dev/vite-plus-core@<version>
     vite-plus: <version>
 overrides:
-  vite: catalog:vite-stack
+  vite@*: catalog:vite-stack
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_prettier/snapshots/migration_prettier.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_prettier/snapshots/migration_prettier.md
@@ -51,7 +51,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_prettier_eslint_combo/snapshots/migration_prettier_eslint_combo.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_prettier_eslint_combo/snapshots/migration_prettier_eslint_combo.md
@@ -53,7 +53,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_prettier_ignore_unknown/snapshots/migration_prettier_ignore_unknown.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_prettier_ignore_unknown/snapshots/migration_prettier_ignore_unknown.md
@@ -51,7 +51,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_prettier_lint_staged/snapshots/migration_prettier_lint_staged.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_prettier_lint_staged/snapshots/migration_prettier_lint_staged.md
@@ -48,7 +48,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_prettier_pkg_json/snapshots/migration_prettier_pkg_json.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_prettier_pkg_json/snapshots/migration_prettier_pkg_json.md
@@ -49,7 +49,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_rewrite_declare_module/snapshots/migration_rewrite_declare_module.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_rewrite_declare_module/snapshots/migration_rewrite_declare_module.md
@@ -83,8 +83,8 @@ catalog:
   vitest: <version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
-  vitest: 'catalog:'
+  vite@*: 'catalog:'
+  vitest@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_skip_vite_dependency/snapshots/migration_skip_vite_dependency.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_skip_vite_dependency/snapshots/migration_skip_vite_dependency.md
@@ -75,7 +75,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_skip_vite_peer_dependency/snapshots/migration_skip_vite_peer_dependency.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_skip_vite_peer_dependency/snapshots/migration_skip_vite_peer_dependency.md
@@ -75,7 +75,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_standalone_pnpm/snapshots/migration_standalone_pnpm.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_standalone_pnpm/snapshots/migration_standalone_pnpm.md
@@ -40,7 +40,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: "catalog:"
+  vite@*: "catalog:"
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_subpath/snapshots/migration_subpath.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_subpath/snapshots/migration_subpath.md
@@ -76,7 +76,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_tsconfig_esmoduleinterop/snapshots/migration_tsconfig_esmoduleinterop.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_tsconfig_esmoduleinterop/snapshots/migration_tsconfig_esmoduleinterop.md
@@ -77,7 +77,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_upgrade_browser_peer_only_pnpm/snapshots/migration_upgrade_browser_peer_only_pnpm.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_upgrade_browser_peer_only_pnpm/snapshots/migration_upgrade_browser_peer_only_pnpm.md
@@ -53,8 +53,8 @@ catalog:
   vitest: <version>
   '@vitest/browser-playwright': <version>
 overrides:
-  vite: 'catalog:'
-  vitest: 'catalog:'
+  vite@*: 'catalog:'
+  vitest@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_upgrade_browser_source_only_pnpm/snapshots/migration_upgrade_browser_source_only_pnpm.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_upgrade_browser_source_only_pnpm/snapshots/migration_upgrade_browser_source_only_pnpm.md
@@ -51,8 +51,8 @@ catalog:
   vitest: <version>
   '@vitest/browser-playwright': <version>
 overrides:
-  vite: 'catalog:'
-  vitest: 'catalog:'
+  vite@*: 'catalog:'
+  vitest@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_upgrade_browser_webdriverio_pnpm/snapshots/migration_upgrade_browser_webdriverio_pnpm.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_upgrade_browser_webdriverio_pnpm/snapshots/migration_upgrade_browser_webdriverio_pnpm.md
@@ -50,8 +50,8 @@ catalog:
   vitest: <version>
   '@vitest/browser-webdriverio': <version>
 overrides:
-  vite: 'catalog:'
-  vitest: 'catalog:'
+  vite@*: 'catalog:'
+  vitest@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_upgrade_monorepo_vitest_localized_pnpm/snapshots/migration_upgrade_monorepo_vitest_localized_pnpm.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_upgrade_monorepo_vitest_localized_pnpm/snapshots/migration_upgrade_monorepo_vitest_localized_pnpm.md
@@ -66,8 +66,8 @@ catalog:
   vitest: <version>
   '@vitest/ui': <version>
 overrides:
-  vite: 'catalog:'
-  vitest: 'catalog:'
+  vite@*: 'catalog:'
+  vitest@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_upgrade_nuxt_test_utils_monorepo/snapshots/migration_upgrade_nuxt_test_utils_monorepo.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_upgrade_nuxt_test_utils_monorepo/snapshots/migration_upgrade_nuxt_test_utils_monorepo.md
@@ -58,8 +58,8 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
 
 overrides:
-  vite: 'catalog:'
-  vitest: 'catalog:'
+  vite@*: 'catalog:'
+  vitest@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_upgrade_peer_vitest_catalog_pnpm/snapshots/migration_upgrade_peer_vitest_catalog_pnpm.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_upgrade_peer_vitest_catalog_pnpm/snapshots/migration_upgrade_peer_vitest_catalog_pnpm.md
@@ -50,7 +50,7 @@ catalog:
 catalogs:
   test: {}
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_upgrade_pkg_pr_new_pnpm/snapshots/migration_upgrade_pkg_pr_new_pnpm.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_upgrade_pkg_pr_new_pnpm/snapshots/migration_upgrade_pkg_pr_new_pnpm.md
@@ -51,8 +51,8 @@ catalog:
   '@vitest/coverage-v8': <version>
 
 overrides:
-  vite: 'catalog:'
-  vitest: 'catalog:'
+  vite@*: 'catalog:'
+  vitest@*: 'catalog:'
 
 peerDependencyRules:
   allowAny:
@@ -107,8 +107,8 @@ catalog:
   '@vitest/coverage-v8': <version>
 
 overrides:
-  vite: 'catalog:'
-  vitest: 'catalog:'
+  vite@*: 'catalog:'
+  vitest@*: 'catalog:'
 
 peerDependencyRules:
   allowAny:

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_upgrade_pnpm9_overrides/snapshots/migration_upgrade_pnpm9_overrides.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_upgrade_pnpm9_overrides/snapshots/migration_upgrade_pnpm9_overrides.md
@@ -33,8 +33,8 @@ pnpm.overrides stay catalog: (not inlined to a version)
   "packageManager": "pnpm@9.15.9",
   "pnpm": {
     "overrides": {
-      "vite": "catalog:",
-      "vitest": "catalog:"
+      "vite@*": "catalog:",
+      "vitest@*": "catalog:"
     },
     "peerDependencyRules": {
       "allowAny": [

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_upgrade_pnpm_bundled_catalog_dep/snapshots/migration_upgrade_pnpm_bundled_catalog_dep.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_upgrade_pnpm_bundled_catalog_dep/snapshots/migration_upgrade_pnpm_bundled_catalog_dep.md
@@ -48,7 +48,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_upgrade_pnpm_catalogs_default/snapshots/migration_upgrade_pnpm_catalogs_default.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_upgrade_pnpm_catalogs_default/snapshots/migration_upgrade_pnpm_catalogs_default.md
@@ -51,7 +51,7 @@ catalogs:
   default:
     rari: ^0.14.12
 overrides:
-  vite: catalog:build
+  vite@*: catalog:build
 peerDependencyRules:
   allowAny:
     - vite
@@ -105,7 +105,7 @@ catalogs:
   default:
     rari: ^0.14.12
 overrides:
-  vite: catalog:build
+  vite@*: catalog:build
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_upgrade_pnpm_named_catalog/snapshots/migration_upgrade_pnpm_named_catalog.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_upgrade_pnpm_named_catalog/snapshots/migration_upgrade_pnpm_named_catalog.md
@@ -52,7 +52,7 @@ catalogs:
     vitest: <version>
     vite-plus: <version>
 overrides:
-  vite: catalog:vite-stack
+  vite@*: catalog:vite-stack
 peerDependencyRules:
   allowAny:
     - vite
@@ -107,7 +107,7 @@ catalogs:
     vitest: <version>
     vite-plus: <version>
 overrides:
-  vite: catalog:vite-stack
+  vite@*: catalog:vite-stack
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_upgrade_setup_skipped_default_pnpm/snapshots/migration_upgrade_setup_skipped_default_pnpm.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_upgrade_setup_skipped_default_pnpm/snapshots/migration_upgrade_setup_skipped_default_pnpm.md
@@ -43,7 +43,7 @@ pnpm settings consolidated by the version upgrade
 
 ```
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_upgrade_stale_local_pnpm/snapshots/migration_upgrade_stale_local_pnpm.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_upgrade_stale_local_pnpm/snapshots/migration_upgrade_stale_local_pnpm.md
@@ -45,7 +45,7 @@ pnpm settings should be consolidated here
 
 ```
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_upgrade_vitest_reference_whitespace_pnpm/snapshots/migration_upgrade_vitest_reference_whitespace_pnpm.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_upgrade_vitest_reference_whitespace_pnpm/snapshots/migration_upgrade_vitest_reference_whitespace_pnpm.md
@@ -53,7 +53,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_vite_plus_in_dependencies_pnpm/snapshots/migration_vite_plus_in_dependencies_pnpm.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_vite_plus_in_dependencies_pnpm/snapshots/migration_vite_plus_in_dependencies_pnpm.md
@@ -47,7 +47,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_vite_version/snapshots/migration_vite_version.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_vite_version/snapshots/migration_vite_version.md
@@ -47,7 +47,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_vitest_import_only/snapshots/migration_vitest_import_only.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_vitest_import_only/snapshots/migration_vitest_import_only.md
@@ -56,7 +56,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_vitest_peer_dep/snapshots/migration_vitest_peer_dep.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_vitest_peer_dep/snapshots/migration_vitest_peer_dep.md
@@ -49,8 +49,8 @@ catalog:
   vitest: <version>
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
-  vitest: 'catalog:'
+  vite@*: 'catalog:'
+  vitest@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_vitest_unmanaged_override/snapshots/migration_vitest_unmanaged_override.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_vitest_unmanaged_override/snapshots/migration_vitest_unmanaged_override.md
@@ -48,7 +48,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@latest
   vite-plus: <version>
 overrides:
-  vite: 'catalog:'
+  vite@*: 'catalog:'
 peerDependencyRules:
   allowAny:
     - vite

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/new_vite_monorepo/snapshots/new_vite_monorepo.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/new_vite_monorepo/snapshots/new_vite_monorepo.md
@@ -93,7 +93,7 @@ catalog:
   vite: npm:@voidzero-dev/vite-plus-core@<version>
   vite-plus: <version>
 overrides:
-  vite: "catalog:"
+  vite@*: "catalog:"
 peerDependencyRules:
   allowAny:
     - vite

--- a/docs/guide/migrate-rules.md
+++ b/docs/guide/migrate-rules.md
@@ -82,6 +82,14 @@ Related rules:
 - A direct `vite` declaration is never removed merely because a root override
   exists.
 - Plain or stale aliases are normalized; named catalog references are kept.
+- Under pnpm the managed override keys carry an explicit `@*` range (`vite@*`,
+  `vitest@*`). pnpm applies overrides by replacing the declared spec on every
+  manifest, importers included, and a bare key matches any spec — including
+  `catalog:`, which would make `vp up` rewrite the reference to a concrete
+  version. The range keeps the override on the transitive and peer declarations
+  it exists for and leaves `catalog:` references to the catalog, which already
+  resolves them to Vite+ core. Migration re-keys a project still carrying the
+  bare key and preserves its named-catalog choice.
 - The direct-entry rule above is pnpm-specific. Bun mirrors its core alias as
   a direct dependency for its peer resolver, and npm browser-provider layouts
   may need a top-level `vite` edge so nested Vitest packages can resolve

--- a/docs/guide/upgrade.md
+++ b/docs/guide/upgrade.md
@@ -69,7 +69,9 @@ If you migrated with `vp migrate`, your project pins `vitest` to an exact versio
 
 - **npm / Bun:** a `vitest` entry under `overrides` in `package.json`
 - **Yarn:** a `vitest` entry under `resolutions` in `package.json`
-- **pnpm:** a `vitest` entry under `overrides` in `pnpm-workspace.yaml` — unless your `package.json` already had a `pnpm` field, in which case it lives under `pnpm.overrides` in `package.json` instead (pnpm ignores `pnpm-workspace.yaml` overrides when `package.json` defines `pnpm.overrides`)
+- **pnpm:** a `vitest@*` entry under `overrides` in `pnpm-workspace.yaml` — unless your `package.json` already had a `pnpm` field, in which case it lives under `pnpm.overrides` in `package.json` instead (pnpm ignores `pnpm-workspace.yaml` overrides when `package.json` defines `pnpm.overrides`)
+
+Under pnpm the managed keys carry an explicit `@*` range (`vite@*`, `vitest@*`). pnpm applies overrides by replacing the declared spec on every manifest, importers included, and a bare key matches any spec — including `catalog:`. The range keeps the override on the transitive and peer declarations it exists for while leaving `catalog:` references intact, so `vp up` no longer rewrites them to a concrete version.
 
 A Vite+ release can bump the bundled Vitest. Because that pin also applies to `vite-plus`'s own `vitest` dependency, an out-of-date pin keeps installing the previous runner even after you upgrade `vite-plus` — splitting Vitest's internals (mocks, `expect`, runner state) between the pinned copy and the one `vp test` loads.
 

--- a/packages/cli/src/create/templates/monorepo.ts
+++ b/packages/cli/src/create/templates/monorepo.ts
@@ -231,20 +231,21 @@ export function alignMonorepoTypeScriptVersion(
  * scaffolded sub-package. After migration its scripts already use `vp ...` and
  * nothing imports `'vite'` directly, so `vite-plus` provides them transitively.
  *
- * pnpm is the exception and keeps them: pnpm only surfaces the
- * pnpm-workspace.yaml `overrides.vite: catalog:` entry through a package that
- * directly depends on `vite`, so keeping the aliased devDep lets `vp why vite`
- * reflect the override (resolving to @voidzero-dev/vite-plus-core). npm, yarn,
- * and bun redirect the transitive/peer vite via their root
- * overrides/resolutions regardless of a direct dep, so the aliased keys are
- * dead weight and are dropped.
+ * pnpm is the exception and keeps them: a package needs a DIRECT `vite` edge for
+ * `vite` to resolve to @voidzero-dev/vite-plus-core there (and for `vp why vite`
+ * to show it) rather than pnpm auto-installing an upstream Vite to satisfy
+ * Vitest's peer. Migration points that edge at the workspace catalog, which owns
+ * the alias; the `vite@*` workspace override covers the transitive and peer
+ * declarations instead (see `pnpmOverrideKey`). npm, yarn, and bun redirect the
+ * transitive/peer vite via their root overrides/resolutions regardless of a
+ * direct dep, so the aliased keys are dead weight and are dropped.
  */
 export function dropAliasedRuntimeDevDeps(
   appProjectPath: string,
   packageManager: PackageManager,
 ): void {
-  // pnpm keeps the aliased vite/vitest so the pnpm-workspace.yaml override has
-  // a direct consumer to redirect; see the doc comment above.
+  // pnpm keeps the aliased vite/vitest so the package has a direct `vite` edge
+  // to point at the workspace catalog; see the doc comment above.
   if (packageManager === PackageManager.pnpm) {
     return;
   }

--- a/packages/cli/src/migration/__tests__/migrator.spec.ts
+++ b/packages/cli/src/migration/__tests__/migrator.spec.ts
@@ -60,8 +60,15 @@ const {
   detectYarnPnpMode,
   configureYarnNodeModulesMode,
   pnpmSupportsWorkspaceSettings,
+  pnpmOverrideKey,
   setPackageManager,
 } = await import('../migrator.js');
+
+// pnpm's managed override keys are range-qualified so they never rewrite an
+// importer's `catalog:` spec (issue #2309). npm/bun `overrides` and yarn
+// `resolutions` keep bare package-name keys.
+const PNPM_VITE_OVERRIDE_KEY = pnpmOverrideKey('vite');
+const PNPM_VITEST_OVERRIDE_KEY = pnpmOverrideKey('vitest');
 
 const { collectMigrationSetupPlan } = await import('../setup-plan.js');
 
@@ -2870,7 +2877,7 @@ describe('ensureVitePlusBootstrap', () => {
       catalog?: Record<string, string>;
     };
     // The vite override stays `catalog:` (settings remain in package.json below 10.6.2).
-    expect(rootPkg.pnpm?.overrides?.vite).toBe('catalog:');
+    expect(rootPkg.pnpm?.overrides?.[PNPM_VITE_OVERRIDE_KEY]).toBe('catalog:');
     // The catalog entries are rewritten off the stale 0.1.18 wrappers.
     expect(workspace.catalog?.vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
     expect(workspace.catalog?.['vite-plus']).toBe('latest');
@@ -3453,7 +3460,7 @@ describe('ensureVitePlusBootstrap', () => {
     };
     expect(workspace.catalog['@vitest/browser-playwright']).toBe(VITEST_VERSION);
     expect(workspace.catalog.vitest).toBe(VITEST_VERSION);
-    expect(workspace.overrides.vitest).toBe('catalog:');
+    expect(workspace.overrides[PNPM_VITEST_OVERRIDE_KEY]).toBe('catalog:');
     expect(detectVitePlusBootstrapPending(tmpDir, PackageManager.pnpm)).toBe(false);
   });
 
@@ -3640,8 +3647,9 @@ describe('ensureVitePlusBootstrap', () => {
     // Managed `vitest` is gone from every sink; `vite` stays managed.
     expect(workspace.catalog.vitest).toBeUndefined();
     expect(workspace.catalog.vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
+    expect(workspace.overrides[PNPM_VITEST_OVERRIDE_KEY]).toBeUndefined();
     expect(workspace.overrides.vitest).toBeUndefined();
-    expect(workspace.overrides.vite).toBe('catalog:');
+    expect(workspace.overrides[PNPM_VITE_OVERRIDE_KEY]).toBe('catalog:');
     expect(workspace.peerDependencyRules.allowAny).toEqual(['vite']);
     expect(workspace.peerDependencyRules.allowedVersions).toEqual({ vite: '*' });
     expect(detectVitePlusBootstrapPending(tmpDir, PackageManager.pnpm)).toBe(false);
@@ -3716,7 +3724,7 @@ describe('ensureVitePlusBootstrap', () => {
       overrides: Record<string, string>;
     };
     expect(workspace.catalog['vite-plus']).toBe('latest');
-    expect(workspace.overrides.vite).toBe('catalog:');
+    expect(workspace.overrides[PNPM_VITE_OVERRIDE_KEY]).toBe('catalog:');
   });
 
   it('moves existing pnpm settings to pnpm-workspace.yaml', () => {
@@ -3839,7 +3847,9 @@ describe('ensureVitePlusBootstrap', () => {
       };
     };
     expect(pkg.pnpm.overrides.react).toBe('18.3.1');
-    expect(pkg.pnpm.overrides.vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
+    expect(pkg.pnpm.overrides[PNPM_VITE_OVERRIDE_KEY]).toBe(
+      'npm:@voidzero-dev/vite-plus-core@latest',
+    );
     expect(pkg.pnpm.peerDependencyRules.allowAny).toEqual(['react', 'vite']);
   });
 
@@ -4023,6 +4033,7 @@ describe('ensureVitePlusBootstrap', () => {
       peerDependencyRules: { allowAny: string[]; allowedVersions: Record<string, string> };
     };
     expect(workspace.catalog.vitest).toBeUndefined();
+    expect(workspace.overrides[PNPM_VITEST_OVERRIDE_KEY]).toBeUndefined();
     expect(workspace.overrides.vitest).toBeUndefined();
     expect(workspace.peerDependencyRules.allowAny).toEqual(['vite']);
     expect(workspace.peerDependencyRules.allowedVersions).toEqual({
@@ -4697,9 +4708,10 @@ describe('rewriteStandaloneProject pnpm workspace yaml', () => {
     };
     const overrides = workspace.overrides;
     expect(overrides['some-pkg']).toBe('1.0.0');
-    expect(overrides.vite).toBeDefined();
+    expect(overrides[PNPM_VITE_OVERRIDE_KEY]).toBeDefined();
     // Common case (no @vitest/* dep, no vitest source): `vitest` is not managed,
     // so no override is written — it arrives transitively through vite-plus.
+    expect(overrides[PNPM_VITEST_OVERRIDE_KEY]).toBeUndefined();
     expect(overrides.vitest).toBeUndefined();
 
     // peerDependencyRules should be present
@@ -4745,11 +4757,71 @@ describe('rewriteStandaloneProject pnpm workspace yaml', () => {
     rewriteStandaloneProject(tmpDir, makeWorkspaceInfo(tmpDir, PackageManager.pnpm), true, true);
 
     const yaml = readYaml(path.join(tmpDir, 'pnpm-workspace.yaml'));
-    expect(yaml).toContain("vite: 'catalog:'");
+    expect(yaml).toContain(`${PNPM_VITE_OVERRIDE_KEY}: 'catalog:'`);
     // Common case (no @vitest/* dep, no vitest source): `vitest` is not managed,
     // so no `vitest` override is written — it arrives transitively through
     // vite-plus.
     expect(yaml).not.toContain('vitest');
+  });
+
+  it('range-qualifies managed pnpm override keys so `vp up` keeps `catalog:` (#2309)', () => {
+    // pnpm applies overrides by REPLACING the declared spec on every manifest,
+    // importers included. A bare `vite` key has no range and so matches even a
+    // `catalog:` spec, which strips the catalog provenance and makes
+    // `pnpm update` write the resolved core alias into package.json. `vite@*`
+    // matches every real semver range (what transitive/peer `vite` uses) and
+    // never `catalog:`, which is not a valid range.
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ name: 'test', devDependencies: { vite: '^7.0.0' } }),
+    );
+    rewriteStandaloneProject(tmpDir, makeWorkspaceInfo(tmpDir, PackageManager.pnpm), true, true);
+
+    const workspace = readYamlObject(path.join(tmpDir, 'pnpm-workspace.yaml')) as {
+      overrides: Record<string, string>;
+    };
+    const pkg = readJson(path.join(tmpDir, 'package.json')) as {
+      devDependencies: Record<string, string>;
+    };
+    expect(PNPM_VITE_OVERRIDE_KEY).toBe('vite@*');
+    expect(Object.keys(workspace.overrides)).toEqual([PNPM_VITE_OVERRIDE_KEY]);
+    expect(workspace.overrides[PNPM_VITE_OVERRIDE_KEY]).toBe('catalog:');
+    // The importer keeps referencing the catalog: that is what the override key
+    // must no longer be able to rewrite.
+    expect(pkg.devDependencies.vite).toBe('catalog:');
+  });
+
+  it('drops a pre-#2309 bare managed pnpm override key when adding the ranged one', () => {
+    // Leaving both keys in place would restore the clobbering match, so the bare
+    // key hands its `catalog:<name>` choice over and is removed.
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ name: 'test', devDependencies: { vite: 'catalog:' } }),
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'pnpm-workspace.yaml'),
+      [
+        'overrides:',
+        "  vite: 'catalog:'",
+        '  react: 18.3.1',
+        'catalog:',
+        '  vite: npm:@voidzero-dev/vite-plus-core@latest',
+        '',
+      ].join('\n'),
+    );
+    rewriteStandaloneProject(tmpDir, makeWorkspaceInfo(tmpDir, PackageManager.pnpm), true, true);
+
+    const workspace = readYamlObject(path.join(tmpDir, 'pnpm-workspace.yaml')) as {
+      overrides: Record<string, string>;
+    };
+    expect(workspace.overrides[PNPM_VITE_OVERRIDE_KEY]).toBe('catalog:');
+    expect(workspace.overrides).not.toHaveProperty('vite');
+    // Unrelated user overrides are untouched — the rewrite only re-keys managed
+    // entries.
+    expect(workspace.overrides.react).toBe('18.3.1');
+    // A project still on the bare key must read as pending so one `vp migrate`
+    // repairs it; once re-keyed it converges.
+    expect(detectVitePlusBootstrapPending(tmpDir, PackageManager.pnpm)).toBe(false);
   });
 
   it('rewrites named catalogs in pnpm-workspace.yaml without adding new entries', () => {
@@ -4791,11 +4863,15 @@ describe('rewriteStandaloneProject pnpm workspace yaml', () => {
       overrides: Record<string, string>;
       catalogs: Record<string, Record<string, string>>;
     };
-    expect(yaml.overrides.vite).toBe('catalog:vite7');
+    // A pre-#2309 bare key hands its named-catalog choice to the range-qualified
+    // key and is dropped, so only one managed `vite` override remains.
+    expect(yaml.overrides[PNPM_VITE_OVERRIDE_KEY]).toBe('catalog:vite7');
+    expect(yaml.overrides.vite).toBeUndefined();
     // Common case (no @vitest/* dep, no vitest source): `vitest` is not managed,
     // so no override is added and the pre-existing managed `vitest` catalog
     // entries (default + named) are REMOVED — it arrives transitively through
     // vite-plus.
+    expect(yaml.overrides[PNPM_VITEST_OVERRIDE_KEY]).toBeUndefined();
     expect(yaml.overrides.vitest).toBeUndefined();
     expect(yaml.catalog?.vitest).toBeUndefined();
     expect(yaml.catalogs.vite7.vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
@@ -4868,7 +4944,7 @@ describe('rewriteStandaloneProject pnpm workspace yaml', () => {
     expect(workspace.catalogs.default).toEqual({ rari: '^0.14.12' });
     expect(workspace.catalogs.build.vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
     expect(workspace.catalogs.build['vite-plus']).toBe('latest');
-    expect(workspace.overrides.vite).toBe('catalog:build');
+    expect(workspace.overrides[PNPM_VITE_OVERRIDE_KEY]).toBe('catalog:build');
     expect(pkg.devDependencies.vite).toBe('catalog:build');
     expect(pkg.devDependencies['vite-plus']).toBe('catalog:build');
     expect(detectVitePlusBootstrapPending(tmpDir, PackageManager.pnpm)).toBe(false);
@@ -4919,7 +4995,7 @@ describe('rewriteStandaloneProject pnpm workspace yaml', () => {
     expect(workspace.catalogs.default.react).toBe('^19.0.0');
     expect(workspace.catalogs.default.vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
     expect(workspace.catalogs.default['vite-plus']).toBe('latest');
-    expect(workspace.overrides.vite).toBe('catalog:');
+    expect(workspace.overrides[PNPM_VITE_OVERRIDE_KEY]).toBe('catalog:');
     expect(detectVitePlusBootstrapPending(tmpDir, PackageManager.pnpm)).toBe(false);
   });
 
@@ -4973,7 +5049,7 @@ describe('rewriteStandaloneProject pnpm workspace yaml', () => {
     expect(workspace.catalogs['repo-tooling']).toEqual({ prettier: '3.8.3' });
     expect(workspace.catalogs['vite-stack'].vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
     expect(workspace.catalogs['vite-stack']['vite-plus']).toBe('latest');
-    expect(workspace.overrides.vite).toBe('catalog:vite-stack');
+    expect(workspace.overrides[PNPM_VITE_OVERRIDE_KEY]).toBe('catalog:vite-stack');
     expect(pkg.devDependencies.vite).toBe('catalog:vite-stack');
     expect(pkg.devDependencies['vite-plus']).toBe('catalog:vite-stack');
     expect(detectVitePlusBootstrapPending(tmpDir, PackageManager.pnpm)).toBe(false);
@@ -5537,7 +5613,7 @@ describe('rewriteStandaloneProject pnpm workspace yaml', () => {
     expect(yaml.overrides).not.toHaveProperty('@vitejs/plugin-react>vite');
     expect(yaml.overrides).not.toHaveProperty('vite-plugin-svgr>vite');
     // The managed `vite` override stays and unrelated selectors survive.
-    expect(yaml.overrides).toHaveProperty('vite');
+    expect(yaml.overrides).toHaveProperty(PNPM_VITE_OVERRIDE_KEY);
     expect(yaml.overrides['some-other-pkg']).toBe('1.0.0');
   });
 
@@ -6277,9 +6353,11 @@ describe('rewriteStandaloneProject pnpm workspace yaml', () => {
       overrides: Record<string, string>;
       catalogs: Record<string, Record<string, string>>;
     };
-    expect(yaml.overrides.vite).toBe('catalog:vite7');
+    expect(yaml.overrides[PNPM_VITE_OVERRIDE_KEY]).toBe('catalog:vite7');
+    expect(yaml.overrides.vite).toBeUndefined();
     // Common case (no @vitest/* dep, no vitest source): `vitest` is not managed,
     // so no `vitest` override is injected.
+    expect(yaml.overrides[PNPM_VITEST_OVERRIDE_KEY]).toBeUndefined();
     expect(yaml.overrides.vitest).toBeUndefined();
     expect(yaml.overrides.react).toBe('^18.0.0');
     expect(yaml.catalogs.vite7.vite).toBe('npm:@voidzero-dev/vite-plus-core@latest');
@@ -6323,9 +6401,11 @@ describe('rewriteStandaloneProject pnpm workspace yaml', () => {
     const yaml = readYamlObject(path.join(tmpDir, 'pnpm-workspace.yaml')) as {
       overrides: Record<string, string>;
     };
-    expect(yaml.overrides.vite).toBe('catalog:');
+    expect(yaml.overrides[PNPM_VITE_OVERRIDE_KEY]).toBe('catalog:');
+    expect(yaml.overrides.vite).toBeUndefined();
     // Common case (no @vitest/* dep, no vitest source): `vitest` is not managed,
     // so no `vitest` override is added.
+    expect(yaml.overrides[PNPM_VITEST_OVERRIDE_KEY]).toBeUndefined();
     expect(yaml.overrides.vitest).toBeUndefined();
   });
 

--- a/packages/cli/src/migration/migrator/catalog.ts
+++ b/packages/cli/src/migration/migrator/catalog.ts
@@ -36,6 +36,7 @@ import {
   REMOVE_PACKAGES,
   VITEST_IS_MANAGED_OVERRIDE,
   isPlainRecord,
+  pnpmOverrideKey,
   type CatalogDependencyResolver,
   type PackageJsonDependencyField,
   type PnpmPackageJsonSettings,
@@ -313,11 +314,20 @@ export function rewritePnpmWorkspaceYaml(
       removeYamlMapVitestEntry(doc.getIn(['overrides']));
     }
     for (const key of Object.keys(managed)) {
-      const currentVersion = getYamlMapScalarStringValue(overrides, key);
+      // Managed keys are range-qualified (`vite@*`) so the override never
+      // rewrites an importer's `catalog:` spec — see `pnpmOverrideKey`. Carry a
+      // pre-#2309 bare key's value over to the new key so a user's own
+      // `catalog:<name>` choice survives, then drop the bare key: leaving both
+      // in place would restore the clobbering match.
+      const overrideKey = pnpmOverrideKey(key);
+      const currentVersion =
+        getYamlMapScalarStringValue(overrides, overrideKey) ??
+        getYamlMapScalarStringValue(overrides, key);
       const version = getCatalogDependencySpec(currentVersion, managed[key], true, {
         preferredCatalogSpec,
       });
-      doc.setIn(['overrides', scalarString(key)], scalarString(version));
+      deleteYamlMapKey(overrides, key);
+      doc.setIn(['overrides', scalarString(overrideKey)], scalarString(version));
     }
     // remove dependency selector from vite, e.g. "vite-plugin-svgr>vite": "npm:vite@7.0.12"
     // Snapshot the keys before deleting (mirrors the `keysSnapshot` loop above):
@@ -575,14 +585,17 @@ export function getCatalogDependencySpec(
 
 /**
  * #1932: under pnpm, an importer that depends on `vite-plus` (which bundles
- * `vitest`) needs a DIRECT `vite` devDep so the `vite` override binds vitest's
- * required `vite` peer to @voidzero-dev/vite-plus-core. Without a direct edge,
- * pnpm's `autoInstallPeers` fabricates a separate upstream `vite` to satisfy the
+ * `vitest`) needs a DIRECT `vite` devDep pointing at @voidzero-dev/vite-plus-core
+ * so vitest's required `vite` peer binds to it. Without a direct edge, pnpm's
+ * `autoInstallPeers` fabricates a separate upstream `vite` to satisfy the
  * peer, splitting vite-plus / vite / vitest into duplicate instances (the extra
  * vite also lacks vite's `@voidzero-dev/vite-task-client` integration, breaking
- * the `vp test` cache). npm/yarn/bun redirect transitive/peer vite via root
- * overrides/resolutions (and drop the aliased vite), so this is pnpm-only,
- * mirroring the bun root-package branch in `rewriteRootWorkspacePackageJson`.
+ * the `vp test` cache). Under a catalog the edge is a `catalog:` reference and
+ * the catalog entry carries the alias; the `vite@*` workspace override covers
+ * transitive and peer declarations instead of this one (see `pnpmOverrideKey`).
+ * npm/yarn/bun redirect transitive/peer vite via root overrides/resolutions (and
+ * drop the aliased vite), so this is pnpm-only, mirroring the bun root-package
+ * branch in `rewriteRootWorkspacePackageJson`.
  *
  * A package that already declares `vite` in ANY dependency field, including
  * `peerDependencies` (e.g. a vite plugin pinning `vite ^6`), is left untouched
@@ -821,6 +834,21 @@ function getYamlMapScalarStringValue(map: unknown, key: string): string | undefi
     }
   }
   return undefined;
+}
+
+// Delete a key by its literal name. `YAMLMap.delete` compares the key NODE, so
+// the node has to be looked up in `.items` first — passing a fresh scalar would
+// silently no-op.
+function deleteYamlMapKey(map: unknown, key: string): void {
+  if (!(map instanceof YAMLMap)) {
+    return;
+  }
+  const target = map.items.find(
+    (item) => item.key instanceof Scalar && item.key.value === key,
+  )?.key;
+  if (target) {
+    map.delete(target);
+  }
 }
 
 function pruneYamlMapLegacyWrapperAliases(map: unknown): void {

--- a/packages/cli/src/migration/migrator/orchestrators.ts
+++ b/packages/cli/src/migration/migrator/orchestrators.ts
@@ -56,6 +56,7 @@ import { type MigrationReport } from '../report.ts';
 import {
   PROVIDER_OVERRIDE_DROP_NAMES,
   pnpmMajor,
+  pnpmOverrideKey,
   type CatalogDependencyResolver,
   type PnpmPackageJsonSettings,
 } from './shared.ts';
@@ -190,12 +191,27 @@ export function rewriteStandaloneProject(
             removeVitestPeerDependencyRule(pkg.pnpm.peerDependencyRules);
           }
         }
+        // Managed pnpm override keys are range-qualified (`vite@*`) so they never
+        // rewrite an importer's `catalog:` spec — see `pnpmOverrideKey`. Drop the
+        // pre-#2309 bare keys the user's config may still carry; keeping both
+        // would restore the clobbering match. `peerDependencyRules` below keys on
+        // plain package names and stays bare.
+        for (const key of overrideKeys) {
+          delete pkg.pnpm?.overrides?.[key];
+        }
         // Project already has pnpm config in package.json -- keep using it.
         pkg.pnpm = {
           ...pkg.pnpm,
           overrides: {
             ...pkg.pnpm?.overrides,
-            ...managed,
+            ...Object.fromEntries(
+              Object.entries(managed).map(([key, spec]) => [pnpmOverrideKey(key), spec]),
+            ),
+            // The force-override `vite-plus` pin keeps a BARE key: it only exists
+            // in `file:` tgz mode, where migration writes the tgz spec straight
+            // into every manifest instead of a `catalog:` reference, so there is
+            // no catalog provenance for a bare key to strip. This matches the
+            // workspace-yaml force-override path in `rewriteStandaloneProject`.
             ...(isForceOverrideMode() ? { [VITE_PLUS_NAME]: VITE_PLUS_VERSION } : {}),
           },
           peerDependencyRules: {

--- a/packages/cli/src/migration/migrator/shared.ts
+++ b/packages/cli/src/migration/migrator/shared.ts
@@ -161,6 +161,47 @@ export const LEGACY_WRAPPER_FALLBACK_VERSIONS: Record<string, string> = {
   vitest: VITEST_VERSION,
 };
 
+/**
+ * Managed pnpm override keys carry an explicit `@*` range instead of being bare
+ * package names (`vite@*`, not `vite`).
+ *
+ * pnpm applies overrides through a read-package hook that REPLACES the declared
+ * spec on every manifest, importers included, before resolution runs. A BARE
+ * override key has no range, and pnpm treats "no range" as "matches every
+ * declared spec" — `catalog:` included. An importer that declares
+ * `vite: "catalog:"` therefore loses its catalog provenance during resolution,
+ * and `pnpm update` writes the resolved core alias back into its package.json
+ * (issue #2309). Qualifying the key with `@*` keeps the override on every real
+ * semver range — which is what the transitive and peer `vite` declarations this
+ * override exists for always use — while leaving `catalog:` specs alone: `*` is
+ * a valid range and `catalog:` is not, so pnpm's `isIntersectingRange` never
+ * matches the two. Nothing changes about what gets installed, because an
+ * importer that references the catalog already resolves to the aliased core
+ * through its catalog entry.
+ *
+ * This is pnpm-only. npm/bun `overrides` and yarn `resolutions` keep bare keys:
+ * those managers have no `catalog:` importer specs to lose (bun catalogs live in
+ * package.json and are resolved before overrides apply).
+ */
+export function pnpmOverrideKey(dependencyName: string): string {
+  return `${dependencyName}@*`;
+}
+
+/**
+ * How a sink spells its managed override keys: pnpm's `overrides` use the
+ * range-qualified form ({@link pnpmOverrideKey}), every other sink uses the bare
+ * package name. A pnpm sink still carrying a bare managed key predates the
+ * #2309 fix, so it deliberately reads as UNSATISFIED and gets rewritten.
+ */
+export type ManagedOverrideKeyStyle = 'bare' | 'pnpm-ranged';
+
+export function managedOverrideKey(
+  dependencyName: string,
+  keyStyle: ManagedOverrideKeyStyle,
+): string {
+  return keyStyle === 'pnpm-ranged' ? pnpmOverrideKey(dependencyName) : dependencyName;
+}
+
 export type PackageJsonDependencyField =
   | 'devDependencies'
   | 'dependencies'

--- a/packages/cli/src/migration/migrator/vite-plus-bootstrap.ts
+++ b/packages/cli/src/migration/migrator/vite-plus-bootstrap.ts
@@ -59,8 +59,10 @@ import {
   OPT_IN_BROWSER_PROVIDERS,
   REMOVE_PACKAGES,
   VITEST_IS_MANAGED_OVERRIDE,
+  managedOverrideKey,
   pnpmMajor,
   type CatalogDependencyResolver,
+  type ManagedOverrideKeyStyle,
   type PnpmPackageJsonSettings,
 } from './shared.ts';
 
@@ -143,16 +145,24 @@ export function overridesSatisfyVitePlus(
   overrides: Record<string, string> | undefined,
   usesVitest: boolean,
   catalogDependencyResolver?: CatalogDependencyResolver,
+  keyStyle: ManagedOverrideKeyStyle = 'bare',
 ): boolean {
   // Common case: a lingering managed `vitest` override is NOT satisfied — it
-  // must be removed, so the bootstrap stays pending until it is.
-  if (!usesVitest && VITEST_IS_MANAGED_OVERRIDE && typeof overrides?.vitest === 'string') {
+  // must be removed, so the bootstrap stays pending until it is. Both key
+  // spellings count: a pnpm sink migrated before #2309 still carries the bare
+  // one (see `managedOverrideKey`).
+  if (
+    !usesVitest &&
+    VITEST_IS_MANAGED_OVERRIDE &&
+    (typeof overrides?.[managedOverrideKey('vitest', keyStyle)] === 'string' ||
+      typeof overrides?.vitest === 'string')
+  ) {
     return false;
   }
   return Object.keys(managedOverridePackages(usesVitest)).every((dependencyName) =>
     overrideSpecSatisfiesVitePlus(
       dependencyName,
-      overrides?.[dependencyName],
+      overrides?.[managedOverrideKey(dependencyName, keyStyle)],
       catalogDependencyResolver,
     ),
   );
@@ -743,20 +753,30 @@ export function detectVitePlusBootstrapPending(
       if (supportCatalog) {
         return (
           catalogVitePlusDependencyPending(pkg, catalogDependencyResolver) ||
-          !overridesSatisfyVitePlus(pkg.pnpm?.overrides, usesVitest, catalogDependencyResolver) ||
+          !overridesSatisfyVitePlus(
+            pkg.pnpm?.overrides,
+            usesVitest,
+            catalogDependencyResolver,
+            'pnpm-ranged',
+          ) ||
           !pnpmPeerDependencyRulesSatisfyVitePlus(pkg.pnpm?.peerDependencyRules, usesVitest)
         );
       }
       return (
         vitePlusDependencyNeedsConcreteVersion(pkg) ||
-        !overridesSatisfyVitePlus(pkg.pnpm?.overrides, usesVitest) ||
+        !overridesSatisfyVitePlus(pkg.pnpm?.overrides, usesVitest, undefined, 'pnpm-ranged') ||
         !pnpmPeerDependencyRulesSatisfyVitePlus(pkg.pnpm?.peerDependencyRules, usesVitest)
       );
     }
     const resolver = readPnpmWorkspaceCatalogDependencyResolver(projectPath);
     return (
       workspaceCatalogVitePlusDependencyPending(projectPath, packages, resolver) ||
-      !overridesSatisfyVitePlus(readPnpmWorkspaceOverrides(projectPath), usesVitest, resolver) ||
+      !overridesSatisfyVitePlus(
+        readPnpmWorkspaceOverrides(projectPath),
+        usesVitest,
+        resolver,
+        'pnpm-ranged',
+      ) ||
       !pnpmPeerDependencyRulesSatisfyVitePlus(
         readPnpmWorkspacePeerDependencyRules(projectPath),
         usesVitest,
@@ -850,6 +870,7 @@ function ensureOverrideEntries(
   overrides: Record<string, string> | undefined,
   usesVitest: boolean,
   catalogDependencyResolver?: CatalogDependencyResolver,
+  keyStyle: ManagedOverrideKeyStyle = 'bare',
 ): { overrides: Record<string, string>; changed: boolean } {
   const next = { ...overrides };
   let changed = false;
@@ -860,15 +881,20 @@ function ensureOverrideEntries(
   for (const [dependencyName, overrideSpec] of Object.entries(
     managedOverridePackages(usesVitest),
   )) {
-    if (
-      !overrideSpecSatisfiesVitePlus(
-        dependencyName,
-        next[dependencyName],
-        catalogDependencyResolver,
-      )
-    ) {
-      next[dependencyName] = overrideSpec;
+    const overrideKey = managedOverrideKey(dependencyName, keyStyle);
+    // Carry a pre-#2309 bare key's value over to the range-qualified key so the
+    // user's own `catalog:<name>` choice survives, then drop the bare key —
+    // keeping both would restore the match that clobbers `catalog:` importers.
+    const currentSpec = next[overrideKey] ?? next[dependencyName];
+    if (overrideKey !== dependencyName && next[dependencyName] !== undefined) {
+      delete next[dependencyName];
       changed = true;
+    }
+    if (!overrideSpecSatisfiesVitePlus(dependencyName, currentSpec, catalogDependencyResolver)) {
+      next[overrideKey] = overrideSpec;
+      changed = true;
+    } else if (next[overrideKey] !== currentSpec) {
+      next[overrideKey] = currentSpec;
     }
   }
   return { overrides: next, changed };
@@ -1052,6 +1078,7 @@ export function ensureVitePlusBootstrap(
         pkg.pnpm.overrides,
         usesVitest,
         supportCatalog ? readPnpmWorkspaceCatalogDependencyResolver(projectPath) : undefined,
+        'pnpm-ranged',
       );
       if (ensured.changed) {
         pkg.pnpm.overrides = ensured.overrides;
@@ -1151,6 +1178,7 @@ export function ensureVitePlusBootstrap(
           readPnpmWorkspaceOverrides(projectPath),
           usesVitest,
           catalogDependencyResolver,
+          'pnpm-ranged',
         ) ||
         !pnpmPeerDependencyRulesSatisfyVitePlus(
           readPnpmWorkspacePeerDependencyRules(projectPath),

--- a/packages/cli/src/migration/migrator/vitest-ecosystem.ts
+++ b/packages/cli/src/migration/migrator/vitest-ecosystem.ts
@@ -25,6 +25,7 @@ import {
   REMOVE_PACKAGES,
   VITEST_BROWSER_DEP_NAMES,
   VITEST_IS_MANAGED_OVERRIDE,
+  pnpmOverrideKey,
   type CatalogDependencyResolver,
   type PackageJsonDependencyField,
 } from './shared.ts';
@@ -546,12 +547,22 @@ export function projectUsesVitestDirectly(
 // alias is always a string, whereas a nested object value (npm/bun `overrides`)
 // is a user override scoped under `vitest` and must be left intact. Returns true
 // iff an entry was removed.
+//
+// pnpm override sinks spell the managed key `vitest@*` (see `pnpmOverrideKey`),
+// so both spellings are swept: which one a project carries depends on whether it
+// was last migrated before or after the #2309 fix.
 export function removeManagedVitestEntry(record: Record<string, string> | undefined): boolean {
-  if (VITEST_IS_MANAGED_OVERRIDE && typeof record?.vitest === 'string') {
-    delete record.vitest;
-    return true;
+  if (!VITEST_IS_MANAGED_OVERRIDE || !record) {
+    return false;
   }
-  return false;
+  let removed = false;
+  for (const key of Object.keys(record)) {
+    if (isManagedVitestOverrideKey(key) && typeof record[key] === 'string') {
+      delete record[key];
+      removed = true;
+    }
+  }
+  return removed;
 }
 
 // Remove a managed `vitest` scalar key from a YAMLMap (pnpm-workspace.yaml
@@ -560,12 +571,24 @@ export function removeYamlMapVitestEntry(map: unknown): void {
   if (!VITEST_IS_MANAGED_OVERRIDE || !(map instanceof YAMLMap)) {
     return;
   }
-  const target = map.items.find(
-    (item) => item.key instanceof Scalar && item.key.value === 'vitest',
-  )?.key;
-  if (target) {
+  const targets = map.items
+    .filter(
+      (item) =>
+        item.key instanceof Scalar &&
+        typeof item.key.value === 'string' &&
+        isManagedVitestOverrideKey(item.key.value),
+    )
+    .map((item) => item.key);
+  for (const target of targets) {
     map.delete(target);
   }
+}
+
+// `vitest` itself, or the range-qualified pnpm override spelling of it. A
+// selector-scoped key (`some-app>vitest`) constrains that parent's subtree only
+// and is never a managed key, so the `>`-bearing forms stay out.
+function isManagedVitestOverrideKey(key: string): boolean {
+  return key === 'vitest' || key === pnpmOverrideKey('vitest');
 }
 
 // Remove the managed `vitest` entry from pnpm peerDependencyRules (its


### PR DESCRIPTION
`vp up` in a pnpm monorepo rewrote `vite: "catalog:"` in package.json to the concrete `npm:@voidzero-dev/vite-plus-core@<version>` alias. pnpm applies overrides by replacing the declared spec on every manifest, importers included, and a bare override key has no range, so it matched the `catalog:` reference and `pnpm update` resolved it away.

The managed pnpm override keys are now range-qualified (`vite@*`, `vitest@*`): `*` intersects every real semver range (what the transitive and peer `vite` declarations use) and never `catalog:`, which is not a valid range. Migration re-keys projects still carrying the bare key (preserving a user's `catalog:<name>` choice), and pending-detection treats a bare managed key as unsatisfied so one `vp migrate` repairs existing projects.

Covered by two new snapshot fixtures (the reported shape and the bare-key repair path) plus re-recorded pnpm migration snapshots; unit tests updated.

Closes #2309
