### PR TITLE
fix(config): skip git lookup when hooks are disabled

### DIFF
--- a/packages/cli/src/config/__tests__/bin.spec.ts
+++ b/packages/cli/src/config/__tests__/bin.spec.ts
@@ -1,0 +1,35 @@
+import { beforeEach, expect, it, vi } from 'vitest';
+
+const hooks = vi.hoisted(() => ({
+  install: vi.fn(),
+  isGitHooksEnvDisabled: vi.fn(() => true),
+  isHooksUserDisabled: vi.fn(),
+  resolveHooksLocation: vi.fn(() => {
+    throw new Error('git command not found');
+  }),
+}));
+const terminal = vi.hoisted(() => ({ log: vi.fn(), printHeader: vi.fn() }));
+
+vi.mock('mri', () => ({ default: () => ({ agent: false }) }));
+vi.mock('../../utils/agent.ts', () => ({ updateExistingAgentInstructions: vi.fn() }));
+vi.mock('../../utils/help.ts', () => ({ renderCliDoc: vi.fn() }));
+vi.mock('../../utils/prompts.ts', () => ({
+  defaultInteractive: () => false,
+  promptGitHooks: vi.fn(),
+}));
+vi.mock('../../utils/terminal.ts', () => terminal);
+vi.mock('../hooks.ts', () => hooks);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+it('skips Git-backed hook resolution when hooks are disabled by environment', async () => {
+  await import('../bin.ts');
+
+  expect(hooks.isGitHooksEnvDisabled).toHaveBeenCalledOnce();
+  expect(hooks.resolveHooksLocation).not.toHaveBeenCalled();
+  expect(hooks.isHooksUserDisabled).not.toHaveBeenCalled();
+  expect(hooks.install).not.toHaveBeenCalled();
+  expect(terminal.log).toHaveBeenCalledWith('skip install (git hooks disabled)');
+});

--- a/packages/cli/src/config/bin.ts
+++ b/packages/cli/src/config/bin.ts
@@ -7,7 +7,12 @@ import { updateExistingAgentInstructions } from '../utils/agent.ts';
 import { renderCliDoc } from '../utils/help.ts';
 import { defaultInteractive, promptGitHooks } from '../utils/prompts.ts';
 import { log, printHeader } from '../utils/terminal.ts';
-import { install, isHooksUserDisabled, resolveHooksLocation } from './hooks.ts';
+import {
+  install,
+  isGitHooksEnvDisabled,
+  isHooksUserDisabled,
+  resolveHooksLocation,
+} from './hooks.ts';
 
 async function main() {
   const args = mri(process.argv.slice(3), {
@@ -56,9 +61,10 @@ async function main() {
 
   // --- Step 1: Hooks setup ---
   // Prefer CLI flag, then last-used dir from local git config, then default.
-  // Skip location resolution entirely when `--no-hooks` so agent-only runs
-  // do not fail on a missing git repo or invalid `--hooks-dir`.
-  if (!skipHooks) {
+  // Check environment opt-outs before the Git-backed location lookup.
+  if (!skipHooks && isGitHooksEnvDisabled()) {
+    log('skip install (git hooks disabled)');
+  } else if (!skipHooks) {
     const location = resolveHooksLocation(dir);
     if ('isError' in location) {
       if (location.message) {

--- a/packages/cli/src/config/hooks.ts
+++ b/packages/cli/src/config/hooks.ts
@@ -516,13 +516,17 @@ export interface InstallOptions {
   ignoreUserPreference?: boolean;
 }
 
-export function install(dir?: string, options: InstallOptions = {}): InstallResult {
-  // VP_GIT_HOOKS is the canonical name; VITE_GIT_HOOKS is kept for backwards compatibility.
-  if (
+export function isGitHooksEnvDisabled(): boolean {
+  // VP_GIT_HOOKS is canonical; VITE_GIT_HOOKS remains for backwards compatibility.
+  return (
     process.env.HUSKY === '0' ||
     process.env.VP_GIT_HOOKS === '0' ||
     process.env.VITE_GIT_HOOKS === '0'
-  ) {
+  );
+}
+
+export function install(dir?: string, options: InstallOptions = {}): InstallResult {
+  if (isGitHooksEnvDisabled()) {
     return { message: 'skip install (git hooks disabled)', isError: false };
   }
   if (!options.ignoreUserPreference && isHooksUserDisabled()) {


### PR DESCRIPTION
## What changed

`vp config` now checks the Git hooks environment opt-out before resolving the hook location. With `HUSKY=0`, `VP_GIT_HOOKS=0`, or the legacy `VITE_GIT_HOOKS=0`, it skips hook setup without invoking Git.

## Why

The opt-out previously lived inside `install()`, but `vp config` called the Git-backed location resolver first. Git-less containers therefore failed even though hooks were explicitly disabled.

## Tests

- Focused config hook tests: 36 passed, 1 existing platform skip
- Regression test imports the real config entrypoint and makes the Git resolver throw if reached
- Oxlint on the changed files

Fixes #2441
