### PR TITLE
refactor(js-runtime): drop unused async-trait from JsRuntimeProvider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8576,7 +8576,6 @@ dependencies = [
 name = "vp_js_runtime"
 version = "0.0.0"
 dependencies = [
- "async-trait",
  "backon",
  "flate2",
  "futures-util",

--- a/crates/vp_js_runtime/Cargo.toml
+++ b/crates/vp_js_runtime/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 rust-version.workspace = true
 
 [dependencies]
-async-trait = { workspace = true }
 backon = { workspace = true }
 flate2 = { workspace = true }
 futures-util = { workspace = true }

--- a/crates/vp_js_runtime/src/provider.rs
+++ b/crates/vp_js_runtime/src/provider.rs
@@ -3,7 +3,6 @@
 //! This module defines the trait that all runtime providers (Node, Bun, Deno)
 //! must implement, along with types for describing download information.
 
-use async_trait::async_trait;
 use vt_str::Str;
 
 use crate::{Error, Platform};
@@ -77,7 +76,6 @@ pub struct DownloadInfo {
 ///
 /// Each runtime (Node.js, Bun, Deno) implements this trait to provide
 /// runtime-specific logic for downloading and installing.
-#[async_trait]
 pub trait JsRuntimeProvider: Send + Sync {
     /// Get the name of this runtime (e.g., "node", "bun", "deno")
     fn name(&self) -> &'static str;

--- a/crates/vp_js_runtime/src/providers/node.rs
+++ b/crates/vp_js_runtime/src/providers/node.rs
@@ -2,7 +2,6 @@
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use async_trait::async_trait;
 use node_semver::{Range, Version};
 use serde::{Deserialize, Serialize};
 use vt_path::{AbsolutePath, AbsolutePathBuf};
@@ -590,7 +589,6 @@ fn is_official_dist_host(base_url: &str) -> bool {
     host.eq_ignore_ascii_case("nodejs.org")
 }
 
-#[async_trait]
 impl JsRuntimeProvider for NodeProvider {
     fn name(&self) -> &'static str {
         "node"


### PR DESCRIPTION
`JsRuntimeProvider` was annotated with `#[async_trait]`, but none of its methods are async. `name`, `platform_string`, `get_download_info`, `binary_relative_path`, `bin_dir_relative_path`, and `parse_shasums` are all synchronous, so the macro had nothing to transform and generated the same code as the plain trait.

If a future runtime provider (Bun, Deno) needs async trait methods, the attribute can be added back at that point.