### PR TITLE
docs: add vp hooks to README command list

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Use `vp migrate` to migrate to Vite+. It merges tool-specific config files such 
 - **create** - Create a new project from a template
 - **migrate** - Migrate an existing project to Vite+
 - **config** - Configure hooks and agent integration
+- **hooks** - Manage the Git hook dispatcher
 - **staged** - Run linters on staged files
 - **install** (`i`) - Install dependencies
 - **env** - Manage Node.js versions

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -96,6 +96,7 @@ Use `vp migrate` to migrate to Vite+. It merges tool-specific config files such 
 - **create** - Create a new project from a template
 - **migrate** - Migrate an existing project to Vite+
 - **config** - Configure hooks and agent integration
+- **hooks** - Manage the Git hook dispatcher
 - **staged** - Run linters on staged files
 - **install** (`i`) - Install dependencies
 - **env** - Manage Node.js versions


### PR DESCRIPTION
The README command list was missing `vp hooks`, even though it is already part of `vp help` and the docs site. This adds it next to `vp config` and `vp staged` in both the root and package READMEs so the lists stay in sync.