### PR TITLE
feat(cli): use Unicode tree glyphs in toolchain output

### DIFF
--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_toolchain/snapshots/toolchain_filters.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_toolchain/snapshots/toolchain_filters.md
@@ -8,11 +8,11 @@ a tool filter keeps its ownership and engine chain
 Vite+ toolchain (local)
 
 vite-plus@<version>
-`-- depends on @voidzero-dev/vite-plus-core@<version>
-    `-- bundles vite@<version>
-        `-- uses rolldown@<version>
-            |-- compiles oxc@<version>
-            `-- compiles oxc-resolver@<version>
+└── depends on @voidzero-dev/vite-plus-core@<version>
+    └── bundles vite@<version>
+        └── uses rolldown@<version>
+            ├── compiles oxc@<version>
+            └── compiles oxc-resolver@<version>
 ```
 
 ## `vp toolchain vite vitest`
@@ -23,12 +23,12 @@ multiple filters return a stable union
 Vite+ toolchain (local)
 
 vite-plus@<version>
-|-- depends on @voidzero-dev/vite-plus-core@<version>
-|   `-- bundles vite@<version>
-|       `-- uses rolldown@<version>
-|           |-- compiles oxc@<version>
-|           `-- compiles oxc-resolver@<version>
-`-- depends on vitest@<version>
+├── depends on @voidzero-dev/vite-plus-core@<version>
+│   └── bundles vite@<version>
+│       └── uses rolldown@<version>
+│           ├── compiles oxc@<version>
+│           └── compiles oxc-resolver@<version>
+└── depends on vitest@<version>
 ```
 
 ## `vp toolchain vite-plus-core tsgolint vite-task`
@@ -39,7 +39,7 @@ stable IDs and declared aliases resolve
 Vite+ toolchain (local)
 
 vite-plus@<version>
-|-- depends on @voidzero-dev/vite-plus-core@<version>
-|-- depends on oxlint-tsgolint@<version>
-`-- compiles vite-task (built <build-time>, revision <revision>)
+├── depends on @voidzero-dev/vite-plus-core@<version>
+├── depends on oxlint-tsgolint@<version>
+└── compiles vite-task (built <build-time>, revision <revision>)
 ```

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_toolchain/snapshots/toolchain_full_global.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_toolchain/snapshots/toolchain_full_global.md
@@ -8,18 +8,18 @@ The global flag reads the manifest paired with the global binary.
 Vite+ toolchain (global)
 
 vite-plus@<version>
-|-- depends on @voidzero-dev/vite-plus-core@<version>
-|   |-- bundles vite@<version>
-|   |   `-- uses rolldown@<version>
-|   |       |-- compiles oxc@<version>
-|   |       `-- compiles oxc-resolver@<version>
-|   |-- bundles rolldown@<version>
-|   |   |-- compiles oxc@<version>
-|   |   `-- compiles oxc-resolver@<version>
-|   `-- bundles tsdown@<version>
-|-- depends on vitest@<version>
-|-- depends on oxlint@<version>
-|-- depends on oxlint-tsgolint@<version>
-|-- depends on oxfmt@<version>
-`-- compiles vite-task (built <build-time>, revision <revision>)
+├── depends on @voidzero-dev/vite-plus-core@<version>
+│   ├── bundles vite@<version>
+│   │   └── uses rolldown@<version>
+│   │       ├── compiles oxc@<version>
+│   │       └── compiles oxc-resolver@<version>
+│   ├── bundles rolldown@<version>
+│   │   ├── compiles oxc@<version>
+│   │   └── compiles oxc-resolver@<version>
+│   └── bundles tsdown@<version>
+├── depends on vitest@<version>
+├── depends on oxlint@<version>
+├── depends on oxlint-tsgolint@<version>
+├── depends on oxfmt@<version>
+└── compiles vite-task (built <build-time>, revision <revision>)
 ```

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_toolchain/snapshots/toolchain_full_local.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_toolchain/snapshots/toolchain_full_local.md
@@ -8,18 +8,18 @@ The local CLI reads the manifest shipped in its vite-plus package.
 Vite+ toolchain (local)
 
 vite-plus@<version>
-|-- depends on @voidzero-dev/vite-plus-core@<version>
-|   |-- bundles vite@<version>
-|   |   `-- uses rolldown@<version>
-|   |       |-- compiles oxc@<version>
-|   |       `-- compiles oxc-resolver@<version>
-|   |-- bundles rolldown@<version>
-|   |   |-- compiles oxc@<version>
-|   |   `-- compiles oxc-resolver@<version>
-|   `-- bundles tsdown@<version>
-|-- depends on vitest@<version>
-|-- depends on oxlint@<version>
-|-- depends on oxlint-tsgolint@<version>
-|-- depends on oxfmt@<version>
-`-- compiles vite-task (built <build-time>, revision <revision>)
+├── depends on @voidzero-dev/vite-plus-core@<version>
+│   ├── bundles vite@<version>
+│   │   └── uses rolldown@<version>
+│   │       ├── compiles oxc@<version>
+│   │       └── compiles oxc-resolver@<version>
+│   ├── bundles rolldown@<version>
+│   │   ├── compiles oxc@<version>
+│   │   └── compiles oxc-resolver@<version>
+│   └── bundles tsdown@<version>
+├── depends on vitest@<version>
+├── depends on oxlint@<version>
+├── depends on oxlint-tsgolint@<version>
+├── depends on oxfmt@<version>
+└── compiles vite-task (built <build-time>, revision <revision>)
 ```

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_toolchain/snapshots/toolchain_old_local_routing.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_toolchain/snapshots/toolchain_old_local_routing.md
@@ -37,20 +37,20 @@ a package without a runnable local CLI uses the global toolchain
 Vite+ toolchain (global)
 
 vite-plus@<version>
