### PR TITLE
fix(global): run npm view in global mode

### DIFF
--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_update_global_dev_engines/package.json
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_update_global_dev_engines/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "command-update-global-dev-engines",
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": "11.20.0",
+      "onFail": "download"
+    }
+  }
+}

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_update_global_dev_engines/snapshots.toml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_update_global_dev_engines/snapshots.toml
@@ -1,7 +1,6 @@
 [[case]]
 name = "command_update_global_dev_engines"
 vp = "global"
-skip-platforms = ["windows"]
 comment = "Global updates ignore the current project's package-manager requirement."
 steps = [
   { argv = ["vp", "install", "-g", "testnpm2@1.0.0"], snapshot = false, continue-on-failure = true },

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_update_global_dev_engines/snapshots.toml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_update_global_dev_engines/snapshots.toml
@@ -1,0 +1,12 @@
+[[case]]
+name = "command_update_global_dev_engines"
+vp = "global"
+skip-platforms = ["windows"]
+comment = "Global updates ignore the current project's package-manager requirement."
+steps = [
+  { argv = ["vp", "install", "-g", "testnpm2@1.0.0"], snapshot = false, continue-on-failure = true },
+  { tty = false, argv = ["vp", "update", "-g", "--latest"], continue-on-failure = true },
+]
+after = [
+  { argv = ["vp", "remove", "-g", "testnpm2"], continue-on-failure = true },
+]

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_update_global_dev_engines/snapshots/command_update_global_dev_engines.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_update_global_dev_engines/snapshots/command_update_global_dev_engines.md
@@ -1,0 +1,13 @@
+# command_update_global_dev_engines
+
+Global updates ignore the current project's package-manager requirement.
+
+## `vp install -g testnpm2@1.0.0`
+
+
+## `vp update -g --latest`
+
+```
+[1m[94minfo:[39m[0m Updating 1 global package with Node.js <version>
+[32m✓[39m Updated [1mtestnpm2[0m to [1m1.0.1[0m
+```

--- a/crates/vp_global_cli/src/commands/global/mod.rs
+++ b/crates/vp_global_cli/src/commands/global/mod.rs
@@ -60,10 +60,8 @@ async fn npm_view(
     package_spec: &str,
     field: &str,
 ) -> Result<Vec<u8>, Error> {
-    let vp_home = vp_shared::get_vp_home()?;
     let output = Command::new(npm_path.as_path())
-        .args(["view", package_spec, field, "--json"])
-        .current_dir(vp_home.as_path())
+        .args(["view", "-g", package_spec, field, "--json"])
         .env("PATH", format_path_prepended(node_bin_dir.as_path()))
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/crates/vp_global_cli/src/commands/global/mod.rs
+++ b/crates/vp_global_cli/src/commands/global/mod.rs
@@ -60,8 +60,10 @@ async fn npm_view(
     package_spec: &str,
     field: &str,
 ) -> Result<Vec<u8>, Error> {
+    let vp_home = vp_shared::get_vp_home()?;
     let output = Command::new(npm_path.as_path())
         .args(["view", package_spec, field, "--json"])
+        .current_dir(vp_home.as_path())
         .env("PATH", format_path_prepended(node_bin_dir.as_path()))
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())


### PR DESCRIPTION
## Summary
`vp up -g` now checks global package versions independently of the project it runs from. The registry lookup uses   npm's global mode, matching the global install path, so project-level settings no longer cause `npm view` to fail and skip available updates.

Fixes #2437