### PR TITLE
fix(cli): make pack --no-config skip Vite config loading

### DIFF
--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_pack/snapshots.toml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_pack/snapshots.toml
@@ -8,3 +8,12 @@ steps = [
   { argv = ["vpt", "list-dir", "dist"], comment = "should have the library", continue-on-failure = true },
   { argv = ["vp", "run", "pack"], comment = "should hit cache", continue-on-failure = true },
 ]
+
+[[case]]
+name = "command_pack_no_config"
+vp = "local"
+env = { CONFIG_MUST_NOT_LOAD = "1" }
+steps = [
+  { argv = ["vp", "pack", "--no-config", "src/index.ts"], comment = "should build without loading vite.config.ts", continue-on-failure = true },
+  { argv = ["vpt", "stat-file", "dist/index.mjs", "--assert", "file"], comment = "should write the bundle", continue-on-failure = true },
+]

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_pack/snapshots/command_pack_no_config.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_pack/snapshots/command_pack_no_config.md
@@ -1,0 +1,21 @@
+# command_pack_no_config
+
+## `vp pack --no-config src/index.ts`
+
+should build without loading vite.config.ts
+
+```
+ℹ entry: src/index.ts
+ℹ Build start
+ℹ dist/index.mjs  <size> kB │ gzip: <size> kB
+ℹ 1 files, total: <size> kB
+✔ Build complete in <duration>
+```
+
+## `vpt stat-file dist/index.mjs --assert file`
+
+should write the bundle
+
+```
+dist/index.mjs: file
+```

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_pack/vite.config.ts
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_pack/vite.config.ts
@@ -1,3 +1,7 @@
+if (process.env.CONFIG_MUST_NOT_LOAD) {
+  throw new Error('CONFIG_MUST_NOT_LOAD');
+}
+
 export default {
   run: {
     tasks: {

--- a/packages/cli/src/pack-bin.ts
+++ b/packages/cli/src/pack-bin.ts
@@ -146,19 +146,20 @@ cli
     }
 
     async function runBuild() {
-      const viteConfig = await resolveViteConfig(process.cwd(), {
-        traverseUp: flags.config !== false,
-      });
+      const viteConfig =
+        flags.config === false
+          ? undefined
+          : await resolveViteConfig(process.cwd(), { traverseUp: true });
 
       const configDeps = new Set<string>();
-      if (viteConfig.configFile) {
+      if (viteConfig?.configFile) {
         configDeps.add(viteConfig.configFile);
       }
 
       const configs: ResolvedConfig[] = [];
-      const packConfigs = Array.isArray(viteConfig.pack)
+      const packConfigs = Array.isArray(viteConfig?.pack)
         ? viteConfig.pack
-        : [viteConfig.pack ?? {}];
+        : [viteConfig?.pack ?? {}];
       for (const packConfig of packConfigs) {
         const merged = { ...packConfig, ...flags };
         // Keep postcss/lightningcss external to the dts bundle (see plugin doc)
@@ -167,6 +168,7 @@ cli
           merged.plugins = [...existingPlugins, externalDtsTypeOnlyPlugin()];
         }
         const resolvedConfig = await resolveUserConfig(merged, flags, configDeps);
+        resolvedConfig.forEach((config) => config.configDeps.forEach((dep) => configDeps.add(dep)));
         configs.push(...resolvedConfig);
       }
 


### PR DESCRIPTION
## Summary 

`vp pack --no-config` now skips automatic Vite config resolution instead of only disabling parent-directory traversal.
Local `vite.config.*` files, including `pack` options and hooks, no longer execute when config loading is disabled.

 Explicit `--from-vite` resolution keeps its discovered dependencies so watch mode can still restart when those files change.