### PR TITLE
test(cli): redact bun build hash in snapshots

### DIFF
--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_add_bun/snapshots/command_add_bun.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_add_bun/snapshots/command_add_bun.md
@@ -55,7 +55,7 @@ For more information, try '--help'.
 should add package as dev dependencies
 
 ```
-bun add <version> (af24e281)
+bun add <version> (<hash>)
 
 installed testnpm2@1.0.1
 
@@ -80,7 +80,7 @@ installed testnpm2@1.0.1
 should add packages to dependencies
 
 ```
-bun add <version> (af24e281)
+bun add <version> (<hash>)
 
 installed testnpm2@1.0.1
 installed test-vite-plus-install@1.0.0
@@ -111,7 +111,7 @@ should install package alias for add
 ```
 VITE+ - The Unified Toolchain for the Web
 
-bun add <version> (af24e281)
+bun add <version> (<hash>)
 
 installed test-vite-plus-package@1.0.0
 
@@ -142,7 +142,7 @@ installed test-vite-plus-package@1.0.0
 should add package as optional dependencies
 
 ```
-bun add <version> (af24e281)
+bun add <version> (<hash>)
 
 installed test-vite-plus-package-optional@1.0.0
 

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_list_bun/snapshots/command_list_bun.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_list_bun/snapshots/command_list_bun.md
@@ -7,7 +7,7 @@ should install packages first
 ```
 VITE+ - The Unified Toolchain for the Web
 
-bun install <version> (af24e281)
+bun install <version> (<hash>)
 
  test-vite-plus-package@1.0.0
  test-vite-plus-package-optional@1.0.0

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_outdated_bun/snapshots/command_outdated_bun.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_outdated_bun/snapshots/command_outdated_bun.md
@@ -40,7 +40,7 @@ should install packages first
 ```
 VITE+ - The Unified Toolchain for the Web
 
-bun install <version> (af24e281)
+bun install <version> (<hash>)
 
  test-vite-plus-top-package@1.0.0 (<version> available)
  test-vite-plus-other-optional@1.0.0 (<version> available)
@@ -54,7 +54,7 @@ bun install <version> (af24e281)
 should show outdated package
 
 ```
-bun outdated <version> (af24e281)
+bun outdated <version> (<hash>)
 ┌──────────┬─────────┬────────┬────────┐
 │ Package  │ Current │ Update │ Latest │
 ├──────────┼─────────┼────────┼────────┤
@@ -67,7 +67,7 @@ bun outdated <version> (af24e281)
 should support recursive output
 
 ```
-bun outdated <version> (af24e281)
+bun outdated <version> (<hash>)
 ┌──────────────────────────────────────────┬─────────┬────────┬────────┬──────────────────────┐
 │ Package                                  │ Current │ Update │ Latest │ Workspace            │
 ├──────────────────────────────────────────┼─────────┼────────┼────────┼──────────────────────┤

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_pm_approve_builds_bun/snapshots/command_pm_approve_builds_bun.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_pm_approve_builds_bun/snapshots/command_pm_approve_builds_bun.md
@@ -45,6 +45,6 @@ forwards bun pm trust --all (errors on empty project — no lockfile)
 **Exit code:** 1
 
 ```
-bun pm trust <version> (af24e281)
+bun pm trust <version> (<hash>)
 error: Lockfile not found
 ```

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_remove_bun/snapshots/command_remove_bun.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_remove_bun/snapshots/command_remove_bun.md
@@ -49,7 +49,7 @@ For more information, try '--help'.
 should error when remove not exists package from dev dependencies
 
 ```
-bun remove <version> (af24e281)
+bun remove <version> (<hash>)
 package.json doesn't have dependencies, there's nothing to remove!
 ```
 
@@ -68,7 +68,7 @@ package.json doesn't have dependencies, there's nothing to remove!
 should add packages to dependencies
 
 ```
-bun add <version> (af24e281)
+bun add <version> (<hash>)
 
 installed testnpm2@1.0.1
 
@@ -78,7 +78,7 @@ installed testnpm2@1.0.1
 ## `vp add -D test-vite-plus-install`
 
 ```
-bun add <version> (af24e281)
+bun add <version> (<hash>)
 
 installed test-vite-plus-install@1.0.0
 
@@ -88,7 +88,7 @@ installed test-vite-plus-install@1.0.0
 ## `vp add -O test-vite-plus-package-optional`
 
 ```
-bun add <version> (af24e281)
+bun add <version> (<hash>)
 
 installed test-vite-plus-package-optional@1.0.0
 
@@ -119,7 +119,7 @@ installed test-vite-plus-package-optional@1.0.0
 should remove packages from dependencies
 
 ```
-bun remove <version> (af24e281)
+bun remove <version> (<hash>)
 
 - testnpm2
 - test-vite-plus-install
@@ -144,7 +144,7 @@ bun remove <version> (af24e281)
 should remove package from optional dependencies
 
 ```
-bun remove <version> (af24e281)
+bun remove <version> (<hash>)
 
 package.json has no dependencies! Deleted empty lockfile
 

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_update_bun/snapshots/command_update_bun.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_update_bun/snapshots/command_update_bun.md
@@ -40,7 +40,7 @@ Documentation: https://viteplus.dev/guide/install
 should update package within semver range
 
 ```
-bun update <version> (af24e281)
+bun update <version> (<hash>)
 
  test-vite-plus-package@1.0.0
  test-vite-plus-package-optional@1.0.0
@@ -74,7 +74,7 @@ installed testnpm2@1.0.1
 should update to absolute latest version
 
 ```
-bun update <version> (af24e281)
+bun update <version> (<hash>)
 
 installed testnpm2@1.0.1
 

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_why_bun/snapshots/command_why_bun.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_why_bun/snapshots/command_why_bun.md
@@ -40,7 +40,7 @@ should install packages first
 ```
 VITE+ - The Unified Toolchain for the Web
 
