### PR TITLE
fix(installer): hide shell config warnings in CI

### DIFF
--- a/.github/workflows/test-standalone-install.yml
+++ b/.github/workflows/test-standalone-install.yml
@@ -237,7 +237,7 @@ jobs:
           OUTPUT=$(append_source_to_file "$SHELL_CONFIG" '. "$HOME/.vite-plus/env"' 2>&1) || RESULT=$?
           test "$RESULT" -eq 3
           echo "$OUTPUT" | grep -F "trace"
-          echo "$OUTPUT" | grep -F "Vite+ cannot write"
+          echo "$OUTPUT" | grep -F "permission denied"
 
           CI=false
           unset VP_LOG
@@ -245,7 +245,7 @@ jobs:
           OUTPUT=$(append_source_to_file "$SHELL_CONFIG" '. "$HOME/.vite-plus/env"' 2>&1) || RESULT=$?
           test "$RESULT" -eq 3
           echo "$OUTPUT" | grep -F "warn"
-          echo "$OUTPUT" | grep -F "Vite+ cannot write"
+          echo "$OUTPUT" | grep -F "permission denied"
 
       - name: Incomplete directory overrides are rejected
         run: |
@@ -563,7 +563,7 @@ jobs:
           # CI gets PATH from the runner environment.
           # VP_LOG=trace shows shell file errors.
           # Normal output does not show these errors.
-          if echo "$output" | grep -Eqi "Vite[+] cannot (write|create)|Shell configuration:|Some shells still need manual setup"; then
+          if echo "$output" | grep -Eqi "permission denied|Shell configuration:|Some shells still need manual setup"; then
             echo "Installer printed shell configuration details in CI"
             exit 1
           fi

--- a/.github/workflows/test-standalone-install.yml
+++ b/.github/workflows/test-standalone-install.yml
@@ -218,6 +218,35 @@ jobs:
       - name: Build local vp
         run: cargo build --release -p vp_global_cli
 
+      - name: CI hides shell config permission warnings
+        run: |
+          set -euo pipefail
+          eval "$(sed '/^main "[$]@"$/d' packages/cli/install.sh)"
+
+          SHELL_CONFIG=$(mktemp)
+          chmod 444 "$SHELL_CONFIG"
+
+          CI=true
+          RESULT=0
+          OUTPUT=$(append_source_to_file "$SHELL_CONFIG" '. "$HOME/.vite-plus/env"' 2>&1) || RESULT=$?
+          test "$RESULT" -eq 3
+          test -z "$OUTPUT"
+
+          VP_LOG=trace
+          RESULT=0
+          OUTPUT=$(append_source_to_file "$SHELL_CONFIG" '. "$HOME/.vite-plus/env"' 2>&1) || RESULT=$?
+          test "$RESULT" -eq 3
+          echo "$OUTPUT" | grep -F "trace"
+          echo "$OUTPUT" | grep -F "permission denied"
+
+          CI=false
+          unset VP_LOG
+          RESULT=0
+          OUTPUT=$(append_source_to_file "$SHELL_CONFIG" '. "$HOME/.vite-plus/env"' 2>&1) || RESULT=$?
+          test "$RESULT" -eq 3
+          echo "$OUTPUT" | grep -F "warn"
+          echo "$OUTPUT" | grep -F "permission denied"
+
       - name: Incomplete directory overrides are rejected
         run: |
           set -euo pipefail
@@ -531,10 +560,12 @@ jobs:
           echo "$output" | grep -q "Install locations:"
           echo "$output" | grep -q "Data directory: ~/.vite-plus"
           echo "$output" | grep -q "Bin directory:  ~/.vite-plus/bin"
-          # Verify fallback message shows manual instructions
-          echo "$output" | grep -q "Or run vp directly:"
-          # Verify the permission warning was shown
-          echo "$output" | grep -qi "permission denied"
+          # CI uses the runner environment for PATH. Shell config failures are
+          # available at trace level, not in the normal installer output.
+          if echo "$output" | grep -Eqi "permission denied|Shell configuration:|Some shells still need manual setup"; then
+            echo "Installer printed shell configuration noise in CI"
+            exit 1
+          fi
 
       - name: Verify vp works via direct path
         run: |

--- a/.github/workflows/test-standalone-install.yml
+++ b/.github/workflows/test-standalone-install.yml
@@ -218,7 +218,7 @@ jobs:
       - name: Build local vp
         run: cargo build --release -p vp_global_cli
 
