### PR TITLE
fix(env): escape and deduplicate POSIX shell paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -959,6 +959,18 @@ jobs:
       - name: Install Fish
         uses: fish-actions/install-fish@4bb37a71daebb76c6fb7d83771cff31b8a78c28e # v1.2.0
 
+      - name: Ensure Zsh is installed
+        run: |
+          if ! command -v zsh >/dev/null 2>&1; then
+            if [ "$RUNNER_OS" = 'Linux' ]; then
+              sudo apt-get update
+              sudo apt-get install --yes zsh
+            else
+              brew install zsh
+            fi
+          fi
+          zsh --version
+
       # https://github.com/marketplace/actions/setup-nu
       - name: Install Nushell
         uses: hustcer/setup-nu@ccd5bb5426b05a32009c2ba967946231f3919c97 # v3.25
@@ -981,6 +993,9 @@ jobs:
 
       - name: Run PTY snapshot tests
         run: |
+          export VP_SNAP_SH_BIN="$(command -v sh)"
+          export VP_SNAP_BASH_BIN="$(command -v bash)"
+          export VP_SNAP_ZSH_BIN="$(command -v zsh)"
           VP_SNAP_GLOBAL_VP="$HOME/.vite-plus/bin/vp" \
           VP_SNAP_JS_RUNTIME_DIR="$HOME/.vite-plus/js_runtime" \
           VP_SNAP_FISH_BIN="$(command -v fish)" \

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/README.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/README.md
@@ -63,6 +63,9 @@ Environment overrides, mainly for CI:
 | `VP_SNAP_GLOBAL_VP`         | Path to a prebuilt global `vp` binary (skips the target-dir lookup) |
 | `VP_SNAP_LOCAL_CLI_BIN_DIR` | Local CLI bin dir (default `<repo>/packages/cli/bin`)               |
 | `VP_SNAP_JS_RUNTIME_DIR`    | Provisioned managed runtime to seed case homes with                 |
+| `VP_SNAP_SH_BIN`            | POSIX `sh` binary for cases that execute the generated `env` file   |
+| `VP_SNAP_BASH_BIN`          | Bash binary for cases that execute the generated `env` file         |
+| `VP_SNAP_ZSH_BIN`           | Zsh binary for cases that execute the generated `env` file          |
 | `VP_SNAP_FISH_BIN`          | Fish binary for cases that execute generated `env.fish` files       |
 | `VP_SNAP_NU_BIN`            | Nushell binary for cases that execute generated `env.nu` files      |
 | `VP_SNAP_SKIP_FLAVORS`      | Comma-separated flavors to skip registering (e.g. `local`)          |
@@ -76,7 +79,7 @@ vp = "local"                  # "local" | "global" | ["local", "global"]
 comment = "What this proves." # rendered into the snapshot
 cwd = "packages/app"          # optional, relative to the fixture root
 skip-platforms = ["windows"]  # or { os = "linux", libc = "musl" }
-requires = ["fish"]           # "fish" | "nu"; ignore when the tool is absent
+requires = ["bash"]           # "sh" | "bash" | "zsh" | "fish" | "nu"
 ignore = false                # true: only runs with `-- --ignored`
 seed-runtime = true           # false: start from an empty VP_HOME
 link-node-modules = false     # true: expose the run-root node_modules as
