### PR TITLE
chore(deps): update napi to 3.12.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3738,15 +3738,16 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "3.11.0"
+version = "3.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de33522036981030a75c231829566bc63414e08101a6f5ff4ac6cef19c8e0941"
+checksum = "58c5f4d5375213fdb7be2655e152386e82f026f9a5ba36a75556e11359aafe09"
 dependencies = [
  "anyhow",
  "bitflags 2.13.1",
  "ctor",
  "futures",
  "indexmap",
+ "libc",
  "napi-build",
  "napi-sys",
  "nohash-hasher",
@@ -3759,9 +3760,9 @@ dependencies = [
 
 [[package]]
 name = "napi-build"
-version = "2.3.2"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9c366d2c8c60b86fa632df75f745509b52f9128f91a6bad4c796e44abb505e1"
+checksum = "60fdf9b392c50e7c4170fa633bd909490ed7835cea4c046776d1a4dd8d2ae0ab"
 
 [[package]]
 name = "napi-derive"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,7 +209,7 @@ libtest-mimic = "0.8.2"
 memchr = "2.7.4"
 mimalloc-safe = "0.1.62"
 mime = "0.3.17"
-napi = { version = "3.0.0", default-features = false, features = [
+napi = { version = "3.12.2", default-features = false, features = [
   "async",
   "error_anyhow",
   "anyhow",


### PR DESCRIPTION
This change updates `napi` to `3.12.2`. This release fixes `GHSA-wrm3-6gmv-vpmw` and `GHSA-qr54-xrr9-7575`.

The lockfile also updates `napi-build` to `2.4.1`. No source code changes are necessary.