### PR TITLE
fix(trampoline): reject unversioned shim pointers

### DIFF
--- a/.github/workflows/test-standalone-install.yml
+++ b/.github/workflows/test-standalone-install.yml
@@ -218,6 +218,23 @@ jobs:
       - name: Build local vp
         run: cargo build --release -p vp_global_cli
 
+      - name: Shell installer rejects an unversioned Node sidecar
+        run: |
+          set -euo pipefail
+          eval "$(sed '/^main "[$]@"$/d' packages/cli/install.sh)"
+
+          TEST_ROOT=$(mktemp -d)
+          TEST_BIN="$TEST_ROOT/bin"
+          INSTALL_DIR="$TEST_ROOT/data"
+          mkdir -p "$TEST_BIN"
+          touch "$TEST_BIN/node.exe" "$TEST_ROOT/vp.exe"
+          printf '%s\n' "$INSTALL_DIR" > "$TEST_BIN/node.shim"
+
+          if is_vite_plus_node_shim "$TEST_BIN" "$TEST_ROOT/vp.exe"; then
+            echo "install.sh accepted an unversioned node.shim"
+            exit 1
+          fi
+
       - name: CI hides shell file warnings
         run: |
           set -euo pipefail
@@ -1438,7 +1455,7 @@ jobs:
           if (Test-Path $legacyRoot) { throw "implode left the monolithic root" }
           if ($removingRoots.Count -ne 0) { throw "implode left a renamed monolithic root" }
 
-      - name: PowerShell installer preserves an unrelated Node executable
+      - name: PowerShell installer rejects an unversioned Node sidecar
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
@@ -1447,10 +1464,12 @@ jobs:
           $bin = Join-Path $root "bin"
           $cache = Join-Path $root "cache"
           $node = Join-Path $bin "node.exe"
+          $pointer = Join-Path $bin "node.shim"
           $fakeTgz = Join-Path $root "vite-plus.tgz"
           Remove-Item -Recurse -Force $root -ErrorAction SilentlyContinue
           New-Item -ItemType Directory -Force -Path $bin | Out-Null
           [System.IO.File]::WriteAllText($node, "foreign-node")
+          [System.IO.File]::WriteAllText($pointer, "$data`n")
           New-Item -ItemType File -Force -Path $fakeTgz | Out-Null
 
           Remove-Item Env:VP_HOME -ErrorAction SilentlyContinue
@@ -1469,8 +1488,8 @@ jobs:
           if ([System.IO.File]::ReadAllText($node) -ne "foreign-node") {
             Write-Error "install.ps1 replaced an unrelated node.exe"
           }
-          if (Test-Path (Join-Path $bin "node.shim")) {
-            Write-Error "install.ps1 claimed an unrelated node.exe"
+          if ([System.IO.File]::ReadAllText($pointer) -ne "$data`n") {
+            Write-Error "install.ps1 changed the unversioned node.shim"
           }
 
       - name: Complete directory overrides keep the split layout through the trampoline

--- a/crates/vp_shared/src/dirs.rs
+++ b/crates/vp_shared/src/dirs.rs
@@ -35,7 +35,7 @@ pub const SHIM_POINTER_HEADER: &str = "vite-plus-shim-v1";
 /// The complete `VP_BIN_DIR`, `VP_DATA_DIR`, and `VP_CACHE_DIR` group can put
 /// the shim and payload under different parents. A trampoline must not read
 /// directory environment variables. Installers and `vp env setup` write this
-/// one-line UTF-8 file next to each trampoline copy.
+/// versioned UTF-8 sidecar next to each trampoline copy.
 pub const SHIM_POINTER_EXTENSION: &str = "shim";
 
 /// Sidecar filename for a trampoline named `<exe_stem>.exe`.
@@ -187,8 +187,7 @@ fn shim_pointer_data(text: &str) -> Option<&str> {
     }
     let mut lines = text.lines();
     if lines.next()? != SHIM_POINTER_HEADER {
-        // Compatibility with the one-line sidecars from earlier PR previews.
-        return Some(text);
+        return None;
     }
     lines.find_map(|line| line.strip_prefix("data=").filter(|data| !data.is_empty()))
 }
@@ -247,7 +246,7 @@ mod tests {
     }
 
     #[test]