@@ -119,7 +122,7 @@ A step is a bare argv array or a table:
   interactions = [ ... ] }
 ```
 
-`argv[0]` may be `vpt`, a runner-provisioned tool such as `fish` or `nu`, or any
+`argv[0]` may be `vpt`, a runner-provisioned shell, or any
 executable exposed by the case's Vite+ installation, including default shims
 such as `vp`, `node`, and `corepack` and globally installed package binaries.
 There is no shell: no `&&`, no
@@ -186,8 +189,8 @@ case-owned tool dirs, then a system tail for child processes and direct `git` st
 `TERM=xterm-256color`, `VP_CLI_TEST=1`, `VP_EMIT_MILESTONES=1`, a fresh
 `HOME`, `VP_HOME`, and npm prefix. The runner still rejects direct step tools
 that resolve outside the case-owned dirs, except for `git`; `vpt` is the only
-required runner helper on PATH, while optional tools such as `fish` and `nu`
-are linked there when available. `CI` and `NO_COLOR` are deliberately NOT
+required runner helper on PATH, while optional shells are linked there when
+available. `CI` and `NO_COLOR` are deliberately NOT
 set: with a PTY attached, the CLI behaves interactively by default, which is
 the point.
 `seed-runtime = true` (default) symlinks a provisioned managed Node runtime

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_env_posix/assert_posix.sh
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_env_posix/assert_posix.sh
@@ -1,0 +1,107 @@
+. ./env || {
+    echo "failed to source env"
+    exit 1
+}
+
+if [ "$VP_HOME" != "$EXPECTED_VP_HOME" ]; then
+    echo "VP_HOME mismatch: expected $EXPECTED_VP_HOME, got $VP_HOME"
+    exit 1
+fi
+
+expected_bin="$EXPECTED_VP_HOME/bin"
+first_path_entry=${PATH%%:*}
+if [ "$first_path_entry" != "$expected_bin" ]; then
+    echo "PATH mismatch: expected first entry $expected_bin, got $first_path_entry"
+    exit 1
+fi
+
+bin_count=0
+remaining_path=$PATH
+while :; do
+    case $remaining_path in
+        *:*)
+            path_entry=${remaining_path%%:*}
+            remaining_path=${remaining_path#*:}
+            ;;
+        *)
+            path_entry=$remaining_path
+            remaining_path=
+            ;;
+    esac
+    if [ "$path_entry" = "$expected_bin" ]; then
+        bin_count=$((bin_count + 1))
+    fi
+    if [ -z "$remaining_path" ]; then
+        break
+    fi
+done
+if [ "$bin_count" -ne 1 ]; then
+    echo "PATH contains the Vite+ bin directory $bin_count times"
+    exit 1
+fi
+
+command -v vp >/dev/null || {
+    echo "env did not define the vp wrapper"
+    exit 1
+}
+
+vp_output=$(vp --version) || {
+    echo "vp --version failed through the POSIX wrapper"
+    exit 1
+}
+if [ -z "$vp_output" ]; then
+    echo "vp --version returned no output"
+    exit 1
+fi
+
+VP_NODE_VERSION=18.20.0
+export VP_NODE_VERSION
+vp env use --help >/dev/null || {
+    echo "vp env use --help failed through the POSIX wrapper"
+    exit 1
+}
+if [ "$VP_NODE_VERSION" != "18.20.0" ]; then
+    echo "vp env use --help changed VP_NODE_VERSION"
+    exit 1
+fi
+
+vp env use 20.18.0 --no-install || {
+    echo "vp env use failed through the POSIX wrapper"
+    exit 1
+}
+if [ "${VP_NODE_VERSION:-}" != "20.18.0" ]; then
+    echo "VP_NODE_VERSION mismatch: expected 20.18.0, got ${VP_NODE_VERSION:-<unset>}"
+    exit 1
+fi
+
+vp env use --unset || {
+    echo "vp env use --unset failed through the POSIX wrapper"
+    exit 1
+}
+if [ "${VP_NODE_VERSION+x}" = x ]; then
+    echo "vp env use --unset did not remove VP_NODE_VERSION"
+    exit 1
+fi
+
+vp env use --no-install || {
+    echo "vp env use without a version failed through the POSIX wrapper"
+    exit 1
+}
+if [ "${VP_NODE_VERSION:-}" != "22.18.0" ]; then
+    echo "file-based VP_NODE_VERSION mismatch: expected 22.18.0, got ${VP_NODE_VERSION:-<unset>}"
+    exit 1
+fi
+
+if [ -n "${BASH_VERSION:-}" ]; then
+    complete -p vp >/dev/null || {
+        echo "env did not register Bash completions"
+        exit 1
+    }
+elif [ -n "${ZSH_VERSION:-}" ]; then
+    whence -w _vpr_complete >/dev/null || {
+        echo "env did not register Zsh completions"
+        exit 1
+    }
+fi
+
+echo "POSIX environment checks passed ($SHELL_LABEL)"

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_env_posix/snapshots.toml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_env_posix/snapshots.toml
@@ -1,0 +1,35 @@
+[[case]]
+name = "command_env_posix_sh"
+vp = "global"
+skip-platforms = ["windows"]
+requires = ["sh"]
+steps = [
+  { argv = ["vp", "env", "setup", "--refresh"], envs = [["VP_HOME", '${workspace}/vp "$project\with `spaces`"']], snapshot = false },
+  { argv = ["vpt", "cp", "assert_posix.sh", 'vp "$project\with `spaces`"/assert_posix.sh'], snapshot = false },
+  { argv = ["vpt", "write-file", 'vp "$project\with `spaces`"/.node-version', "22.18.0\n"], snapshot = false },
+  { argv = ["sh", "assert_posix.sh"], cwd = 'vp "$project\with `spaces`"', comment = "loads the generated env file in sh and verifies PATH, wrapper, and version switching", envs = [["EXPECTED_VP_HOME", "${workspace}"], ["SHELL_LABEL", "sh"], ["PATH", "${workspace}/bin:${workspace}/bin:${PATH}"]] },
+]
+
+[[case]]
+name = "command_env_posix_bash"
+vp = "global"
+skip-platforms = ["windows"]
+requires = ["bash"]
+steps = [
+  { argv = ["vp", "env", "setup", "--refresh"], envs = [["VP_HOME", '${workspace}/vp "$project\with `spaces`"']], snapshot = false },
+  { argv = ["vpt", "cp", "assert_posix.sh", 'vp "$project\with `spaces`"/assert_posix.sh'], snapshot = false },
+  { argv = ["vpt", "write-file", 'vp "$project\with `spaces`"/.node-version', "22.18.0\n"], snapshot = false },
+  { argv = ["bash", "--noprofile", "--norc", "assert_posix.sh"], cwd = 'vp "$project\with `spaces`"', comment = "loads the generated env file in Bash and verifies PATH, wrapper, completions, and version switching", envs = [["EXPECTED_VP_HOME", "${workspace}"], ["SHELL_LABEL", "bash"], ["PATH", "${workspace}/bin:${workspace}/bin:${PATH}"]] },
+]
+
+[[case]]
+name = "command_env_posix_zsh"
+vp = "global"
+skip-platforms = ["windows"]
+requires = ["zsh"]
+steps = [
+  { argv = ["vp", "env", "setup", "--refresh"], envs = [["VP_HOME", '${workspace}/vp "$project\with `spaces`"']], snapshot = false },
+  { argv = ["vpt", "cp", "assert_posix.sh", 'vp "$project\with `spaces`"/assert_posix.sh'], snapshot = false },
+  { argv = ["vpt", "write-file", 'vp "$project\with `spaces`"/.node-version', "22.18.0\n"], snapshot = false },
+  { argv = ["zsh", "-f", "-c", 'autoload -Uz compinit; compinit -i -d "$HOME/.zcompdump"; . ./assert_posix.sh'], cwd = 'vp "$project\with `spaces`"', comment = "loads the generated env file in Zsh and verifies PATH, wrapper, completions, and version switching", envs = [["EXPECTED_VP_HOME", "${workspace}"], ["SHELL_LABEL", "zsh"], ["PATH", "${workspace}/bin:${workspace}/bin:${PATH}"]] },
+]

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_env_posix/snapshots/command_env_posix_bash.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_env_posix/snapshots/command_env_posix_bash.md
@@ -1,0 +1,22 @@
+# command_env_posix_bash
+
+## `VP_HOME=${workspace}/vp "$project\with `spaces`" vp env setup --refresh`
+
+
+## `vpt cp assert_posix.sh 'vp "$project\with `spaces`"/assert_posix.sh'`
+
+
+## `vpt write-file 'vp "$project\with `spaces`"/.node-version' '22.18.0
+'`
+
+
+## `cd 'vp "$project\with `spaces`"' && EXPECTED_VP_HOME=${workspace} SHELL_LABEL=bash PATH=${workspace}/bin:${workspace}/bin:${PATH} bash --noprofile --norc assert_posix.sh`
+
+loads the generated env file in Bash and verifies PATH, wrapper, completions, and version switching
+
+```
+Using Node.js <version> (resolved from 20.18.0)
+Reverted to file-based Node.js version resolution
+Using Node.js <version> (resolved from .node-version)
+POSIX environment checks passed (bash)
+```

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_env_posix/snapshots/command_env_posix_sh.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_env_posix/snapshots/command_env_posix_sh.md
@@ -1,0 +1,22 @@
+# command_env_posix_sh
+
+## `VP_HOME=${workspace}/vp "$project\with `spaces`" vp env setup --refresh`
+
+
+## `vpt cp assert_posix.sh 'vp "$project\with `spaces`"/assert_posix.sh'`
+
+
+## `vpt write-file 'vp "$project\with `spaces`"/.node-version' '22.18.0
+'`
+
+
+## `cd 'vp "$project\with `spaces`"' && EXPECTED_VP_HOME=${workspace} SHELL_LABEL=sh PATH=${workspace}/bin:${workspace}/bin:${PATH} sh assert_posix.sh`
+
+loads the generated env file in sh and verifies PATH, wrapper, and version switching
+
+```
+Using Node.js <version> (resolved from 20.18.0)
+Reverted to file-based Node.js version resolution
+Using Node.js <version> (resolved from .node-version)
+POSIX environment checks passed (sh)
+```

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_env_posix/snapshots/command_env_posix_zsh.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_env_posix/snapshots/command_env_posix_zsh.md
@@ -1,0 +1,22 @@
+# command_env_posix_zsh
+
+## `VP_HOME=${workspace}/vp "$project\with `spaces`" vp env setup --refresh`
+
+
+## `vpt cp assert_posix.sh 'vp "$project\with `spaces`"/assert_posix.sh'`
+
+
+## `vpt write-file 'vp "$project\with `spaces`"/.node-version' '22.18.0
+'`
+
+
+## `cd 'vp "$project\with `spaces`"' && EXPECTED_VP_HOME=${workspace} SHELL_LABEL=zsh PATH=${workspace}/bin:${workspace}/bin:${PATH} zsh -f -c 'autoload -Uz compinit; compinit -i -d "$HOME/.zcompdump"; . ./assert_posix.sh'`
+
+loads the generated env file in Zsh and verifies PATH, wrapper, completions, and version switching
+
+```
+Using Node.js <version> (resolved from 20.18.0)
+Reverted to file-based Node.js version resolution
+Using Node.js <version> (resolved from .node-version)
+POSIX environment checks passed (zsh)
+```

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/flavor.rs
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/flavor.rs
@@ -6,7 +6,7 @@
 //!
 //! Each flavor gets one runner bin directory per run (created under the run
 //! temp root) for runner-owned helpers. `vpt` always lives there; optional
