### PR TITLE
ci: keep binary size report in job summary for fork PRs

### DIFF
--- a/.github/workflows/vp-binary-size.yml
+++ b/.github/workflows/vp-binary-size.yml
@@ -17,7 +17,6 @@ defaults:
 jobs:
   inputs:
     name: Detect native input changes
-    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -237,8 +236,9 @@ jobs:
   comment:
     name: Report binary size
     needs: build
-    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    # Fork runs get a read-only token regardless of this block; the script
+    # then keeps the report in the job summary and skips the PR comment.
     permissions:
       contents: read
       issues: write
@@ -256,6 +256,7 @@ jobs:
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           SIZE_DIR: ${{ runner.temp }}/native-size
+          SAME_REPO: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           script: |
             const fs = require('node:fs');
@@ -367,6 +368,11 @@ jobs:
             ].join('\n');
 
             await core.summary.addRaw(body.replace(marker, '')).write();
+
+            if (process.env.SAME_REPO !== 'true') {
+              core.info('Fork PR: the report stays in the job summary above.');
+              return;
+            }
 
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,


### PR DESCRIPTION
Fork `pull_request` runs get a read-only token, so `vp-binary-size.yml` gated every job to same-repo PRs. Fork PRs that change native inputs (for example #2346, which touches Cargo.lock and many crates) got no size report at all.

Changes:

- Drop the fork gate from the `inputs` job, so fork PRs run the native input compare and the base/head builds when inputs changed.
- Let the `comment` job run for fork PRs. It always writes the size table to the job summary, and returns before the comment API calls when the PR head is a fork.
- Keep the `cleanup` job same-repo only, because comment deletion needs a write token.

Same-repo PRs keep the current behavior, summary plus sticky comment. Fork PRs get the report in the run's job summary.

The build jobs receive no secrets, checkout uses `persist-credentials: false`, and the Rust cache save is disabled, so the untrusted fork code runs with the same exposure as the regular CI jobs that already run for fork PRs.
