### PR TITLE
fix(ci): ignore every vite-task git dependency in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -41,16 +41,9 @@
       "enabled": false
     },
     {
-      "description": "Ignore vite-task git dependency digest updates (bumped via the bump-vite-task workflow).",
-      "matchDepNames": [
-        "fspy",
-        "vt_glob",
-        "vt_path",
-        "vt_powershell",
-        "vt_str",
-        "vt",
-        "vt_workspace"
-      ],
+      "description": "Ignore vite-task git dependency digest updates: every crate from that repository shares one revision and is bumped by hand with the bump-vite-task skill. Match the git source, not crate names, so crates added upstream (pty_terminal_test, snapshot_test, vt_select) stay covered without editing a list here.",
+      "matchDatasources": ["git-refs"],
+      "matchPackageNames": ["https://github.com/voidzero-dev/vite-task.git"],
       "enabled": false
     }
   ]


### PR DESCRIPTION
The Renovate ignore rule listed vite-task crates by name and covered 6 of the 10 crates that `Cargo.toml` pulls from `voidzero-dev/vite-task` (one of them, `vt_glob`, no longer exists). The 4 uncovered crates got auto-update PRs, with automerge on: #2470 `pty_terminal_test`, #2471 `pty_terminal_test_client`, #2472 `snapshot_test`, #2473 `vt_select`.

These crates all share one revision and are bumped by hand with the `bump-vite-task` skill, so this matches the git source instead of crate names. Crates added upstream stay covered without editing a list.

## Validation

Ran renovate 44.31.0 with `--platform=local --dry-run=full --enabled-managers=cargo` against the real `Cargo.toml`, once per config:

| | branches planned | cargo updates |
|---|---|---|
| before | the 4 digest branches above, plus `rust-crates` and `major-rust-crates` | 24 |
| after | `rust-crates`, `major-rust-crates` | 20 |

The debug log reports all 10 vite-task crates as disabled, the oxc rule still applies, and the other 20 crate updates are untouched. `renovate-config-validator` passes.

After this merges, Renovate should prune the 4 stale branches and close their PRs. Worth confirming on the next run.
