### PR TITLE
fix(installer): enforce Windows setup requirements

### DIFF
--- a/.github/workflows/test-standalone-install.yml
+++ b/.github/workflows/test-standalone-install.yml
@@ -9,6 +9,7 @@ on:
       - 'packages/cli/install.sh'
       - 'packages/cli/install.ps1'
       - 'packages/tools/src/install-global-cli.ts'
+      - 'packages/tools/src/local-npm-registry.ts'
       - 'crates/vp_installer/**'
       - 'crates/vp_trampoline/**'
       - 'crates/vp_global_cli/**'
@@ -1278,40 +1279,33 @@ jobs:
           # exit code after the assertions so the PowerShell step succeeds.
           $global:LASTEXITCODE = 0
 
-      - name: vp-setup.exe pre-split fallback leaves no split roots
+      - name: vp-setup.exe rejects releases before 0.3.0
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $false
           $installer = Join-Path $env:DEV_DRIVE "target/release/vp-setup.exe"
-          $profile = Join-Path $env:RUNNER_TEMP "vp-setup-0.2.9-profile"
-          $localSplitRoot = Join-Path $env:LOCALAPPDATA "vite-plus"
-          $roamingSplitRoot = Join-Path $env:APPDATA "vite-plus"
-          $splitRoots = @($localSplitRoot, $roamingSplitRoot)
-          Remove-Item -Recurse -Force $profile -ErrorAction SilentlyContinue
-          foreach ($splitRoot in $splitRoots) {
-            if (Test-Path $splitRoot) {
-              throw "fresh-install test requires an absent split root: $splitRoot"
-            }
-          }
-          New-Item -ItemType Directory -Force -Path $profile | Out-Null
+          $installRoot = Join-Path $env:RUNNER_TEMP "vp-setup-unsupported-version"
+          Remove-Item -Recurse -Force $installRoot -ErrorAction SilentlyContinue
+          $env:VP_HOME = $installRoot
+          Remove-Item Env:VP_BIN_DIR, Env:VP_DATA_DIR, Env:VP_CACHE_DIR -ErrorAction SilentlyContinue
 
-          Remove-Item Env:VP_HOME, Env:VP_BIN_DIR, Env:VP_DATA_DIR, Env:VP_CACHE_DIR -ErrorAction SilentlyContinue
-          $env:USERPROFILE = $profile
-          $env:HOME = $profile
-          & $installer --yes --version 0.2.9 --no-node-manager --no-modify-path
-          if ($LASTEXITCODE -ne 0) {
-            throw "vp-setup.exe exited with $LASTEXITCODE"
+          $output = (& $installer --yes --quiet --version 0.2.9 --no-node-manager --no-modify-path 2>&1) | Out-String
+          $exitCode = $LASTEXITCODE
+          Write-Host $output
+          if ($exitCode -ne 1) {
+            throw "vp-setup.exe exited with $exitCode, expected 1"
           }
-
-          $legacyRoot = Join-Path $profile ".vite-plus"
-          if (-not (Test-Path (Join-Path $legacyRoot "current/bin/vp.exe"))) {
-            throw "pre-split payload missing from $legacyRoot"
+          if (-not $output.Contains("Install vite-plus 0.3.0 or later")) {
+            throw "vp-setup.exe did not report its minimum supported version"
           }
-          foreach ($splitRoot in $splitRoots) {
-            if (Test-Path $splitRoot) {
-              throw "vp-setup.exe left split root $splitRoot"
-            }
+          if ($output -match "(?i)preview") {
+            throw "vp-setup.exe exposed preview-build guidance"
           }
+          if (Test-Path $installRoot) {
+            throw "vp-setup.exe created unsupported-version root $installRoot"
+          }
+          $global:LASTEXITCODE = 0
 
       - name: Incomplete directory overrides are rejected in PowerShell
         shell: pwsh
@@ -1590,9 +1584,58 @@ jobs:
           }
           & $vp --version
 
-      - name: Install via vp-setup.exe (silent)
+      - name: Start local preview registry for vp-setup.exe
+        shell: bash
+        run: |
+          test_version="0.0.0-commit.${GITHUB_SHA}"
+          registry_root="$RUNNER_TEMP/vp-setup-local-registry"
+          packages_dir="$registry_root/packages"
+          main_dir="$registry_root/vite-plus"
+          platform_dir="$registry_root/vite-plus-cli-win32-x64-msvc"
+          rm -rf "$registry_root"
+          mkdir -p "$packages_dir" "$main_dir" "$platform_dir"
+
+          node -e '
+            const fs = require("node:fs");
+            const path = require("node:path");
+            const [dir, version] = process.argv.slice(1);
+            fs.writeFileSync(path.join(dir, "package.json"), JSON.stringify({ name: "vite-plus", version }));
+          ' "$main_dir" "$test_version"
+          node -e '
+            const fs = require("node:fs");
+            const path = require("node:path");
+            const [dir, version] = process.argv.slice(1);
+            const manifest = {
+              name: "@voidzero-dev/vite-plus-cli-win32-x64-msvc",
+              version,
+              files: ["vp.exe", "vp-shim.exe"],
+            };
+            fs.writeFileSync(path.join(dir, "package.json"), JSON.stringify(manifest));
+          ' "$platform_dir" "$test_version"
+          cp "$DEV_DRIVE/target/release/vp.exe" "$DEV_DRIVE/target/release/vp-shim.exe" "$platform_dir/"
+          npm pack "$main_dir" --pack-destination "$packages_dir"
+          npm pack "$platform_dir" --pack-destination "$packages_dir"
+
+          registry_log="$registry_root/registry.out"
+          node "$GITHUB_WORKSPACE/packages/tools/src/local-npm-registry.ts" --serve --packages-dir "$packages_dir" > "$registry_log" 2>&1 &
+          server_pid=$!
+          until grep -q '"registry"' "$registry_log" 2>/dev/null; do
+            if ! kill -0 "$server_pid" 2>/dev/null; then
+              cat "$registry_log"
+              exit 1
+            fi
+            sleep 0.2
+          done
+          handshake=$(grep -m1 '"registry"' "$registry_log")
+          registry=$(echo "$handshake" | node -e 'process.stdin.on("data", data => process.stdout.write(JSON.parse(data).registry))')
+          echo "VP_SETUP_TEST_REGISTRY=$registry" >> "$GITHUB_ENV"
+          echo "VP_SETUP_TEST_VERSION=$test_version" >> "$GITHUB_ENV"
+
+      - name: Install local preview via vp-setup.exe (silent)
         shell: pwsh
-        run: ${{ format('{0}/target/release/vp-setup.exe', env.DEV_DRIVE) }}
+        run: |
+          $installer = Join-Path $env:DEV_DRIVE "target/release/vp-setup.exe"
+          & $installer --version $env:VP_SETUP_TEST_VERSION --registry $env:VP_SETUP_TEST_REGISTRY
 
       - name: Set PATH
         shell: bash

--- a/.github/workflows/test-standalone-install.yml
+++ b/.github/workflows/test-standalone-install.yml
@@ -1584,6 +1584,10 @@ jobs:
           }
           & $vp --version
 
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 24
+
       - name: Start local preview registry for vp-setup.exe
         shell: bash
         run: |

--- a/.github/workflows/test-standalone-install.yml
+++ b/.github/workflows/test-standalone-install.yml
@@ -1225,6 +1225,89 @@ jobs:
         shell: bash
         run: cargo build --release -p vp_global_cli -p vp_installer -p vp_trampoline
 
+      - name: vp-setup.exe rejects invalid directory overrides
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $false
+          $installer = Join-Path $env:DEV_DRIVE "target/release/vp-setup.exe"
+          $root = Join-Path $env:RUNNER_TEMP "vp-setup-invalid-dirs"
+          $defaultRoot = Join-Path $env:LOCALAPPDATA "vite-plus"
+          $defaultRootExisted = Test-Path $defaultRoot
+          $dirVars = @("VP_HOME", "VP_BIN_DIR", "VP_DATA_DIR", "VP_CACHE_DIR")
+          $togetherError = "Set VP_BIN_DIR, VP_DATA_DIR, and VP_CACHE_DIR together"
+          $cases = @(
+            @{ Name = "bin"; Values = @{ VP_BIN_DIR = Join-Path $root "bin" }; Error = $togetherError }
+            @{ Name = "data"; Values = @{ VP_DATA_DIR = Join-Path $root "data" }; Error = $togetherError }
+            @{ Name = "cache"; Values = @{ VP_CACHE_DIR = Join-Path $root "cache" }; Error = $togetherError }
+            @{ Name = "bin-data"; Values = @{ VP_BIN_DIR = Join-Path $root "bin"; VP_DATA_DIR = Join-Path $root "data" }; Error = $togetherError }
+            @{ Name = "bin-cache"; Values = @{ VP_BIN_DIR = Join-Path $root "bin"; VP_CACHE_DIR = Join-Path $root "cache" }; Error = $togetherError }
+            @{ Name = "data-cache"; Values = @{ VP_DATA_DIR = Join-Path $root "data"; VP_CACHE_DIR = Join-Path $root "cache" }; Error = $togetherError }
+            @{ Name = "relative-home"; Values = @{ VP_HOME = "relative-home" }; Error = "VP_HOME must be an absolute path" }
+            @{ Name = "relative-split"; Values = @{ VP_BIN_DIR = "relative-bin"; VP_DATA_DIR = "relative-data"; VP_CACHE_DIR = "relative-cache" }; Error = "VP_BIN_DIR must be an absolute path" }
+          )
+
+          foreach ($case in $cases) {
+            foreach ($name in $dirVars) {
+              [Environment]::SetEnvironmentVariable($name, $null)
+            }
+            foreach ($entry in $case.Values.GetEnumerator()) {
+              [Environment]::SetEnvironmentVariable($entry.Key, $entry.Value)
+            }
+
+            $output = (& $installer --yes --quiet --no-node-manager --no-modify-path 2>&1) | Out-String
+            $exitCode = $LASTEXITCODE
+            Write-Host $output
+            if ($exitCode -ne 1) {
+              throw "$($case.Name) exited with $exitCode, expected 1"
+            }
+            if (-not $output.Contains($case.Error)) {
+              throw "$($case.Name) did not report '$($case.Error)'"
+            }
+            foreach ($value in $case.Values.Values) {
+              if ([System.IO.Path]::IsPathRooted($value) -and (Test-Path $value)) {
+                throw "$($case.Name) created requested root $value"
+              }
+            }
+            if (-not $defaultRootExisted -and (Test-Path $defaultRoot)) {
+              throw "$($case.Name) created default root $defaultRoot"
+            }
+          }
+
+      - name: vp-setup.exe pre-split fallback leaves no split roots
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $installer = Join-Path $env:DEV_DRIVE "target/release/vp-setup.exe"
+          $profile = Join-Path $env:RUNNER_TEMP "vp-setup-0.2.9-profile"
+          $localSplitRoot = Join-Path $env:LOCALAPPDATA "vite-plus"
+          $roamingSplitRoot = Join-Path $env:APPDATA "vite-plus"
+          Remove-Item -Recurse -Force $profile -ErrorAction SilentlyContinue
+          foreach ($splitRoot in @($localSplitRoot, $roamingSplitRoot)) {
+            if (Test-Path $splitRoot) {
+              throw "fresh-install test requires an absent split root: $splitRoot"
+            }
+          }
+          New-Item -ItemType Directory -Force -Path $profile | Out-Null
+
+          Remove-Item Env:VP_HOME, Env:VP_BIN_DIR, Env:VP_DATA_DIR, Env:VP_CACHE_DIR -ErrorAction SilentlyContinue
+          $env:USERPROFILE = $profile
+          $env:HOME = $profile
+          & $installer --yes --version 0.2.9 --no-node-manager --no-modify-path
+          if ($LASTEXITCODE -ne 0) {
+            throw "vp-setup.exe exited with $LASTEXITCODE"
+          }
+
+          $legacyRoot = Join-Path $profile ".vite-plus"
+          if (-not (Test-Path (Join-Path $legacyRoot "current/bin/vp.exe"))) {
+            throw "pre-split payload missing from $legacyRoot"
+          }
+          foreach ($splitRoot in @($localSplitRoot, $roamingSplitRoot)) {
+            if (Test-Path $splitRoot) {
+              throw "vp-setup.exe left split root $splitRoot"
+            }
+          }
+
       - name: Incomplete directory overrides are rejected in PowerShell
         shell: pwsh
         run: |

--- a/.github/workflows/test-standalone-install.yml
+++ b/.github/workflows/test-standalone-install.yml
@@ -1236,7 +1236,7 @@ jobs:
           $defaultRoot = Join-Path $env:LOCALAPPDATA "vite-plus"
           $defaultRootExisted = Test-Path $defaultRoot
           $dirVars = @("VP_HOME", "VP_BIN_DIR", "VP_DATA_DIR", "VP_CACHE_DIR")
-          $togetherError = "Set VP_BIN_DIR, VP_DATA_DIR, and VP_CACHE_DIR together"
+          $togetherError = "Set all three variables together: VP_BIN_DIR, VP_DATA_DIR, and VP_CACHE_DIR"
           $cases = @(
             @{ Name = "bin"; Values = @{ VP_BIN_DIR = Join-Path $root "bin" }; Error = $togetherError }
             @{ Name = "data"; Values = @{ VP_DATA_DIR = Join-Path $root "data" }; Error = $togetherError }
@@ -1244,8 +1244,8 @@ jobs:
             @{ Name = "bin-data"; Values = @{ VP_BIN_DIR = Join-Path $root "bin"; VP_DATA_DIR = Join-Path $root "data" }; Error = $togetherError }
             @{ Name = "bin-cache"; Values = @{ VP_BIN_DIR = Join-Path $root "bin"; VP_CACHE_DIR = Join-Path $root "cache" }; Error = $togetherError }
             @{ Name = "data-cache"; Values = @{ VP_DATA_DIR = Join-Path $root "data"; VP_CACHE_DIR = Join-Path $root "cache" }; Error = $togetherError }
-            @{ Name = "relative-home"; Values = @{ VP_HOME = "relative-home" }; Error = "VP_HOME must be an absolute path" }
-            @{ Name = "relative-split"; Values = @{ VP_BIN_DIR = "relative-bin"; VP_DATA_DIR = "relative-data"; VP_CACHE_DIR = "relative-cache" }; Error = "VP_BIN_DIR must be an absolute path" }
+            @{ Name = "relative-home"; Values = @{ VP_HOME = "relative-home" }; Error = "Set VP_HOME to an absolute path" }
+            @{ Name = "relative-split"; Values = @{ VP_BIN_DIR = "relative-bin"; VP_DATA_DIR = "relative-data"; VP_CACHE_DIR = "relative-cache" }; Error = "Set VP_BIN_DIR to an absolute path" }
           )
 
           foreach ($case in $cases) {
@@ -1275,8 +1275,8 @@ jobs:
             }
           }
 
-          # Each installer process must fail in this test. Reset the native
-          # exit code after the assertions so the PowerShell step succeeds.
+          # Each installer process must fail in this test. Reset the native exit
+          # code after the assertions. This lets the PowerShell step succeed.
           $global:LASTEXITCODE = 0
 
       - name: vp-setup.exe rejects releases before 0.3.0
@@ -1300,10 +1300,10 @@ jobs:
             throw "vp-setup.exe did not report its minimum supported version"
           }
           if ($output -match "(?i)preview") {
-            throw "vp-setup.exe exposed preview-build guidance"
+            throw "vp-setup.exe mentioned preview builds"
           }
           if (Test-Path $installRoot) {
-            throw "vp-setup.exe created unsupported-version root $installRoot"
+            throw "vp-setup.exe created an installation root for version 0.2.9: $installRoot"
           }
           $global:LASTEXITCODE = 0
 

--- a/.github/workflows/test-standalone-install.yml
+++ b/.github/workflows/test-standalone-install.yml
@@ -285,7 +285,12 @@ jobs:
           export VP_VPDIRS_AWARE=1
           unset VP_HOME VP_BIN_DIR VP_DATA_DIR VP_CACHE_DIR
           unset XDG_DATA_HOME XDG_CACHE_HOME XDG_CONFIG_HOME XDG_STATE_HOME
-          VP_LOCAL_TGZ="$FAKE_TGZ" VP_VERSION=local-test bash packages/cli/install.sh
+          OUTPUT=$(mktemp)
+          VP_LOCAL_TGZ="$FAKE_TGZ" VP_VERSION=local-test bash packages/cli/install.sh | tee "$OUTPUT"
+
+          grep -F "Install locations:" "$OUTPUT"
+          grep -F "Data directory: ~/.local/share/vite-plus" "$OUTPUT"
+          grep -F "Bin directory:  ~/.local/share/vite-plus/bin" "$OUTPUT"
 
           test ! -d "$FRESH/.vite-plus"
           test -e "$FRESH/.local/share/vite-plus/current"
@@ -457,6 +462,18 @@ jobs:
             Write-Error "Expected the pre-split fallback notice in installer output"
             exit 1
           }
+          if (-not (Select-String -Path install-output.txt -Pattern "Install locations:" -SimpleMatch -Quiet)) {
+            Write-Error "Expected install locations in installer output"
+            exit 1
+          }
+          if (-not (Select-String -Path install-output.txt -Pattern "Data directory: ~\.vite-plus" -SimpleMatch -Quiet)) {
+            Write-Error "Expected the single-root data directory in installer output"
+            exit 1
+          }
+          if (-not (Select-String -Path install-output.txt -Pattern "Bin directory:  ~\.vite-plus\bin" -SimpleMatch -Quiet)) {
+            Write-Error "Expected the single-root bin directory in installer output"
+            exit 1
+          }
 
       - name: Verify monolithic layout
         shell: pwsh
@@ -510,8 +527,10 @@ jobs:
           echo "$output"
           # Verify installation succeeds (not a fatal error)
           echo "$output" | grep -q "successfully installed"
-          # Verify fallback message shows binary location
-          echo "$output" | grep -q "vp was installed to:"
+          # Verify the success message shows the single-root locations
+          echo "$output" | grep -q "Install locations:"
+          echo "$output" | grep -q "Data directory: ~/.vite-plus"
+          echo "$output" | grep -q "Bin directory:  ~/.vite-plus/bin"
           # Verify fallback message shows manual instructions
           echo "$output" | grep -q "Or run vp directly:"
           # Verify the permission warning was shown
@@ -1422,7 +1441,17 @@ jobs:
           New-Item -ItemType Directory -Force -Path $root | Out-Null
           New-Item -ItemType File -Force -Path $env:VP_LOCAL_TGZ | Out-Null
 
-          & ./packages/cli/install.ps1
+          $output = (& ./packages/cli/install.ps1 *>&1) | Out-String
+          Write-Host $output
+          if (-not $output.Contains("Install locations:")) {
+            throw "install.ps1 did not print install locations"
+          }
+          if (-not $output.Contains("Data directory: $($env:VP_DATA_DIR)")) {
+            throw "install.ps1 did not print the split data directory"
+          }
+          if (-not $output.Contains("Bin directory:  $($env:VP_BIN_DIR)")) {
+            throw "install.ps1 did not print the split bin directory"
+          }
 
           function Get-DirMap([string]$VpBinary) {
             $env:VP_DUMP_DIRS = "1"

--- a/.github/workflows/test-standalone-install.yml
+++ b/.github/workflows/test-standalone-install.yml
@@ -1274,6 +1274,10 @@ jobs:
             }
           }
 
+          # Each installer process must fail in this test. Reset the native
+          # exit code after the assertions so the PowerShell step succeeds.
+          $global:LASTEXITCODE = 0
+
       - name: vp-setup.exe pre-split fallback leaves no split roots
         shell: pwsh
         run: |