-      - name: CI hides shell config permission warnings
+      - name: CI hides shell file warnings
         run: |
           set -euo pipefail
           eval "$(sed '/^main "[$]@"$/d' packages/cli/install.sh)"
@@ -237,7 +237,7 @@ jobs:
           OUTPUT=$(append_source_to_file "$SHELL_CONFIG" '. "$HOME/.vite-plus/env"' 2>&1) || RESULT=$?
           test "$RESULT" -eq 3
           echo "$OUTPUT" | grep -F "trace"
-          echo "$OUTPUT" | grep -F "permission denied"
+          echo "$OUTPUT" | grep -F "Vite+ cannot write"
 
           CI=false
           unset VP_LOG
@@ -245,7 +245,7 @@ jobs:
           OUTPUT=$(append_source_to_file "$SHELL_CONFIG" '. "$HOME/.vite-plus/env"' 2>&1) || RESULT=$?
           test "$RESULT" -eq 3
           echo "$OUTPUT" | grep -F "warn"
-          echo "$OUTPUT" | grep -F "permission denied"
+          echo "$OUTPUT" | grep -F "Vite+ cannot write"
 
       - name: Incomplete directory overrides are rejected
         run: |
@@ -560,10 +560,11 @@ jobs:
           echo "$output" | grep -q "Install locations:"
           echo "$output" | grep -q "Data directory: ~/.vite-plus"
           echo "$output" | grep -q "Bin directory:  ~/.vite-plus/bin"
-          # CI uses the runner environment for PATH. Shell config failures are
-          # available at trace level, not in the normal installer output.
-          if echo "$output" | grep -Eqi "permission denied|Shell configuration:|Some shells still need manual setup"; then
-            echo "Installer printed shell configuration noise in CI"
+          # CI gets PATH from the runner environment.
+          # VP_LOG=trace shows shell file errors.
+          # Normal output does not show these errors.
+          if echo "$output" | grep -Eqi "Vite[+] cannot (write|create)|Shell configuration:|Some shells still need manual setup"; then
+            echo "Installer printed shell configuration details in CI"
             exit 1
           fi
 

--- a/docs/guide/installer-env-vars.md
+++ b/docs/guide/installer-env-vars.md
@@ -195,6 +195,8 @@ Vite+ sets additional `VP_*` variables during shim dispatch and shell integratio
 ### `VP_LOG`
 
 - **Purpose**: Log filter string for `tracing_subscriber`
+- **Installer behavior**: `VP_LOG=trace` shows shell configuration failures
+  that `install.sh` hides when `CI=true`.
 - **Default**: None
 - **Example**:
   ```bash

--- a/docs/guide/installer-env-vars.md
+++ b/docs/guide/installer-env-vars.md
@@ -195,8 +195,8 @@ Vite+ sets additional `VP_*` variables during shim dispatch and shell integratio
 ### `VP_LOG`
 
 - **Purpose**: Log filter string for `tracing_subscriber`
-- **Installer behavior**: `VP_LOG=trace` shows shell configuration failures
-  that `install.sh` hides when `CI=true`.
+- **Installer behavior**: When `CI=true`, `install.sh` hides shell file errors.
+  Set `VP_LOG=trace` to show these errors.
 - **Default**: None
 - **Example**:
   ```bash

--- a/packages/cli/install.sh
+++ b/packages/cli/install.sh
@@ -71,7 +71,7 @@ trace() {
   echo -e "${DIM}trace${NC}: $1"
 }
 
