### PR TITLE
fix(migrate): report lint rules dropped during oxlint sanitization

### DIFF
--- a/packages/cli/src/migration/__tests__/migrator.spec.ts
+++ b/packages/cli/src/migration/__tests__/migrator.spec.ts
@@ -1187,6 +1187,66 @@ describe('collectInstalledPackageNames', () => {
     sanitizeMigratedOxlintConfig(config, available);
     expect(config.jsPlugins).toEqual([]);
   });
+
+  // #2231: a local jsPlugin's real namespace comes from its `meta.name`,
+  // which can't be derived from the path, so its rules get filtered out.
+  // Dropping them is currently required (Oxlint refuses to start on a rule
+  // whose plugin it can't resolve), but it must not happen silently.
+  it('warns which rules it dropped when a local jsPlugin namespace is unresolvable', () => {
+    writeRootPkg({ devDependencies: { vite: '^7.0.0' } });
+    const available = collectInstalledPackageNames(tmpDir);
+    const report = createMigrationReport();
+    const config: import('oxlint').OxlintConfig = {
+      jsPlugins: ['./lint/kumo.js'],
+      rules: { 'kumo/no-foo': 'error', 'no-debugger': 'error' },
+    };
+
+    sanitizeMigratedOxlintConfig(config, available, report);
+
+    // The unbacked rule still has to go, and the native one stays.
+    expect(config.rules).toEqual({ 'no-debugger': 'error' });
+    // The local plugin itself is preserved — Oxlint resolves it by path.
+    expect(config.jsPlugins).toEqual(['./lint/kumo.js']);
+    // The drop is reported, names the rule, and points at the fix.
+    const warning = report.warnings.find((w) => w.includes('Stripped lint rule(s)'));
+    expect(warning).toBeDefined();
+    expect(warning).toContain('kumo/no-foo');
+    expect(warning).not.toContain('no-debugger');
+    expect(warning).toContain('specifier');
+  });
+
+  it('reports rules dropped from overrides, not just base rules', () => {
+    writeRootPkg({ devDependencies: { vite: '^7.0.0' } });
+    const available = collectInstalledPackageNames(tmpDir);
+    const report = createMigrationReport();
+    const config: import('oxlint').OxlintConfig = {
+      overrides: [{ files: ['**/*.ts'], rules: { 'kumo/no-bar': 'warn' } }],
+    };
+
+    sanitizeMigratedOxlintConfig(config, available, report);
+
+    expect(config.overrides?.[0]?.rules).toEqual({});
+    const warning = report.warnings.find((w) => w.includes('Stripped lint rule(s)'));
+    expect(warning).toBeDefined();
+    expect(warning).toContain('kumo/no-bar');
+  });
+
+  it('does not warn about rules when nothing was dropped', () => {
+    writeRootPkg({ devDependencies: { vite: '^7.0.0' } });
+    const available = collectInstalledPackageNames(tmpDir);
+    const report = createMigrationReport();
+    const config: import('oxlint').OxlintConfig = {
+      rules: { 'no-debugger': 'error', 'typescript/no-explicit-any': 'error' },
+    };
+
+    sanitizeMigratedOxlintConfig(config, available, report);
+
+    expect(config.rules).toEqual({
+      'no-debugger': 'error',
+      'typescript/no-explicit-any': 'error',
+    });
+    expect(report.warnings.some((w) => w.includes('Stripped lint rule(s)'))).toBe(false);
+  });
 });
 
 describe('ensureSvelteRuneGlobals', () => {

--- a/packages/cli/src/migration/migrator/eslint.ts
+++ b/packages/cli/src/migration/migrator/eslint.ts
@@ -541,15 +541,23 @@ function ruleKeyMatchesNamespace(key: string, namespaces: Set<string>): boolean 
   return false;
 }
 
-/** Filter a rules object to only entries whose namespace is recognized. */
+/**
+ * Filter a rules object to only entries whose namespace is recognized.
+ * Every removed key is recorded in `dropped` so the caller can tell the
+ * user which rules it lost — silently discarding a user's custom rules
+ * is the failure mode reported in #2231.
+ */
 function filterRulesAgainstNamespaces(
   rules: Record<string, unknown>,
   namespaces: Set<string>,
+  dropped?: Set<string>,
 ): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(rules)) {
     if (ruleKeyMatchesNamespace(key, namespaces)) {
       out[key] = value;
+    } else {
+      dropped?.add(key);
     }
   }
   return out;