-|-- depends on @voidzero-dev/vite-plus-core@<version>
-|   |-- bundles vite@<version>
-|   |   `-- uses rolldown@<version>
-|   |       |-- compiles oxc@<version>
-|   |       `-- compiles oxc-resolver@<version>
-|   |-- bundles rolldown@<version>
-|   |   |-- compiles oxc@<version>
-|   |   `-- compiles oxc-resolver@<version>
-|   `-- bundles tsdown@<version>
-|-- depends on vitest@<version>
-|-- depends on oxlint@<version>
-|-- depends on oxlint-tsgolint@<version>
-|-- depends on oxfmt@<version>
-`-- compiles vite-task (built <build-time>, revision <revision>)
+├── depends on @voidzero-dev/vite-plus-core@<version>
+│   ├── bundles vite@<version>
+│   │   └── uses rolldown@<version>
+│   │       ├── compiles oxc@<version>
+│   │       └── compiles oxc-resolver@<version>
+│   ├── bundles rolldown@<version>
+│   │   ├── compiles oxc@<version>
+│   │   └── compiles oxc-resolver@<version>
+│   └── bundles tsdown@<version>
+├── depends on vitest@<version>
+├── depends on oxlint@<version>
+├── depends on oxlint-tsgolint@<version>
+├── depends on oxfmt@<version>
+└── compiles vite-task (built <build-time>, revision <revision>)
 ```
 
 ## `vp why vite`
@@ -71,18 +71,18 @@ Run `vp toolchain vite` to show these versions and relationships.
 Vite+ toolchain (global)
 
 vite-plus@<version>
-|-- depends on @voidzero-dev/vite-plus-core@<version>
-|   |-- bundles vite@<version>
-|   |   `-- uses rolldown@<version>
-|   |       |-- compiles oxc@<version>
-|   |       `-- compiles oxc-resolver@<version>
-|   |-- bundles rolldown@<version>
-|   |   |-- compiles oxc@<version>
-|   |   `-- compiles oxc-resolver@<version>
-|   `-- bundles tsdown@<version>
-|-- depends on vitest@<version>
-|-- depends on oxlint@<version>
-|-- depends on oxlint-tsgolint@<version>
-|-- depends on oxfmt@<version>
-`-- compiles vite-task (built <build-time>, revision <revision>)
+├── depends on @voidzero-dev/vite-plus-core@<version>
+│   ├── bundles vite@<version>
+│   │   └── uses rolldown@<version>
+│   │       ├── compiles oxc@<version>
+│   │       └── compiles oxc-resolver@<version>
+│   ├── bundles rolldown@<version>
+│   │   ├── compiles oxc@<version>
+│   │   └── compiles oxc-resolver@<version>
+│   └── bundles tsdown@<version>
+├── depends on vitest@<version>
+├── depends on oxlint@<version>
+├── depends on oxlint-tsgolint@<version>
+├── depends on oxfmt@<version>
+└── compiles vite-task (built <build-time>, revision <revision>)
 ```