--- a/.github/workflows/test-standalone-install.yml
+++ b/.github/workflows/test-standalone-install.yml
@@ -1631,11 +1631,64 @@ jobs:
           echo "VP_SETUP_TEST_REGISTRY=$registry" >> "$GITHUB_ENV"
           echo "VP_SETUP_TEST_VERSION=$test_version" >> "$GITHUB_ENV"
 
-      - name: Install local preview via vp-setup.exe (silent)
+      - name: Create a dangling current junction
         shell: pwsh
         run: |
+          $ErrorActionPreference = "Stop"
+          $current = Join-Path $env:VP_HOME "current"
+          $removedTarget = Join-Path $env:RUNNER_TEMP "vp-setup-removed-target"
+          Remove-Item -Recurse -Force $env:VP_HOME, $removedTarget -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Force -Path $env:VP_HOME, $removedTarget | Out-Null
+
+          & cmd.exe /d /c "mklink /J `"$current`" `"$removedTarget`""
+          if ($LASTEXITCODE -ne 0) {
+            throw "cmd.exe could not create the test junction"
+          }
+          Remove-Item -Recurse -Force $removedTarget
+          & fsutil.exe reparsepoint query $current | Out-Null
+          if ($LASTEXITCODE -ne 0) {
+            throw "the dangling current entry is not a reparse point"
+          }
+
+      - name: Repair the dangling junction without ANSI output
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
           $installer = Join-Path $env:DEV_DRIVE "target/release/vp-setup.exe"
