### PR TITLE
test(env): cover nushell file-based use

### DIFF
--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_env_nushell/assert.nu
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_env_nushell/assert.nu
@@ -53,4 +53,16 @@ if ("VP_NODE_VERSION" in $env) {
   }
 }
 
+vp env use --no-install
+if ("VP_NODE_VERSION" not-in $env) {
+  error make {
+    msg: "vp env use without a version did not set VP_NODE_VERSION"
+  }
+}
+if $env.VP_NODE_VERSION != "22.18.0" {
+  error make {
+    msg: $"file-based VP_NODE_VERSION mismatch: expected 22.18.0, got ($env.VP_NODE_VERSION)"
+  }
+}
+
 print "Nushell environment checks passed"

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_env_nushell/snapshots.toml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_env_nushell/snapshots.toml
@@ -6,7 +6,8 @@ requires = ["nu"]
 steps = [
   { argv = ["vp", "env", "setup", "--refresh"], envs = [["VP_HOME", '${workspace}/vp "home\with spaces"']], snapshot = false },
   { argv = ["vpt", "cp", "assert.nu", 'vp "home\with spaces"/assert.nu'], snapshot = false },
-  { argv = ["nu", "assert.nu"], cwd = 'vp "home\with spaces"', comment = "loads the generated env.nu and verifies the Nushell wrapper", envs = [["EXPECTED_VP_HOME", "${workspace}"], ["PATH", "${workspace}/bin:${workspace}/bin:${PATH}"]] },
+  { argv = ["vpt", "write-file", 'vp "home\with spaces"/.node-version', "22.18.0\n"], snapshot = false },
+  { argv = ["nu", "assert.nu"], cwd = 'vp "home\with spaces"', comment = "loads the generated env.nu and verifies setup, explicit use, unset, and file-based use", envs = [["EXPECTED_VP_HOME", "${workspace}"], ["PATH", "${workspace}/bin:${workspace}/bin:${PATH}"]] },
 ]
 
 [[case]]

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_env_nushell/snapshots/command_env_nushell.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_env_nushell/snapshots/command_env_nushell.md
@@ -6,12 +6,17 @@
 ## `vpt cp assert.nu 'vp "home\with spaces"/assert.nu'`
 
 
+## `vpt write-file 'vp "home\with spaces"/.node-version' '22.18.0
+'`
+
+
 ## `cd 'vp "home\with spaces"' && EXPECTED_VP_HOME=${workspace} PATH=${workspace}/bin:${workspace}/bin:${PATH} nu assert.nu`
 
-loads the generated env.nu and verifies the Nushell wrapper
+loads the generated env.nu and verifies setup, explicit use, unset, and file-based use
 
 ```
 Using Node.js <version> (resolved from 20.18.0)
 Reverted to file-based Node.js version resolution
+Using Node.js <version> (resolved from .node-version)
 Nushell environment checks passed
 ```


### PR DESCRIPTION
The Nushell snapshot checked explicit version selection and unset. It did not check version selection from a project file.

The fixture writes a `.node-version` file. It runs `vp env use --no-install` without a version argument. The test checks that Nushell exports the version from the file.

This test covers the file-based selection path that the other shell tests use.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>