-    fn windows_trampoline_ownership_accepts_legacy_sidecar() {
+    fn windows_trampoline_ownership_rejects_unversioned_sidecar() {
         EnvConfig::scoped(|config| {
             let node = config.dirs.bin.join("node.exe");
             std::fs::create_dir_all(&config.dirs.bin).unwrap();
@@ -258,7 +257,7 @@ mod tests {
             )
             .unwrap();
 
-            assert!(config.dirs.owns_windows_trampoline(node.as_path()));
+            assert!(!config.dirs.owns_windows_trampoline(node.as_path()));
         });
     }
 

--- a/crates/vp_trampoline/src/main.rs
+++ b/crates/vp_trampoline/src/main.rs
@@ -40,11 +40,7 @@ const SHIM_POINTER_HEADER: &str = "vite-plus-shim-v1";
 
 enum ShimLayout {
     SingleRoot,
-    Split {
-        cache: std::path::PathBuf,
-    },
-    /// One-line sidecars from earlier PR previews did not record provenance.
-    Legacy,
+    Split { cache: std::path::PathBuf },
 }
 
 struct ShimPointer {
@@ -63,31 +59,12 @@ enum ChildDirPins<'a> {
     SingleRoot,
     /// The versioned sidecar explicitly selected split roots.
     Split { cache: &'a std::path::Path },
-    /// A legacy sidecar and independent roots. Old sidecars did not record
-    /// cache, so use the Windows platform fallback.
-    LegacySplit { cache: std::path::PathBuf },
 }
 
-fn legacy_split_cache(data: &std::path::Path) -> std::path::PathBuf {
-    env::var_os("LOCALAPPDATA")
-        .map(std::path::PathBuf::from)
-        .filter(|path| path.is_absolute())
-        .map(|path| path.join("vite-plus").join("cache"))
-        .unwrap_or_else(|| data.join("cache"))
-}
-
-fn child_dir_pins<'a>(bin_dir: &std::path::Path, pointer: &'a ShimPointer) -> ChildDirPins<'a> {
+fn child_dir_pins(pointer: &ShimPointer) -> ChildDirPins<'_> {
     match &pointer.layout {
         ShimLayout::SingleRoot => ChildDirPins::SingleRoot,
         ShimLayout::Split { cache } => ChildDirPins::Split { cache },
-        ShimLayout::Legacy if bin_dir == pointer.data.join("bin").as_path() => {
-            // Compatibility with one-line sidecars from earlier PR previews.
-            // Their path shape is ambiguous, so preserve their old behavior.
-            ChildDirPins::SingleRoot
-        }
-        ShimLayout::Legacy => {
-            ChildDirPins::LegacySplit { cache: legacy_split_cache(&pointer.data) }
-        }
     }
 }
 
@@ -112,10 +89,7 @@ fn read_shim_pointer(exe_path: &std::path::Path) -> Option<ShimPointer> {
     }
     let mut lines = text.lines();
     if lines.next()? != SHIM_POINTER_HEADER {
-        return Some(ShimPointer {
-            data: std::path::PathBuf::from(text),
-            layout: ShimLayout::Legacy,
-        });
+        return None;
     }
 
     let mut layout = None;