--- a/crates/vp_cli_snapshots/tests/redact_unit.rs
+++ b/crates/vp_cli_snapshots/tests/redact_unit.rs
@@ -308,11 +308,11 @@ fn masks_toolchain_build_time_in_human_and_json_output() {
 fn masks_toolchain_versions_and_revisions_in_human_hint_and_json_output() {
     let revision = "ebe583739b0b1e7828199b9ee9dd52273fa2fd20";
     let human = format!(
-        "Vite+ toolchain (global)\n\nvite-plus@0.2.8\n|-- bundles vite@8.2.1\n`-- compiles vite-task (revision {revision})\n"
+        "Vite+ toolchain (global)\n\nvite-plus@0.2.8\n├── bundles vite@8.2.1\n└── compiles vite-task (revision {revision})\n"
     );
     assert_eq!(
         redact_output(human, &[], true),
-        "Vite+ toolchain (global)\n\nvite-plus@<version>\n|-- bundles vite@<version>\n`-- compiles vite-task (revision <revision>)\n"
+        "Vite+ toolchain (global)\n\nvite-plus@<version>\n├── bundles vite@<version>\n└── compiles vite-task (revision <revision>)\n"
     );
 
     let hint = "Vite+ also provides vite@8.2.1 through its toolchain.\n".to_owned();

--- a/crates/vp_toolchain/src/lib.rs
+++ b/crates/vp_toolchain/src/lib.rs
@@ -384,7 +384,7 @@ fn render_children<'a>(
     };
     for (index, edge) in edges.iter().enumerate() {
         let is_last = index + 1 == edges.len();
-        let connector = if is_last { "`-- " } else { "|-- " };
+        let connector = if is_last { "└── " } else { "├── " };
         let Some(node) = nodes.get(edge.to.as_str()) else {
             continue;
         };
@@ -396,7 +396,7 @@ fn render_children<'a>(
         output.push('\n');
 
         if path.insert(node.id.as_str()) {
-            let child_prefix = vt_str::format!("{prefix}{}", if is_last { "    " } else { "|   " });
+            let child_prefix = vt_str::format!("{prefix}{}", if is_last { "    " } else { "│   " });
             render_children(output, node.id.as_str(), child_prefix.as_str(), nodes, children, path);
             path.remove(node.id.as_str());
         }
@@ -579,15 +579,15 @@ mod tests {
             "Vite+ toolchain (local)\n\
              \n\
              vite-plus@1.0.0\n\
-             |-- depends on @scope/core@1.0.0\n\
-             |   |-- bundles vite@8.0.0\n\
-             |   |   `-- uses rolldown@1.0.0\n\
-             |   |       |-- compiles oxc@0.1.0\n\
-             |   |       `-- compiles oxc-resolver@1.0.0\n\
-             |   `-- bundles rolldown@1.0.0\n\
-             |       |-- compiles oxc@0.1.0\n\
-             |       `-- compiles oxc-resolver@1.0.0\n\
-             `-- depends on vitest@4.0.0\n"
+             ├── depends on @scope/core@1.0.0\n\
+             │   ├── bundles vite@8.0.0\n\
+             │   │   └── uses rolldown@1.0.0\n\
+             │   │       ├── compiles oxc@0.1.0\n\
+             │   │       └── compiles oxc-resolver@1.0.0\n\
+             │   └── bundles rolldown@1.0.0\n\
+             │       ├── compiles oxc@0.1.0\n\
+             │       └── compiles oxc-resolver@1.0.0\n\
+             └── depends on vitest@4.0.0\n"
         );
     }
 

--- a/rfcs/toolchain-command.md
+++ b/rfcs/toolchain-command.md
@@ -155,18 +155,18 @@ The command prints an ownership tree with relationship labels:
 Vite+ toolchain (local)
 
 vite-plus@0.2.4
-|-- depends on @voidzero-dev/vite-plus-core@0.2.4
-|   |-- bundles vite@8.1.3
-|   |   `-- uses rolldown@1.1.4
-|   |-- bundles rolldown@1.1.4
-|   |   |-- compiles oxc@0.138.0
-|   |   `-- compiles oxc-resolver@11.22.0
-|   `-- bundles tsdown@0.22.3
-|-- depends on vitest@4.1.10
-|-- depends on oxlint@1.72.0
-|-- depends on oxlint-tsgolint@0.24.0
-|-- depends on oxfmt@0.57.0
-`-- compiles vite-task (built 2026-08-06T09:30:00Z, revision <revision>)
+├── depends on @voidzero-dev/vite-plus-core@0.2.4
+│   ├── bundles vite@8.1.3
+│   │   └── uses rolldown@1.1.4
+│   ├── bundles rolldown@1.1.4
+│   │   ├── compiles oxc@0.138.0
+│   │   └── compiles oxc-resolver@11.22.0
+│   └── bundles tsdown@0.22.3
+├── depends on vitest@4.1.10
+├── depends on oxlint@1.72.0
+├── depends on oxlint-tsgolint@0.24.0
+├── depends on oxfmt@0.57.0
+└── compiles vite-task (built 2026-08-06T09:30:00Z, revision <revision>)
 ```
 
 These versions show the repository state when this RFC was written. They are
@@ -190,11 +190,11 @@ $ vp toolchain vite
 Vite+ toolchain (local)
 
 vite-plus@0.2.4
-`-- depends on @voidzero-dev/vite-plus-core@0.2.4
-    `-- bundles vite@8.1.3
-        `-- uses rolldown@1.1.4
-            |-- compiles oxc@0.138.0
-            `-- compiles oxc-resolver@11.22.0
+└── depends on @voidzero-dev/vite-plus-core@0.2.4
+    └── bundles vite@8.1.3
+        └── uses rolldown@1.1.4
+            ├── compiles oxc@0.138.0
+            └── compiles oxc-resolver@11.22.0
 ```
 
 For multiple filters, the command returns the union of those nodes and edges.


### PR DESCRIPTION
#2111 introduces `vp toolchain` command. However, its output and connector chars are all old ASCII-style. 

Considering other parts of Vite+ uses unicode a lot, I don't think it is an intentional design for compatibility. Unicode-style (`├──`, `└──`, and `│`) is more modern and feels like more professional. So this PR updates it to this style

🤖 Generated with Codex 