-bun install <version> (af24e281)
+bun install <version> (<hash>)
 
  test-vite-plus-package@1.0.0
  test-vite-plus-package-optional@1.0.0

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/create_approve_builds_bun/snapshots/create_approve_builds_bun.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/create_approve_builds_bun/snapshots/create_approve_builds_bun.md
@@ -98,7 +98,7 @@ no trustedDependencies, the build was not run
 the guidance's `vp pm approve-builds` command approves the gated build
 
 ```
-bun pm trust <version> (0d9b296a)
+bun pm trust <version> (<hash>)
 
 ./node_modules/core-js @3.39.0
  ✓ [postinstall]: node -e "try{require('./postinstall')}catch(e){}"

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/redact.rs
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/redact.rs
@@ -49,6 +49,12 @@ static TOOL_VERSION_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
     )
     .unwrap()
 });
+// bun banners append the build's short commit hash after the version
+// ("bun pm trust v1.4.0 (34cbb9a40)"), which changes with every bun release.
+// The version is already masked to `<version>` by the passes above; anchor on
+// that token so parenthesized hex elsewhere stays assertable.
+static BUN_BUILD_HASH_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"(<version> )\([0-9a-f]{6,12}\)").unwrap());
 // The workspace's own vite-plus / @voidzero-dev/vite-plus-core version is
 // written verbatim into scaffolded catalogs and manifests (`vite-plus: 0.2.3`,
 // `"vite-plus": "0.2.3"`, `npm:@voidzero-dev/vite-plus-core@0.2.3`). Unlike
@@ -428,6 +434,10 @@ pub fn redact_output(
 
     // Redact bare runtime-tool versions by name context (see TOOL_VERSION_RE)
     output = TOOL_VERSION_RE.replace_all(&output, "$1$2<version>").into_owned();
+
+    // Redact bun's build hash next to an already-masked version
+    // (see BUN_BUILD_HASH_RE), which changes with every bun release.
+    output = BUN_BUILD_HASH_RE.replace_all(&output, "$1(<hash>)").into_owned();
 
     // Redact the workspace's own vite-plus/core version by package context
     // (see VP_VERSION_RE), which bumps on every release.

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/redact.rs
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/redact.rs
@@ -51,10 +51,12 @@ static TOOL_VERSION_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
 });
 // bun banners append the build's short commit hash after the version
 // ("bun pm trust v1.4.0 (34cbb9a40)"), which changes with every bun release.
-// The version is already masked to `<version>` by the passes above; anchor on
-// that token so parenthesized hex elsewhere stays assertable.
-static BUN_BUILD_HASH_RE: LazyLock<regex::Regex> =
-    LazyLock::new(|| regex::Regex::new(r"(<version> )\([0-9a-f]{6,12}\)").unwrap());
+// The version is already masked to `<version>` by the passes above; require
+// the leading `bun <subcommand>` context so version-plus-hash lines from
+// other tools stay assertable.
+static BUN_BUILD_HASH_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r"(\bbun(?: [a-z-]+)* <version> )\([0-9a-f]{6,12}\)").unwrap()
+});
 // The workspace's own vite-plus / @voidzero-dev/vite-plus-core version is
 // written verbatim into scaffolded catalogs and manifests (`vite-plus: 0.2.3`,
 // `"vite-plus": "0.2.3"`, `npm:@voidzero-dev/vite-plus-core@0.2.3`). Unlike

--- a/crates/vp_cli_snapshots/tests/redact_unit.rs
+++ b/crates/vp_cli_snapshots/tests/redact_unit.rs
@@ -77,6 +77,17 @@ fn masks_bare_runtime_tool_versions_by_name_context() {
 }
 
 #[test]
+fn masks_bun_build_hash_after_masked_version() {
+    // bun banners append the build's short commit hash after the version,
+    // which changes with every bun release.
+    let input = "bun pm trust v1.4.0 (34cbb9a40)\n".to_owned();
+    assert_eq!(redact_output(input, &[], true), "bun pm trust <version> (<hash>)\n");
+    // Parenthesized hex without a preceding masked version stays verbatim.
+    let unrelated = "commit (deadbeef1) applied\n".to_owned();
+    assert_eq!(redact_output(unrelated.clone(), &[], true), unrelated);
+}
+
+#[test]
 fn masks_managed_node_versions_in_environment_output() {
     let input = concat!(
         "Node: 24.18.1\n",

--- a/crates/vp_cli_snapshots/tests/redact_unit.rs
+++ b/crates/vp_cli_snapshots/tests/redact_unit.rs
@@ -77,7 +77,7 @@ fn masks_bare_runtime_tool_versions_by_name_context() {
 }
 
 #[test]
-fn masks_bun_build_hash_after_masked_version() {
+fn masks_bun_build_hash_only_in_bun_banners() {
     // bun banners append the build's short commit hash after the version,
     // which changes with every bun release.
     let input = "bun pm trust v1.4.0 (34cbb9a40)\n".to_owned();


### PR DESCRIPTION
bun banners append the build's short commit hash after the version ("bun pm trust v1.4.0 (34cbb9a40)"), and the hash changes with every bun release. The version was already masked, but the hash was recorded verbatim, so snapshots of fixtures that follow the latest bun broke whenever bun shipped a release, as create_approve_builds_bun did when bun 1.4.0 came out.

Ref: #2513 [CI Failure](https://github.com/voidzero-dev/vite-plus/actions/runs/32384435197/job/96475848783)