### PR TITLE
fix(create): skip hooks prompt when git is declined

### DIFF
--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/create_skip_hooks_without_git/snapshots.toml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/create_skip_hooks_without_git/snapshots.toml
@@ -1,0 +1,12 @@
+[[case]]
+name = "create_skip_hooks_without_git"
+vp = "local"
+steps = [
+  { argv = ["vp", "create", "vite:application", "--directory", "app", "--package-manager", "pnpm", "--no-agent", "--no-editor"], comment = "declining Git initialization should skip the pre-commit hooks prompt", snapshot = false, continue-on-failure = true, interactions = [
+    { "expect-milestone" = "confirm:confirm:yes" },
+    { "write-key" = "left" },
+    { "expect-milestone" = "confirm:confirm:no" },
+    { "write-key" = "enter" },
+  ] },
+  { argv = ["vpt", "stat-file", "app/.vite-hooks/pre-commit", "--assert", "missing"], comment = "pre-commit hooks should not be configured without a Git repository", continue-on-failure = true },
+]

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/create_skip_hooks_without_git/snapshots/create_skip_hooks_without_git.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/create_skip_hooks_without_git/snapshots/create_skip_hooks_without_git.md
@@ -1,0 +1,14 @@
+# create_skip_hooks_without_git
+
+## `vp create vite:application --directory app --package-manager pnpm --no-agent --no-editor`
+
+declining Git initialization should skip the pre-commit hooks prompt
+
+
+## `vpt stat-file app/.vite-hooks/pre-commit --assert missing`
+
+pre-commit hooks should not be configured without a Git repository
+
+```
+app/.vite-hooks/pre-commit: missing
+```

--- a/packages/cli/src/create/bin.ts
+++ b/packages/cli/src/create/bin.ts
@@ -875,7 +875,7 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
   }
 
   const shouldSetupGit = await resolveGitInit(options, isMonorepo);
-  if (!isMonorepo) {
+  if (!isMonorepo && (!options.interactive || shouldSetupGit || options.hooks === true)) {
     shouldSetupHooks = await promptGitHooks(options);
   }
 


### PR DESCRIPTION
Close #2459

This PR skips the pre-commit hooks prompt when an interactive create declines Git initialization. Non-interactive default hook setup and explicit `--hooks` remain unchanged.

🤖 Generated with Codex