### PR TITLE
fix(cli): support GitLab setup-vp legacy layout

### DIFF
--- a/.github/workflows/test-standalone-install.yml
+++ b/.github/workflows/test-standalone-install.yml
@@ -233,7 +233,7 @@ jobs:
           cat "$OUTPUT"
           grep -F "Set VP_BIN_DIR, VP_DATA_DIR, and VP_CACHE_DIR together" "$OUTPUT"
 
-      - name: Existing setup-vp uses legacy layout
+      - name: Existing GitHub setup-vp uses legacy layout
         run: |
           set -euo pipefail
           LEGACY=$(mktemp -d)
@@ -245,6 +245,27 @@ jobs:
           unset VP_HOME VP_BIN_DIR VP_DATA_DIR VP_CACHE_DIR
           unset XDG_DATA_HOME XDG_CACHE_HOME XDG_CONFIG_HOME XDG_STATE_HOME
           VP_LOCAL_TGZ="$FAKE_TGZ" VP_VERSION=local-setup-vp-legacy bash packages/cli/install.sh
+
+          test -e "$LEGACY/.vite-plus/current"
+          test -e "$LEGACY/.vite-plus/bin/vp"
+          test ! -d "$LEGACY/.local/share/vite-plus"
+          test "$(readlink "$LEGACY/.vite-plus/bin/vp")" = "$LEGACY/.vite-plus/current/bin/vp"
+          "$LEGACY/.vite-plus/bin/vp" --version
+
+      - name: Existing GitLab setup-vp uses legacy layout
+        run: |
+          set -euo pipefail
+          LEGACY=$(mktemp -d)
+          FAKE_TGZ=$(mktemp)
+          export HOME="$LEGACY"
+          export USERPROFILE="$LEGACY"
+          unset GITHUB_ACTION_REPOSITORY
+          export GITLAB_CI=true
+          export SETUP_VP_SETUP_REF=v1.15.0
+          unset VP_VPDIRS_AWARE
+          unset VP_HOME VP_BIN_DIR VP_DATA_DIR VP_CACHE_DIR
+          unset XDG_DATA_HOME XDG_CACHE_HOME XDG_CONFIG_HOME XDG_STATE_HOME
+          VP_LOCAL_TGZ="$FAKE_TGZ" VP_VERSION=local-setup-vp-gitlab-legacy bash packages/cli/install.sh
 
           test -e "$LEGACY/.vite-plus/current"
           test -e "$LEGACY/.vite-plus/bin/vp"

--- a/packages/cli/install.sh
+++ b/packages/cli/install.sh
@@ -176,11 +176,14 @@ resolution_home_dir() {
   fi
 }
 
-# Released setup-vp versions add ~/.vite-plus/bin to the GitHub Actions PATH.
-# They do this after the installer exits. Use the monolithic layout until
-# setup-vp declares support for VP_DUMP_DIRS.
+# Released setup-vp versions add ~/.vite-plus/bin to the GitHub Actions or
+# GitLab CI/CD PATH. They do this after the installer exits. Use the monolithic
+# layout until setup-vp declares support for VP_DUMP_DIRS.
 enable_setup_vp_legacy_compatibility() {
-  [ "${GITHUB_ACTION_REPOSITORY:-}" = "voidzero-dev/setup-vp" ] || return 0
+  if [ "${GITHUB_ACTION_REPOSITORY:-}" != "voidzero-dev/setup-vp" ]; then
+    [ "${GITLAB_CI:-}" = "true" ] || return 0
+    [ -n "${SETUP_VP_SETUP_REF:-}" ] || return 0
+  fi
   [ "${VP_VPDIRS_AWARE:-}" != "1" ] || return 0
   [ -z "${VP_HOME:-}" ] || return 0
   [ -z "${VP_BIN_DIR:-}" ] || return 0


### PR DESCRIPTION
Older GitLab setup-vp templates add `~/.vite-plus/bin` to PATH after the installer exits. The installer now selects the legacy layout for these templates. A template can set `VP_VPDIRS_AWARE=1` to select the new layout.

The standalone installer workflow now tests the GitHub and GitLab compatibility paths.