-          & $installer --version $env:VP_SETUP_TEST_VERSION --registry $env:VP_SETUP_TEST_REGISTRY
+          $stdout = Join-Path $env:RUNNER_TEMP "vp-setup-no-color.stdout.txt"
+          $stderr = Join-Path $env:RUNNER_TEMP "vp-setup-no-color.stderr.txt"
+          $env:NO_COLOR = "1"
+          try {
+            $process = Start-Process -FilePath $installer `
+              -ArgumentList @(
+                "--yes",
+                "--version", $env:VP_SETUP_TEST_VERSION,
+                "--registry", $env:VP_SETUP_TEST_REGISTRY,
+                "--no-node-manager",
+                "--no-modify-path"
+              ) `
+              -RedirectStandardOutput $stdout -RedirectStandardError $stderr `
+              -Wait -PassThru -NoNewWindow
+          } finally {
+            Remove-Item Env:NO_COLOR -ErrorAction SilentlyContinue
+          }
+
+          Get-Content -Raw $stdout | Write-Host
+          Get-Content -Raw $stderr | Write-Host
+          if ($process.ExitCode -ne 0) {
+            throw "vp-setup.exe exited with $($process.ExitCode)"
+          }
+          foreach ($path in @($stdout, $stderr)) {
+            if ([System.IO.File]::ReadAllBytes($path) -contains [byte]0x1b) {
+              throw "$path contains an ANSI escape"
+            }
+          }
+          if (-not (Test-Path (Join-Path $env:VP_HOME "current/bin/vp.exe"))) {
+            throw "vp-setup.exe did not repair the dangling current junction"
+          }
+          if (-not (Test-Path (Join-Path $env:VP_HOME "bin/vp.exe"))) {
+            throw "vp-setup.exe did not create the global vp.exe"
+          }
 
       - name: Set PATH
         shell: bash

--- a/.github/workflows/test-standalone-install.yml
+++ b/.github/workflows/test-standalone-install.yml
@@ -1282,8 +1282,9 @@ jobs:
           $profile = Join-Path $env:RUNNER_TEMP "vp-setup-0.2.9-profile"
           $localSplitRoot = Join-Path $env:LOCALAPPDATA "vite-plus"
           $roamingSplitRoot = Join-Path $env:APPDATA "vite-plus"
+          $splitRoots = @($localSplitRoot, $roamingSplitRoot)
           Remove-Item -Recurse -Force $profile -ErrorAction SilentlyContinue
-          foreach ($splitRoot in @($localSplitRoot, $roamingSplitRoot)) {
+          foreach ($splitRoot in $splitRoots) {
             if (Test-Path $splitRoot) {
               throw "fresh-install test requires an absent split root: $splitRoot"
             }
@@ -1302,7 +1303,7 @@ jobs:
           if (-not (Test-Path (Join-Path $legacyRoot "current/bin/vp.exe"))) {
             throw "pre-split payload missing from $legacyRoot"
           }
-          foreach ($splitRoot in @($localSplitRoot, $roamingSplitRoot)) {
+          foreach ($splitRoot in $splitRoots) {
             if (Test-Path $splitRoot) {
               throw "vp-setup.exe left split root $splitRoot"
             }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8559,8 +8559,8 @@ name = "vp_installer"
 version = "0.0.0"
 dependencies = [
  "clap",
+ "console",
  "indicatif",
- "owo-colors",
  "tempfile",
  "tokio",
  "vp_pm_cli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,6 +168,7 @@ blake3 = "1.8.2"
 chrono = { version = "0.4", features = ["serde"] }
 clap = "4.5.40"
 clap_complete = "4.6.0"
+console = "0.16.4"
 cow-utils = "0.1.3"
 cp_r = "0.5.2"
 criterion = { version = "0.7", features = ["html_reports"] }

--- a/crates/vp_global_cli/src/commands/upgrade/mod.rs
+++ b/crates/vp_global_cli/src/commands/upgrade/mod.rs
@@ -101,7 +101,7 @@ pub async fn execute(options: UpgradeOptions) -> Result<ExitStatus, Error> {
     // binary. A monolithic install accepts each release. This includes a
     // VP_HOME pin and an existing ~/.vite-plus install.
     let legacy = vp_shared::VpDirs::legacy_single_root(&config.user_home);
-    if legacy.data != config.dirs.data && !supports_split_layout(&resolved.version) {
+    if legacy.data != config.dirs.data && !vp_setup::supports_split_layout(&resolved.version) {
         return Err(Error::Upgrade(
             format!(
                 "vite-plus {} does not support this split directory layout. \
@@ -279,36 +279,4 @@ async fn execute_rollback(
     }
 
     Ok(ExitStatus::default())
-}
-
-/// Return `true` if `version` supports the split layout.
-///
-/// Version 0.3.0 and later support it, including prereleases. Preview builds
-/// (`0.0.0-commit.<sha>`) also support it because they track the current branch.
-fn supports_split_layout(version: &str) -> bool {
-    let Ok(version) = node_semver::Version::parse(version) else {
-        return false;
-    };
-    if version.major == 0 && version.minor == 0 && version.patch == 0 {
-        return !version.pre_release.is_empty() || !version.build.is_empty();
-    }
-    version.major > 0 || version.minor >= 3
-}
-
-#[cfg(test)]
-mod tests {
-    use super::supports_split_layout;
-
-    #[test]
-    fn split_layout_support_by_version() {
-        assert!(supports_split_layout("0.3.0"));
-        assert!(supports_split_layout("0.3.0-alpha.1"));
-        assert!(supports_split_layout("0.4.2"));
-        assert!(supports_split_layout("1.0.0"));
-        assert!(supports_split_layout("0.0.0-commit.0123abc"));
-        assert!(!supports_split_layout("0.2.9"));
-        assert!(!supports_split_layout("0.2.0"));
-        assert!(!supports_split_layout("0.1.14-alpha.1"));
-        assert!(!supports_split_layout("not-a-version"));
-    }
 }

--- a/crates/vp_installer/Cargo.toml
+++ b/crates/vp_installer/Cargo.toml
@@ -13,8 +13,8 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
+console = { workspace = true }
 indicatif = { workspace = true }
-owo-colors = { workspace = true, features = ["supports-colors"] }
 tokio = { workspace = true, features = ["full"] }
 vp_pm_cli = { workspace = true }
 vt_path = { workspace = true }

--- a/crates/vp_installer/src/cli.rs
+++ b/crates/vp_installer/src/cli.rs
@@ -22,15 +22,6 @@ pub struct Options {
     #[arg(long = "tag", default_value = "latest")]
     pub tag: String,
 
-    /// Set a custom single-root installation directory and set `VP_HOME`.
-    ///
-    /// By default, Vite+ reuses an existing `~/.vite-plus` install. Otherwise,
-    /// it uses the platform data directory. This directory is
-    /// `~/.local/share/vite-plus` on Unix and `%LOCALAPPDATA%\vite-plus\data`
-    /// on Windows.
-    #[arg(long = "install-dir")]
-    pub install_dir: Option<String>,
-
     /// Custom npm registry URL
     #[arg(long = "registry")]
     pub registry: Option<String>,
@@ -54,7 +45,6 @@ pub fn parse() -> Options {
         opts.version = std::env::var("VP_VERSION").ok();
     }
     // `VP_HOME` / `VP_*_DIR` / `XDG_*` are owned by [`vp_shared::EnvConfig`].
-    // Do not promote them to `--install-dir` here.
     if opts.registry.is_none() {
         opts.registry = std::env::var("NPM_CONFIG_REGISTRY").ok();
     }

--- a/crates/vp_installer/src/main.rs
+++ b/crates/vp_installer/src/main.rs
@@ -31,6 +31,39 @@ use vp_setup::{VP_BINARY_NAME, install, integrity, platform, registry};
 use vp_shared::VpDirs;
 use vt_path::AbsolutePathBuf;
 
+#[derive(Debug)]
+struct AbandonedSplitData {
+    data: AbsolutePathBuf,
+    empty_parent: Option<std::path::PathBuf>,
+}
+
+impl AbandonedSplitData {
+    async fn capture(data: AbsolutePathBuf) -> Option<Self> {
+        if tokio::fs::try_exists(&data).await.unwrap_or(true) {
+            return None;
+        }
+
+        let empty_parent = if let Some(parent) = data.as_path().parent()
+            && !tokio::fs::try_exists(parent).await.unwrap_or(true)
+        {
+            Some(parent.to_path_buf())
+        } else {
+            None
+        };
+        Some(Self { data, empty_parent })
+    }
+
+    async fn remove(self) {
+        let _ = tokio::fs::remove_dir_all(&self.data).await;
+        if let Some(parent) = self.empty_parent {
+            // Remove only the parent that did not exist before probing. A
+            // concurrent file or directory makes this non-recursive removal
+            // fail and preserves the parent.
+            let _ = tokio::fs::remove_dir(parent).await;
+        }
+    }
+}
+
 /// Restrict DLL search to system32 only to prevent DLL hijacking
 /// when the installer is run from a Downloads folder.
 #[cfg(windows)]
@@ -250,6 +283,11 @@ async fn do_install(
         // use split roots. Use that monolithic root when the payload cannot
         // report split category roots.
         let legacy = VpDirs::legacy_single_root(&vp_shared::EnvConfig::get().user_home);
+        let split_data_cleanup = if legacy.data == dirs.data {
+            None
+        } else {
+            AbandonedSplitData::capture(dirs.data.clone()).await
+        };
         let abandoned_split_data = if legacy.data == dirs.data {
             // Pre-split and split-aware payloads use the same monolithic root
             // here. Skip the probe because it extracts and starts the payload.
@@ -273,10 +311,8 @@ async fn do_install(
                     legacy.data.as_path().display()
                 ));
             }
-            let split_data = dirs.data.clone();
-            let preexisted = tokio::fs::try_exists(&split_data).await.unwrap_or(true);
             dirs = legacy;
-            (!preexisted).then_some(split_data)
+            split_data_cleanup
         };
 
         let install_dir = &dirs.data;
@@ -300,9 +336,10 @@ async fn do_install(
 
         // The managed node and pnpm use paths from the process EnvConfig. The
         // installer pinned this configuration before the payload selected the
-        // monolithic root. Remove the split data root if this run created it.
+        // monolithic root. Remove the split data root and its empty application
+        // parent if this run created them.
         if let Some(split_data) = abandoned_split_data {
-            let _ = tokio::fs::remove_dir_all(&split_data).await;
+            split_data.remove().await;
         }
         result?;
     }
@@ -566,11 +603,13 @@ async fn download_with_progress(
     Ok(data)
 }
 
-/// Resolve install category roots from [`vp_shared::EnvConfig`].
+/// Validate installer directory overrides and resolve category roots from
+/// [`vp_shared::EnvConfig`].
 ///
 /// `--install-dir` is the only override that the installer owns. It pins
-/// `VP_HOME`, so EnvConfig produces a single-root layout. This function never
-/// reads directory environment variables (`VP_HOME`, `VP_*_DIR`, `XDG_*`).
+/// `VP_HOME`, so EnvConfig produces a single-root layout. Unlike runtime
+/// resolution, the installer rejects a relative `VP_HOME` and rejects an
+/// incomplete or relative `VP_*_DIR` group instead of ignoring it.
 fn prepare_dirs(opts: &cli::Options) -> Result<VpDirs, Box<dyn std::error::Error>> {
     if let Some(ref dir) = opts.install_dir {
         let path = std::path::PathBuf::from(dir);
@@ -581,7 +620,39 @@ fn prepare_dirs(opts: &cli::Options) -> Result<VpDirs, Box<dyn std::error::Error
         // EnvConfig::with_vars in tests, which serializes env mutation).
         unsafe { std::env::set_var("VP_HOME", abs.as_path()) };
     }
+    validate_dir_env()?;
     Ok(vp_shared::EnvConfig::get().dirs.clone())
+}
+
+fn validate_dir_env() -> Result<(), Box<dyn std::error::Error>> {
+    use vp_shared::env_vars;
+
+    let env_path = |name| std::env::var_os(name).filter(|value| !value.is_empty());
+    if let Some(home) = env_path(env_vars::VP_HOME)
+        && !std::path::Path::new(&home).is_absolute()
+    {
+        return Err(format!("{} must be an absolute path.", env_vars::VP_HOME).into());
+    }
+
+    let split = [
+        (env_vars::VP_BIN_DIR, env_path(env_vars::VP_BIN_DIR)),
+        (env_vars::VP_DATA_DIR, env_path(env_vars::VP_DATA_DIR)),
+        (env_vars::VP_CACHE_DIR, env_path(env_vars::VP_CACHE_DIR)),
+    ];
+    let set_count = split.iter().filter(|(_, value)| value.is_some()).count();
+    if set_count != 0 && set_count != split.len() {
+        return Err(
+            "Set VP_BIN_DIR, VP_DATA_DIR, and VP_CACHE_DIR together, or leave all three unset."
+                .into(),
+        );
+    }
+    for (name, value) in split {
+        if value.is_some_and(|path| !std::path::Path::new(&path).is_absolute()) {
+            return Err(format!("{name} must be an absolute path.").into());
+        }
+    }
+
+    Ok(())
 }
 
 #[allow(clippy::print_stdout)]
@@ -889,5 +960,134 @@ mod tests {
                 assert!(std::env::var_os(env_vars::VP_HOME).is_none());
             },
         );
+    }
+
+    #[test]
+    fn incomplete_vp_dir_groups_are_rejected_without_creating_roots() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("requested-bin");
+        let data = tmp.path().join("requested-data");
+        let cache = tmp.path().join("requested-cache");
+
+        with_clean_home(tmp.path(), || {
+            let default_dirs = EnvConfig::get().dirs.clone();
+            let default_roots = [
+                default_dirs.bin.as_path().to_path_buf(),
+                default_dirs.data.as_path().to_path_buf(),
+                default_dirs.cache.as_path().to_path_buf(),
+                default_dirs.config.as_path().to_path_buf(),
+                default_dirs.state.as_path().to_path_buf(),
+            ];
+            let default_existed = default_roots.each_ref().map(|root| root.exists());
+            let paths = [bin.as_os_str(), data.as_os_str(), cache.as_os_str()];
+
+            for mask in 1_u8..7 {
+                let values = std::array::from_fn::<_, 3, _>(|index| {
+                    ((mask & (1 << index)) != 0).then_some(paths[index])
+                });
+                EnvConfig::with_vars(
+                    [
+                        (env_vars::VP_HOME, None),
+                        (env_vars::VP_BIN_DIR, values[0]),
+                        (env_vars::VP_DATA_DIR, values[1]),
+                        (env_vars::VP_CACHE_DIR, values[2]),
+                    ],
+                    |_| {
+                        let error = prepare_dirs(&opts(None)).unwrap_err().to_string();
+                        assert_eq!(
+                            error,
+                            "Set VP_BIN_DIR, VP_DATA_DIR, and VP_CACHE_DIR together, or leave all three unset."
+                        );
+                    },
+                );
+            }
+
+            for requested in [&bin, &data, &cache] {
+                assert!(!requested.exists(), "validation created {}", requested.display());
+            }
+            for (root, existed) in default_roots.iter().zip(default_existed) {
+                if !existed {
+                    assert!(!root.exists(), "validation created default root {}", root.display());
+                }
+            }
+        });
+    }
+
+    #[test]
+    fn relative_directory_overrides_are_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        with_clean_home(tmp.path(), || {
+            EnvConfig::with_vars(
+                [
+                    (env_vars::VP_HOME, Some(std::ffi::OsStr::new("relative-home"))),
+                    (env_vars::VP_BIN_DIR, None),
+                    (env_vars::VP_DATA_DIR, None),
+                    (env_vars::VP_CACHE_DIR, None),
+                ],
+                |_| {
+                    let error = prepare_dirs(&opts(None)).unwrap_err().to_string();
+                    assert_eq!(error, "VP_HOME must be an absolute path.");
+                },
+            );
+
+            let absolute =
+                [tmp.path().join("bin"), tmp.path().join("data"), tmp.path().join("cache")];
+            let names = [env_vars::VP_BIN_DIR, env_vars::VP_DATA_DIR, env_vars::VP_CACHE_DIR];
+            for (relative_index, name) in names.into_iter().enumerate() {
+                let values = std::array::from_fn::<_, 3, _>(|index| {
+                    if index == relative_index {
+                        std::ffi::OsStr::new("relative-dir")
+                    } else {
+                        absolute[index].as_os_str()
+                    }
+                });
+                EnvConfig::with_vars(
+                    [
+                        (env_vars::VP_HOME, None),
+                        (env_vars::VP_BIN_DIR, Some(values[0])),
+                        (env_vars::VP_DATA_DIR, Some(values[1])),
+                        (env_vars::VP_CACHE_DIR, Some(values[2])),
+                    ],
+                    |_| {
+                        let error = prepare_dirs(&opts(None)).unwrap_err().to_string();
+                        assert_eq!(error, format!("{name} must be an absolute path."));
+                    },
+                );
+            }
+
+            for root in absolute {
+                assert!(!root.exists(), "validation created {}", root.display());
+            }
+            assert!(!tmp.path().join("relative-home").exists());
+            assert!(!tmp.path().join("relative-dir").exists());
+        });
+    }
+
+    #[tokio::test]
+    async fn abandoned_split_data_cleanup_removes_new_empty_parent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let parent = tmp.path().join("vite-plus");
+        let data = AbsolutePathBuf::new(parent.join("data")).unwrap();
+        let cleanup = AbandonedSplitData::capture(data.clone()).await.unwrap();
+
+        tokio::fs::create_dir_all(&data).await.unwrap();
+        cleanup.remove().await;
+
+        assert!(!parent.exists());
+    }
+
+    #[tokio::test]
+    async fn abandoned_split_data_cleanup_preserves_existing_parent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let parent = tmp.path().join("vite-plus");
+        std::fs::create_dir(&parent).unwrap();
+        let data = AbsolutePathBuf::new(parent.join("data")).unwrap();
+        let cleanup = AbandonedSplitData::capture(data.clone()).await.unwrap();
+
+        tokio::fs::create_dir_all(&data).await.unwrap();
+        cleanup.remove().await;
+
+        assert!(parent.is_dir());
+        assert!(!data.as_path().exists());
     }
 }

--- a/crates/vp_installer/src/main.rs
+++ b/crates/vp_installer/src/main.rs
@@ -179,15 +179,14 @@ async fn do_install(opts: &cli::Options, dirs: &VpDirs) -> Result<(), Box<dyn st
         print_info(&format!("detected platform: {platform_suffix}"));
     }
 
-    // Check local version first to potentially skip HTTP requests.
-    // This operation is read-only. Create the install root only after the
-    // installer resolves and validates the target version.
+    // Read the installed version first. This operation does not create a
+    // directory. Create the installation root after target-version validation.
     let current_version = install::read_current_version(&dirs.data).await;
 
     let version_or_tag = opts.version.as_deref().unwrap_or(&opts.tag);
 
-    // Resolve the target version — use resolve_version_string first so we can
-    // skip the platform package fetch if the version is already installed
+    // Resolve the target version first. If it matches the installed version,
+    // skip the platform package request.
     if !opts.quiet {
         print_info(&format!("resolving version '{version_or_tag}'..."));
     }
@@ -195,7 +194,7 @@ async fn do_install(opts: &cli::Options, dirs: &VpDirs) -> Result<(), Box<dyn st
         registry::resolve_version_string(version_or_tag, opts.registry.as_deref()).await?;
     if !vp_setup::supports_split_layout(&target_version) {
         return Err(format!(
-            "vite-plus {target_version} is not supported by vp-setup. Install vite-plus 0.3.0 or later."
+            "vp-setup does not support vite-plus {target_version}. Install vite-plus 0.3.0 or later."
         )
         .into());
     }
@@ -413,7 +412,10 @@ async fn install_new_version(
     }
     #[cfg(windows)]
     if !tokio::fs::try_exists(version_dir.join("bin").join("vp-shim.exe")).await.unwrap_or(false) {
-        return Err("Trampoline not found after extraction. The download may be corrupted.".into());
+        return Err(
+            "vp-setup did not find vp-shim.exe after extraction. The downloaded package can be corrupt."
+                .into(),
+        );
     }
 
     install::generate_wrapper_package_json(version_dir, version).await?;
@@ -518,13 +520,13 @@ async fn download_with_progress(
     Ok(data)
 }
 
-/// Validate installer directory overrides and resolve category roots from
+/// Validate installer directory overrides. Then resolve category roots from
 /// [`vp_shared::EnvConfig`].
 ///
 /// `--install-dir` is the only override that the installer owns. It pins
-/// `VP_HOME`, so EnvConfig produces a single-root layout. Unlike runtime
-/// resolution, the installer rejects a relative `VP_HOME` and rejects an
-/// incomplete or relative `VP_*_DIR` group instead of ignoring it.
+/// `VP_HOME`, so EnvConfig produces a single-root layout. Runtime resolution
+/// ignores invalid overrides. The installer rejects a relative `VP_HOME`. It
+/// also rejects an incomplete or relative `VP_*_DIR` group.
 fn prepare_dirs(opts: &cli::Options) -> Result<VpDirs, Box<dyn std::error::Error>> {
     if let Some(ref dir) = opts.install_dir {
         let path = std::path::PathBuf::from(dir);
@@ -872,7 +874,7 @@ mod tests {
                     let error = prepare_dirs(&opts(None)).unwrap_err().to_string();
                     assert_eq!(
                         error,
-                        "Set VP_BIN_DIR, VP_DATA_DIR, and VP_CACHE_DIR together, or leave all three unset."
+                        "Set all three variables together: VP_BIN_DIR, VP_DATA_DIR, and VP_CACHE_DIR. Otherwise, do not set any of them."
                     );
                 },
             );

--- a/crates/vp_installer/src/main.rs
+++ b/crates/vp_installer/src/main.rs
@@ -25,7 +25,7 @@ mod windows_path;
 use std::io::{self, Write};
 
 use indicatif::{ProgressBar, ProgressStyle};
-use owo_colors::OwoColorize;
+use owo_colors::{OwoColorize, Stream, Style};
 use vp_pm_cli::HttpClient;
 use vp_setup::{VP_BINARY_NAME, install, integrity, platform, registry};
 use vp_shared::VpDirs;
@@ -567,28 +567,47 @@ fn show_interactive_menu(opts: &mut cli::Options, data_dir: &str, bin_dir: &str)
         let version = opts.version.as_deref().unwrap_or(&opts.tag);
 
         println!();
-        println!("  {}", "Welcome to Vite+ Installer!".bold());
+        println!(
+            "  {}",
+            "Welcome to Vite+ Installer!".if_supports_color(Stream::Stdout, |text| text.bold())
+        );
         println!();
-        println!("  This will install the {} CLI and monorepo task runner.", "vp".cyan());
+        println!(
+            "  This will install the {} CLI and monorepo task runner.",
+            "vp".if_supports_color(Stream::Stdout, |text| text.cyan())
+        );
         println!();
-        println!("    Data directory:    {}", data_dir.cyan());
-        println!("    Bin directory:     {}", bin_dir.cyan());
+        println!(
+            "    Data directory:    {}",
+            data_dir.if_supports_color(Stream::Stdout, |text| text.cyan())
+        );
+        println!(
+            "    Bin directory:     {}",
+            bin_dir.if_supports_color(Stream::Stdout, |text| text.cyan())
+        );
+        let path_modification = if opts.no_modify_path {
+            "no".to_string()
+        } else {
+            format!("{bin_dir} \u{2192} User PATH")
+        };
         println!(
             "    PATH modification: {}",
-            if opts.no_modify_path {
-                "no".to_string()
-            } else {
-                format!("{bin_dir} \u{2192} User PATH")
-            }
-            .cyan()
+            path_modification.if_supports_color(Stream::Stdout, |text| text.cyan())
         );
-        println!("    Version:           {}", version.cyan());
+        println!(
+            "    Version:           {}",
+            version.if_supports_color(Stream::Stdout, |text| text.cyan())
+        );
         println!(
             "    Node.js manager:   {}",
-            if opts.no_node_manager { "disabled" } else { "enabled" }.cyan()
+            if opts.no_node_manager { "disabled" } else { "enabled" }
+                .if_supports_color(Stream::Stdout, |text| text.cyan())
         );
         println!();
-        println!("  1) {} (default)", "Proceed with installation".bold());
+        println!(
+            "  1) {} (default)",
+            "Proceed with installation".if_supports_color(Stream::Stdout, |text| text.bold())
+        );
         println!("  2) Customize installation");
         println!("  3) Cancel");
         println!();
@@ -612,17 +631,28 @@ fn show_customize_menu(opts: &mut cli::Options) {
         let registry_display = opts.registry.as_deref().unwrap_or("(default)");
 
         println!();
-        println!("  {}", "Customize installation:".bold());
+        println!(
+            "  {}",
+            "Customize installation:".if_supports_color(Stream::Stdout, |text| text.bold())
+        );
         println!();
-        println!("    1) Version:        [{}]", version_display.cyan());
-        println!("    2) npm registry:   [{}]", registry_display.cyan());
+        println!(
+            "    1) Version:        [{}]",
+            version_display.if_supports_color(Stream::Stdout, |text| text.cyan())
+        );
+        println!(
+            "    2) npm registry:   [{}]",
+            registry_display.if_supports_color(Stream::Stdout, |text| text.cyan())
+        );
         println!(
             "    3) Node.js manager: [{}]",
-            if opts.no_node_manager { "disabled" } else { "enabled" }.cyan()
+            if opts.no_node_manager { "disabled" } else { "enabled" }
+                .if_supports_color(Stream::Stdout, |text| text.cyan())
         );
         println!(
             "    4) Modify PATH:    [{}]",
-            if opts.no_modify_path { "no" } else { "yes" }.cyan()
+            if opts.no_modify_path { "no" } else { "yes" }
+                .if_supports_color(Stream::Stdout, |text| text.cyan())
         );
         println!();
 
@@ -665,11 +695,15 @@ fn print_success(opts: &cli::Options, data_dir: &str, bin_dir: &str) {
     }
 
     println!();
-    println!("  {} Vite+ has been installed successfully!", "\u{2714}".green().bold());
+    println!(
+        "  {} Vite+ has been installed successfully!",
+        "\u{2714}"
+            .if_supports_color(Stream::Stdout, |text| { Style::new().green().bold().style(text) })
+    );
     println!();
     println!("  To get started, restart your terminal, then run:");
     println!();
-    println!("    {}", "vp --help".cyan());
+    println!("    {}", "vp --help".if_supports_color(Stream::Stdout, |text| text.cyan()));
     println!();
     println!("  Data directory: {data_dir}");
     println!("  Bin directory:  {bin_dir}");
@@ -679,19 +713,19 @@ fn print_success(opts: &cli::Options, data_dir: &str, bin_dir: &str) {
 
 #[allow(clippy::print_stderr)]
 fn print_info(msg: &str) {
-    eprint!("{}", "info: ".blue());
+    eprint!("{}", "info: ".if_supports_color(Stream::Stderr, |text| text.blue()));
     eprintln!("{msg}");
 }
 
 #[allow(clippy::print_stderr)]
 fn print_warn(msg: &str) {
-    eprint!("{}", "warn: ".yellow());
+    eprint!("{}", "warn: ".if_supports_color(Stream::Stderr, |text| text.yellow()));
     eprintln!("{msg}");
 }
 
 #[allow(clippy::print_stderr)]
 fn print_error(msg: &str) {
-    eprint!("{}", "error: ".red());
+    eprint!("{}", "error: ".if_supports_color(Stream::Stderr, |text| text.red()));
     eprintln!("{msg}");
 }
 

--- a/crates/vp_installer/src/main.rs
+++ b/crates/vp_installer/src/main.rs
@@ -52,10 +52,9 @@ fn main() {
 
     let opts = cli::parse();
 
-    // Resolve the category roots before the tokio runtime starts. EnvConfig
-    // reads an existing VP_HOME value. The --install-dir option sets VP_HOME
-    // here. Thus, the unsafe set_var runs while the process has one thread.
-    let dirs = match prepare_dirs(&opts) {
+    // Validate and resolve the category roots before the installer creates any
+    // directories.
+    let dirs = match prepare_dirs() {
         Ok(dirs) => dirs,
         Err(e) => {
             print_error(&format!("Failed to resolve install directory: {e}"));
@@ -468,21 +467,7 @@ async fn download_with_progress(
 
 /// Validate installer directory overrides. Then resolve category roots from
 /// [`vp_shared::EnvConfig`].
-///
-/// `--install-dir` is the only override that the installer owns. It pins
-/// `VP_HOME`, so EnvConfig produces a single-root layout. Runtime resolution
-/// ignores invalid overrides. The installer rejects a relative `VP_HOME`. It
-/// also rejects an incomplete or relative `VP_*_DIR` group.
-fn prepare_dirs(opts: &cli::Options) -> Result<VpDirs, Box<dyn std::error::Error>> {
-    if let Some(ref dir) = opts.install_dir {
-        let path = std::path::PathBuf::from(dir);
-        let abs = if path.is_absolute() { path } else { std::env::current_dir()?.join(path) };
-        let abs = AbsolutePathBuf::new(abs)
-            .ok_or("The installation directory must be an absolute path")?;
-        // Safety: called in main() before any threads are spawned (or under
-        // EnvConfig::with_vars in tests, which serializes env mutation).
-        unsafe { std::env::set_var(vp_shared::env_vars::VP_HOME, abs.as_path()) };
-    }
+fn prepare_dirs() -> Result<VpDirs, Box<dyn std::error::Error>> {
     vp_shared::validate_vp_dir_env()?;
     Ok(vp_shared::EnvConfig::get().dirs.clone())
 }
@@ -644,19 +629,6 @@ mod tests {
 
     use super::*;
 
-    fn opts(install_dir: Option<String>) -> cli::Options {
-        cli::Options {
-            yes: true,
-            quiet: true,
-            version: None,
-            tag: "latest".into(),
-            install_dir,
-            registry: None,
-            no_node_manager: true,
-            no_modify_path: true,
-        }
-    }
-
     fn with_clean_home<R>(home: &std::path::Path, f: impl FnOnce() -> R) -> R {
         let mut vars =
             vec![("HOME", Some(home.as_os_str())), ("USERPROFILE", Some(home.as_os_str()))];
@@ -704,7 +676,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         with_clean_home(tmp.path(), || {
             let expected = EnvConfig::get().dirs.clone();
-            let dirs = prepare_dirs(&opts(None)).unwrap();
+            let dirs = prepare_dirs().unwrap();
             assert_eq!(dirs, expected);
             assert!(std::env::var_os(env_vars::VP_HOME).is_none());
             #[cfg(not(windows))]
@@ -734,7 +706,7 @@ mod tests {
         std::fs::create_dir_all(legacy.join("current")).unwrap();
 
         with_clean_home(tmp.path(), || {
-            let dirs = prepare_dirs(&opts(None)).unwrap();
+            let dirs = prepare_dirs().unwrap();
             assert_eq!(dirs.data.as_path(), legacy.as_path());
             assert_eq!(dirs.bin.as_path(), legacy.join("bin").as_path());
             assert_eq!(dirs.config.as_path(), legacy.as_path());
@@ -745,17 +717,18 @@ mod tests {
     }
 
     #[test]
-    fn custom_install_dir_pins_vp_home_to_single_root() {
+    fn vp_home_pins_single_root() {
         let tmp = tempfile::tempdir().unwrap();
         let custom = tmp.path().join("custom");
-        std::fs::create_dir_all(&custom).unwrap();
 
         with_clean_home(tmp.path(), || {
-            let dirs = prepare_dirs(&opts(Some(custom.to_string_lossy().into_owned()))).unwrap();
-            assert_eq!(std::env::var_os(env_vars::VP_HOME).as_deref(), Some(custom.as_os_str()));
-            assert_eq!(dirs.data.as_path(), custom.as_path());
-            assert_eq!(dirs.bin.as_path(), custom.join("bin").as_path());
-            assert_eq!(dirs.config.as_path(), custom.as_path());
+            EnvConfig::with_vars([(env_vars::VP_HOME, Some(custom.as_os_str()))], |_| {
+                let dirs = prepare_dirs().unwrap();
+                assert_eq!(dirs.data.as_path(), custom.as_path());
+                assert_eq!(dirs.bin.as_path(), custom.join("bin").as_path());
+                assert_eq!(dirs.cache.as_path(), custom.join("cache").as_path());
+                assert_eq!(dirs.config.as_path(), custom.as_path());
+            });
         });
     }
 
@@ -781,7 +754,7 @@ mod tests {
                 (env_vars::XDG_STATE_HOME, None),
             ],
             |config| {
-                let dirs = prepare_dirs(&opts(None)).unwrap();
+                let dirs = prepare_dirs().unwrap();
                 assert_eq!(dirs.data.as_path(), data.as_path());
                 assert_eq!(dirs.bin.as_path(), bin.as_path());
                 assert_eq!(dirs.cache.as_path(), cache.as_path());
@@ -814,7 +787,7 @@ mod tests {
                     (env_vars::VP_CACHE_DIR, None),
                 ],
                 |_| {
-                    let error = prepare_dirs(&opts(None)).unwrap_err().to_string();
+                    let error = prepare_dirs().unwrap_err().to_string();
                     assert_eq!(
                         error,
                         "Set all three variables together: VP_BIN_DIR, VP_DATA_DIR, and VP_CACHE_DIR. Otherwise, do not set any of them."

--- a/crates/vp_installer/src/main.rs
+++ b/crates/vp_installer/src/main.rs
@@ -616,41 +616,10 @@ fn prepare_dirs(opts: &cli::Options) -> Result<VpDirs, Box<dyn std::error::Error
             .ok_or("The installation directory must be an absolute path")?;
         // Safety: called in main() before any threads are spawned (or under
         // EnvConfig::with_vars in tests, which serializes env mutation).
-        unsafe { std::env::set_var("VP_HOME", abs.as_path()) };
+        unsafe { std::env::set_var(vp_shared::env_vars::VP_HOME, abs.as_path()) };
     }
-    validate_dir_env()?;
+    vp_shared::validate_vp_dir_env()?;
     Ok(vp_shared::EnvConfig::get().dirs.clone())
-}
-
-fn validate_dir_env() -> Result<(), Box<dyn std::error::Error>> {
-    use vp_shared::env_vars;
-
-    let env_path = |name| std::env::var_os(name).filter(|value| !value.is_empty());
-    if let Some(home) = env_path(env_vars::VP_HOME)
-        && !std::path::Path::new(&home).is_absolute()
-    {
-        return Err(format!("{} must be an absolute path.", env_vars::VP_HOME).into());
-    }
-
-    let split_dirs = [
-        (env_vars::VP_BIN_DIR, env_path(env_vars::VP_BIN_DIR)),
-        (env_vars::VP_DATA_DIR, env_path(env_vars::VP_DATA_DIR)),
-        (env_vars::VP_CACHE_DIR, env_path(env_vars::VP_CACHE_DIR)),
-    ];
-    let configured_count = split_dirs.iter().filter(|(_, value)| value.is_some()).count();
-    if configured_count != 0 && configured_count != split_dirs.len() {
-        return Err(
-            "Set VP_BIN_DIR, VP_DATA_DIR, and VP_CACHE_DIR together, or leave all three unset."
-                .into(),
-        );
-    }
-    for (name, value) in split_dirs {
-        if value.is_some_and(|path| !std::path::Path::new(&path).is_absolute()) {
-            return Err(format!("{name} must be an absolute path.").into());
-        }
-    }
-
-    Ok(())
 }
 
 #[allow(clippy::print_stdout)]
@@ -961,11 +930,9 @@ mod tests {
     }
 
     #[test]
-    fn incomplete_vp_dir_groups_are_rejected_without_creating_roots() {
+    fn invalid_vp_dir_env_is_rejected_without_creating_roots() {
         let tmp = tempfile::tempdir().unwrap();
-        let bin = tmp.path().join("requested-bin");
         let data = tmp.path().join("requested-data");
-        let cache = tmp.path().join("requested-cache");
 
         with_clean_home(tmp.path(), || {
             let default_dirs = EnvConfig::get().dirs.clone();
@@ -977,91 +944,28 @@ mod tests {
                 default_dirs.state.as_path().to_path_buf(),
             ];
             let default_existed = default_roots.each_ref().map(|root| root.exists());
-            let paths = [bin.as_os_str(), data.as_os_str(), cache.as_os_str()];
-            let cases = [
-                [Some(paths[0]), None, None],
-                [None, Some(paths[1]), None],
-                [None, None, Some(paths[2])],
-                [Some(paths[0]), Some(paths[1]), None],
-                [Some(paths[0]), None, Some(paths[2])],
-                [None, Some(paths[1]), Some(paths[2])],
-            ];
+            EnvConfig::with_vars(
+                [
+                    (env_vars::VP_HOME, None),
+                    (env_vars::VP_BIN_DIR, None),
+                    (env_vars::VP_DATA_DIR, Some(data.as_os_str())),
+                    (env_vars::VP_CACHE_DIR, None),
+                ],
+                |_| {
+                    let error = prepare_dirs(&opts(None)).unwrap_err().to_string();
+                    assert_eq!(
+                        error,
+                        "Set VP_BIN_DIR, VP_DATA_DIR, and VP_CACHE_DIR together, or leave all three unset."
+                    );
+                },
+            );
 
-            for values in cases {
-                EnvConfig::with_vars(
-                    [
-                        (env_vars::VP_HOME, None),
-                        (env_vars::VP_BIN_DIR, values[0]),
-                        (env_vars::VP_DATA_DIR, values[1]),
-                        (env_vars::VP_CACHE_DIR, values[2]),
-                    ],
-                    |_| {
-                        let error = prepare_dirs(&opts(None)).unwrap_err().to_string();
-                        assert_eq!(
-                            error,
-                            "Set VP_BIN_DIR, VP_DATA_DIR, and VP_CACHE_DIR together, or leave all three unset."
-                        );
-                    },
-                );
-            }
-
-            for requested in [&bin, &data, &cache] {
-                assert!(!requested.exists(), "validation created {}", requested.display());
-            }
+            assert!(!data.exists(), "validation created {}", data.display());
             for (root, existed) in default_roots.iter().zip(default_existed) {
                 if !existed {
                     assert!(!root.exists(), "validation created default root {}", root.display());
                 }
             }
-        });
-    }
-
-    #[test]
-    fn relative_directory_overrides_are_rejected() {
-        let tmp = tempfile::tempdir().unwrap();
-        with_clean_home(tmp.path(), || {
-            EnvConfig::with_vars(
-                [
-                    (env_vars::VP_HOME, Some(std::ffi::OsStr::new("relative-home"))),
-                    (env_vars::VP_BIN_DIR, None),
-                    (env_vars::VP_DATA_DIR, None),
-                    (env_vars::VP_CACHE_DIR, None),
-                ],
-                |_| {
-                    let error = prepare_dirs(&opts(None)).unwrap_err().to_string();
-                    assert_eq!(error, "VP_HOME must be an absolute path.");
-                },
-            );
-
-            let bin = tmp.path().join("bin");
-            let data = tmp.path().join("data");
-            let cache = tmp.path().join("cache");
-            let relative = std::ffi::OsStr::new("relative-dir");
-            let cases = [
-                (env_vars::VP_BIN_DIR, [relative, data.as_os_str(), cache.as_os_str()]),
-                (env_vars::VP_DATA_DIR, [bin.as_os_str(), relative, cache.as_os_str()]),
-                (env_vars::VP_CACHE_DIR, [bin.as_os_str(), data.as_os_str(), relative]),
-            ];
-            for (name, values) in cases {
-                EnvConfig::with_vars(
-                    [
-                        (env_vars::VP_HOME, None),
-                        (env_vars::VP_BIN_DIR, Some(values[0])),
-                        (env_vars::VP_DATA_DIR, Some(values[1])),
-                        (env_vars::VP_CACHE_DIR, Some(values[2])),
-                    ],
-                    |_| {
-                        let error = prepare_dirs(&opts(None)).unwrap_err().to_string();
-                        assert_eq!(error, format!("{name} must be an absolute path."));
-                    },
-                );
-            }
-
-            for root in [&bin, &data, &cache] {
-                assert!(!root.exists(), "validation created {}", root.display());
-            }
-            assert!(!tmp.path().join("relative-home").exists());
-            assert!(!tmp.path().join("relative-dir").exists());
         });
     }
 

--- a/crates/vp_installer/src/main.rs
+++ b/crates/vp_installer/src/main.rs
@@ -31,39 +31,6 @@ use vp_setup::{VP_BINARY_NAME, install, integrity, platform, registry};
 use vp_shared::VpDirs;
 use vt_path::AbsolutePathBuf;
 
-#[derive(Debug)]
-struct AbandonedSplitData {
-    data: AbsolutePathBuf,
-    parent_to_remove: Option<std::path::PathBuf>,
-}
-
-impl AbandonedSplitData {
-    async fn capture(data: AbsolutePathBuf) -> Option<Self> {
-        if tokio::fs::try_exists(&data).await.unwrap_or(true) {
-            return None;
-        }
-
-        let parent_to_remove = if let Some(parent) = data.as_path().parent()
-            && !tokio::fs::try_exists(parent).await.unwrap_or(true)
-        {
-            Some(parent.to_path_buf())
-        } else {
-            None
-        };
-        Some(Self { data, parent_to_remove })
-    }
-
-    async fn remove(self) {
-        let _ = tokio::fs::remove_dir_all(&self.data).await;
-        if let Some(parent) = self.parent_to_remove {
-            // Remove only the parent that did not exist before probing. A
-            // concurrent file or directory makes this non-recursive removal
-            // fail and preserves the parent.
-            let _ = tokio::fs::remove_dir(parent).await;
-        }
-    }
-}
-
 /// Restrict DLL search to system32 only to prevent DLL hijacking
 /// when the installer is run from a Downloads folder.
 #[cfg(windows)]
@@ -185,10 +152,7 @@ async fn run(mut opts: cli::Options, dirs: VpDirs) -> i32 {
     }
 
     let code = match do_install(&opts, &dirs).await {
-        Ok(effective_dirs) => {
-            // do_install uses the monolithic root for a pre-split payload.
-            // Report the directories that it used.
-            let (data_dir_display, bin_dir_display) = dir_displays(&effective_dirs);
+        Ok(()) => {
             print_success(&opts, &data_dir_display, &bin_dir_display);
             0
         }
@@ -207,14 +171,9 @@ async fn run(mut opts: cli::Options, dirs: VpDirs) -> i32 {
     code
 }
 
-/// Install the resolved version and return the directories that the installer
-/// used. The installer uses the monolithic root for a pre-split payload.
+/// Install the resolved version.
 #[allow(clippy::print_stdout)]
-async fn do_install(
-    opts: &cli::Options,
-    dirs: &VpDirs,
-) -> Result<VpDirs, Box<dyn std::error::Error>> {
-    let mut dirs = dirs.clone();
+async fn do_install(opts: &cli::Options, dirs: &VpDirs) -> Result<(), Box<dyn std::error::Error>> {
     let platform_suffix = platform::detect_platform_suffix()?;
     if !opts.quiet {
         print_info(&format!("detected platform: {platform_suffix}"));
@@ -222,8 +181,7 @@ async fn do_install(
 
     // Check local version first to potentially skip HTTP requests.
     // This operation is read-only. Create the install root only after the
-    // downloaded payload confirms the layout. Thus, a pre-split fallback does
-    // not leave empty split directories.
+    // installer resolves and validates the target version.
     let current_version = install::read_current_version(&dirs.data).await;
 
     let version_or_tag = opts.version.as_deref().unwrap_or(&opts.tag);
@@ -235,6 +193,12 @@ async fn do_install(
     }
     let target_version =
         registry::resolve_version_string(version_or_tag, opts.registry.as_deref()).await?;
+    if !vp_setup::supports_split_layout(&target_version) {
+        return Err(format!(
+            "vite-plus {target_version} is not supported by vp-setup. Install vite-plus 0.3.0 or later."
+        )
+        .into());
+    }
 
     // Same version only if the binary is intact — a corrupted install needs a full reinstall.
     // `is_install_dir_for_version` also matches `{version}+force.*` dirs left by a forced
@@ -278,41 +242,6 @@ async fn do_install(
         }
         integrity::verify_integrity(&platform_data, &resolved.platform_integrity)?;
 
-        // A pre-split release resolves every path from VP_HOME. Its default is
-        // ~/.vite-plus. Its environment setup, shims, and trampolines cannot
-        // use split roots. Use that monolithic root when the payload cannot
-        // report split category roots.
-        let legacy = VpDirs::legacy_single_root(&vp_shared::EnvConfig::get().user_home);
-        let abandoned_split_data = if legacy.data == dirs.data {
-            // Pre-split and split-aware payloads use the same monolithic root
-            // here. Skip the probe because it extracts and starts the payload.
-            None
-        } else {
-            let split_data_cleanup = AbandonedSplitData::capture(dirs.data.clone()).await;
-            if let Some(probed) = install::probe_payload_dirs(&platform_data).await {
-                // Use the payload's resolution, as install.sh and install.ps1 do.
-                // This keeps the written layout equal to the resolved layout.
-                dirs = VpDirs::from_resolved_parts(
-                    probed.bin,
-                    probed.data,
-                    probed.cache,
-                    probed.config,
-                    probed.state,
-                    probed.layout,
-                );
-                None
-            } else {
-                if !opts.quiet {
-                    print_info(&format!(
-                        "vite-plus {target_version} does not support the split directory layout. Vite+ will install it in {}.",
-                        legacy.data.as_path().display()
-                    ));
-                }
-                dirs = legacy;
-                split_data_cleanup
-            }
-        };
-
         let install_dir = &dirs.data;
         let version_dir = install_dir.join(&target_version);
         tokio::fs::create_dir_all(&version_dir).await?;
@@ -332,13 +261,6 @@ async fn do_install(
             let _ = tokio::fs::remove_dir_all(&version_dir).await;
         }
 
-        // The managed node and pnpm use paths from the process EnvConfig. The
-        // installer pinned this configuration before the payload selected the
-        // monolithic root. Remove the split data root and its empty application
-        // parent if this run created them.
-        if let Some(split_data) = abandoned_split_data {
-            split_data.remove().await;
-        }
         result?;
     }
 
@@ -371,7 +293,7 @@ async fn do_install(
         }
     }
 
-    Ok(dirs)
+    Ok(())
 }
 
 /// Auto-detect whether the Node.js version manager should be enabled.
@@ -489,6 +411,10 @@ async fn install_new_version(
     if !tokio::fs::try_exists(&binary_path).await.unwrap_or(false) {
         return Err("Binary not found after extraction. The download may be corrupted.".into());
     }
+    #[cfg(windows)]
+    if !tokio::fs::try_exists(version_dir.join("bin").join("vp-shim.exe")).await.unwrap_or(false) {
+        return Err("Trampoline not found after extraction. The download may be corrupted.".into());
+    }
 
     install::generate_wrapper_package_json(version_dir, version).await?;
 
@@ -545,17 +471,8 @@ async fn setup_bin_shims(dirs: &VpDirs) -> Result<(), Box<dyn std::error::Error>
         let shim_src = dirs.data.join("current").join("bin").join("vp-shim.exe");
         let shim_dst = bin_dir.join("vp.exe");
 
-        // Prefer vp-shim.exe (trampoline); fall back to vp.exe for pre-trampoline releases
-        let src = if tokio::fs::try_exists(&shim_src).await.unwrap_or(false) {
-            shim_src
-        } else {
-            dirs.data.join("current").join("bin").join("vp.exe")
-        };
-
-        if tokio::fs::try_exists(&src).await.unwrap_or(false) {
-            replace_windows_exe(&src, &shim_dst, &bin_dir).await?;
-            dirs.write_shim_pointer("vp")?;
-        }
+        replace_windows_exe(&shim_src, &shim_dst, &bin_dir).await?;
+        dirs.write_shim_pointer("vp")?;
 
         // Best-effort cleanup of old shim files
         if let Ok(mut entries) = tokio::fs::read_dir(&bin_dir).await {
@@ -967,33 +884,5 @@ mod tests {
                 }
             }
         });
-    }
-
-    #[tokio::test]
-    async fn abandoned_split_data_cleanup_removes_new_empty_parent() {
-        let tmp = tempfile::tempdir().unwrap();
-        let parent = tmp.path().join("vite-plus");
-        let data = AbsolutePathBuf::new(parent.join("data")).unwrap();
-        let cleanup = AbandonedSplitData::capture(data.clone()).await.unwrap();
-
-        tokio::fs::create_dir_all(&data).await.unwrap();
-        cleanup.remove().await;
-
-        assert!(!parent.exists());
-    }
-
-    #[tokio::test]
-    async fn abandoned_split_data_cleanup_preserves_existing_parent() {
-        let tmp = tempfile::tempdir().unwrap();
-        let parent = tmp.path().join("vite-plus");
-        std::fs::create_dir(&parent).unwrap();
-        let data = AbsolutePathBuf::new(parent.join("data")).unwrap();
-        let cleanup = AbandonedSplitData::capture(data.clone()).await.unwrap();
-
-        tokio::fs::create_dir_all(&data).await.unwrap();
-        cleanup.remove().await;
-
-        assert!(parent.is_dir());
-        assert!(!data.as_path().exists());
     }
 }

--- a/crates/vp_installer/src/main.rs
+++ b/crates/vp_installer/src/main.rs
@@ -34,7 +34,7 @@ use vt_path::AbsolutePathBuf;
 #[derive(Debug)]
 struct AbandonedSplitData {
     data: AbsolutePathBuf,
-    empty_parent: Option<std::path::PathBuf>,
+    parent_to_remove: Option<std::path::PathBuf>,
 }
 
 impl AbandonedSplitData {
@@ -43,19 +43,19 @@ impl AbandonedSplitData {
             return None;
         }
 
-        let empty_parent = if let Some(parent) = data.as_path().parent()
+        let parent_to_remove = if let Some(parent) = data.as_path().parent()
             && !tokio::fs::try_exists(parent).await.unwrap_or(true)
         {
             Some(parent.to_path_buf())
         } else {
             None
         };
-        Some(Self { data, empty_parent })
+        Some(Self { data, parent_to_remove })
     }
 
     async fn remove(self) {
         let _ = tokio::fs::remove_dir_all(&self.data).await;
-        if let Some(parent) = self.empty_parent {
+        if let Some(parent) = self.parent_to_remove {
             // Remove only the parent that did not exist before probing. A
             // concurrent file or directory makes this non-recursive removal
             // fail and preserves the parent.
@@ -283,36 +283,34 @@ async fn do_install(
         // use split roots. Use that monolithic root when the payload cannot
         // report split category roots.
         let legacy = VpDirs::legacy_single_root(&vp_shared::EnvConfig::get().user_home);
-        let split_data_cleanup = if legacy.data == dirs.data {
-            None
-        } else {
-            AbandonedSplitData::capture(dirs.data.clone()).await
-        };
         let abandoned_split_data = if legacy.data == dirs.data {
             // Pre-split and split-aware payloads use the same monolithic root
             // here. Skip the probe because it extracts and starts the payload.
             None
-        } else if let Some(probed) = install::probe_payload_dirs(&platform_data).await {
-            // Use the payload's resolution, as install.sh and install.ps1 do.
-            // This keeps the written layout equal to the resolved layout.
-            dirs = VpDirs::from_resolved_parts(
-                probed.bin,
-                probed.data,
-                probed.cache,
-                probed.config,
-                probed.state,
-                probed.layout,
-            );
-            None
         } else {
-            if !opts.quiet {
-                print_info(&format!(
-                    "vite-plus {target_version} does not support the split directory layout. Vite+ will install it in {}.",
-                    legacy.data.as_path().display()
-                ));
+            let split_data_cleanup = AbandonedSplitData::capture(dirs.data.clone()).await;
+            if let Some(probed) = install::probe_payload_dirs(&platform_data).await {
+                // Use the payload's resolution, as install.sh and install.ps1 do.
+                // This keeps the written layout equal to the resolved layout.
+                dirs = VpDirs::from_resolved_parts(
+                    probed.bin,
+                    probed.data,
+                    probed.cache,
+                    probed.config,
+                    probed.state,
+                    probed.layout,
+                );
+                None
+            } else {
+                if !opts.quiet {
+                    print_info(&format!(
+                        "vite-plus {target_version} does not support the split directory layout. Vite+ will install it in {}.",
+                        legacy.data.as_path().display()
+                    ));
+                }
+                dirs = legacy;
+                split_data_cleanup
             }
-            dirs = legacy;
-            split_data_cleanup
         };
 
         let install_dir = &dirs.data;
@@ -634,19 +632,19 @@ fn validate_dir_env() -> Result<(), Box<dyn std::error::Error>> {
         return Err(format!("{} must be an absolute path.", env_vars::VP_HOME).into());
     }
 
-    let split = [
+    let split_dirs = [
         (env_vars::VP_BIN_DIR, env_path(env_vars::VP_BIN_DIR)),
         (env_vars::VP_DATA_DIR, env_path(env_vars::VP_DATA_DIR)),
         (env_vars::VP_CACHE_DIR, env_path(env_vars::VP_CACHE_DIR)),
     ];
-    let set_count = split.iter().filter(|(_, value)| value.is_some()).count();
-    if set_count != 0 && set_count != split.len() {
+    let configured_count = split_dirs.iter().filter(|(_, value)| value.is_some()).count();
+    if configured_count != 0 && configured_count != split_dirs.len() {
         return Err(
             "Set VP_BIN_DIR, VP_DATA_DIR, and VP_CACHE_DIR together, or leave all three unset."
                 .into(),
         );
     }
-    for (name, value) in split {
+    for (name, value) in split_dirs {
         if value.is_some_and(|path| !std::path::Path::new(&path).is_absolute()) {
             return Err(format!("{name} must be an absolute path.").into());
         }
@@ -980,11 +978,16 @@ mod tests {
             ];
             let default_existed = default_roots.each_ref().map(|root| root.exists());
             let paths = [bin.as_os_str(), data.as_os_str(), cache.as_os_str()];
+            let cases = [
+                [Some(paths[0]), None, None],
+                [None, Some(paths[1]), None],
+                [None, None, Some(paths[2])],
+                [Some(paths[0]), Some(paths[1]), None],
+                [Some(paths[0]), None, Some(paths[2])],
+                [None, Some(paths[1]), Some(paths[2])],
+            ];
 
-            for mask in 1_u8..7 {
-                let values = std::array::from_fn::<_, 3, _>(|index| {
-                    ((mask & (1 << index)) != 0).then_some(paths[index])
-                });
+            for values in cases {
                 EnvConfig::with_vars(
                     [
                         (env_vars::VP_HOME, None),
@@ -1030,17 +1033,16 @@ mod tests {
                 },
             );
 
-            let absolute =
-                [tmp.path().join("bin"), tmp.path().join("data"), tmp.path().join("cache")];
-            let names = [env_vars::VP_BIN_DIR, env_vars::VP_DATA_DIR, env_vars::VP_CACHE_DIR];
-            for (relative_index, name) in names.into_iter().enumerate() {
-                let values = std::array::from_fn::<_, 3, _>(|index| {
-                    if index == relative_index {
-                        std::ffi::OsStr::new("relative-dir")
-                    } else {
-                        absolute[index].as_os_str()
-                    }
-                });
+            let bin = tmp.path().join("bin");
+            let data = tmp.path().join("data");
+            let cache = tmp.path().join("cache");
+            let relative = std::ffi::OsStr::new("relative-dir");
+            let cases = [
+                (env_vars::VP_BIN_DIR, [relative, data.as_os_str(), cache.as_os_str()]),
+                (env_vars::VP_DATA_DIR, [bin.as_os_str(), relative, cache.as_os_str()]),
+                (env_vars::VP_CACHE_DIR, [bin.as_os_str(), data.as_os_str(), relative]),
+            ];
+            for (name, values) in cases {
                 EnvConfig::with_vars(
                     [
                         (env_vars::VP_HOME, None),
@@ -1055,7 +1057,7 @@ mod tests {
                 );
             }
 
-            for root in absolute {
+            for root in [&bin, &data, &cache] {
                 assert!(!root.exists(), "validation created {}", root.display());
             }
             assert!(!tmp.path().join("relative-home").exists());

--- a/crates/vp_installer/src/main.rs
+++ b/crates/vp_installer/src/main.rs
@@ -24,8 +24,8 @@ mod windows_path;
 
 use std::io::{self, Write};
 
+use console::style;
 use indicatif::{ProgressBar, ProgressStyle};
-use owo_colors::{OwoColorize, Stream, Style};
 use vp_pm_cli::HttpClient;
 use vp_setup::{VP_BINARY_NAME, install, integrity, platform, registry};
 use vp_shared::VpDirs;
@@ -47,62 +47,8 @@ fn init_dll_security() {
 #[cfg(not(windows))]
 fn init_dll_security() {}
 
-/// Enable ANSI color support on Windows.
-///
-/// Older Windows consoles (cmd.exe) don't process ANSI escape codes by default.
-/// We try to enable virtual terminal processing; if that fails (e.g. redirected
-/// output, legacy console), we disable colors globally via owo_colors.
-#[cfg(windows)]
-fn init_colors() {
-    // Respect NO_COLOR (https://no-color.org/)
-    if std::env::var_os("NO_COLOR").is_some() {
-        owo_colors::set_override(false);
-        return;
-    }
-
-    unsafe extern "system" {
-        fn GetStdHandle(nStdHandle: u32) -> isize;
-        fn GetConsoleMode(hConsoleHandle: isize, lpMode: *mut u32) -> i32;
-        fn SetConsoleMode(hConsoleHandle: isize, dwMode: u32) -> i32;
-    }
-    const STD_OUTPUT_HANDLE: u32 = 0xFFFF_FFF5; // -11i32 as u32
-    const STD_ERROR_HANDLE: u32 = 0xFFFF_FFF4; // -12i32 as u32
-    const ENABLE_VIRTUAL_TERMINAL_PROCESSING: u32 = 0x0004;
-
-    let enable_vt = |std_handle: u32| -> bool {
-        unsafe {
-            let handle = GetStdHandle(std_handle);
-            // INVALID_HANDLE_VALUE (-1) or NULL (0, no console attached)
-            if handle == -1_isize || handle == 0 {
-                return false;
-            }
-            let mut mode: u32 = 0;
-            if GetConsoleMode(handle, &mut mode) != 0 {
-                SetConsoleMode(handle, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING) != 0
-            } else {
-                false
-            }
-        }
-    };
-
-    let stdout_ok = enable_vt(STD_OUTPUT_HANDLE);
-    let stderr_ok = enable_vt(STD_ERROR_HANDLE);
-
-    if !stdout_ok && !stderr_ok {
-        owo_colors::set_override(false);
-    }
-}
-
-#[cfg(not(windows))]
-fn init_colors() {
-    if std::env::var_os("NO_COLOR").is_some() {
-        owo_colors::set_override(false);
-    }
-}
-
 fn main() {
     init_dll_security();
-    init_colors();
 
     let opts = cli::parse();
 
@@ -567,47 +513,28 @@ fn show_interactive_menu(opts: &mut cli::Options, data_dir: &str, bin_dir: &str)
         let version = opts.version.as_deref().unwrap_or(&opts.tag);
 
         println!();
-        println!(
-            "  {}",
-            "Welcome to Vite+ Installer!".if_supports_color(Stream::Stdout, |text| text.bold())
-        );
+        println!("  {}", style("Welcome to Vite+ Installer!").bold());
         println!();
-        println!(
-            "  This will install the {} CLI and monorepo task runner.",
-            "vp".if_supports_color(Stream::Stdout, |text| text.cyan())
-        );
+        println!("  This will install the {} CLI and monorepo task runner.", style("vp").cyan());
         println!();
-        println!(
-            "    Data directory:    {}",
-            data_dir.if_supports_color(Stream::Stdout, |text| text.cyan())
-        );
-        println!(
-            "    Bin directory:     {}",
-            bin_dir.if_supports_color(Stream::Stdout, |text| text.cyan())
-        );
-        let path_modification = if opts.no_modify_path {
-            "no".to_string()
-        } else {
-            format!("{bin_dir} \u{2192} User PATH")
-        };
+        println!("    Data directory:    {}", style(data_dir).cyan());
+        println!("    Bin directory:     {}", style(bin_dir).cyan());
         println!(
             "    PATH modification: {}",
-            path_modification.if_supports_color(Stream::Stdout, |text| text.cyan())
+            style(if opts.no_modify_path {
+                "no".to_string()
+            } else {
+                format!("{bin_dir} \u{2192} User PATH")
+            })
+            .cyan()
         );
-        println!(
-            "    Version:           {}",
-            version.if_supports_color(Stream::Stdout, |text| text.cyan())
-        );
+        println!("    Version:           {}", style(version).cyan());
         println!(
             "    Node.js manager:   {}",
-            if opts.no_node_manager { "disabled" } else { "enabled" }
-                .if_supports_color(Stream::Stdout, |text| text.cyan())
+            style(if opts.no_node_manager { "disabled" } else { "enabled" }).cyan()
         );
         println!();
-        println!(
-            "  1) {} (default)",
-            "Proceed with installation".if_supports_color(Stream::Stdout, |text| text.bold())
-        );
+        println!("  1) {} (default)", style("Proceed with installation").bold());
         println!("  2) Customize installation");
         println!("  3) Cancel");
         println!();
@@ -631,28 +558,17 @@ fn show_customize_menu(opts: &mut cli::Options) {
         let registry_display = opts.registry.as_deref().unwrap_or("(default)");
 
         println!();
-        println!(
-            "  {}",
-            "Customize installation:".if_supports_color(Stream::Stdout, |text| text.bold())
-        );
+        println!("  {}", style("Customize installation:").bold());
         println!();
-        println!(
-            "    1) Version:        [{}]",
-            version_display.if_supports_color(Stream::Stdout, |text| text.cyan())
-        );
-        println!(
-            "    2) npm registry:   [{}]",
-            registry_display.if_supports_color(Stream::Stdout, |text| text.cyan())
-        );
+        println!("    1) Version:        [{}]", style(version_display).cyan());
+        println!("    2) npm registry:   [{}]", style(registry_display).cyan());
         println!(
             "    3) Node.js manager: [{}]",
-            if opts.no_node_manager { "disabled" } else { "enabled" }
-                .if_supports_color(Stream::Stdout, |text| text.cyan())
+            style(if opts.no_node_manager { "disabled" } else { "enabled" }).cyan()
         );
         println!(
             "    4) Modify PATH:    [{}]",
-            if opts.no_modify_path { "no" } else { "yes" }
-                .if_supports_color(Stream::Stdout, |text| text.cyan())
+            style(if opts.no_modify_path { "no" } else { "yes" }).cyan()
         );
         println!();
 
@@ -695,15 +611,11 @@ fn print_success(opts: &cli::Options, data_dir: &str, bin_dir: &str) {
     }
 
     println!();
-    println!(
-        "  {} Vite+ has been installed successfully!",
-        "\u{2714}"
-            .if_supports_color(Stream::Stdout, |text| { Style::new().green().bold().style(text) })
-    );
+    println!("  {} Vite+ has been installed successfully!", style("\u{2714}").green().bold());
     println!();
     println!("  To get started, restart your terminal, then run:");
     println!();
-    println!("    {}", "vp --help".if_supports_color(Stream::Stdout, |text| text.cyan()));
+    println!("    {}", style("vp --help").cyan());
     println!();
     println!("  Data directory: {data_dir}");
     println!("  Bin directory:  {bin_dir}");
@@ -713,20 +625,17 @@ fn print_success(opts: &cli::Options, data_dir: &str, bin_dir: &str) {
 
 #[allow(clippy::print_stderr)]
 fn print_info(msg: &str) {
-    eprint!("{}", "info: ".if_supports_color(Stream::Stderr, |text| text.blue()));
-    eprintln!("{msg}");
+    eprintln!("{}{msg}", style("info: ").blue().for_stderr());
 }
 
 #[allow(clippy::print_stderr)]
 fn print_warn(msg: &str) {
-    eprint!("{}", "warn: ".if_supports_color(Stream::Stderr, |text| text.yellow()));
-    eprintln!("{msg}");
+    eprintln!("{}{msg}", style("warn: ").yellow().for_stderr());
 }
 
 #[allow(clippy::print_stderr)]
 fn print_error(msg: &str) {
-    eprint!("{}", "error: ".if_supports_color(Stream::Stderr, |text| text.red()));
-    eprintln!("{msg}");
+    eprintln!("{}{msg}", style("error: ").red().for_stderr());
 }
 
 #[cfg(test)]

--- a/crates/vp_installer/tests/no_color.rs
+++ b/crates/vp_installer/tests/no_color.rs
@@ -2,9 +2,16 @@ use std::{
     io::Write as _,
     process::{Command, Stdio},
 };
+use vt_path::AbsolutePathBuf;
 
 fn installer_command() -> Command {
-    let mut command = Command::new(env!("CARGO_BIN_EXE_vp-setup"));
+    // nextest rewrites this variable when it runs a relocated test archive.
+    let runtime_path = std::env::var_os("CARGO_BIN_EXE_vp-setup")
+        .and_then(|path| AbsolutePathBuf::new(path.into()));
+    let installer = runtime_path
+        .filter(|path| path.as_path().is_file())
+        .unwrap_or_else(|| AbsolutePathBuf::new(env!("CARGO_BIN_EXE_vp-setup").into()).unwrap());
+    let mut command = Command::new(installer.as_path());
     command
         .env("NO_COLOR", "1")
         .env_remove("CI")

--- a/crates/vp_installer/tests/no_color.rs
+++ b/crates/vp_installer/tests/no_color.rs
@@ -2,6 +2,7 @@ use std::{
     io::Write as _,
     process::{Command, Stdio},
 };
+
 use vt_path::AbsolutePathBuf;
 
 fn installer_command() -> Command {

--- a/crates/vp_installer/tests/no_color.rs
+++ b/crates/vp_installer/tests/no_color.rs
@@ -1,0 +1,62 @@
+use std::{
+    io::Write as _,
+    process::{Command, Stdio},
+};
+
+fn installer_command() -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_vp-setup"));
+    command
+        .env("NO_COLOR", "1")
+        .env_remove("CI")
+        .env_remove("VP_VERSION")
+        .env_remove("VP_BIN_DIR")
+        .env_remove("VP_DATA_DIR")
+        .env_remove("VP_CACHE_DIR");
+    command
+}
+
+fn assert_has_no_ansi(bytes: &[u8]) {
+    assert!(!bytes.contains(&0x1b), "output contains an ANSI escape: {bytes:?}");
+}
+
+fn assert_contains(bytes: &[u8], expected: &[u8]) {
+    assert!(
+        bytes.windows(expected.len()).any(|window| window == expected),
+        "output does not contain {expected:?}: {bytes:?}"
+    );
+}
+
+#[test]
+fn no_color_removes_ansi_from_interactive_output() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut child = installer_command()
+        .args(["--no-node-manager", "--no-modify-path"])
+        .env("VP_HOME", temp.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child.stdin.take().unwrap().write_all(b"3\n").unwrap();
+
+    let output = child.wait_with_output().unwrap();
+
+    assert!(output.status.success());
+    assert_contains(&output.stdout, b"Welcome to Vite+ Installer!");
+    assert_has_no_ansi(&output.stdout);
+    assert_has_no_ansi(&output.stderr);
+}
+
+#[test]
+fn no_color_removes_ansi_from_error_output() {
+    let output = installer_command()
+        .args(["--yes", "--quiet", "--no-node-manager", "--no-modify-path"])
+        .env("VP_HOME", "relative-home")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert_contains(&output.stderr, b"Set VP_HOME to an absolute path");
+    assert_has_no_ansi(&output.stdout);
+    assert_has_no_ansi(&output.stderr);
+}

--- a/crates/vp_setup/Cargo.toml
+++ b/crates/vp_setup/Cargo.toml
@@ -15,7 +15,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 tar = { workspace = true }
-tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
@@ -27,6 +26,9 @@ vt_str = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 junction = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
 
 [lib]
 doctest = false

--- a/crates/vp_setup/src/install.rs
+++ b/crates/vp_setup/src/install.rs
@@ -412,24 +412,7 @@ pub async fn swap_current_link(install_dir: &AbsolutePath, version: &str) -> Res
     #[cfg(windows)]
     {
         // Windows: junction swap (not atomic)
-        // Remove whatever exists at current_link — could be a junction, symlink, or directory.
-        // We don't rely on junction::exists() since it may not detect junctions created by
-        // cmd /c mklink /J (used by install.ps1).
-        if current_link.as_path().exists() {
-            // std::fs::remove_dir works on junctions/symlinks without removing target contents
-            if let Err(e) = std::fs::remove_dir(&current_link) {
-                tracing::debug!("remove_dir failed ({}), trying junction::delete", e);
-                junction::delete(&current_link).map_err(|e| {
-                    Error::Setup(
-                        format!(
-                            "Failed to remove existing junction at {}: {e}",
-                            current_link.as_path().display()
-                        )
-                        .into(),
-                    )
-                })?;
-            }
-        }
+        remove_windows_current_link(&current_link)?;
 
         junction::create(&version_dir, &current_link).map_err(|e| {
             Error::Setup(
@@ -443,6 +426,56 @@ pub async fn swap_current_link(install_dir: &AbsolutePath, version: &str) -> Res
     }
 
     tracing::debug!("Swapped current → {}", version);
+    Ok(())
+}
+
+/// Remove the Windows `current` entry without following its target.
+#[cfg(windows)]
+fn remove_windows_current_link(current_link: &AbsolutePath) -> Result<(), Error> {
+    match std::fs::symlink_metadata(current_link) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(Error::Setup(
+                format!(
+                    "Failed to inspect the current link at {}: {error}",
+                    current_link.as_path().display()
+                )
+                .into(),
+            ));
+        }
+        Ok(_) => {}
+    }
+
+    // remove_dir removes a junction or directory symlink without changing its
+    // target. It also detects a dangling junction because symlink_metadata did
+    // not follow the missing target.
+    if let Err(remove_error) = std::fs::remove_dir(current_link) {
+        tracing::debug!("remove_dir failed ({remove_error}), trying junction::delete");
+        junction::delete(current_link).map_err(|junction_error| {
+            Error::Setup(
+                format!(
+                    "Failed to remove the current link at {}: {remove_error}. Junction cleanup also failed: {junction_error}",
+                    current_link.as_path().display()
+                )
+                .into(),
+            )
+        })?;
+
+        // junction::delete removes the reparse data. Remove the empty directory
+        // that remains, unless the API removed the directory too.
+        if let Err(error) = std::fs::remove_dir(current_link)
+            && error.kind() != std::io::ErrorKind::NotFound
+        {
+            return Err(Error::Setup(
+                format!(
+                    "Failed to remove the current directory at {}: {error}",
+                    current_link.as_path().display()
+                )
+                .into(),
+            ));
+        }
+    }
+
     Ok(())
 }
 
@@ -653,6 +686,29 @@ mod tests {
         assert!(is_install_dir_for_version("0.1.23+force.1.2", "0.1.23"));
         assert!(!is_install_dir_for_version("0.1.230", "0.1.23"));
         assert!(!is_install_dir_for_version("0.1.24", "0.1.23"));
+    }
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn swap_current_link_replaces_a_dangling_windows_junction() {
+        let temp = tempfile::tempdir().unwrap();
+        let install_dir = AbsolutePathBuf::new(temp.path().to_path_buf()).unwrap();
+        let old_version = install_dir.join("old-version");
+        let new_version = install_dir.join("new-version");
+        let current_link = install_dir.join("current");
+
+        std::fs::create_dir(&old_version).unwrap();
+        std::fs::create_dir(&new_version).unwrap();
+        std::fs::write(new_version.join("active"), b"active").unwrap();
+        junction::create(&old_version, &current_link).unwrap();
+        std::fs::remove_dir(&old_version).unwrap();
+
+        assert!(!current_link.as_path().exists());
+        assert!(std::fs::symlink_metadata(&current_link).is_ok());
+
+        swap_current_link(&install_dir, "new-version").await.unwrap();
+
+        assert!(current_link.join("active").as_path().is_file());
     }
 
     #[test]

--- a/crates/vp_setup/src/install.rs
+++ b/crates/vp_setup/src/install.rs
@@ -92,71 +92,6 @@ pub async fn extract_platform_package(
     Ok(())
 }
 
-/// Layout mode and category roots a split-aware payload reports via
-/// `VP_DUMP_DIRS`.
-pub struct PayloadDirs {
-    pub layout: vp_shared::VpDirsLayout,
-    pub data: AbsolutePathBuf,
-    pub bin: AbsolutePathBuf,
-    pub cache: AbsolutePathBuf,
-    pub config: AbsolutePathBuf,
-    pub state: AbsolutePathBuf,
-}
-
-/// Ask a downloaded platform payload for its directory layout.
-///
-/// A split-aware `vp` prints tab-separated category roots when
-/// `VP_DUMP_DIRS=1`. A pre-split release prints its help instead. An error
-/// means that the payload gave no answer. Every release supports the
-/// monolithic root, so that fallback is safe.
-pub async fn probe_payload_dirs(platform_data: &[u8]) -> Option<PayloadDirs> {
-    let temp = tempfile::tempdir().ok()?;
-    let temp_root = AbsolutePathBuf::new(temp.path().to_path_buf())?;
-    extract_platform_package(platform_data, &temp_root).await.ok()?;
-
-    let vp_binary = temp_root.join("bin").join(crate::VP_BINARY_NAME);
-    let output = tokio::process::Command::new(vp_binary.as_path())
-        .env(vp_shared::env_vars::VP_DUMP_DIRS, "1")
-        .output()
-        .await
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-
-    use vp_shared::env_vars::dump_dirs;
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let value =
-        |key: &str| stdout.lines().find_map(|line| line.strip_prefix(key)?.strip_prefix('\t'));
-    let category = |key: &str| {
-        let root = value(key)?;
-        AbsolutePathBuf::new(root.into())
-    };
-    let data = category(dump_dirs::DATA)?;
-    let bin = category(dump_dirs::BIN)?;
-    let cache = category(dump_dirs::CACHE)?;
-    let config = category(dump_dirs::CONFIG)?;
-    let state = category(dump_dirs::STATE)?;
-    let layout = value(dump_dirs::LAYOUT)
-        .and_then(vp_shared::VpDirsLayout::parse)
-        .unwrap_or_else(|| infer_payload_layout(&bin, &data, &cache, &config, &state));
-    Some(PayloadDirs { layout, data, bin, cache, config, state })
-}
-
-fn infer_payload_layout(
-    bin: &AbsolutePathBuf,
-    data: &AbsolutePathBuf,
-    cache: &AbsolutePathBuf,
-    config: &AbsolutePathBuf,
-    state: &AbsolutePathBuf,
-) -> vp_shared::VpDirsLayout {
-    if bin == &data.join("bin") && cache == &data.join("cache") && config == data && state == data {
-        vp_shared::VpDirsLayout::SingleRoot
-    } else {
-        vp_shared::VpDirsLayout::Split
-    }
-}
-
 /// The pnpm version pinned in the wrapper package.json for global installs.
 /// This ensures consistent install behavior regardless of the user's global pnpm version.
 const PINNED_PNPM_VERSION: &str = "10.33.0";
@@ -1037,57 +972,5 @@ mod tests {
     #[test]
     fn test_is_release_age_error_ignores_npm_min_release_age() {
         assert!(!is_release_age_error(b"", b"min-release-age prevented installing vite-plus",));
-    }
-
-    /// A platform tarball whose `package/vp` is the given shell script.
-    #[cfg(unix)]
-    fn fake_platform_tgz(vp_script: &str) -> Vec<u8> {
-        use flate2::{Compression, write::GzEncoder};
-        let mut tar = tar::Builder::new(GzEncoder::new(Vec::new(), Compression::fast()));
-        let mut header = tar::Header::new_gnu();
-        header.set_path("package/vp").unwrap();
-        header.set_size(vp_script.len() as u64);
-        header.set_mode(0o755);
-        header.set_cksum();
-        tar.append(&header, vp_script.as_bytes()).unwrap();
-        tar.into_inner().unwrap().finish().unwrap()
-    }
-
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn probe_payload_dirs_parses_split_aware_output() {
-        let script = "#!/bin/sh\nprintf 'layout\\tsplit\\ndata\\t/probe-data\\nbin\\t/probe-bin\\ncache\\t/probe-cache\\nconfig\\t/probe-config\\nstate\\t/probe-state\\n'\n";
-        let dirs = probe_payload_dirs(&fake_platform_tgz(script)).await.unwrap();
-        assert_eq!(dirs.layout, vp_shared::VpDirsLayout::Split);
-        assert_eq!(dirs.data.as_path(), Path::new("/probe-data"));
-        assert_eq!(dirs.bin.as_path(), Path::new("/probe-bin"));
-        assert_eq!(dirs.cache.as_path(), Path::new("/probe-cache"));
-        assert_eq!(dirs.config.as_path(), Path::new("/probe-config"));
-        assert_eq!(dirs.state.as_path(), Path::new("/probe-state"));
-    }
-
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn probe_payload_dirs_infers_old_single_root_output() {
-        let script = "#!/bin/sh\nprintf 'data\\t/probe-root\\nbin\\t/probe-root/bin\\ncache\\t/probe-root/cache\\nconfig\\t/probe-root\\nstate\\t/probe-root\\n'\n";
-        let dirs = probe_payload_dirs(&fake_platform_tgz(script)).await.unwrap();
-        assert_eq!(dirs.layout, vp_shared::VpDirsLayout::SingleRoot);
-    }
-
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn probe_payload_dirs_does_not_infer_single_root_from_data_bin_alone() {
-        let script = "#!/bin/sh\nprintf 'data\\t/probe-data\\nbin\\t/probe-data/bin\\ncache\\t/platform-cache\\nconfig\\t/platform-config\\nstate\\t/platform-state\\n'\n";
-        let dirs = probe_payload_dirs(&fake_platform_tgz(script)).await.unwrap();
-        assert_eq!(dirs.layout, vp_shared::VpDirsLayout::Split);
-    }
-
-    /// A pre-split `vp` prints its help and exits 0; the probe must report
-    /// "no answer".
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn probe_payload_dirs_rejects_pre_split_help_output() {
-        let script = "#!/bin/sh\necho 'Usage: vp [COMMAND]'\n";
-        assert!(probe_payload_dirs(&fake_platform_tgz(script)).await.is_none());
     }
 }

--- a/crates/vp_setup/src/lib.rs
+++ b/crates/vp_setup/src/lib.rs
@@ -25,3 +25,36 @@ pub mod registry;
 pub const MAX_VERSIONS_KEEP: usize = 3;
 
 pub use vp_shared::VP_BINARY_NAME;
+
+/// Return `true` if `version` supports the split directory layout.
+///
+/// Version 0.3.0 and later support it, including prereleases. Preview builds
+/// (`0.0.0-commit.<sha>`) also support it because they track the current branch.
+#[must_use]
+pub fn supports_split_layout(version: &str) -> bool {
+    let Ok(version) = node_semver::Version::parse(version) else {
+        return false;
+    };
+    if version.major == 0 && version.minor == 0 && version.patch == 0 {
+        return !version.pre_release.is_empty() || !version.build.is_empty();
+    }
+    version.major > 0 || version.minor >= 3
+}
+
+#[cfg(test)]
+mod tests {
+    use super::supports_split_layout;
+
+    #[test]
+    fn split_layout_support_by_version() {
+        assert!(supports_split_layout("0.3.0"));
+        assert!(supports_split_layout("0.3.0-alpha.1"));
+        assert!(supports_split_layout("0.4.2"));
+        assert!(supports_split_layout("1.0.0"));
+        assert!(supports_split_layout("0.0.0-commit.0123abc"));
+        assert!(!supports_split_layout("0.2.9"));
+        assert!(!supports_split_layout("0.2.0"));
+        assert!(!supports_split_layout("0.1.14-alpha.1"));
+        assert!(!supports_split_layout("not-a-version"));
+    }
+}

--- a/crates/vp_setup/src/lib.rs
+++ b/crates/vp_setup/src/lib.rs
@@ -28,8 +28,9 @@ pub use vp_shared::VP_BINARY_NAME;
 
 /// Return `true` if `version` supports the split directory layout.
 ///
-/// Version 0.3.0 and later support it, including prereleases. Preview builds
-/// (`0.0.0-commit.<sha>`) also support it because they track the current branch.
+/// Vite+ 0.3.0 and later versions support this layout. This includes
+/// prereleases. Internal `0.0.0-commit.<sha>` builds also support it because
+/// they contain code from the current branch.
 #[must_use]
 pub fn supports_split_layout(version: &str) -> bool {
     let Ok(version) = node_semver::Version::parse(version) else {

--- a/crates/vp_setup/src/lib.rs
+++ b/crates/vp_setup/src/lib.rs
@@ -37,7 +37,10 @@ pub fn supports_split_layout(version: &str) -> bool {
         return false;
     };
     if version.major == 0 && version.minor == 0 && version.patch == 0 {
-        return !version.pre_release.is_empty() || !version.build.is_empty();
+        return matches!(
+            version.pre_release.as_slice(),
+            [node_semver::Identifier::AlphaNumeric(label), _, ..] if label == "commit"
+        );
     }
     version.major > 0 || version.minor >= 3
 }
@@ -53,6 +56,10 @@ mod tests {
         assert!(supports_split_layout("0.4.2"));
         assert!(supports_split_layout("1.0.0"));
         assert!(supports_split_layout("0.0.0-commit.0123abc"));
+        assert!(!supports_split_layout("0.0.0-alpha.1"));
+        assert!(!supports_split_layout("0.0.0-dev"));
+        assert!(!supports_split_layout("0.0.0+foo"));
+        assert!(!supports_split_layout("0.0.0-commit"));
         assert!(!supports_split_layout("0.2.9"));
         assert!(!supports_split_layout("0.2.0"));
         assert!(!supports_split_layout("0.1.14-alpha.1"));

--- a/crates/vp_shared/src/dirs.rs
+++ b/crates/vp_shared/src/dirs.rs
@@ -63,15 +63,6 @@ impl VpDirsLayout {
             Self::Split => "split",
         }
     }
-
-    #[must_use]
-    pub fn parse(value: &str) -> Option<Self> {
-        match value {
-            "single-root" => Some(Self::SingleRoot),
-            "split" => Some(Self::Split),
-            _ => None,
-        }
-    }
 }
 
 /// On-disk category roots for the vite-plus install.
@@ -124,19 +115,6 @@ impl VpDirs {
             state: resolution::state_dir(home)?,
             layout: resolution::layout(home),
         })
-    }
-
-    /// Construct category roots reported by another Vite+ binary.
-    #[must_use]
-    pub fn from_resolved_parts(
-        bin: AbsolutePathBuf,
-        data: AbsolutePathBuf,
-        cache: AbsolutePathBuf,
-        config: AbsolutePathBuf,
-        state: AbsolutePathBuf,
-        layout: VpDirsLayout,
-    ) -> Self {
-        Self { bin, data, cache, config, state, layout }
     }
 
     /// Return the resolution mode that selected these roots.

--- a/crates/vp_shared/src/dirs.rs
+++ b/crates/vp_shared/src/dirs.rs
@@ -10,9 +10,16 @@
 //! `<CONFIG>/`, and `<STATE>/` for category roots. They do not use a concrete
 //! path for each layout. See `rfcs/directory-layout.md`.
 
+mod env_overrides;
 mod resolution;
 
+pub use env_overrides::{VpDirEnvError, validate_vp_dir_env};
 use vt_path::{AbsolutePath, AbsolutePathBuf};
+
+/// Absolute `VP_HOME` override from the process environment, if set.
+pub(crate) fn vp_home_override() -> Option<AbsolutePathBuf> {
+    env_overrides::DirEnvOverrides::from_env().home()
+}
 
 /// Platform-specific binary name for the `vp` CLI.
 pub const VP_BINARY_NAME: &str = if cfg!(windows) { "vp.exe" } else { "vp" };
@@ -146,8 +153,7 @@ impl VpDirs {
     /// payload cannot report category roots through `VP_DUMP_DIRS`.
     #[must_use]
     pub fn legacy_single_root(home: &AbsolutePath) -> Self {
-        let root = resolution::vp_home_override()
-            .unwrap_or_else(|| home.join(resolution::VP_HOME_DIR_NAME));
+        let root = vp_home_override().unwrap_or_else(|| home.join(resolution::VP_HOME_DIR_NAME));
         resolution::single_root_dirs(root)
     }
 

--- a/crates/vp_shared/src/dirs.rs
+++ b/crates/vp_shared/src/dirs.rs
@@ -16,7 +16,8 @@ mod resolution;
 pub use env_overrides::{VpDirEnvError, validate_vp_dir_env};
 use vt_path::{AbsolutePath, AbsolutePathBuf};
 
-/// Absolute `VP_HOME` override from the process environment, if set.
+/// Return the absolute `VP_HOME` value from the process environment. Return
+/// `None` if the variable is unset or relative.
 pub(crate) fn vp_home_override() -> Option<AbsolutePathBuf> {
     env_overrides::DirEnvOverrides::from_env().home()
 }

--- a/crates/vp_shared/src/dirs/env_overrides.rs
+++ b/crates/vp_shared/src/dirs/env_overrides.rs
@@ -87,19 +87,21 @@ impl DirEnvOverrides {
     }
 }
 
-/// An invalid Vite+ directory override configuration.
+/// An error in the Vite+ directory overrides.
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum VpDirEnvError {
-    #[error("Set VP_BIN_DIR, VP_DATA_DIR, and VP_CACHE_DIR together, or leave all three unset.")]
+    #[error(
+        "Set all three variables together: VP_BIN_DIR, VP_DATA_DIR, and VP_CACHE_DIR. Otherwise, do not set any of them."
+    )]
     IncompleteSplitGroup,
-    #[error("{name} must be an absolute path.")]
+    #[error("Set {name} to an absolute path.")]
     RelativePath { name: &'static str },
 }
 
 /// Validate Vite+ directory overrides for an installer.
 ///
-/// Runtime resolution ignores relative or incomplete overrides and continues
-/// to the next source. Installers use this stricter check before they resolve
+/// `VpDirs` ignores invalid overrides during runtime resolution. It then checks
+/// the next directory source. Installers call this function before they resolve
 /// or create installation roots.
 pub fn validate_vp_dir_env() -> Result<(), VpDirEnvError> {
     DirEnvOverrides::from_env().validate()

--- a/crates/vp_shared/src/dirs/env_overrides.rs
+++ b/crates/vp_shared/src/dirs/env_overrides.rs
@@ -1,0 +1,197 @@
+use thiserror::Error;
+use vt_path::AbsolutePathBuf;
+
+use crate::env_vars;
+
+enum PathOverride {
+    Unset,
+    Absolute(AbsolutePathBuf),
+    Relative,
+}
+
+impl PathOverride {
+    fn from_env(name: &str) -> Self {
+        let Some(path) = std::env::var_os(name).filter(|value| !value.is_empty()) else {
+            return Self::Unset;
+        };
+        AbsolutePathBuf::new(path.into()).map_or(Self::Relative, Self::Absolute)
+    }
+
+    fn absolute(&self) -> Option<&AbsolutePathBuf> {
+        match self {
+            Self::Absolute(path) => Some(path),
+            Self::Unset | Self::Relative => None,
+        }
+    }
+
+    fn is_set(&self) -> bool {
+        !matches!(self, Self::Unset)
+    }
+
+    fn is_relative(&self) -> bool {
+        matches!(self, Self::Relative)
+    }
+}
+
+/// One snapshot of the Vite+ directory override variables.
+pub(super) struct DirEnvOverrides {
+    home: PathOverride,
+    bin: PathOverride,
+    data: PathOverride,
+    cache: PathOverride,
+}
+
+impl DirEnvOverrides {
+    pub(super) fn from_env() -> Self {
+        Self {
+            home: PathOverride::from_env(env_vars::VP_HOME),
+            bin: PathOverride::from_env(env_vars::VP_BIN_DIR),
+            data: PathOverride::from_env(env_vars::VP_DATA_DIR),
+            cache: PathOverride::from_env(env_vars::VP_CACHE_DIR),
+        }
+    }
+
+    pub(super) fn home(&self) -> Option<AbsolutePathBuf> {
+        self.home.absolute().cloned()
+    }
+
+    pub(super) fn split_dirs(&self) -> Option<(AbsolutePathBuf, AbsolutePathBuf, AbsolutePathBuf)> {
+        Some((
+            self.bin.absolute()?.clone(),
+            self.data.absolute()?.clone(),
+            self.cache.absolute()?.clone(),
+        ))
+    }
+
+    fn validate(&self) -> Result<(), VpDirEnvError> {
+        if self.home.is_relative() {
+            return Err(VpDirEnvError::RelativePath { name: env_vars::VP_HOME });
+        }
+
+        let split_dirs = [
+            (env_vars::VP_BIN_DIR, &self.bin),
+            (env_vars::VP_DATA_DIR, &self.data),
+            (env_vars::VP_CACHE_DIR, &self.cache),
+        ];
+        let configured_count = split_dirs.iter().filter(|(_, value)| value.is_set()).count();
+        if configured_count != 0 && configured_count != split_dirs.len() {
+            return Err(VpDirEnvError::IncompleteSplitGroup);
+        }
+        for (name, value) in split_dirs {
+            if value.is_relative() {
+                return Err(VpDirEnvError::RelativePath { name });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// An invalid Vite+ directory override configuration.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum VpDirEnvError {
+    #[error("Set VP_BIN_DIR, VP_DATA_DIR, and VP_CACHE_DIR together, or leave all three unset.")]
+    IncompleteSplitGroup,
+    #[error("{name} must be an absolute path.")]
+    RelativePath { name: &'static str },
+}
+
+/// Validate Vite+ directory overrides for an installer.
+///
+/// Runtime resolution ignores relative or incomplete overrides and continues
+/// to the next source. Installers use this stricter check before they resolve
+/// or create installation roots.
+pub fn validate_vp_dir_env() -> Result<(), VpDirEnvError> {
+    DirEnvOverrides::from_env().validate()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsStr;
+
+    use super::*;
+
+    fn validate_with(
+        home: Option<&OsStr>,
+        [bin, data, cache]: [Option<&OsStr>; 3],
+    ) -> Result<(), VpDirEnvError> {
+        temp_env::with_vars(
+            [
+                (env_vars::VP_HOME, home),
+                (env_vars::VP_BIN_DIR, bin),
+                (env_vars::VP_DATA_DIR, data),
+                (env_vars::VP_CACHE_DIR, cache),
+            ],
+            validate_vp_dir_env,
+        )
+    }
+
+    #[test]
+    fn installer_validation_accepts_valid_overrides() {
+        let root = tempfile::tempdir().unwrap();
+        let bin = root.path().join("bin");
+        let data = root.path().join("data");
+        let cache = root.path().join("cache");
+
+        assert_eq!(validate_with(None, [None, None, None]), Ok(()));
+        assert_eq!(validate_with(Some(root.path().as_os_str()), [None, None, None]), Ok(()));
+        assert_eq!(
+            validate_with(
+                None,
+                [Some(bin.as_os_str()), Some(data.as_os_str()), Some(cache.as_os_str())],
+            ),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn installer_validation_rejects_incomplete_split_groups() {
+        let root = tempfile::tempdir().unwrap();
+        let paths = [root.path().join("bin"), root.path().join("data"), root.path().join("cache")];
+        let paths = paths.each_ref().map(|path| path.as_os_str());
+        let cases = [
+            [Some(paths[0]), None, None],
+            [None, Some(paths[1]), None],
+            [None, None, Some(paths[2])],
+            [Some(paths[0]), Some(paths[1]), None],
+            [Some(paths[0]), None, Some(paths[2])],
+            [None, Some(paths[1]), Some(paths[2])],
+        ];
+
+        for dirs in cases {
+            assert_eq!(validate_with(None, dirs), Err(VpDirEnvError::IncompleteSplitGroup));
+        }
+    }
+
+    #[test]
+    fn installer_validation_rejects_relative_overrides() {
+        let root = tempfile::tempdir().unwrap();
+        let bin = root.path().join("bin");
+        let data = root.path().join("data");
+        let cache = root.path().join("cache");
+        let relative = OsStr::new("relative-dir");
+
+        assert_eq!(
+            validate_with(Some(relative), [None, None, None]),
+            Err(VpDirEnvError::RelativePath { name: env_vars::VP_HOME })
+        );
+
+        let cases = [
+            (
+                env_vars::VP_BIN_DIR,
+                [Some(relative), Some(data.as_os_str()), Some(cache.as_os_str())],
+            ),
+            (
+                env_vars::VP_DATA_DIR,
+                [Some(bin.as_os_str()), Some(relative), Some(cache.as_os_str())],
+            ),
+            (
+                env_vars::VP_CACHE_DIR,
+                [Some(bin.as_os_str()), Some(data.as_os_str()), Some(relative)],
+            ),
+        ];
+        for (name, dirs) in cases {
+            assert_eq!(validate_with(None, dirs), Err(VpDirEnvError::RelativePath { name }));
+        }
+    }
+}

--- a/crates/vp_shared/src/dirs/resolution.rs
+++ b/crates/vp_shared/src/dirs/resolution.rs
@@ -43,8 +43,8 @@ trait DirResolution {
     fn state_dir(&self) -> Option<AbsolutePathBuf>;
 }
 
-/// Absolute path from a non-Vite+ process environment variable, or `None` if
-/// unset or relative.
+/// Return an absolute path from a non-Vite+ environment variable. Return `None`
+/// if the variable is unset or relative.
 #[cfg(not(target_os = "windows"))]
 fn process_env_var(name: &str) -> Option<AbsolutePathBuf> {
     std::env::var_os(name).and_then(|path| AbsolutePathBuf::new(path.into()))

--- a/crates/vp_shared/src/dirs/resolution.rs
+++ b/crates/vp_shared/src/dirs/resolution.rs
@@ -29,8 +29,7 @@
 
 use vt_path::{AbsolutePath, AbsolutePathBuf};
 
-use super::{APP_DIR_NAME, VpDirsLayout};
-use crate::env_vars;
+use super::{APP_DIR_NAME, VpDirsLayout, env_overrides::DirEnvOverrides, vp_home_override};
 
 /// Directory name of the single-root install probed under the user home.
 pub(super) const VP_HOME_DIR_NAME: &str = ".vite-plus";
@@ -44,15 +43,11 @@ trait DirResolution {
     fn state_dir(&self) -> Option<AbsolutePathBuf>;
 }
 
-/// Absolute path from the process environment, or `None` if unset /
-/// relative.
+/// Absolute path from a non-Vite+ process environment variable, or `None` if
+/// unset or relative.
+#[cfg(not(target_os = "windows"))]
 fn process_env_var(name: &str) -> Option<AbsolutePathBuf> {
     std::env::var_os(name).and_then(|path| AbsolutePathBuf::new(path.into()))
-}
-
-/// Absolute `VP_HOME` override from the process environment, if set.
-pub(super) fn vp_home_override() -> Option<AbsolutePathBuf> {
-    process_env_var(env_vars::VP_HOME)
 }
 
 /// Complete category overrides from the `VP_*_DIR` environment variables.
@@ -64,18 +59,13 @@ struct VpEnvs {
 
 impl VpEnvs {
     fn resolver(_home: &AbsolutePath) -> Self {
-        let dirs = (
-            process_env_var(env_vars::VP_BIN_DIR),
-            process_env_var(env_vars::VP_DATA_DIR),
-            process_env_var(env_vars::VP_CACHE_DIR),
-        );
-        match dirs {
-            (Some(bin_dir), Some(data_dir), Some(cache_dir)) => Self {
+        match DirEnvOverrides::from_env().split_dirs() {
+            Some((bin_dir, data_dir, cache_dir)) => Self {
                 bin_dir: Some(bin_dir),
                 data_dir: Some(data_dir),
                 cache_dir: Some(cache_dir),
             },
-            _ => Self { bin_dir: None, data_dir: None, cache_dir: None },
+            None => Self { bin_dir: None, data_dir: None, cache_dir: None },
         }
     }
 }

--- a/crates/vp_shared/src/env_config.rs
+++ b/crates/vp_shared/src/env_config.rs
@@ -95,11 +95,8 @@ fn user_home_path() -> Option<AbsolutePathBuf> {
 /// cannot be resolved again. Do not write resolved `VP_*_DIR` or `XDG_*`
 /// values. Split layouts resolve them from each process environment.
 fn persisted_dir_envs() -> HashMap<&'static str, String> {
-    if let Some(home) = std::env::var_os(env_vars::VP_HOME).and_then(|path| {
-        let display = path.to_string_lossy().into_owned();
-        AbsolutePathBuf::new(path.into()).map(|_| display)
-    }) {
-        return HashMap::from([(env_vars::VP_HOME, home)]);
+    if let Some(home) = crate::dirs::vp_home_override() {
+        return HashMap::from([(env_vars::VP_HOME, home.as_path().to_string_lossy().into_owned())]);
     }
     HashMap::default()
 }

--- a/crates/vp_shared/src/lib.rs
+++ b/crates/vp_shared/src/lib.rs
@@ -25,8 +25,8 @@ mod tls;
 mod tracing;
 
 pub use dirs::{
-    SHIM_POINTER_EXTENSION, SHIM_POINTER_HEADER, VP_BINARY_NAME, VpDirs, VpDirsLayout,
-    shim_pointer_file_name,
+    SHIM_POINTER_EXTENSION, SHIM_POINTER_HEADER, VP_BINARY_NAME, VpDirEnvError, VpDirs,
+    VpDirsLayout, shim_pointer_file_name, validate_vp_dir_env,
 };
 pub use env_config::EnvConfig;
 pub use error::format_error_chain;

--- a/docs/guide/installer-env-vars.md
+++ b/docs/guide/installer-env-vars.md
@@ -38,7 +38,6 @@ These variables control the installer scripts and the standalone Windows install
   Unix, it uses `~/.local/share/vite-plus` and its Vite+-owned `bin`
   subdirectory. On Windows, it uses `%LOCALAPPDATA%\vite-plus\data` and
   `%LOCALAPPDATA%\vite-plus\bin`.
-- **CLI equivalent**: `--install-dir`
 - **Example**:
 
   ```bash

--- a/packages/cli/install.ps1
+++ b/packages/cli/install.ps1
@@ -1177,9 +1177,10 @@ exec "`$VP_HOME/current/bin/vp.exe" "`$@"
     $pathResult = Configure-UserPath
     $nushellResult = Configure-Nushell
 
-    # Use ~ when the shim directory is under USERPROFILE. Otherwise, show the
+    # Use ~ when an install location is under USERPROFILE. Otherwise, show the
     # full path.
-    $displayDir = $ShimDir -replace [regex]::Escape($env:USERPROFILE), '~'
+    $displayDataDir = $InstallDir -replace [regex]::Escape($env:USERPROFILE), '~'
+    $displayBinDir = $ShimDir -replace [regex]::Escape($env:USERPROFILE), '~'
     $displayConfigDir = $ConfigDir -replace [regex]::Escape($env:USERPROFILE), '~'
 
     # ANSI color codes for consistent output
@@ -1216,6 +1217,11 @@ exec "`$VP_HOME/current/bin/vp.exe" "`$@"
     Write-Host "  Run ${BRIGHT_BLUE}vp help${NC} to see available commands."
 
     Write-Host ""
+    Write-Host "  ${BOLD}Install locations:${NC}"
+    Write-Host "    Data directory: $displayDataDir"
+    Write-Host "    Bin directory:  $displayBinDir"
+
+    Write-Host ""
     Write-Host "  Shell configuration:"
     switch ($pathResult) {
         "true" { Write-Host "    - Windows PATH: updated" }
@@ -1237,8 +1243,6 @@ exec "`$VP_HOME/current/bin/vp.exe" "`$@"
     if ($pathResult -eq "failed" -or $nushellResult.Status -eq "failed") {
         Write-Host ""
         Write-Host "  ${YELLOW}note${NC}: Some shells still need manual setup."
-        Write-Host ""
-        Write-Host "  vp was installed to: ${BOLD}${displayDir}${NC}"
         Write-Host ""
         if ($pathResult -eq "failed") {
             Write-Host "  To use vp in Powershell/cmd, manually add it to your PATH:"

--- a/packages/cli/install.sh
+++ b/packages/cli/install.sh
@@ -1411,9 +1411,10 @@ WRAPPER_EOF
   # Configure shell PATH after the install is otherwise complete.
   configure_shell_path
 
-  # Use ~ when the shim directory is under HOME. Otherwise, show the full path.
-  local display_location
-  display_location="$(abbreviate_path "$SHIM_DIR")"
+  # Use ~ when an install location is under HOME. Otherwise, show the full path.
+  local display_data_dir display_bin_dir
+  display_data_dir="$(abbreviate_path "$INSTALL_DIR")"
+  display_bin_dir="$(abbreviate_path "$SHIM_DIR")"
 
   # Print success message
   echo ""
@@ -1437,6 +1438,11 @@ WRAPPER_EOF
   echo -e "  Run ${BRIGHT_BLUE}vp help${NC} to see available commands."
 
   echo ""
+  echo -e "  ${BOLD}Install locations:${NC}"
+  echo "    Data directory: $display_data_dir"
+  echo "    Bin directory:  $display_bin_dir"
+
+  echo ""
   echo "  Shell configuration:"
   local summary_line
   for summary_line in "${SHELL_CONFIG_SUMMARY[@]}"; do
@@ -1454,8 +1460,6 @@ WRAPPER_EOF
     echo ""
     echo -e "  ${YELLOW}note${NC}: Some shells still need manual setup."
     echo ""
-    echo -e "  vp was installed to: ${BOLD}${display_location}${NC}"
-    echo ""
     echo "  Manual setup instructions:"
     echo "    - Bash/Zsh: add the following to your shell config (~/.bashrc, ~/.zshrc, etc.):"
     printf '        . "%s/env"\n' "$CONFIG_DIR_REF_POSIX"
@@ -1466,7 +1470,7 @@ WRAPPER_EOF
     echo ""
     echo "  Or run vp directly:"
     echo ""
-    echo -e "    ${display_location}/vp"
+    echo -e "    ${display_bin_dir}/vp"
   fi
 
   echo ""

--- a/packages/tools/src/local-npm-registry.ts
+++ b/packages/tools/src/local-npm-registry.ts
@@ -366,6 +366,21 @@ async function resolveLocalPackument(name: string): Promise<Packument> {
   return merged;
 }
 
+function resolveLocalVersion(key: string): unknown {
+  const separator = key.lastIndexOf('/');
+  if (separator === -1) {
+    return undefined;
+  }
+  const name = key.slice(0, separator);
+  const specifier = key.slice(separator + 1);
+  const packument = localPackuments.get(name);
+  if (!packument) {
+    return undefined;
+  }
+  const version = packument['dist-tags'][specifier] ?? specifier;
+  return packument.versions[version];
+}
+
 // Stream the upstream response byte-for-byte. Unlike `fetch`, `https` does not
 // auto-decompress, so the tarball reaches the client exactly as the registry
 // served it (content-encoding and all). bun verifies tarball integrity and
@@ -473,6 +488,15 @@ const server = createServer(async (req, res) => {
     const packument = localPackuments.has(key) ? await resolveLocalPackument(key) : manifest[key];
     res.writeHead(200, { 'content-type': 'application/json' });
     res.end(serializeForRegistry(packument, registry));
+    return;
+  }
+  const localVersion = resolveLocalVersion(key);
+  if (localVersion) {
+    const address = server.address();
+    const registry =
+      address && typeof address !== 'string' ? `http://127.0.0.1:${address.port}` : '';
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(serializeForRegistry(localVersion, registry));
     return;
   }
   const tarMatch = key.match(/\/-\/([^/]+\.tgz)$/);

--- a/rfcs/directory-layout.md
+++ b/rfcs/directory-layout.md
@@ -146,6 +146,13 @@ Thus, `user_home` and `dirs` cannot use different home directories. Directory
 resolution reads only `VP_HOME`, `VP_*_DIR`, and `XDG_*`. It does not read
 `HOME` or `USERPROFILE`.
 
+`crates/vp_shared/src/dirs/env_overrides.rs` classifies `VP_HOME`,
+`VP_BIN_DIR`, `VP_DATA_DIR`, and `VP_CACHE_DIR` as unset, absolute, or
+relative. Runtime resolution accepts absolute candidates and skips invalid
+candidates. `validate_vp_dir_env` applies the installer policy to the same
+classification. The function returns an error for a relative `VP_HOME`, an
+incomplete split group, or a relative path in a complete split group.
+
 Directory resolution has no test-only branches. Tests use the process
 environment to run the production resolution chain. See
 [Test configuration](#test-configuration).
@@ -242,7 +249,7 @@ A restricted service or CI environment can prevent the known-folder query.
 When this occurs, Vite+ uses `AppData\Local` and `AppData\Roaming` under the
 resolved user home. Thus, a known home always produces a complete layout.
 
-| Source                                            | Behavior                                                                                            |
+| Source                                            | Runtime behavior                                                                                    |
 | ------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
 | **`VP_HOME`**                                     | Vite+ puts the **monolithic mapping** for all categories under this root.                           |
 | **`~/.vite-plus`**                                | Vite+ uses the monolithic mapping when this directory contains a `current` link.                    |
@@ -250,8 +257,9 @@ resolved user home. Thus, a known home always produces a complete layout.
 | **`XDG_*`** (Unix)                                | Vite+ uses absolute XDG category roots with the app name `vite-plus`. Bin resolves to `<DATA>/bin`. |
 | **Platform defaults**                             | [Category mapping](#category-mapping) defines the Unix and Windows defaults.                        |
 
-Vite+ ignores relative `VP_*` and `XDG_*` values. This behavior follows the XDG
-Base Directory Specification.
+Runtime resolution ignores relative `VP_*` and `XDG_*` values. This behavior
+follows the XDG Base Directory Specification. Installers apply stricter rules
+before they create installation roots.
 
 ### Category mapping
 
@@ -314,11 +322,18 @@ root. Features must not store machine identity or durable state in these files.
 `install.sh`, `install.ps1`, and the local `install-global-cli` use the CLI
 resolution chain:
 
-1. If `VP_HOME` is set, use that root for the **monolithic** layout.
+1. If `VP_HOME` contains an absolute path, use that root for the
+   **monolithic** layout.
 2. Otherwise, check the default `~/.vite-plus` directory or its Windows
    equivalent. If it contains a `current` link, keep the monolithic root.
 3. Otherwise, use a complete `VP_*_DIR` group, `XDG_*`, or platform defaults
    for the **split** layout.
+
+The script installers reject an incomplete or relative `VP_*_DIR` group.
+`vp-setup` rejects those groups and a relative `VP_HOME`. It calls
+`vp_shared::validate_vp_dir_env` before `EnvConfig` resolves paths. A validation
+error makes `vp-setup` exit with status 1 before it creates a requested or
+default installation root.
 
 Each platform has one install script. There is no separate script for each
 layout. Local bootstrap does not set `VP_HOME`. It resolves the install data
@@ -387,8 +402,8 @@ However, the installer still exits with status 0:
 **Detection.** Each installer downloads the platform payload before it selects
 the final layout. This includes `install.sh`, `install.ps1`, and `vp-setup`. The
 installer then runs the payload binary once with `VP_DUMP_DIRS=1`. The shell and
-PowerShell installers do not resolve `VP_*_DIR`, XDG variables, platform
-defaults, or legacy installs themselves:
+PowerShell installers validate the split override group, but they do not
+resolve `VP_*_DIR`, XDG variables, platform defaults, or legacy installs:
 
 - A current split-aware binary prints the layout mode and one tab-separated line
   for each category root. The categories are `bin`, `data`, `cache`, `config`,
@@ -431,7 +446,10 @@ directories for the success summary.
 The wrapper install uses managed Node.js and pnpm. These tools get their paths
 from the process-wide `EnvConfig`, which resolves before the fallback. Therefore,
 the tools first go into the unused split data root. `do_install` removes this
-root if the current run created it.
+root if the current run created it. Before the probe, `vp-setup` records
+whether the split data parent exists. After a legacy fallback, it removes that
+parent with a non-recursive operation if the current run created it and left it
+empty. Existing parents and parents with new contents remain in place.
 
 The interactive menu has one known limit. It shows the split directories before
 the download. For a pinned pre-split version, the user confirms those
@@ -451,6 +469,11 @@ define the boundary.
 `test-install-ps1-old-version` job runs on Windows. These jobs install a pinned
 pre-split release without `VP_HOME`. They check the monolithic layout, the
 absence of split roots, and commands that run through `PATH`.
+
+The `test-vp-setup-exe` job rejects each incomplete split-variable combination,
+a relative `VP_HOME`, and a relative complete split group. It checks that
+validation creates no requested or default roots. The pinned `0.2.9` case
+checks that the legacy install works and that no empty split root remains.
 
 This mechanism also keeps fresh default installs of `latest` functional before
 the 0.3.0 release becomes available.

--- a/rfcs/directory-layout.md
+++ b/rfcs/directory-layout.md
@@ -399,11 +399,11 @@ However, the installer still exits with status 0:
 - Shell startup sources an env script from a config dir the binary never writes.
 - The binary's own env setup builds a second, incomplete `~/.vite-plus` tree.
 
-**Detection.** Each installer downloads the platform payload before it selects
-the final layout. This includes `install.sh`, `install.ps1`, and `vp-setup`. The
-installer then runs the payload binary once with `VP_DUMP_DIRS=1`. The shell and
-PowerShell installers validate the split override group, but they do not
-resolve `VP_*_DIR`, XDG variables, platform defaults, or legacy installs:
+**Detection.** `install.sh` and `install.ps1` download the platform payload
+before they select the final layout. Each script then runs the payload binary
+once with `VP_DUMP_DIRS=1`. The scripts validate the split override group, but
+they do not resolve `VP_*_DIR`, XDG variables, platform defaults, or legacy
+installs:
 
 - A current split-aware binary prints the layout mode and one tab-separated line
   for each category root. The categories are `bin`, `data`, `cache`, `config`,
@@ -429,31 +429,22 @@ The `test-install-sh-layout` CI job tests this case. It creates a split install
 and a stray `~/.vite-plus` tree. It then checks that resolution and a reinstall
 remain split.
 
-**Probe failure.** A payload can fail to run because it is for the wrong platform
-or requires a missing VC++ runtime. The installer then selects the monolithic
-root. The dependency-install step reports the applicable error as before.
+**Probe failure.** A payload can fail to run because it is for the wrong
+platform or requires a missing VC++ runtime. The script installer then selects
+the monolithic root. The dependency-install step reports the applicable error
+as before.
 
 The monolithic root works for old and new releases. A split-aware binary keeps
 an existing `~/.vite-plus` install. Thus, an incorrect pre-split result still
 produces a compatible layout. An incorrect split-aware result is not possible.
 Only a binary that implements `VP_DUMP_DIRS` can print the roots.
 
-**`vp-setup` behavior.** `vp-setup` resolves `EnvConfig` when the process starts.
-Therefore, a pre-split fallback occurs during the install. After the probe,
-`do_install` changes to the monolithic mapping. It returns the effective
-directories for the success summary.
-
-The wrapper install uses managed Node.js and pnpm. These tools get their paths
-from the process-wide `EnvConfig`, which resolves before the fallback. Therefore,
-the tools first go into the unused split data root. `do_install` removes this
-root if the current run created it. Before the probe, `vp-setup` records
-whether the split data parent exists. After a legacy fallback, it removes that
-parent with a non-recursive operation if the current run created it and left it
-empty. Existing parents and parents with new contents remain in place.
-
-The interactive menu has one known limit. It shows the split directories before
-the download. For a pinned pre-split version, the user confirms those
-directories. The installer then uses the monolithic root and prints the notice.
+**`vp-setup` behavior.** `vp-setup` supports version 0.3.0 and later, including
+0.3.0 prereleases. It also supports preview versions that use the
+`0.0.0-commit.<sha>` format. The installer rejects an older target after version
+resolution and before it downloads the platform payload or creates an
+installation root. It uses the directories from `EnvConfig` without a payload
+probe or a monolithic fallback.
 
 **`vp upgrade`.** On a split install, `vp upgrade` rejects a target earlier than
 0.3.0 before the download. It tells the user to run `vp upgrade` to install the
@@ -472,10 +463,11 @@ absence of split roots, and commands that run through `PATH`.
 
 The `test-vp-setup-exe` job rejects each incomplete split-variable combination,
 a relative `VP_HOME`, and a relative complete split group. It checks that
-validation creates no requested or default roots. The pinned `0.2.9` case
-checks that the legacy install works and that no empty split root remains.
+validation creates no requested or default roots. It also checks that
+`vp-setup` rejects version `0.2.9` without creating an installation root. The
+successful install uses a local `0.0.0-commit.<sha>` preview package.
 
-This mechanism also keeps fresh default installs of `latest` functional before
+The script fallback keeps fresh default installs of `latest` functional before
 the 0.3.0 release becomes available.
 
 ### Global CLI → JS children

--- a/rfcs/directory-layout.md
+++ b/rfcs/directory-layout.md
@@ -146,12 +146,20 @@ Thus, `user_home` and `dirs` cannot use different home directories. Directory
 resolution reads only `VP_HOME`, `VP_*_DIR`, and `XDG_*`. It does not read
 `HOME` or `USERPROFILE`.
 
-`crates/vp_shared/src/dirs/env_overrides.rs` classifies `VP_HOME`,
-`VP_BIN_DIR`, `VP_DATA_DIR`, and `VP_CACHE_DIR` as unset, absolute, or
-relative. Runtime resolution accepts absolute candidates and skips invalid
-candidates. `validate_vp_dir_env` applies the installer policy to the same
-classification. The function returns an error for a relative `VP_HOME`, an
-incomplete split group, or a relative path in a complete split group.
+`DirEnvOverrides` reads `VP_HOME`, `VP_BIN_DIR`, `VP_DATA_DIR`, and
+`VP_CACHE_DIR`. It records one of these states for each variable:
+
+- unset
+- absolute path
+- relative path
+
+Runtime resolution uses only absolute paths. `validate_vp_dir_env` uses the
+same states to apply the installer policy. The function returns an error for
+these conditions:
+
+- `VP_HOME` contains a relative path.
+- The split group is incomplete.
+- A variable in the complete split group contains a relative path.
 
 Directory resolution has no test-only branches. Tests use the process
 environment to run the production resolution chain. See
@@ -257,9 +265,9 @@ resolved user home. Thus, a known home always produces a complete layout.
 | **`XDG_*`** (Unix)                                | Vite+ uses absolute XDG category roots with the app name `vite-plus`. Bin resolves to `<DATA>/bin`. |
 | **Platform defaults**                             | [Category mapping](#category-mapping) defines the Unix and Windows defaults.                        |
 
-Runtime resolution ignores relative `VP_*` and `XDG_*` values. This behavior
-follows the XDG Base Directory Specification. Installers apply stricter rules
-before they create installation roots.
+`VpDirs` ignores relative `VP_*` and `XDG_*` values during runtime resolution.
+This behavior follows the XDG Base Directory Specification. Installers apply
+stricter rules before they create installation roots.
 
 ### Category mapping
 
@@ -330,10 +338,10 @@ resolution chain:
    for the **split** layout.
 
 The script installers reject an incomplete or relative `VP_*_DIR` group.
-`vp-setup` rejects those groups and a relative `VP_HOME`. It calls
-`vp_shared::validate_vp_dir_env` before `EnvConfig` resolves paths. A validation
-error makes `vp-setup` exit with status 1 before it creates a requested or
-default installation root.
+`vp-setup` rejects the same groups. It also rejects a relative `VP_HOME`.
+`vp-setup` calls `vp_shared::validate_vp_dir_env` before `EnvConfig` resolves
+paths. If validation fails, `vp-setup` returns status 1. It does not create a
+requested or default installation root.
 
 Each platform has one install script. There is no separate script for each
 layout. Local bootstrap does not set `VP_HOME`. It resolves the install data
@@ -429,22 +437,22 @@ The `test-install-sh-layout` CI job tests this case. It creates a split install
 and a stray `~/.vite-plus` tree. It then checks that resolution and a reinstall
 remain split.
 
-**Probe failure.** A payload can fail to run because it is for the wrong
-platform or requires a missing VC++ runtime. The script installer then selects
-the monolithic root. The dependency-install step reports the applicable error
-as before.
+**Probe failure.** A payload can fail on the wrong platform. It can also fail
+if Windows does not have the required VC++ runtime. The script installer then
+selects the monolithic root. The dependency-install step reports the applicable
+error as before.
 
 The monolithic root works for old and new releases. A split-aware binary keeps
 an existing `~/.vite-plus` install. Thus, an incorrect pre-split result still
 produces a compatible layout. An incorrect split-aware result is not possible.
 Only a binary that implements `VP_DUMP_DIRS` can print the roots.
 
-**`vp-setup` behavior.** `vp-setup` supports version 0.3.0 and later, including
-0.3.0 prereleases. It also supports preview versions that use the
-`0.0.0-commit.<sha>` format. The installer rejects an older target after version
-resolution and before it downloads the platform payload or creates an
-installation root. It uses the directories from `EnvConfig` without a payload
-probe or a monolithic fallback.
+**`vp-setup` behavior.** `vp-setup` supports Vite+ 0.3.0 and later. This
+includes 0.3.0 prereleases. It also supports internal preview versions that use
+the `0.0.0-commit.<sha>` format. The installer resolves the target version
+first. It rejects an older version before it downloads the platform payload or
+creates an installation root. It uses the directories from `EnvConfig`. It does
+not probe the payload or use a monolithic fallback.
 
 **`vp upgrade`.** On a split install, `vp upgrade` rejects a target earlier than
 0.3.0 before the download. It tells the user to run `vp upgrade` to install the
@@ -461,14 +469,18 @@ define the boundary.
 pre-split release without `VP_HOME`. They check the monolithic layout, the
 absence of split roots, and commands that run through `PATH`.
 
-The `test-vp-setup-exe` job rejects each incomplete split-variable combination,
-a relative `VP_HOME`, and a relative complete split group. It checks that
-validation creates no requested or default roots. It also checks that
-`vp-setup` rejects version `0.2.9` without creating an installation root. The
-successful install uses a local `0.0.0-commit.<sha>` preview package.
+The `test-vp-setup-exe` job checks these invalid configurations:
 
-The script fallback keeps fresh default installs of `latest` functional before
-the 0.3.0 release becomes available.
+- Each incomplete split-variable combination.
+- A relative `VP_HOME`.
+- A complete split group that contains relative paths.
+
+The job checks that validation creates no requested or default roots. It also
+checks that `vp-setup` rejects version `0.2.9` without creating an installation
+root. The successful test installs a local `0.0.0-commit.<sha>` preview package.
+
+`install.sh` and `install.ps1` use their fallback to install `latest` before
+Vite+ 0.3.0 is available.
 
 ### Global CLI → JS children
 

--- a/rfcs/windows-installer.md
+++ b/rfcs/windows-installer.md
@@ -207,15 +207,16 @@ vp-setup.exe --version 0.3.0 --no-node-manager --registry https://registry.npmmi
 
 CLI flags take precedence over environment variables.
 
-`vp-setup.exe` requires an absolute `VP_HOME`. Callers that set a split root
-must set all three `VP_*_DIR` variables to absolute paths. The installer calls
-the shared `vp_shared::validate_vp_dir_env` check before it resolves or creates
-installation roots. The installer returns exit code 1 for invalid configuration.
+`vp-setup.exe` requires an absolute `VP_HOME`. If callers set one split root,
+they must set all three `VP_*_DIR` variables. Each variable must contain an
+absolute path. The installer calls `vp_shared::validate_vp_dir_env` before it
+resolves or creates installation roots. The installer returns exit code 1 for
+invalid configuration.
 
-The installer supports version 0.3.0 and later, including 0.3.0 prereleases.
-It also supports preview versions that use the `0.0.0-commit.<sha>` format. It
-rejects older versions before it downloads the platform payload or creates an
-installation root.
+The installer supports Vite+ 0.3.0 and later. This includes 0.3.0 prereleases.
+It also supports internal preview versions that use the
+`0.0.0-commit.<sha>` format. It rejects older versions before it downloads the
+platform payload or creates an installation root.
 
 ## Installation Flow
 
@@ -477,14 +478,19 @@ test-vp-setup-exe:
       # verifies from all three shells after a single install
 ```
 
-The workflow path filter covers the installer, shared directory resolution,
-setup helpers, shims, global CLI, install scripts, and the workflow file.
+The workflow path filter includes these files:
 
-The job checks invalid directory overrides and the minimum supported version.
-Invalid overrides must leave requested and default roots absent. A request for
-version `0.2.9` must fail without creating an installation root. The successful
-install uses a local registry package with the `0.0.0-commit.<sha>` preview
-version format.
+- the installer and setup helpers
+- shared directory resolution
+- shims and the global CLI
+- install scripts
+- the workflow file
+
+The job tests invalid directory overrides and versions older than 0.3.0. The
+installer must not create requested or default roots for invalid overrides. A
+request for version `0.2.9` must fail without creating an installation root.
+For the successful test, the job installs a local
+`0.0.0-commit.<sha>` preview package.
 
 ## Code Signing
 

--- a/rfcs/windows-installer.md
+++ b/rfcs/windows-installer.md
@@ -188,7 +188,7 @@ vp-setup.exe --version 0.3.0 --no-node-manager --registry https://registry.npmmi
 | `-q` / `--quiet`       | Suppress output except errors | false                        |
 | `--version <VER>`      | Install specific version      | latest                       |
 | `--tag <TAG>`          | npm dist-tag                  | latest                       |
-| `--install-dir <PATH>` | Installation directory        | `%USERPROFILE%\.vite-plus`   |
+| `--install-dir <PATH>` | Installation directory        | resolved Vite+ layout        |
 | `--registry <URL>`     | npm registry URL              | `https://registry.npmjs.org` |
 | `--no-node-manager`    | Skip Node.js manager setup    | auto-detect                  |
 | `--no-modify-path`     | Don't modify User PATH        | modify                       |
@@ -198,11 +198,19 @@ vp-setup.exe --version 0.3.0 --no-node-manager --registry https://registry.npmmi
 | Variable                  | Maps to             |
 | ------------------------- | ------------------- |
 | `VP_VERSION`              | `--version`         |
-| `VP_HOME`                 | `--install-dir`     |
+| `VP_HOME`                 | single-root layout  |
+| `VP_BIN_DIR`              | split bin root      |
+| `VP_DATA_DIR`             | split data root     |
+| `VP_CACHE_DIR`            | split cache root    |
 | `NPM_CONFIG_REGISTRY`     | `--registry`        |
 | `VP_NODE_MANAGER=yes\|no` | `--no-node-manager` |
 
 CLI flags take precedence over environment variables.
+
+`vp-setup.exe` requires an absolute `VP_HOME`. Callers that set a split root
+must set all three `VP_*_DIR` variables to absolute paths. The installer calls
+the shared `vp_shared::validate_vp_dir_env` check before it resolves or creates
+installation roots. The installer returns exit code 1 for invalid configuration.
 
 ## Installation Flow
 
@@ -215,7 +223,7 @@ The installer replicates the same result as `install.ps1`, implemented in Rust v
 │  ┌─ detect platform ──────── win32-x64-msvc                 │
 │  │                           win32-arm64-msvc                │
 │  │                                                          │
-│  ├─ check existing ──────── read %VP_HOME%\current           │
+│  ├─ check existing ──────── read <DATA>\current              │
 │  │                                                          │
 │  └─ resolve version ──────── resolve_version_string()        │
 │                              1 HTTP call: "latest" → "0.3.0" │
@@ -242,7 +250,7 @@ The installer replicates the same result as `install.ps1`, implemented in Rust v
 ┌─────────────────────────────────────────────────────────────┐
 │                      INSTALL                                │
 │                                                             │
-│  ┌─ extract binary ──────── %VP_HOME%\{version}\bin\         │
+│  ┌─ extract binary ──────── <DATA>\{version}\bin\            │
 │  │                          vp.exe + vp-shim.exe             │
 │  │                                                          │
 │  ├─ generate package.json ─ wrapper with vite-plus dep       │
@@ -274,7 +282,7 @@ The installer replicates the same result as `install.ps1`, implemented in Rust v
 │       CONFIGURE         (best-effort, always runs,           │
 │                          even for same-version repair)        │
 │                                                             │
-│  ┌─ create bin shims ────── copy vp-shim.exe → bin\vp.exe   │
+│  ┌─ create bin shims ────── copy vp-shim.exe → <BIN>\vp.exe │
 │  │                          (rename-to-.old if running)      │
 │  │                                                          │
 │  ├─ Node.js manager ────── if enabled (pre-computed):        │
@@ -284,7 +292,7 @@ The installer replicates the same result as `install.ps1`, implemented in Rust v
 │  │                                                          │
 │  └─ modify User PATH ────── if --no-modify-path not set:     │
 │                              HKCU\Environment\Path           │
-│                              prepend %VP_HOME%\bin           │
+│                              prepend <BIN>                   │
 │                              broadcast WM_SETTINGCHANGE      │
 └─────────────────────────────────────────────────────────────┘
                               │
@@ -464,8 +472,12 @@ test-vp-setup-exe:
       # verifies from all three shells after a single install
 ```
 
-The workflow triggers on changes to `crates/vp_installer/**`, `crates/vp_pm_cli/**`, and
-`crates/vp_setup/**`.
+The workflow path filter covers the installer, shared directory resolution,
+setup helpers, shims, global CLI, install scripts, and the workflow file.
+
+The job checks invalid directory overrides and a pinned `0.2.9` install.
+Invalid overrides must leave requested and default roots absent. The old-version
+case must produce a working monolithic install and leave no empty split root.
 
 ## Code Signing
 
@@ -572,6 +584,8 @@ Embed the PowerShell script in a self-extracting exe. Fragile, still requires Po
 - Fresh install from cmd.exe, PowerShell, Git Bash
 - Silent mode (`-y`) installation
 - Custom registry, custom install dir
+- Invalid `VP_HOME` and `VP_*_DIR` configuration
+- Pre-split fallback without an empty split root
 - Upgrade over existing installation
 - Verify `vp --version` works after install
 - Verify PATH is modified correctly

--- a/rfcs/windows-installer.md
+++ b/rfcs/windows-installer.md
@@ -330,6 +330,9 @@ Each phase maps to `vp_setup` library functions shared with `vp upgrade`:
 
 **Failure recovery**: Before the **Activate** phase, failures clean up the version directory and leave the existing installation untouched. After **Activate**, all CONFIGURE steps are best-effort — failures log a warning but do not cause exit code 1. Rerunning the installer always retries CONFIGURE.
 
+On Windows, activation checks the `current` entry without following its target.
+The installer removes a dangling junction before it creates the new junction.
+
 ## Node.js Manager Auto-Detection
 
 The Node.js manager decision (`enabled`/`disabled`) is pre-computed before the interactive menu is shown, so the user sees the resolved value and can override it via the customize submenu. No prompts occur during the installation phase.
@@ -389,6 +392,10 @@ fn init_dll_security() {
 ### Console Allocation
 
 The binary uses the console subsystem (default for Rust binaries on Windows). When double-clicked, Windows allocates a console window automatically. No special handling needed.
+
+The installer applies colors only when the output stream supports them. If the
+`NO_COLOR` variable is present, stdout and stderr contain no ANSI escape
+sequences. This rule also applies when callers redirect output to files.
 
 ### Existing Installation Handling
 
@@ -490,7 +497,9 @@ The job tests invalid directory overrides and versions older than 0.3.0. The
 installer must not create requested or default roots for invalid overrides. A
 request for version `0.2.9` must fail without creating an installation root.
 For the successful test, the job installs a local
-`0.0.0-commit.<sha>` preview package.
+`0.0.0-commit.<sha>` preview package. This test starts with a dangling `current`
+junction. It also sets `NO_COLOR` and checks the redirected output for ANSI
+escape sequences.
 
 ## Code Signing
 
@@ -599,6 +608,8 @@ Embed the PowerShell script in a self-extracting exe. Fragile, still requires Po
 - Custom registry, custom install dir
 - Invalid `VP_HOME` and `VP_*_DIR` configuration
 - Rejection of releases before 0.3.0
+- Repair of a dangling `current` junction
+- `NO_COLOR` output without ANSI escape sequences
 - Upgrade over existing installation
 - Verify `vp --version` works after install
 - Verify PATH is modified correctly

--- a/rfcs/windows-installer.md
+++ b/rfcs/windows-installer.md
@@ -212,6 +212,11 @@ must set all three `VP_*_DIR` variables to absolute paths. The installer calls
 the shared `vp_shared::validate_vp_dir_env` check before it resolves or creates
 installation roots. The installer returns exit code 1 for invalid configuration.
 
+The installer supports version 0.3.0 and later, including 0.3.0 prereleases.
+It also supports preview versions that use the `0.0.0-commit.<sha>` format. It
+rejects older versions before it downloads the platform payload or creates an
+installation root.
+
 ## Installation Flow
 
 The installer replicates the same result as `install.ps1`, implemented in Rust via `vp_setup`.
@@ -463,11 +468,11 @@ test-vp-setup-exe:
     - uses: oxc-project/setup-rust@v1
     - name: Build vp-setup.exe
       run: cargo build --release -p vp_installer
-    - name: Install via vp-setup.exe (silent)
+    - name: Start local preview registry
+      # packs the current vp.exe and vp-shim.exe as 0.0.0-commit.<sha>
+    - name: Install local preview via vp-setup.exe (silent)
       shell: pwsh
-      run: ./target/release/vp-setup.exe
-      env:
-        VP_VERSION: alpha
+      run: ./target/release/vp-setup.exe --version $VP_SETUP_TEST_VERSION --registry $VP_SETUP_TEST_REGISTRY
     - name: Verify installation (pwsh/cmd/bash)
       # verifies from all three shells after a single install
 ```
@@ -475,9 +480,11 @@ test-vp-setup-exe:
 The workflow path filter covers the installer, shared directory resolution,
 setup helpers, shims, global CLI, install scripts, and the workflow file.
 
-The job checks invalid directory overrides and a pinned `0.2.9` install.
-Invalid overrides must leave requested and default roots absent. The old-version
-case must produce a working monolithic install and leave no empty split root.
+The job checks invalid directory overrides and the minimum supported version.
+Invalid overrides must leave requested and default roots absent. A request for
+version `0.2.9` must fail without creating an installation root. The successful
+install uses a local registry package with the `0.0.0-commit.<sha>` preview
+version format.
 
 ## Code Signing
 
@@ -585,7 +592,7 @@ Embed the PowerShell script in a self-extracting exe. Fragile, still requires Po
 - Silent mode (`-y`) installation
 - Custom registry, custom install dir
 - Invalid `VP_HOME` and `VP_*_DIR` configuration
-- Pre-split fallback without an empty split root
+- Rejection of releases before 0.3.0
 - Upgrade over existing installation
 - Verify `vp --version` works after install
 - Verify PATH is modified correctly

--- a/rfcs/windows-installer.md
+++ b/rfcs/windows-installer.md
@@ -182,15 +182,15 @@ vp-setup.exe --version 0.3.0 --no-node-manager --registry https://registry.npmmi
 
 ### CLI Flags
 
-| Flag                   | Description                   | Default                      |
-| ---------------------- | ----------------------------- | ---------------------------- |
-| `-y` / `--yes`         | Accept defaults, no prompts   | interactive                  |
-| `-q` / `--quiet`       | Suppress output except errors | false                        |
-| `--version <VER>`      | Install specific version      | latest                       |
-| `--tag <TAG>`          | npm dist-tag                  | latest                       |
-| `--registry <URL>`     | npm registry URL              | `https://registry.npmjs.org` |
-| `--no-node-manager`    | Skip Node.js manager setup    | auto-detect                  |
-| `--no-modify-path`     | Don't modify User PATH        | modify                       |
+| Flag                | Description                   | Default                      |
+| ------------------- | ----------------------------- | ---------------------------- |
+| `-y` / `--yes`      | Accept defaults, no prompts   | interactive                  |
+| `-q` / `--quiet`    | Suppress output except errors | false                        |
+| `--version <VER>`   | Install specific version      | latest                       |
+| `--tag <TAG>`       | npm dist-tag                  | latest                       |
+| `--registry <URL>`  | npm registry URL              | `https://registry.npmjs.org` |
+| `--no-node-manager` | Skip Node.js manager setup    | auto-detect                  |
+| `--no-modify-path`  | Don't modify User PATH        | modify                       |
 
 ### Environment Variables (compatible with `install.ps1`)
 

--- a/rfcs/windows-installer.md
+++ b/rfcs/windows-installer.md
@@ -188,7 +188,6 @@ vp-setup.exe --version 0.3.0 --no-node-manager --registry https://registry.npmmi
 | `-q` / `--quiet`       | Suppress output except errors | false                        |
 | `--version <VER>`      | Install specific version      | latest                       |
 | `--tag <TAG>`          | npm dist-tag                  | latest                       |
-| `--install-dir <PATH>` | Installation directory        | resolved Vite+ layout        |
 | `--registry <URL>`     | npm registry URL              | `https://registry.npmjs.org` |
 | `--no-node-manager`    | Skip Node.js manager setup    | auto-detect                  |
 | `--no-modify-path`     | Don't modify User PATH        | modify                       |


### PR DESCRIPTION
vp-setup.exe now validates directory variables before it resolves a version or creates an installation root. VP_HOME is the single-root override. Users must set VP_BIN_DIR, VP_DATA_DIR, and VP_CACHE_DIR together. Each value must be an absolute path. Users can set each XDG_* variable independently. The installer no longer provides the redundant `--install-dir` option.

vp-setup.exe accepts Vite+ 0.3.0 or later. CI can also install internal 0.0.0-commit.<sha> builds. The installer rejects all other 0.0.0 versions and earlier releases before it downloads a payload. It no longer probes payloads or uses the monolithic layout.

vp_shared owns directory validation. vp_setup owns version support checks. vp-setup and vp upgrade use these shared checks.

The Windows installer now replaces a dangling current junction. It also removes ANSI output when NO_COLOR is set. The Windows workflow tests invalid directory variables, unsupported versions, junction repair, and NO_COLOR output.