### PR TITLE
ci: link preview installers and pin install scripts

### DIFF
--- a/.github/workflows/publish-preview-register.yml
+++ b/.github/workflows/publish-preview-register.yml
@@ -77,6 +77,8 @@ jobs:
       pr-url: ${{ steps.check.outputs.pr_url }}
       is-fork: ${{ steps.check.outputs.is_fork }}
       head-repo: ${{ steps.check.outputs.head_repo }}
+      installer-x64-id: ${{ steps.check.outputs.installer_x64_id }}
+      installer-arm64-id: ${{ steps.check.outputs.installer_arm64_id }}
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         id: check
@@ -187,6 +189,19 @@ jobs:
               );
               core.setOutput('eligible', 'false');
               return;
+            }
+
+            const installerTargets = {
+              installer_x64_id: 'vp-setup-x86_64-pc-windows-msvc',
+              installer_arm64_id: 'vp-setup-aarch64-pc-windows-msvc',
+            };
+            for (const [output, name] of Object.entries(installerTargets)) {
+              const artifact = artifacts.find((a) => a.name === name && !a.expired);
+              if (!artifact) {
+                core.setFailed(`run ${process.env.RUN_ID} has no active ${name} artifact`);
+                return;
+              }
+              core.setOutput(output, String(artifact.id));
             }
 
             const headRepo = pr.head.repo?.full_name ?? '(deleted fork)';
@@ -329,6 +344,9 @@ jobs:
           IS_FORK: ${{ needs.authorize.outputs.is-fork }}
           HEAD_REPO: ${{ needs.authorize.outputs.head-repo }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          INSTALLER_X64_ID: ${{ needs.authorize.outputs.installer-x64-id }}
+          INSTALLER_ARM64_ID: ${{ needs.authorize.outputs.installer-arm64-id }}
         with:
           script: |
             const version = process.env.BRIDGE_VERSION;
@@ -337,6 +355,8 @@ jobs:
             const isFork = process.env.IS_FORK === 'true';
             const marker = '<!-- pkg-pr-bridge-version -->';
             const bridge = 'https://registry-bridge.viteplus.dev/';
+            const artifactUrl = (id) =>
+              `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.RUN_ID}/artifacts/${id}`;
             // Built as a line array (not a template literal) so the inline
             // backticks and the fenced json block don't need backslash-escaping.
             const body = [
@@ -371,6 +391,19 @@ jobs:
               '```powershell',
               '# Windows (PowerShell)',
               `$env:VP_PR_VERSION="${pr}"; irm https://vite.plus/ps1 | iex`,
+              '```',
+              '',
+              '**Or download the standalone Windows installer built from this commit:**',
+              '',
+              '| Architecture | Installer |',
+              '| --- | --- |',
+              `| x64 | [\`vp-setup-x86_64-pc-windows-msvc.exe\`](${artifactUrl(process.env.INSTALLER_X64_ID)}) |`,
+              `| Arm64 | [\`vp-setup-aarch64-pc-windows-msvc.exe\`](${artifactUrl(process.env.INSTALLER_ARM64_ID)}) |`,
+              '',
+              'GitHub requires you to sign in and downloads each installer as a ZIP artifact. Extract `vp-setup.exe`, then run it against this preview build:',
+              '',
+              '```powershell',
+              `.\\vp-setup.exe --version "${version}" --registry "${bridge}"`,
               '```',
               '',
               `After installing, upgrade the current project's \`vite-plus\` to this test build with:`,

--- a/.github/workflows/publish-preview-register.yml
+++ b/.github/workflows/publish-preview-register.yml
@@ -355,6 +355,8 @@ jobs:
             const isFork = process.env.IS_FORK === 'true';
             const marker = '<!-- pkg-pr-bridge-version -->';
             const bridge = 'https://registry-bridge.viteplus.dev/';
+            const installerScripts =
+              `https://raw.githubusercontent.com/${process.env.HEAD_REPO}/${process.env.HEAD_SHA}/packages/cli`;
             const artifactUrl = (id) =>
               `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.RUN_ID}/artifacts/${id}`;
             // Built as a line array (not a template literal) so the inline
@@ -386,11 +388,11 @@ jobs:
               '',
               '```bash',
               '# macOS / Linux',
-              `curl -fsSL https://vite.plus | VP_PR_VERSION=${pr} bash`,
+              `curl -fsSL ${installerScripts}/install.sh | VP_PR_VERSION=${pr} bash`,
               '```',
               '```powershell',
               '# Windows (PowerShell)',
-              `$env:VP_PR_VERSION="${pr}"; irm https://vite.plus/ps1 | iex`,
+              `$env:VP_PR_VERSION="${pr}"; irm ${installerScripts}/install.ps1 | iex`,
               '```',
               '',
               '**Or download the standalone Windows installer built from this commit:**',


### PR DESCRIPTION
Preview builds upload x64 and Arm64 `vp-setup.exe` artifacts, but the preview comment did not link to them. The comment also fetched installation scripts from `vite.plus`, which serves the latest release.

Now the comment links to both installer artifacts. GitHub requires sign-in and downloads each artifact as a ZIP file.

The shell commands fetch `install.sh` and `install.ps1` from the exact PR head commit. They then install the matching registry bridge version.