### PR TITLE
fix(ci): exclude test fixtures from Renovate scanning

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,10 +1,16 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>Boshen/renovate"],
-  "description": "Skip lockfile artifact updates (npm and cargo): they fail in Renovate's clone because vite/ and rolldown/ are gitignored. The renovate-lockfiles workflow regenerates lockfiles on renovate/** pushes; gitIgnoredAuthors keeps Renovate managing branches with its commits.",
+  "description": "Skip lockfile artifact updates (npm and cargo): they fail in Renovate's clone because vite/ and rolldown/ are gitignored. The renovate-lockfiles workflow regenerates lockfiles on renovate/** pushes; gitIgnoredAuthors keeps Renovate managing branches with its commits. ignorePaths excludes test fixtures: their deps are test data, and the migration_monorepo_pnpm_overrides_dependency_selector fixture's multi-level pnpm override selector aborts the whole Renovate scan with ERR_PNPM_INVALID_SELECTOR.",
   "gitIgnoredAuthors": ["278573678+voidzero-guard[bot]@users.noreply.github.com"],
   "skipArtifactsUpdate": true,
-  "ignorePaths": ["bench/fixtures/**", "rolldown/**", "vite/**"],
+  "ignorePaths": [
+    "bench/fixtures/**",
+    "crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/**",
+    "packages/cli/src/__tests__/fixtures/**",
+    "rolldown/**",
+    "vite/**"
+  ],
   "packageRules": [
     {
       "description": "Ignore upstream toolchain npm packages (vendored via sync-remote or bumped by the proactive catalog workflow); everything else stays enabled so security alerts get fixed.",


### PR DESCRIPTION
Renovate aborts the whole repository scan with `ERR_PNPM_INVALID_SELECTOR` when it parses the multi-level pnpm override selector (`vite-plugin-svgr>foo>vite`) in the `migration_monorepo_pnpm_overrides_dependency_selector` snapshot fixture ([error log](https://developer.mend.io/github/voidzero-dev/vite-plus/-/job/5694ac3b-1f35-49c0-b558-51d59fe4842b)). The selector is intentional `vp migrate` test data, but `@pnpm/parse-overrides` cannot parse two `>` levels. Every run since mid-June failed, so the update PRs #1780, #1782, and #1831 went stale.

Fix: add the snapshot and unit-test fixture trees to `ignorePaths`. Renovate applies `ignorePaths` before extraction, so fixture files never reach the parser on any Renovate version. Fixture dependencies also stop receiving bump PRs, which would break recorded snapshots.

Verified with `renovate-config-validator` and a local dry run (`npx renovate --platform=local --dry-run=extract`): the npm manager drops from 726 files to 11 real package files, no fixture file is extracted, and the cargo and github-actions managers are unchanged (`crates/vp_cli_snapshots/Cargo.toml` stays managed).

Closes #2451
