### PR TITLE
fix(cli): run root-only workspaces in place

### DIFF
--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/settings_only_workspace/snapshots.toml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/settings_only_workspace/snapshots.toml
@@ -17,4 +17,7 @@ A root-only workspace has no target ambiguity. Static extraction cannot see
 the build input that the plugin supplies. Bare vp build must run in place in
 a non-interactive terminal.
 """
-steps = [{ argv = ["vp", "build"], tty = false }]
+steps = [
+  { argv = ["vp", "build"], tty = false, snapshot = false },
+  { argv = ["vpt", "list-dir", "dist/assets"], comment = "build output stays in the root workspace" },
+]

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/settings_only_workspace/snapshots.toml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/settings_only_workspace/snapshots.toml
@@ -8,3 +8,13 @@ a workspace root whose only runnable candidate is itself. Bare vp pack must
 run in place, TTY or not, never print the target listing.
 """
 steps = [{ argv = ["vp", "pack"], tty = false }]
+
+[[case]]
+name = "build_in_place"
+vp = ["local", "global"]
+comment = """
+A root-only workspace has no target ambiguity. Static extraction cannot see
+the build input that the plugin supplies. Bare vp build must run in place in
+a non-interactive terminal.
+"""
+steps = [{ argv = ["vp", "build"], tty = false }]

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/settings_only_workspace/snapshots/build_in_place.global.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/settings_only_workspace/snapshots/build_in_place.global.md
@@ -1,0 +1,17 @@
+# build_in_place
+
+A root-only workspace has no target ambiguity. Static extraction cannot see
+the build input that the plugin supplies. Bare vp build must run in place in
+a non-interactive terminal.
+
+## `vp build`
+
+```
+transforming...
+✓ 2 modules transformed.
+rendering chunks...
+computing gzip size...
+dist/assets/index-<hash>.js  <size> kB │ gzip: <size> kB
+
+✓ built in <duration>
+```

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/settings_only_workspace/snapshots/build_in_place.global.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/settings_only_workspace/snapshots/build_in_place.global.md
@@ -6,12 +6,11 @@ a non-interactive terminal.
 
 ## `vp build`
 
-```
-transforming...
-✓ 2 modules transformed.
-rendering chunks...
-computing gzip size...
-dist/assets/index-<hash>.js  <size> kB │ gzip: <size> kB
 
-✓ built in <duration>
+## `vpt list-dir dist/assets`
+
+build output stays in the root workspace
+
+```
+index-<hash>.js
 ```

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/settings_only_workspace/snapshots/build_in_place.local.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/settings_only_workspace/snapshots/build_in_place.local.md
@@ -1,0 +1,17 @@
+# build_in_place
+
+A root-only workspace has no target ambiguity. Static extraction cannot see
+the build input that the plugin supplies. Bare vp build must run in place in
+a non-interactive terminal.
+
+## `vp build`
+
+```
+transforming...
+✓ 2 modules transformed.
+rendering chunks...
+computing gzip size...
+dist/assets/index-<hash>.js  <size> kB │ gzip: <size> kB
+
+✓ built in <duration>
+```

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/settings_only_workspace/snapshots/build_in_place.local.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/settings_only_workspace/snapshots/build_in_place.local.md
@@ -6,12 +6,11 @@ a non-interactive terminal.
 
 ## `vp build`
 
-```
-transforming...
-✓ 2 modules transformed.
-rendering chunks...
-computing gzip size...
-dist/assets/index-<hash>.js  <size> kB │ gzip: <size> kB
 
-✓ built in <duration>
+## `vpt list-dir dist/assets`
+
+build output stays in the root workspace
+
+```
+index-<hash>.js
 ```

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/settings_only_workspace/vite.config.ts
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/settings_only_workspace/vite.config.ts
@@ -1,3 +1,17 @@
 export default {
+  plugins: [
+    {
+      name: 'root-only-build-input',
+      config() {
+        return {
+          build: {
+            rolldownOptions: {
+              input: 'src/index.ts',
+            },
+          },
+        };
+      },
+    },
+  ],
   pack: {},
 };

--- a/packages/cli/binding/src/cli/app_target.rs
+++ b/packages/cli/binding/src/cli/app_target.rs
@@ -345,6 +345,11 @@ pub(super) fn resolve_app_target(
             }
         })
         .collect();
+    if rows.is_empty() {
+        // The workspace root is the only target. Static extraction can miss
+        // plugin-provided config, so run the command in place.
+        return Ok((AppTarget::CurrentDir, Some(workspace_root)));
+    }
     rows.sort_by(|a, b| {
         (!a.likely_runnable, a.path.as_str()).cmp(&(!b.likely_runnable, b.path.as_str()))
     });


### PR DESCRIPTION
Run exact bare app commands in place when the workspace has no member packages. This keeps the `.` fallback for workspaces that contain members.

This change supports valid root configurations that static extraction cannot read. One example is a plugin that supplies the build input.

Add local and global snapshots for `vp build` in a settings-only root workspace. The fixture supplies its build input through a Vite plugin.

This fixes the ecosystem CI regression after #2530.