-shell_config_warn() {
+report_shell_config_error() {
   if [ "${CI:-}" = "true" ]; then
     trace "$1"
   else
@@ -744,7 +744,7 @@ append_source_to_file() {
   fi
 
   if [ ! -w "$shell_config" ]; then
-    shell_config_warn "Cannot write to $shell_config (permission denied), skipping."
+    report_shell_config_error "Vite+ cannot write to $shell_config. Vite+ skips this file."
     return 3
   fi
 
@@ -771,12 +771,12 @@ write_managed_snippet() {
 
   snippet_dir=$(dirname "$snippet_file")
   if ! mkdir -p "$snippet_dir" 2>/dev/null; then
-    shell_config_warn "Cannot create $snippet_dir, skipping."
+    report_shell_config_error "Vite+ cannot create $snippet_dir. Vite+ skips this shell configuration."
     return 3
   fi
 
   if [ -f "$snippet_file" ] && [ ! -w "$snippet_file" ]; then
-    shell_config_warn "Cannot write to $snippet_file (permission denied), skipping."
+    report_shell_config_error "Vite+ cannot write to $snippet_file. Vite+ skips this file."
     return 3
   fi
 
@@ -785,7 +785,7 @@ write_managed_snippet() {
   fi
 
   if ! printf '%s' "$snippet_content" > "$snippet_file"; then
-    shell_config_warn "Cannot write to $snippet_file, skipping."
+    report_shell_config_error "Vite+ cannot write to $snippet_file. Vite+ skips this file."
     return 3
   fi
   return 0
@@ -820,7 +820,7 @@ configure_zsh_path() {
   local result
 
   if ! mkdir -p "$zsh_dir" 2>/dev/null; then
-    shell_config_warn "Cannot create $zsh_dir, skipping zsh."
+    report_shell_config_error "Vite+ cannot create $zsh_dir. Vite+ skips zsh configuration."
     SHELL_CONFIG_HAS_FAILURE="true"
     SHELL_CONFIG_FAILED_SHELLS+=("zsh")
     record_shell_summary "zsh" "failed (could not create $(abbreviate_path "$zsh_dir"))"
@@ -828,7 +828,7 @@ configure_zsh_path() {
   fi
 
   if [ ! -f "$zshenv" ] && ! touch "$zshenv" 2>/dev/null; then
-    shell_config_warn "Cannot create $zshenv, skipping zsh."
+    report_shell_config_error "Vite+ cannot create $zshenv. Vite+ skips zsh configuration."
     SHELL_CONFIG_HAS_FAILURE="true"
     SHELL_CONFIG_FAILED_SHELLS+=("zsh")
     record_shell_summary "zsh" "failed (could not create $(abbreviate_path "$zshenv"))"
@@ -1455,8 +1455,9 @@ WRAPPER_EOF
   echo "    Data directory: $display_data_dir"
   echo "    Bin directory:  $display_bin_dir"
 
-  # CI jobs must configure PATH through their runner. Shell files do not affect
-  # later job steps, so keep shell configuration details out of normal CI logs.
+  # CI jobs configure PATH through the runner.
+  # Shell files do not change PATH for later steps.
+  # Do not print shell details in normal CI output.
   if [ "${CI:-}" = "true" ]; then
     echo ""
     return

--- a/packages/cli/install.sh
+++ b/packages/cli/install.sh
@@ -66,6 +66,19 @@ warn() {
   echo -e "${YELLOW}warn${NC}: $1"
 }
 
+trace() {
+  [ "${VP_LOG:-}" = "trace" ] || return 0
+  echo -e "${DIM}trace${NC}: $1"
+}
+
+shell_config_warn() {
+  if [ "${CI:-}" = "true" ]; then
+    trace "$1"
+  else
+    warn "$1"
+  fi
+}
+
 error() {
   echo -e "${RED}error${NC}: $1"
   exit 1
@@ -731,7 +744,7 @@ append_source_to_file() {
   fi
 
   if [ ! -w "$shell_config" ]; then
-    warn "Cannot write to $shell_config (permission denied), skipping."
+    shell_config_warn "Cannot write to $shell_config (permission denied), skipping."
     return 3
   fi
 
@@ -758,12 +771,12 @@ write_managed_snippet() {
 
   snippet_dir=$(dirname "$snippet_file")
   if ! mkdir -p "$snippet_dir" 2>/dev/null; then
-    warn "Cannot create $snippet_dir, skipping."
+    shell_config_warn "Cannot create $snippet_dir, skipping."
     return 3
   fi
 
   if [ -f "$snippet_file" ] && [ ! -w "$snippet_file" ]; then
-    warn "Cannot write to $snippet_file (permission denied), skipping."
+    shell_config_warn "Cannot write to $snippet_file (permission denied), skipping."
     return 3
   fi
 
@@ -772,7 +785,7 @@ write_managed_snippet() {
   fi
 
   if ! printf '%s' "$snippet_content" > "$snippet_file"; then
-    warn "Cannot write to $snippet_file, skipping."
+    shell_config_warn "Cannot write to $snippet_file, skipping."
     return 3
   fi
   return 0
@@ -807,7 +820,7 @@ configure_zsh_path() {
   local result
 
   if ! mkdir -p "$zsh_dir" 2>/dev/null; then
-    warn "Cannot create $zsh_dir, skipping zsh."
+    shell_config_warn "Cannot create $zsh_dir, skipping zsh."
     SHELL_CONFIG_HAS_FAILURE="true"
     SHELL_CONFIG_FAILED_SHELLS+=("zsh")
     record_shell_summary "zsh" "failed (could not create $(abbreviate_path "$zsh_dir"))"
@@ -815,7 +828,7 @@ configure_zsh_path() {
   fi
 
   if [ ! -f "$zshenv" ] && ! touch "$zshenv" 2>/dev/null; then
-    warn "Cannot create $zshenv, skipping zsh."
+    shell_config_warn "Cannot create $zshenv, skipping zsh."
     SHELL_CONFIG_HAS_FAILURE="true"
     SHELL_CONFIG_FAILED_SHELLS+=("zsh")
     record_shell_summary "zsh" "failed (could not create $(abbreviate_path "$zshenv"))"
@@ -1441,6 +1454,13 @@ WRAPPER_EOF
   echo -e "  ${BOLD}Install locations:${NC}"
   echo "    Data directory: $display_data_dir"
   echo "    Bin directory:  $display_bin_dir"
+
+  # CI jobs must configure PATH through their runner. Shell files do not affect
+  # later job steps, so keep shell configuration details out of normal CI logs.
+  if [ "${CI:-}" = "true" ]; then
+    echo ""
+    return
+  fi
 
   echo ""
   echo "  Shell configuration:"

--- a/packages/cli/install.sh
+++ b/packages/cli/install.sh
@@ -744,7 +744,7 @@ append_source_to_file() {
   fi
 
   if [ ! -w "$shell_config" ]; then
-    report_shell_config_error "Vite+ cannot write to $shell_config. Vite+ skips this file."
+    report_shell_config_error "Cannot write to $shell_config (permission denied), skipping."
     return 3
   fi
 
@@ -771,12 +771,12 @@ write_managed_snippet() {
 
   snippet_dir=$(dirname "$snippet_file")
   if ! mkdir -p "$snippet_dir" 2>/dev/null; then
-    report_shell_config_error "Vite+ cannot create $snippet_dir. Vite+ skips this shell configuration."
+    report_shell_config_error "Cannot create $snippet_dir, skipping."
     return 3
   fi
 
   if [ -f "$snippet_file" ] && [ ! -w "$snippet_file" ]; then
-    report_shell_config_error "Vite+ cannot write to $snippet_file. Vite+ skips this file."
+    report_shell_config_error "Cannot write to $snippet_file (permission denied), skipping."
     return 3
   fi
 
@@ -785,7 +785,7 @@ write_managed_snippet() {
   fi
 
   if ! printf '%s' "$snippet_content" > "$snippet_file"; then
-    report_shell_config_error "Vite+ cannot write to $snippet_file. Vite+ skips this file."
+    report_shell_config_error "Cannot write to $snippet_file, skipping."
     return 3
   fi
   return 0
@@ -820,7 +820,7 @@ configure_zsh_path() {
   local result
 
   if ! mkdir -p "$zsh_dir" 2>/dev/null; then
-    report_shell_config_error "Vite+ cannot create $zsh_dir. Vite+ skips zsh configuration."
+    report_shell_config_error "Cannot create $zsh_dir, skipping zsh."
     SHELL_CONFIG_HAS_FAILURE="true"
     SHELL_CONFIG_FAILED_SHELLS+=("zsh")
     record_shell_summary "zsh" "failed (could not create $(abbreviate_path "$zsh_dir"))"
@@ -828,7 +828,7 @@ configure_zsh_path() {
   fi
 
   if [ ! -f "$zshenv" ] && ! touch "$zshenv" 2>/dev/null; then
-    report_shell_config_error "Vite+ cannot create $zshenv. Vite+ skips zsh configuration."
+    report_shell_config_error "Cannot create $zshenv, skipping zsh."
     SHELL_CONFIG_HAS_FAILURE="true"
     SHELL_CONFIG_FAILED_SHELLS+=("zsh")
     record_shell_summary "zsh" "failed (could not create $(abbreviate_path "$zshenv"))"


### PR DESCRIPTION
`install.sh` now hides shell configuration warnings and instructions when `CI=true`. CI runners set `PATH` through the job environment. Changes to shell files do not change later job steps.

The examples show only the relevant output lines.

Before:

```text
warn: Cannot write to /home/runner/.bashrc (permission denied), skipping.
warn: Cannot write to /home/runner/.profile (permission denied), skipping.

Shell configuration:
    - bash: failed ~/.bashrc, ~/.profile

note: Some shells still need manual setup.
Manual setup instructions:
```

After:

```text
Install locations:
    Data directory: <data-directory>
    Bin directory:  <bin-directory>
```

Set `VP_LOG=trace` to show the hidden shell file errors. Installations outside CI keep the warnings and manual setup instructions.

This PR is stacked on #2505.

Closes voidzero-dev/setup-vp#87