@@ -167,17 +141,11 @@ fn main() {
     //    - Otherwise, set VP_SHIM_TOOL so vp.exe enters shim dispatch
     let mut cmd = Command::new(&location.exe);
     cmd.args(env::args_os().skip(1));
-    match child_dir_pins(bin_dir, &location.pointer) {
+    match child_dir_pins(&location.pointer) {
         ChildDirPins::SingleRoot => {
             cmd.env("VP_HOME", &location.pointer.data);
         }
         ChildDirPins::Split { cache } => {
-            cmd.env_remove("VP_HOME");
-            cmd.env("VP_DATA_DIR", &location.pointer.data);
-            cmd.env("VP_BIN_DIR", bin_dir);
-            cmd.env("VP_CACHE_DIR", cache);
-        }
-        ChildDirPins::LegacySplit { cache } => {
             cmd.env_remove("VP_HOME");
             cmd.env("VP_DATA_DIR", &location.pointer.data);
             cmd.env("VP_BIN_DIR", bin_dir);
@@ -263,7 +231,8 @@ mod resolve_tests {
         let data = root.join("data-root");
         fs::create_dir_all(&bin).unwrap();
         fs::create_dir_all(&data).unwrap();
-        fs::write(bin.join("vp.shim"), format!("{}\n", data.display())).unwrap();
+        fs::write(bin.join("vp.shim"), versioned_pointer("split", &data, &root.join("cache")))
+            .unwrap();
 
         assert!(resolve_vp_exe(&bin.join("vp.exe")).is_none());
         let _ = fs::remove_dir_all(&root);
@@ -278,12 +247,28 @@ mod resolve_tests {
         fs::create_dir_all(&bin).unwrap();
         write_exe(&data.join("current").join("bin").join("vp.exe"));
         write_exe(&root.join("data").join("current").join("bin").join("vp.exe"));
-        fs::write(bin.join("vp.shim"), format!("{}\n", data.display())).unwrap();
+        fs::write(bin.join("vp.shim"), versioned_pointer("split", &data, &root.join("cache")))
+            .unwrap();
 
         let location = resolve_vp_exe(&bin.join("vp.exe")).unwrap();
         assert_eq!(location.exe, data.join("current").join("bin").join("vp.exe"));
         assert_eq!(location.pointer.data, data);
-        assert!(matches!(location.pointer.layout, ShimLayout::Legacy));
+        assert!(matches!(location.pointer.layout, ShimLayout::Split { .. }));
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn unversioned_pointer_is_rejected() {
+        let root =
+            std::env::temp_dir().join(format!("vp-trampoline-unversioned-{}", process::id()));
+        let _ = fs::remove_dir_all(&root);
+        let bin = root.join("bin");
+        let data = root.join("data");
+        fs::create_dir_all(&bin).unwrap();
+        write_exe(&data.join("current").join("bin").join("vp.exe"));
+        fs::write(bin.join("vp.shim"), format!("{}\n", data.display())).unwrap();
+
+        assert!(resolve_vp_exe(&bin.join("vp.exe")).is_none());
         let _ = fs::remove_dir_all(&root);
     }
 
@@ -297,8 +282,16 @@ mod resolve_tests {
         fs::create_dir_all(&bin).unwrap();
         write_exe(&node_data.join("current").join("bin").join("vp.exe"));
         write_exe(&decoy_data.join("current").join("bin").join("vp.exe"));
-        fs::write(bin.join("vp.shim"), format!("{}\n", decoy_data.display())).unwrap();
-        fs::write(bin.join("node.shim"), format!("{}\n", node_data.display())).unwrap();
+        fs::write(
+            bin.join("vp.shim"),
+            versioned_pointer("split", &decoy_data, &root.join("cache")),
+        )
+        .unwrap();
+        fs::write(
+            bin.join("node.shim"),
+            versioned_pointer("split", &node_data, &root.join("cache")),
+        )
+        .unwrap();
 
         let location = resolve_vp_exe(&bin.join("node.exe")).unwrap();
         assert_eq!(location.exe, node_data.join("current").join("bin").join("vp.exe"));
@@ -340,7 +333,7 @@ mod resolve_tests {
 
         let location = resolve_vp_exe(&bin.join("vp.exe")).unwrap();
         assert!(matches!(
-            child_dir_pins(&bin, &location.pointer),
+            child_dir_pins(&location.pointer),
             ChildDirPins::Split { cache: value } if value == cache
         ));
         let _ = fs::remove_dir_all(&root);
@@ -361,17 +354,8 @@ mod resolve_tests {
         .unwrap();
 
         let location = resolve_vp_exe(&bin.join("vp.exe")).unwrap();
-        assert!(matches!(child_dir_pins(&bin, &location.pointer), ChildDirPins::SingleRoot));
+        assert!(matches!(child_dir_pins(&location.pointer), ChildDirPins::SingleRoot));
         let _ = fs::remove_dir_all(&root);
-    }
-
-    #[test]
-    fn legacy_pointer_preserves_path_based_behavior() {
-        let data = std::path::PathBuf::from("/data/root");
-        let bin = std::path::PathBuf::from("/other/bin");
-        let pointer = ShimPointer { data: data.clone(), layout: ShimLayout::Legacy };
-        assert!(matches!(child_dir_pins(&data.join("bin"), &pointer), ChildDirPins::SingleRoot));
-        assert!(matches!(child_dir_pins(&bin, &pointer), ChildDirPins::LegacySplit { .. }));
     }
 }
 

--- a/packages/cli/install.ps1
+++ b/packages/cli/install.ps1
@@ -326,8 +326,7 @@ function Get-ShimPointerData {
     }
     $lines = $contents -split "`r?`n"
     if ($lines[0] -ne "vite-plus-shim-v1") {
-        # Compatibility with one-line sidecars from earlier PR previews.
-        return $contents
+        return $null
     }
     foreach ($line in $lines) {
         if ($line.StartsWith("data=")) {

--- a/packages/cli/install.sh
+++ b/packages/cli/install.sh
@@ -1055,8 +1055,7 @@ shim_pointer_data() {
   IFS= read -r first < "$file" || [ -n "$first" ] || return 1
   first="${first%$'\r'}"
   if [ "$first" != "vite-plus-shim-v1" ]; then
-    printf '%s\n' "$first"
-    return 0
+    return 1
   fi
   while IFS= read -r line || [ -n "$line" ]; do
     line="${line%$'\r'}"

--- a/rfcs/directory-layout.md
+++ b/rfcs/directory-layout.md
@@ -384,7 +384,8 @@ Vite+ writes a sidecar immediately after it copies a trampoline executable.
 `vp env setup --env-only` does not write sidecars. Setup without `--refresh`
 does not add a sidecar to a skipped executable. `vp env setup --refresh`
 replaces the executable and then records ownership of the new trampoline.
-The trampoline rejects sidecars that do not have the versioned format.
+The trampoline and ownership readers require the `vite-plus-shim-v1` header.
+They reject unversioned sidecars.
 
 On Windows, `vp implode` cannot delete the trampoline that started the current
 command. For a separate `<BIN>`, it renames the owned executable and its

--- a/rfcs/directory-layout.md
+++ b/rfcs/directory-layout.md
@@ -384,8 +384,7 @@ Vite+ writes a sidecar immediately after it copies a trampoline executable.
 `vp env setup --env-only` does not write sidecars. Setup without `--refresh`
 does not add a sidecar to a skipped executable. `vp env setup --refresh`
 replaces the executable and then records ownership of the new trampoline.
-The trampoline also accepts the earlier one-line sidecar format. That format
-contains only the data root, so it keeps the earlier path-based behavior.
+The trampoline rejects sidecars that do not have the versioned format.
 
 On Windows, `vp implode` cannot delete the trampoline that started the current
 command. For a separate `<BIN>`, it renames the owned executable and its

--- a/rfcs/trampoline-exe-for-shims.md
+++ b/rfcs/trampoline-exe-for-shims.md
@@ -41,7 +41,7 @@ This is a fundamental limitation of batch file execution on Windows. The prompt:
 As demonstrated in [issue #835](https://github.com/voidzero-dev/vite-plus/issues/835):
 
 1. Running `vp dev` (through `vp.cmd`) shows `Terminate batch job (Y/N)?` on Ctrl+C
-2. Running `~/.vite-plus/current/bin/vp.exe dev` directly does **NOT** show the prompt
+2. Running `<DATA>/current/bin/vp.exe dev` directly does **NOT** show the prompt
 3. Running `npm.cmd run dev` shows the prompt; running `npm.ps1 run dev` does not
 4. The prompt can appear multiple times when `.cmd` wrappers chain (e.g., `vp.cmd` → `npm.cmd`)
 
@@ -55,36 +55,66 @@ PowerShell `.ps1` scripts avoid the Ctrl+C issue but have critical limitations:
 
 ## Architecture
 
+This RFC uses the `<BIN>`, `<DATA>`, and `<CACHE>` roots from the
+[directory layout RFC](./directory-layout.md).
+
 ### Unix (Symlink-Based — Unchanged)
 
 On Unix, shims are symlinks to the `vp` binary. The binary detects the tool name from `argv[0]`:
 
 ```
-~/.vite-plus/bin/
-├── vp       → ../current/bin/vp     (symlink)
-├── node     → ../current/bin/vp     (symlink)
-├── npm      → ../current/bin/vp     (symlink)
-├── npx      → ../current/bin/vp     (symlink)
-├── corepack → ../current/bin/vp     (symlink)
-├── vpx      → ../current/bin/vp     (symlink)
-└── vpr      → ../current/bin/vp     (symlink)
+<BIN>/
+├── vp       → <DATA>/current/bin/vp     (symlink)
+├── node     → <DATA>/current/bin/vp     (symlink)
+├── npm      → <DATA>/current/bin/vp     (symlink)
+├── npx      → <DATA>/current/bin/vp     (symlink)
+├── corepack → <DATA>/current/bin/vp     (symlink)
+├── vpx      → <DATA>/current/bin/vp     (symlink)
+└── vpr      → <DATA>/current/bin/vp     (symlink)
 ```
 
 ### Windows (Trampoline `.exe` Files)
 
 ```
-~/.vite-plus/bin/
-├── vp.exe       # Trampoline → spawns current\bin\vp.exe
-├── node.exe     # Trampoline → sets VP_SHIM_TOOL=node, spawns vp.exe
-├── npm.exe      # Trampoline → sets VP_SHIM_TOOL=npm, spawns vp.exe
-├── npx.exe      # Trampoline → sets VP_SHIM_TOOL=npx, spawns vp.exe
-├── corepack.exe # Trampoline → sets VP_SHIM_TOOL=corepack, spawns vp.exe
-├── vpx.exe      # Trampoline → sets VP_SHIM_TOOL=vpx, spawns vp.exe
-├── vpr.exe      # Trampoline → sets VP_SHIM_TOOL=vpr, spawns vp.exe
-└── tsc.exe      # Trampoline → sets VP_SHIM_TOOL=tsc, spawns vp.exe (package shim)
+<BIN>/
+├── vp.exe       # Trampoline executable
+├── vp.shim      # Directory-layout sidecar for vp.exe
+├── node.exe     # Trampoline executable
+├── node.shim    # Directory-layout sidecar for node.exe
+├── npm.exe      # Trampoline executable
+├── npm.shim     # Directory-layout sidecar for npm.exe
+└── ...
+
+<DATA>/current/bin/
+├── vp.exe       # Main CLI binary
+└── vp-shim.exe  # Trampoline template
 ```
 
-Each trampoline is a copy of `vp-shim.exe` (the template binary distributed alongside `vp.exe`).
+Each trampoline is a copy of `vp-shim.exe`. Each copy has a sidecar with the
+same file stem. For example, `node.exe` reads `node.shim`. The tool name is not
+stored in the sidecar.
+
+A split-layout sidecar has this format:
+
+```text
+vite-plus-shim-v1
+layout=split
+data=C:\Users\alice\AppData\Local\vite-plus\data
+cache=C:\Users\alice\AppData\Local\vite-plus\cache
+```
+
+A `VP_HOME=C:\Tools\vite-plus` install uses the single-root layout:
+
+```text
+vite-plus-shim-v1
+layout=single-root
+data=C:\Tools\vite-plus
+cache=C:\Tools\vite-plus\cache
+```
+
+The exact `vite-plus-shim-v1` header is required. The trampoline and ownership
+checks reject unversioned sidecars. The sidecar is the source of truth for the
+layout and also records that Vite+ owns the adjacent executable.
 
 **Note**: npm-installed packages (via `npm install -g`) still use `.cmd` wrappers because they lack `PackageMetadata` and need to point directly at npm's generated scripts.
 
@@ -96,64 +126,29 @@ Each trampoline is a copy of `vp-shim.exe` (the template binary distributed alon
 crates/vp_trampoline/
 ├── Cargo.toml      # Zero external dependencies
 ├── src/
-│   └── main.rs     # ~90 lines, single-file binary
+│   └── main.rs     # Sidecar parser, launcher, and portable tests
 ```
 
 ### Trampoline Binary
 
-The trampoline has **zero external dependencies** — the Win32 FFI call (`SetConsoleCtrlHandler`) is declared inline to avoid the heavy `windows`/`windows-core` crates. It also avoids `core::fmt` (~100KB overhead) by never using `format!`, `eprintln!`, `println!`, or `.unwrap()`.
+The trampoline has **zero external dependencies**. It declares the Win32
+`SetConsoleCtrlHandler` call inline to avoid the `windows` and `windows-core`
+crates. It also avoids direct `core::fmt` use. It does not use `format!`,
+`eprintln!`, `println!`, or `.unwrap()` in the production path.
 
-```rust
-use std::{env, process::{self, Command}};
+The trampoline performs these steps:
 
-fn main() {
-    // 1. Determine tool name from own filename (e.g., node.exe → "node")
-    let exe_path = env::current_exe().unwrap_or_else(|_| process::exit(1));
-    let tool_name = exe_path.file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or_else(|| process::exit(1));
+1. Read its executable path and get the tool name from the file stem.
+2. Read the same-stem `.shim` file. Require the `vite-plus-shim-v1` header and
+   parse the layout, data root, and cache root.
+3. Resolve the child executable as `<DATA>/current/bin/vp.exe`.
+4. Pin the recorded layout in the child environment. A `single-root` sidecar
+   sets `VP_HOME`. A `split` sidecar removes `VP_HOME` and sets `VP_DATA_DIR`,
+   `VP_BIN_DIR`, and `VP_CACHE_DIR`.
+5. Install the Ctrl+C handler, start the child, and propagate its exit code.
 
-    // 2. Locate vp.exe at ../current/bin/vp.exe
-    let bin_dir = exe_path.parent().unwrap_or_else(|| process::exit(1));
-    let vp_home = bin_dir.parent().unwrap_or_else(|| process::exit(1));
-    let vp_exe = vp_home.join("current").join("bin").join("vp.exe");
-
-    // 3. Install Ctrl+C handler (ignores signal; child handles it)
-    install_ctrl_handler();
-
-    // 4. Spawn vp.exe with env vars
-    let mut cmd = Command::new(&vp_exe);
-    cmd.args(env::args_os().skip(1));
-    cmd.env("VP_HOME", vp_home);
-
-    if tool_name != "vp" {
-        cmd.env("VP_SHIM_TOOL", tool_name);
-        cmd.env_remove("VP_TOOL_RECURSION");
-    }
-
-    // 5. Propagate exit code (error message via write_all, not eprintln!)
-    match cmd.status() {
-        Ok(status) => process::exit(exit_code_from_status(status)),
-        Err(_) => {
-            use std::io::Write;
-            let mut stderr = std::io::stderr().lock();
-            let _ = stderr.write_all(b"vite-plus: failed to execute ");
-            let _ = stderr.write_all(vp_exe.as_os_str().as_encoded_bytes());
-            let _ = stderr.write_all(b"\n");
-            process::exit(1);
-        }
-    }
-}
-
-fn install_ctrl_handler() {
-    type HandlerRoutine = unsafe extern "system" fn(ctrl_type: u32) -> i32;
-    unsafe extern "system" {
-        fn SetConsoleCtrlHandler(handler: Option<HandlerRoutine>, add: i32) -> i32;
-    }
-    unsafe extern "system" fn handler(_ctrl_type: u32) -> i32 { 1 }
-    unsafe { SetConsoleCtrlHandler(Some(handler), 1); }
-}
-```
+The trampoline fails if the sidecar is missing, malformed, unversioned, or
+points to a missing payload. It does not infer the layout from directory paths.
 
 ### Size Optimization
 
@@ -168,12 +163,16 @@ fn install_ctrl_handler() {
 
 ### Environment Variables
 
-The trampoline sets three env vars before spawning `vp.exe`:
+The trampoline pins the selected directory layout before it starts `vp.exe`:
 
 | Variable            | When                       | Purpose                                                                        |
 | ------------------- | -------------------------- | ------------------------------------------------------------------------------ |
-| `VP_HOME`           | Always                     | Tells vp.exe the install directory (derived from `bin_dir.parent()`)           |
-| `VP_SHIM_TOOL`      | Tool shims only (not "vp") | Tells vp.exe to enter shim dispatch mode for the named tool                    |
+| `VP_HOME`           | `single-root` sidecar      | Pins the data root as the single install root                                  |
+| `VP_HOME`           | `split` sidecar            | Removed so it cannot override the recorded split layout                        |
+| `VP_DATA_DIR`       | `split` sidecar            | Pins the recorded data root                                                    |
+| `VP_BIN_DIR`        | `split` sidecar            | Pins the trampoline executable directory                                       |
+| `VP_CACHE_DIR`      | `split` sidecar            | Pins the recorded cache root                                                   |
+| `VP_SHIM_TOOL`      | Tool shims only (not `vp`) | Tells `vp.exe` to enter shim dispatch mode for the named tool                  |
 | `VP_TOOL_RECURSION` | Removed for tool shims     | Clears the recursion marker for fresh version resolution in nested invocations |
 
 ### Ctrl+C Handling
@@ -193,9 +192,10 @@ The trampoline installs a console control handler that returns `TRUE` (1):
 `detect_shim_tool()` in `shim/mod.rs` checks `VP_SHIM_TOOL` env var **before** `argv[0]`:
 
 ```
-Trampoline (node.exe)
-  → sets VP_SHIM_TOOL=node, VP_HOME=..., removes VP_TOOL_RECURSION
-  → spawns current/bin/vp.exe with original args
+Trampoline (<BIN>/node.exe + <BIN>/node.shim)
+  → reads the recorded layout, data root, and cache root
+  → pins the layout, sets VP_SHIM_TOOL=node, and removes VP_TOOL_RECURSION
+  → spawns <DATA>/current/bin/vp.exe with the original args
     → detect_shim_tool() reads env var → "node"
     → dispatch("node", args)
     → resolves Node.js version, executes real node
@@ -203,7 +203,9 @@ Trampoline (node.exe)
 
 ### Running Exe Overwrite
 
-When `vp env setup --refresh` is invoked through the trampoline (`~/.vite-plus/bin/vp.exe`), the trampoline is still running. Windows prevents overwriting a running `.exe`. The solution:
+When `vp env setup --refresh` is invoked through the trampoline
+(`<BIN>/vp.exe`), the trampoline is still running. Windows prevents
+overwriting a running `.exe`. The solution:
 
 1. Rename existing `vp.exe` to `vp.exe.<unix_timestamp>.old`
 2. Copy new trampoline to `vp.exe`
@@ -214,7 +216,7 @@ When `vp env setup --refresh` is invoked through the trampoline (`~/.vite-plus/b
 During `vp upgrade`, after the `current` link is swapped to the new version, `vp env setup --refresh` is invoked to regenerate all trampoline `.exe` files. This ensures that when the trampoline binary (`vp-shim.exe`) changes between versions, all shims pick up the new version:
 
 1. **Core shims** (`vp.exe`, `node.exe`, `npm.exe`, `npx.exe`, `corepack.exe`, `vpx.exe`, `vpr.exe`) are refreshed by the standard `--refresh` logic.
-2. **Package shims** (e.g., `tsc.exe`, `eslint.exe`, installed via `vp install -g`) are discovered by scanning `~/.vite-plus/bins/` for `BinConfig` entries with `source: Vp`, and each `.exe` is replaced with the new trampoline.
+2. **Package shims** (e.g., `tsc.exe`, `eslint.exe`, installed via `vp install -g`) are discovered by scanning `<DATA>/bins/` for `BinConfig` entries with `source: Vp`, and each `.exe` is replaced with the new trampoline.
 
 Package shims installed via npm interception (`source: Npm`) use `.cmd` wrappers, not trampoline `.exe` files, and are not affected by this refresh.
 
@@ -225,7 +227,7 @@ Additionally, re-installing a global package (`vp install -g <pkg>`) always re-c
 The trampoline binary (`vp-shim.exe`) is distributed alongside `vp.exe`:
 
 ```
-~/.vite-plus/current/bin/
+<DATA>/current/bin/
 ├── vp.exe          # Main CLI binary
 └── vp-shim.exe     # Trampoline template (copied as shims)
 ```
@@ -237,7 +239,7 @@ Included in:
 - `install.ps1` and `install.sh` (both local dev and download paths)
 - `extract_platform_package()` in the upgrade path
 
-### Legacy Fallback
+### Pre-Trampoline Release Fallback
 
 When installing a pre-trampoline version (no `vp-shim.exe` in the package):
 
@@ -246,20 +248,24 @@ When installing a pre-trampoline version (no `vp-shim.exe` in the package):
 
 ## Comparison with uv-trampoline
 
-| Aspect              | uv-trampoline                            | vite-plus trampoline                 |
-| ------------------- | ---------------------------------------- | ------------------------------------ |
-| **Purpose**         | Launch Python with embedded script       | Forward to `vp.exe`                  |
-| **Complexity**      | High (PE resources, zipimport)           | Low (filename + spawn)               |
-| **Data embedding**  | PE resources (kind, path, script ZIP)    | None (uses filename + relative path) |
-| **Dependencies**    | `windows` crate (unsafe, no CRT)         | Zero (raw FFI declaration)           |
-| **Toolchain**       | Nightly Rust (`panic="immediate-abort"`) | Stable Rust                          |
-| **Binary size**     | 39-47 KB                                 | ~200 KB                              |
-| **Entry point**     | `#![no_main]` + `mainCRTStartup`         | Standard `fn main()`                 |
-| **Error output**    | `ufmt` (no `core::fmt`)                  | `write_all` (no `core::fmt`)         |
-| **Ctrl+C handling** | `SetConsoleCtrlHandler` → ignore         | Same approach                        |
-| **Exit code**       | `GetExitCodeProcess` → `exit()`          | `Command::status()` → `exit()`       |
+| Aspect              | uv-trampoline                            | vite-plus trampoline              |
+| ------------------- | ---------------------------------------- | --------------------------------- |
+| **Purpose**         | Launch Python with embedded script       | Forward to `vp.exe`               |
+| **Complexity**      | High (PE resources, zipimport)           | Low (filename + spawn)            |
+| **Data embedding**  | PE resources (kind, path, script ZIP)    | Adjacent directory-layout sidecar |
+| **Dependencies**    | `windows` crate (unsafe, no CRT)         | Zero (raw FFI declaration)        |
+| **Toolchain**       | Nightly Rust (`panic="immediate-abort"`) | Stable Rust                       |
+| **Binary size**     | 39-47 KB                                 | ~200 KB                           |
+| **Entry point**     | `#![no_main]` + `mainCRTStartup`         | Standard `fn main()`              |
+| **Error output**    | `ufmt` (no `core::fmt`)                  | `write_all` (no `core::fmt`)      |
+| **Ctrl+C handling** | `SetConsoleCtrlHandler` → ignore         | Same approach                     |
+| **Exit code**       | `GetExitCodeProcess` → `exit()`          | `Command::status()` → `exit()`    |
 
-The vite-plus trampoline is significantly simpler because it doesn't need to embed data in PE resources — it just reads its own filename, finds `vp.exe` at a fixed relative path, and spawns it. The ~150KB size difference from uv-trampoline comes from `std::process::Command` (which internally pulls in `core::fmt`) versus raw `CreateProcessW` with nightly-only `#![no_main]`.
+The vite-plus trampoline does not embed data in PE resources. It reads its own
+filename and adjacent sidecar. It then resolves `vp.exe` under the recorded data
+root. The ~150KB size difference from uv-trampoline comes from
+`std::process::Command` (which internally pulls in `core::fmt`) versus raw
+`CreateProcessW` with nightly-only `#![no_main]`.
 
 ## Alternatives Considered
 
@@ -277,7 +283,7 @@ Requires administrator privileges or Developer Mode. Not reliable for all users.
 
 ### 4. Copy `vp.exe` as Each Shim (Rejected)
 
-~5-10MB per copy. Trampoline achieves the same result at ~100KB.
+~5-10MB per copy. The trampoline achieves the same result at ~200KB.
 
 ### 5. `windows` Crate for FFI (Rejected)
 
@@ -285,7 +291,7 @@ Adds ~100KB to the binary for a single `SetConsoleCtrlHandler` call. Raw FFI dec
 
 ## Future Optimizations
 
-If the ~100KB binary size needs to be reduced further:
+If the ~200KB binary size needs to be reduced further:
 
 1. **Switch to nightly Rust** with `panic="immediate-abort"` and `#![no_main]` + `mainCRTStartup` (~50KB savings)
 2. **Use raw Win32 `CreateProcessW`** instead of `std::process::Command` (eliminates most of std's process machinery)


### PR DESCRIPTION
Require the `vite-plus-shim-v1` header for each Windows trampoline sidecar. Reject unversioned sidecars in the trampoline, ownership checks, and installers.

Remove the old layout inference and guessed cache path. Keep the explicit `single-root` and `split` behavior.

Update `rfcs/trampoline-exe-for-shims.md` and `rfcs/directory-layout.md`. Add regression tests for the `install.sh` and `install.ps1` ownership checks.