@@ -634,6 +642,7 @@ export function sanitizeMigratedOxlintConfig(
   // Track everything we strip so we can warn the user.
   const allDroppedJsPlugins = new Set<string>();
   const allDroppedPlugins = new Set<string>();
+  const allDroppedRules = new Set<string>();
 
   // 1. Sanitize base-level jsPlugins.
   const baseSplit = partitionJsPlugins(config.jsPlugins ?? [], availablePackages);
@@ -670,7 +679,7 @@ export function sanitizeMigratedOxlintConfig(
   // `rules: undefined` property that would shift downstream key
   // emission in the merged vite.config.ts.
   if (config.rules) {
-    const filtered = filterRulesAgainstNamespaces(config.rules, baseNamespaces);
+    const filtered = filterRulesAgainstNamespaces(config.rules, baseNamespaces, allDroppedRules);
     if (Object.keys(filtered).length !== Object.keys(config.rules).length) {
       config.rules = filtered as typeof config.rules;
     }
@@ -720,7 +729,11 @@ export function sanitizeMigratedOxlintConfig(
 
       // Override rules.
       if (override.rules) {
-        const filtered = filterRulesAgainstNamespaces(override.rules, overrideNamespaces);
+        const filtered = filterRulesAgainstNamespaces(
+          override.rules,
+          overrideNamespaces,
+          allDroppedRules,
+        );
         if (Object.keys(filtered).length !== Object.keys(override.rules).length) {
           override.rules = filtered as typeof override.rules;
         }
@@ -750,6 +763,19 @@ export function sanitizeMigratedOxlintConfig(
     warnMigration(
       `Stripped unknown plugin reference(s) from the generated lint config: ${[...allDroppedPlugins].join(', ')}. ` +
         "These aren't native Oxlint plugins and no surviving JS plugin contributes them.",
+      report,
+    );
+  }
+  // Rules have to go when nothing backs their namespace: Oxlint refuses to
+  // start at all on a rule whose plugin it can't find ("Plugin 'x' not
+  // found"), so keeping them would break `vp lint` outright rather than
+  // degrade it. But losing a rule the user wrote should never be silent —
+  // dropped plugins already warn, and rules used to disappear quietly.
+  if (allDroppedRules.size > 0) {
+    warnMigration(
+      `Stripped lint rule(s) from the generated lint config: ${[...allDroppedRules].join(', ')}. ` +
+        'No plugin in the migrated config contributes their namespace, and Oxlint fails to start when a rule names a plugin it cannot find. ' +
+        "If a namespace comes from a local JS plugin, name it explicitly in `lint.jsPlugins` as `{ name: '<namespace>', specifier: './path/to/plugin.js' }` and add those rules back.",
       report,
     );
   }


### PR DESCRIPTION
Refs #2231. This fixes the "silently" half of that issue and deliberately leaves the namespace-resolution half open — see **What this leaves for #2231** below.

## Problem

When `vp migrate` merges `.oxlintrc.json` into `vite.config.ts`, `sanitizeMigratedOxlintConfig` removes every rule whose namespace no surviving plugin contributes. Dropped `jsPlugins` and dropped `plugins` each produce a warning; dropped **rules** produced nothing at all.

The case #2231 reports makes it concrete. A local plugin is kept by the sanitizer (`partitionJsPlugins` passes `./`-style specifiers through, because Oxlint resolves them itself), but `deriveJsPluginNamespace` has only the path to work with and returns `./lint/kumo.js` verbatim. No rule key can ever match that, so every `kumo/*` rule is filtered out of the migrated config and the user is told nothing.

## Why the rules still have to be dropped

I checked what Oxlint actually does before assuming the filtering could simply be relaxed, using the bundled oxlint 1.79.0 on a scratch project.

A rule under a namespace no plugin backs is **not** a warning — it stops Oxlint from starting at all:

```
$ cat .oxlintrc.json
{ "jsPlugins": ["./lint/kumo.js"], "rules": { "kumo/no-foo": "error", "ghostplugin/some-rule": "error" } }
$ oxlint a.js
Failed to parse oxlint configuration file.

  x Plugin 'ghostplugin' not found
$ echo $?
1
```

So keeping unattributable rules would trade a silent config loss for `vp lint` failing outright on the whole project. Dropping them is the right behaviour; doing it without a word is not.

Two other things that same probe established, both of which shape the fix:

- Oxlint really does take a local plugin's namespace from its `meta.name` — with `meta: { name: 'kumo' }`, `kumo/no-foo` resolves and fires (`a.js:1:7: error kumo(no-foo): ...`). The migrator has no way to know that from the path alone.
- The `jsPlugins` object form is a working escape hatch, and `name` sets the namespace: `{ "name": "kumo", "specifier": "./lint/kumo.js" }` resolves identically, and `{ "name": "renamed", ... }` re-namespaces the same plugin to `renamed/no-foo`. The migrator already handles this form correctly (`jsPluginsToNamespaces` reads `entry.name`), so it is a real remedy to point users at.

## Changes

- `filterRulesAgainstNamespaces` records every key it removes into a caller-supplied set.
- `sanitizeMigratedOxlintConfig` accumulates those keys across the base config and every override, then warns once, naming the rules and pointing at the `{ name, specifier }` form.

Behaviour is otherwise unchanged: the same rules are dropped as before, and nothing new is kept.

## What this leaves for #2231

The issue suggests resolving the real namespace by importing the plugin and reading `meta.name`, which is exactly what Oxlint does. I have not done that here, because it is a design decision I do not think a contributor should make unilaterally:

- `sanitizeMigratedOxlintConfig` and its caller `mergeViteConfigFiles` are synchronous, so `import()` means making that chain async.
- It would have `vp migrate` execute arbitrary user plugin code, immediately after the ESLint cleanup has removed packages that plugin may well import.

Alternatives that avoid both — a synchronous `require` of the plugin, statically extracting `meta.name`, or having the migrator rewrite local jsPlugins into the object form so the namespace is recorded explicitly — each trade differently. Happy to implement whichever you prefer, here or as a follow-up. In the meantime this at least means the rules no longer vanish silently.

## Testing

Three tests added next to the existing sanitizer tests in `packages/cli/src/migration/__tests__/migrator.spec.ts`: the #2231 local-plugin case, an override-rules case, and a negative case asserting no warning when nothing is dropped.

Verified in both directions — with `migrator/eslint.ts` reverted to `main` and the tests kept, the two positive tests **fail** (`AssertionError: expected undefined to be defined`); with the change applied they **pass**. The negative test passes either way, as it should.

Checks actually run on this branch:

- `vitest run packages/cli/src/migration` — 411 passed across 10 files (408 on `main` here, plus these 3)
- `vitest run` (full unit suite) — 1025 passed, 1 skipped; 7 pre-existing snapshot failures in `packages/prompts/src/__tests__/render.spec.ts` that also fail on an unmodified tree in this environment
- `vp lint --type-aware --type-check` — no diagnostics in either touched file
- `vp fmt --check` — both touched files clean

One caveat on the lint run, in case anyone reproduces it: `pnpm build` generates an untracked `packages/cli/src/migration/versions.ts`, which in a local build carries only `{ vite, vitest }`. While it is present, type-checking reports two errors in `migrator/eslint.ts:139-141` (an unused `@ts-expect-error` and a missing `versions.oxlint`) that have nothing to do with this change — that code deliberately resolves `versions.js` from `dist/` at runtime. With that generated file removed, both errors disappear and the only remaining diagnostics are 19 in the unbuilt `docs/` workspace.

Not run: the PTY snapshot suite and ecosystem e2e. This changes no CLI command output beyond adding a migration warning, which is reported through `MigrationReport` and asserted directly in the tests.

## AI assistance

Claude Opus 5 wrote the implementation, the tests, the oxlint probes, and this description. The change is agent-authored and has not had a separate human review. Every result quoted above is from an actual run on this branch, not an estimate.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PHMqGT3Njbogd81vQh7Cvw)_