### PR TITLE
fix(cli): kill the whole child tree when runCommandSilently times out

### DIFF
--- a/packages/cli/src/utils/__tests__/command.spec.ts
+++ b/packages/cli/src/utils/__tests__/command.spec.ts
@@ -27,6 +27,34 @@ describe('command runners', () => {
     ).rejects.toThrow(/timed out after 200ms/);
   });
 
+  it(
+    'times out even when a grandchild inherits the stdio pipes',
+    { timeout: 10_000 },
+    async () => {
+      // Arbitrary project code run by a config worker can spawn its own
+      // children. This child spawns a grandchild that inherits the piped
+      // stdio, then wedges like a blocking plugin factory. Without a tree
+      // kill the SIGKILL reaches only the direct child, the grandchild
+      // keeps the stdout pipe open, `close` never fires, and the promise
+      // never settles. The grandchild self-terminates after 15s so a
+      // failing run leaves nothing behind.
+      await expect(
+        runCommandSilently({
+          command: process.execPath,
+          args: [
+            '-e',
+            `const { spawn } = require('node:child_process');
+             spawn(process.execPath, ['-e', 'setTimeout(() => {}, 15_000)'], { stdio: 'inherit' });
+             setInterval(() => {}, 1000);`,
+          ],
+          cwd: process.cwd(),
+          envs: process.env,
+          timeoutMs: 500,
+        }),
+      ).rejects.toThrow(/timed out after 500ms/);
+    },
+  );
+
   it('does not reject a fast child because a timeout is configured', async () => {
     const result = await runCommandSilently({
       command: process.execPath,

--- a/packages/cli/src/utils/command.ts
+++ b/packages/cli/src/utils/command.ts
@@ -39,6 +39,9 @@ export async function runCommandSilently(options: RunCommandOptions): Promise<Ru
     stdio: ['ignore', 'pipe', 'pipe'],
     cwd: options.cwd,
     env: options.envs,
+    // Own process group (POSIX) so the timeout can kill the whole tree: the
+    // child runs arbitrary project code that may spawn its own children.
+    detached: process.platform !== 'win32',
   });
   const promise = new Promise<RunCommandResult>((resolve, reject) => {
     const stdout: Buffer[] = [];
@@ -51,7 +54,21 @@ export async function runCommandSilently(options: RunCommandOptions): Promise<Ru
         ? undefined
         : setTimeout(() => {
             timedOut = true;
-            child.kill('SIGKILL');
+            if (process.platform !== 'win32' && child.pid) {
+              try {
+                process.kill(-child.pid, 'SIGKILL');
+              } catch {
+                child.kill('SIGKILL');
+              }
+            } else {
+              child.kill('SIGKILL');
+            }
+            // A descendant that inherited the pipes can hold them open past
+            // the kill (a Windows child tree, or a POSIX process that left
+            // the group). Release our ends so `close` always fires; the
+            // timeout path rejects without reading the output anyway.
+            child.stdout?.destroy();
+            child.stderr?.destroy();
           }, options.timeoutMs);
     timer?.unref();
     child.stdout?.on('data', (data) => {


### PR DESCRIPTION
## Bug

`runCommandSilently` resolves on the child's `close` event, but its timeout killed only the direct child. When arbitrary code run by the child spawned a grandchild that inherited the piped stdio, the SIGKILL left the grandchild holding the pipe, `close` never fired, and the caller hung forever.

`vp migrate` hits this through the config-compat worker: resolving a project's `vite.config` executes project code, and any lingering stdio-inheriting descendant (an esbuild-style service, a daemon) wedges the migration permanently under a frozen "Checking config compatibility" spinner, at 0% CPU after the initial burst. This likely explains previously observed `vp migrate` hangs at 0% CPU.

## Fix

- Spawn the child in its own process group on POSIX and kill the group on timeout, so the whole tree dies with it.
- Destroy our pipe ends after the kill, so `close` always fires even when a survivor holds the far end (the Windows path and escaped-group case). The timeout path rejects without reading output, so nothing is lost.

## Test

The new case wedges a child that hands its pipes to a short-lived grandchild. Before the fix the promise never settled and the test died on its own timeout; with the fix the suite passes in under a second. The compat-runner spec passes unchanged.
