### PR TITLE
feat: ship a Renovate preset and dependency-bot docs for lockstep updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -3,7 +3,7 @@
   "description": "Shared Renovate preset for Vite+ projects: keeps vite-plus, the vite catalog alias (@voidzero-dev/vite-plus-core), and the pinned vitest family in one grouped update. Consume with \"extends\": [\"github>voidzero-dev/vite-plus\"].",
   "packageRules": [
     {
-      "description": "vite-plus and @voidzero-dev/vite-plus-* are published together at one version, and vp pins vitest (plus aligned @vitest/* providers) to the version bundled in vite-plus. One grouped PR keeps the set in lockstep. Explicit minimumReleaseAge and schedule give every member one eligibility policy, so another preset cannot hold one member back and split the group.",
+      "description": "Explicit minimumReleaseAge and schedule give every member one eligibility policy, so another preset cannot hold one member back and split the group.",
       "groupName": "vite+",
       "matchPackageNames": ["vite-plus", "@voidzero-dev/vite-plus-*", "vitest", "@vitest/*"],
       "minimumReleaseAge": "1 day",

--- a/default.json
+++ b/default.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Shared Renovate preset for Vite+ projects: keeps vite-plus, the vite catalog alias (@voidzero-dev/vite-plus-core), and the pinned vitest family in one grouped update. Consume with \"extends\": [\"github>voidzero-dev/vite-plus\"].",
+  "packageRules": [
+    {
+      "description": "vite-plus and @voidzero-dev/vite-plus-* are published together at one version, and vp pins vitest (plus aligned @vitest/* providers) to the version bundled in vite-plus. One grouped PR keeps the set in lockstep. Explicit minimumReleaseAge and schedule give every member one eligibility policy, so another preset cannot hold one member back and split the group.",
+      "groupName": "vite+",
+      "matchPackageNames": ["vite-plus", "@voidzero-dev/vite-plus-*", "vitest", "@vitest/*"],
+      "minimumReleaseAge": "1 day",
+      "schedule": ["at any time"]
+    }
+  ]
+}

--- a/docs/guide/ci.md
+++ b/docs/guide/ci.md
@@ -37,6 +37,47 @@ When you use a commit SHA, add the exact release tag in a comment. Renovate uses
 
 These settings apply only to GitHub Actions workflows. For GitLab CI/CD and Azure Pipelines, update both version values together.
 
+## Dependency Update Bots
+
+`vp create` and `vp migrate` write two npm entries that must stay on one version: the `vite-plus` dependency and the `vite` alias (`npm:@voidzero-dev/vite-plus-core@<version>`). Projects that use `vp test` also carry a `vitest` override pinned to the version bundled in Vite+. A dependency bot sees unrelated packages and updates each one in its own PR. Either PR leaves the project on a Vite+ pairing that was never published together, and `vp build` and `vp test` fail on the mismatch.
+
+Configure your bot to update these packages in one grouped PR.
+
+### Renovate
+
+Extend the official preset from the Vite+ repository:
+
+```json [renovate.json]
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", "github>voidzero-dev/vite-plus"]
+}
+```
+
+The preset groups `vite-plus`, `@voidzero-dev/vite-plus-*`, `vitest`, and `@vitest/*` into one `vite+` PR. It also sets `minimumReleaseAge` and `schedule` on the group, so every member becomes eligible at the same time even when another preset sets a different age gate or schedule for some of them. Rules later in your configuration override these values.
+
+### Dependabot
+
+Add a `groups` entry for the npm ecosystem in `.github/dependabot.yml`:
+
+```yaml [.github/dependabot.yml]
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      vite-plus:
+        patterns:
+          - vite-plus
+          - '@voidzero-dev/vite-plus-*'
+          - vitest
+          - '@vitest/*'
+```
+
+Grouping combines updates that arrive together. A `vitest` release with no Vite+ release still produces a separate `vitest` PR ahead of the bundled version. Run `vp migrate` to realign the `vitest` pin with the bundled version.
+
 ## GitHub Actions
 
 The GitHub Action sets up Vite+, the required Node.js version, and the package manager. This means you usually do not need separate `setup-node`, package-manager setup, or manual dependency caching steps in your workflow.

--- a/docs/guide/ci.md
+++ b/docs/guide/ci.md
@@ -39,7 +39,7 @@ These settings apply only to GitHub Actions workflows. For GitLab CI/CD and Azur
 
 ## Dependency Update Bots
 
-`vp create` and `vp migrate` write two npm entries that must stay on one version: the `vite-plus` dependency and the `vite` alias (`npm:@voidzero-dev/vite-plus-core@<version>`). Projects that use `vp test` also carry a `vitest` override pinned to the version bundled in Vite+. A dependency bot sees unrelated packages and updates each one in its own PR. Either PR leaves the project on a Vite+ pairing that was never published together, and `vp build` and `vp test` fail on the mismatch.
+`vp create` and `vp migrate` write two npm entries that must stay on one version: the `vite-plus` dependency and the `vite` alias (`npm:@voidzero-dev/vite-plus-core@<version>`). Projects that use `vp test` also carry a `vitest` override pinned to the version bundled in Vite+. A dependency bot sees unrelated packages and updates each one in its own PR. Either PR leaves the project on a Vite+ pairing that was never published together, and `vp dev`, `vp build`, `vp preview`, and `vp test` fail on the mismatch.
 
 Configure your bot to update these packages in one grouped PR.
 

--- a/docs/guide/migrate.md
+++ b/docs/guide/migrate.md
@@ -106,6 +106,8 @@ Or, if you are using Yarn:
 }
 ```
 
+These entries and the `vite-plus` dependency must stay on one version. If Renovate or Dependabot updates the project, configure grouped updates so a bot bumps them together; see [Dependency Update Bots](/guide/ci#dependency-update-bots).
+
 ## Migration Prompt
 
 If you want to hand this work to a coding agent (or the reader is a coding agent!), use this migration prompt:


### PR DESCRIPTION
Every `vp create` / `vp migrate` project carries `vite-plus` plus the `vite` alias (`npm:@voidzero-dev/vite-plus-core@<same version>`), and `vp test` projects a pinned `vitest` override. Dependency bots update each package in its own PR, splitting the lockstep set. This is #2356 idea 1, stacked on the fail-fast guard (#2462).

The root `default.json` is a shared Renovate preset, consumed as `"extends": ["github>voidzero-dev/vite-plus"]`. It groups `vite-plus`, `@voidzero-dev/vite-plus-*`, `vitest`, and `@vitest/*` into one PR, and sets `minimumReleaseAge` and `schedule` on the group so no other rule can split member eligibility (the failure mode from voidzero-dev/setup-vp#119; rule shape taken from the merged fixes voidzero-dev/setup-vp#121 and voidzero-dev/setup.viteplus.dev#42). The preset passes `renovate-config-validator`.

Docs: a new "Dependency Update Bots" section in the CI guide documents the preset and an equivalent Dependabot `groups` config, and the migration guide links to it from the overrides section.

Refs #2356

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
