### PR TITLE
ci: include install e2e in aggregate status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1445,6 +1445,7 @@ jobs:
       - cli-snapshot-test-windows
       # Skipped on unlabeled PRs; counted on push-to-main and labeled PRs.
       # `contains(needs.*.result, 'failure')` ignores "skipped" results.
+      - install-e2e-test
       - install-e2e-test-sfw
     steps:
       - run: exit 1


### PR DESCRIPTION
`install-e2e-test` appears to have been omitted from `done`. Add it alongside `install-e2e-test-sfw` so both install E2E jobs are included in the aggregate status.