-//! external tools such as Fish and Nushell are linked there when available.
+//! external shells are linked there when available.
 
 use std::path::{Path, PathBuf};
 
@@ -30,6 +30,11 @@ impl Flavor {
 pub struct FlavorRuntime {
     pub runner_bin_dir: PathBuf,
     pub vpt: PathBuf,
+    /// Runner-owned POSIX shell binaries used by fixtures that execute the
+    /// generated `env` file.
+    pub sh: Option<PathBuf>,
+    pub bash: Option<PathBuf>,
+    pub zsh: Option<PathBuf>,
     /// Runner-owned Fish binary used by fixtures that execute generated
     /// `env.fish` files. CI supplies it through `VP_SNAP_FISH_BIN`.
     pub fish: Option<PathBuf>,
@@ -218,6 +223,18 @@ pub fn fish_path() -> Result<Option<PathBuf>, String> {
     optional_tool_path("VP_SNAP_FISH_BIN", "fish")
 }
 
+pub fn sh_path() -> Result<Option<PathBuf>, String> {
+    optional_tool_path("VP_SNAP_SH_BIN", "sh")
+}
+
+pub fn bash_path() -> Result<Option<PathBuf>, String> {
+    optional_tool_path("VP_SNAP_BASH_BIN", "bash")
+}
+
+pub fn zsh_path() -> Result<Option<PathBuf>, String> {
+    optional_tool_path("VP_SNAP_ZSH_BIN", "zsh")
+}
+
 /// Resolves an optional Nushell binary for fixtures that exercise generated
 /// `env.nu` files.
 pub fn nushell_path() -> Result<Option<PathBuf>, String> {
@@ -321,6 +338,12 @@ pub fn provision(flavor: Flavor, run_root: &Path) -> Result<FlavorRuntime, Strin
         .map_err(|e| format!("failed to create bin dir: {e}"))?;
 
     let vpt = install_runner_tool(&runner_bin_dir, "vpt", &vpt_path()?)?;
+    let sh =
+        sh_path()?.map(|path| install_runner_tool(&runner_bin_dir, "sh", &path)).transpose()?;
+    let bash =
+        bash_path()?.map(|path| install_runner_tool(&runner_bin_dir, "bash", &path)).transpose()?;
+    let zsh =
+        zsh_path()?.map(|path| install_runner_tool(&runner_bin_dir, "zsh", &path)).transpose()?;
     let fish =
         fish_path()?.map(|path| install_runner_tool(&runner_bin_dir, "fish", &path)).transpose()?;
     let nu = nushell_path()?
@@ -331,5 +354,5 @@ pub fn provision(flavor: Flavor, run_root: &Path) -> Result<FlavorRuntime, Strin
         Flavor::Local => local_cli_package_dir()?,
         Flavor::Global => repo_root().join("packages/cli"),
     };
-    Ok(FlavorRuntime { runner_bin_dir, vpt, fish, nu, global_vp, cli_package_dir })
+    Ok(FlavorRuntime { runner_bin_dir, vpt, sh, bash, zsh, fish, nu, global_vp, cli_package_dir })
 }

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/main.rs
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/main.rs
@@ -319,6 +319,9 @@ impl PlatformFilter {
 #[derive(Clone, Copy, serde::Deserialize, Debug)]
 #[serde(rename_all = "lowercase")]
 enum RequiredTool {
+    Sh,
+    Bash,
+    Zsh,
     Fish,
     Nu,
 }
@@ -328,6 +331,9 @@ impl RequiredTool {
     /// reports that error instead of silently hiding a bad override.
     fn is_missing(self) -> bool {
         match self {
+            Self::Sh => matches!(flavor::sh_path(), Ok(None)),
+            Self::Bash => matches!(flavor::bash_path(), Ok(None)),
+            Self::Zsh => matches!(flavor::zsh_path(), Ok(None)),
             Self::Fish => matches!(flavor::fish_path(), Ok(None)),
             Self::Nu => matches!(flavor::nushell_path(), Ok(None)),
         }
@@ -459,6 +465,9 @@ struct CaseInstall {
     path_env: OsString,
     tool_dirs: Vec<PathBuf>,
     vpt: PathBuf,
+    sh: Option<PathBuf>,
+    bash: Option<PathBuf>,
+    zsh: Option<PathBuf>,
     fish: Option<PathBuf>,
     nu: Option<PathBuf>,
 }
@@ -474,6 +483,24 @@ impl CaseInstall {
     ) -> Result<PathBuf, String> {
         if program == "vpt" {
             return Ok(self.vpt.clone());
+        }
+        if program == "sh" {
+            return self.sh.clone().ok_or_else(|| {
+                "`sh` is required by this snapshot case; install it or set VP_SNAP_SH_BIN"
+                    .to_owned()
+            });
+        }
+        if program == "bash" {
+            return self.bash.clone().ok_or_else(|| {
+                "`bash` is required by this snapshot case; install Bash or set VP_SNAP_BASH_BIN"
+                    .to_owned()
+            });
+        }
+        if program == "zsh" {
+            return self.zsh.clone().ok_or_else(|| {
+                "`zsh` is required by this snapshot case; install Zsh or set VP_SNAP_ZSH_BIN"
+                    .to_owned()
+            });
         }
         if program == "fish" {
             return self.fish.clone().ok_or_else(|| {
@@ -582,6 +609,9 @@ impl CaseHome {
             path_env: compose_path_env(&path_dirs),
             tool_dirs,
             vpt: runtime.vpt.clone(),
+            sh: runtime.sh.clone(),
+            bash: runtime.bash.clone(),
+            zsh: runtime.zsh.clone(),
             fish: runtime.fish.clone(),
             nu: runtime.nu.clone(),
         })

--- a/crates/vp_global_cli/src/commands/env/setup.rs
+++ b/crates/vp_global_cli/src/commands/env/setup.rs
@@ -520,28 +520,23 @@ pub(crate) async fn cleanup_legacy_windows_shim(bin_dir: &vt_path::AbsolutePath,
 }
 
 // POSIX env file (bash/zsh)
-// When sourced multiple times, removes existing entry and re-prepends to front
-// Uses parameter expansion to split PATH around the bin entry in O(1) operations
+// When sourced multiple times, removes existing entries and re-prepends to front
+// Uses parameter expansion to preserve PATH entries containing spaces
 // Includes vp() shell function wrapper for `vp env use` (evals stdout)
 // Includes shell completion support
 const ENV_TEMPLATE_POSIX: &str = r#"#!/bin/sh
 # Vite+ environment setup (https://viteplus.dev)
 __ENV_EXPORTS____vp_bin="__VP_BIN__"
-case ":${PATH}:" in
-    *":${__vp_bin}:"*)
-        __vp_tmp=":${PATH}:"
-        __vp_before="${__vp_tmp%%":${__vp_bin}:"*}"
-        __vp_before="${__vp_before#:}"
-        __vp_after="${__vp_tmp#*":${__vp_bin}:"}"
-        __vp_after="${__vp_after%:}"
-        export PATH="${__vp_bin}${__vp_before:+:${__vp_before}}${__vp_after:+:${__vp_after}}"
-        unset __vp_tmp __vp_before __vp_after
-        ;;
-    *)
-        export PATH="$__vp_bin:$PATH"
-        ;;
-esac
-unset __vp_bin
+while case ":${PATH}:" in *":${__vp_bin}:"*) true ;; *) false ;; esac; do
+    __vp_tmp=":${PATH}:"
+    __vp_before="${__vp_tmp%%":${__vp_bin}:"*}"
+    __vp_before="${__vp_before#:}"
+    __vp_after="${__vp_tmp#*":${__vp_bin}:"}"
+    __vp_after="${__vp_after%:}"
+    PATH="${__vp_before}${__vp_before:+${__vp_after:+:}}${__vp_after}"
+done
+export PATH="${__vp_bin}${PATH:+:${PATH}}"
+unset __vp_bin __vp_tmp __vp_before __vp_after
 
 # Shell function wrapper: intercepts `vp env use` to eval its stdout,
 # which sets/unsets VP_NODE_VERSION in the current shell session.
@@ -1388,24 +1383,19 @@ mod tests {
 
                 let env_content = tokio::fs::read_to_string(home.join("env")).await.unwrap();
 
-                // Verify PATH guard structure: case statement checks for duplicate
+                // Verify PATH guard structure: loop removes every duplicate.
                 assert!(
-                    env_content.contains("case \":${PATH}:\" in"),
-                    "env file should contain PATH guard case statement"
+                    env_content.contains("while case \":${PATH}:\" in"),
+                    "env file should contain a PATH cleanup loop"
                 );
                 assert!(
                     env_content.contains("*\":${__vp_bin}:\"*)"),
                     "env file should check for existing bin in PATH"
                 );
-                // Verify it re-prepends to front when already present
+                // Verify it re-prepends exactly once after cleanup.
                 assert!(
-                    env_content.contains("export PATH=\"${__vp_bin}"),
-                    "env file should re-prepend bin to front of PATH"
-                );
-                // Verify simple prepend for new entry
-                assert!(
-                    env_content.contains("export PATH=\"$__vp_bin:$PATH\""),
-                    "env file should prepend bin to PATH for new entry"
+                    env_content.contains("export PATH=\"${__vp_bin}${PATH:+:${PATH}}\""),
+                    "env file should prepend bin to PATH after removing duplicates"
                 );
             },
         )


### PR DESCRIPTION
Tests selected POSIX shell names but did not source the generated environment file. They did not test the generated shell code.

The old template did not escape special characters in paths. It also removed one duplicate Vite+ bin entry and left other duplicates.

The snapshot runner runs the file in sh, Bash, and Zsh. CI installs Zsh when a Linux runner does not have it. CI checks Zsh on each runner and supplies its path to the snapshot runner.

The renderer escapes values in double-quoted strings. It removes the duplicate bin entries before it adds one entry. The tests cover setup, completion, version selection, unset, and `.node-version` selection.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>