### PR TITLE
perf(cli): lazy-load init-only deps out of the vp startup path

### DIFF
--- a/packages/cli/src/init-config.ts
+++ b/packages/cli/src/init-config.ts
@@ -4,10 +4,8 @@ import path from 'node:path';
 import { hasConfigKey, mergeJsonConfig } from '../binding/index.js';
 import { createDefaultVitePlusLintConfig } from './oxlint-plugin-config.ts';
 import { fmt as resolveFmt } from './resolve-fmt.ts';
-import { runCommandSilently } from './utils/command.ts';
 import { BASEURL_TSCONFIG_WARNING, VITE_CONFIG_FILES, VITE_PLUS_NAME } from './utils/constants.ts';
 import { warnMsg } from './utils/terminal.ts';
-import { fixBaseUrlInTsconfig, hasBaseUrlInTsconfig } from './utils/tsconfig.ts';
 
 interface InitCommandSpec {
   configKey: 'lint' | 'fmt';
@@ -130,6 +128,7 @@ export default defineConfig({});
 }
 
 async function vpFmt(cwd: string, filePath: string): Promise<void> {
+  const { runCommandSilently } = await import('./utils/command.ts');
   const { binPath, envs } = await resolveFmt();
   const result = await runCommandSilently({
     command: binPath,
@@ -223,6 +222,7 @@ export async function applyToolInitConfigToViteConfig(
 
   if (spec.configKey === 'lint' && hasTriggerFlag(args, ['--init'])) {
     const lintInitConfigPath = path.join(projectPath, '.vite-plus-lint-init.oxlintrc.json');
+    const { fixBaseUrlInTsconfig, hasBaseUrlInTsconfig } = await import('./utils/tsconfig.ts');
     await fixBaseUrlInTsconfig(projectPath);
     // Skip typeAware/typeCheck when tsconfig still has baseUrl (unsupported by tsgolint)
     const hasBaseUrl = hasBaseUrlInTsconfig(projectPath);


### PR DESCRIPTION
## Summary

Apply lazy loading in `init-config.ts` so the JS resources used only by `vp lint --init` and `vp fmt --init` / `--migrate` (`utils/tsconfig.ts`, `utils/command.ts` and their dependencies) are loaded on demand instead of on every `vp` invocation.

## Benchmark

`node dist/bin.js --help` on macOS (Apple Silicon), Node 24, measured with `hyperfine --warmup 5 --runs 30` against the `main` build and this branch's build placed side by side.

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `before` (main) | 83.7 ± 0.9 | 82.1 | 85.3 | 1.10 ± 0.02 |
| `after` (this PR) | 76.1 ± 0.9 | 74.2 | 78.0 | 1.00 |

The static import closure of `dist/bin.js` drops from 13 files / 540 KB to 9 files / 92 KB, so every `vp` invocation parses about 450 KB less JavaScript. Package size is unchanged.

<img width="1422" height="472" alt="image" src="https://github.com/user-attachments/assets/e71cd828-389b-46cc-96f6-94a5ee0cfa9b" />
