### PR TITLE
fix(cli): show config options in pack help

### DIFF
--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_helper/snapshots/command_helper.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_helper/snapshots/command_helper.md
@@ -52,6 +52,7 @@ Arguments:
   [...files]  Bundle files
 
 Options:
+  --no-config                   Disable config file
   -f, --format <format>         Bundle format: esm, cjs, iife, umd (default: esm)
   --clean                       Clean output directory, --no-clean to disable
   --deps.never-bundle <module>  Mark dependencies as external

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_pack/snapshots/command_pack.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_pack/snapshots/command_pack.md
@@ -16,7 +16,6 @@ Arguments:
   [...files]  Bundle files
 
 Options:
-  --config-loader <loader>      Config loader to use: auto, native, tsx, unrun (default: auto)
   --no-config                   Disable config file
   -f, --format <format>         Bundle format: esm, cjs, iife, umd (default: esm)
   --clean                       Clean output directory, --no-clean to disable

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_pack/snapshots/command_pack.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_pack/snapshots/command_pack.md
@@ -16,6 +16,8 @@ Arguments:
   [...files]  Bundle files
 
 Options:
+  --config-loader <loader>      Config loader to use: auto, native, tsx, unrun (default: auto)
+  --no-config                   Disable config file
   -f, --format <format>         Bundle format: esm, cjs, iife, umd (default: esm)
   --clean                       Clean output directory, --no-clean to disable
   --deps.never-bundle <module>  Mark dependencies as external

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_tool_help/snapshots/command_tool_help.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_tool_help/snapshots/command_tool_help.md
@@ -233,6 +233,7 @@ Arguments:
   [...files]  Bundle files
 
 Options:
+  --no-config                   Disable config file
   -f, --format <format>         Bundle format: esm, cjs, iife, umd (default: esm)
   --clean                       Clean output directory, --no-clean to disable
   --deps.never-bundle <module>  Mark dependencies as external

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -834,10 +834,6 @@ const commandHelpDocs = {
       {
         title: 'Options',
         rows: [
-          {
-            label: '--config-loader <loader>',
-            description: 'Config loader to use: auto, native, tsx, unrun (default: auto)',
-          },
           { label: '--no-config', description: 'Disable config file' },
           {
             label: '-f, --format <format>',

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -835,6 +835,11 @@ const commandHelpDocs = {
         title: 'Options',
         rows: [
           {
+            label: '--config-loader <loader>',
+            description: 'Config loader to use: auto, native, tsx, unrun (default: auto)',
+          },
+          { label: '--no-config', description: 'Disable config file' },
+          {
             label: '-f, --format <format>',
             description: 'Bundle format: esm, cjs, iife, umd (default: esm)',
           },


### PR DESCRIPTION
## Summary
`vp pack --help` now documents the supported `--no-config` options. This keeps the static help output aligned with the Pack CLI without changing runtime behavior.

Depends on #2486