### PR TITLE
fix(create): report install and format failures in the create summary

### DIFF
--- a/packages/cli/src/create/__tests__/summary.spec.ts
+++ b/packages/cli/src/create/__tests__/summary.spec.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getNextCommand, showCreateSummary } from '../summary.js';
+
+// `terminal.ts` reaches the NAPI binding for the Vite+ header, so stub it
+// outright rather than importing the real module. Styling is not asserted.
+const terminal = vi.hoisted(() => ({
+  log: vi.fn(),
+  accent: (text: string) => text,
+  formatDuration: (durationMs: number) => `${durationMs}ms`,
+}));
+
+vi.mock('../../utils/terminal.ts', () => terminal);
+
+const installed = { durationMs: 1200, exitCode: 0, status: 'installed' } as const;
+const formatted = { durationMs: 30, exitCode: 0, status: 'formatted' } as const;
+const failed = { durationMs: 30, exitCode: 1, status: 'failed' } as const;
+
+const baseOptions = {
+  description: 'Vite application',
+  packageManager: 'pnpm',
+  packageManagerVersion: '11.21.0',
+  projectDir: 'create-failure-demo',
+};
+
+// `showCreateSummary` writes through `log`, so assert on the joined output
+// rather than the exact styling of any one line.
+function output() {
+  return terminal.log.mock.calls.map((call) => String(call[0])).join('\n');
+}
+
+describe('getNextCommand', () => {
+  it('prefixes a cd when the project is in a subdirectory', () => {
+    expect(getNextCommand('demo', 'vp run')).toBe('cd demo && vp run');
+  });
+
+  it('omits the cd for the current directory', () => {
+    expect(getNextCommand('.', 'vp run')).toBe('vp run');
+    expect(getNextCommand('', 'vp run')).toBe('vp run');
+  });
+});
+
+describe('showCreateSummary', () => {
+  let previousExitCode: typeof process.exitCode;
+
+  beforeEach(() => {
+    terminal.log.mockClear();
+    previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    process.exitCode = previousExitCode;
+  });
+
+  it('reports a ready project and leaves the exit code alone on success', () => {
+    showCreateSummary({ ...baseOptions, installSummary: installed, fmtSummary: formatted });
+
+    const text = output();
+    expect(text).toContain('Scaffolded');
+    expect(text).toContain('Dependencies installed');
+    expect(text).toContain('Next: ');
+    expect(text).toContain('cd create-failure-demo && vp run');
+    expect(text).not.toContain('were not installed');
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  // Regression test for #2453: a failed install used to be summarized as a
+  // finished project — "Scaffolded", "Next: vp run", exit code 0 — even
+  // though node_modules was missing.
+  it('does not report a failed install as a ready project', () => {
+    showCreateSummary({ ...baseOptions, installSummary: failed, fmtSummary: failed });
+
+    const text = output();
+    expect(text).toContain('Dependencies were not installed');
+    expect(text).toContain('Code was not formatted');
+    expect(text).toContain('cd create-failure-demo && vp install');
+    expect(text).not.toContain('vp run');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('still suggests running the project when only formatting failed', () => {
+    showCreateSummary({ ...baseOptions, installSummary: installed, fmtSummary: failed });
+
+    const text = output();
+    expect(text).toContain('Code was not formatted');
+    expect(text).toContain('cd create-failure-demo && vp run');
+    expect(text).not.toContain('Dependencies were not installed');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('never lowers an exit code another step already raised', () => {
+    process.exitCode = 1;
+    showCreateSummary({ ...baseOptions, installSummary: installed, fmtSummary: formatted });
+
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/packages/cli/src/create/__tests__/summary.spec.ts
+++ b/packages/cli/src/create/__tests__/summary.spec.ts
@@ -79,14 +79,19 @@ describe('showCreateSummary', () => {
     expect(process.exitCode).toBe(1);
   });
 
-  it('still suggests running the project when only formatting failed', () => {
+  // Regression test for the PTY snapshot failures this PR first introduced:
+  // `create_framework_shim_vue` and `new_create_vite` scaffold templates whose
+  // plugin imports are not resolvable when `vp fmt` runs, so the format step
+  // fails on a project that is otherwise complete. Naming it is right; exiting
+  // non-zero for it is not.
+  it('still suggests running the project and succeeds when only formatting failed', () => {
     showCreateSummary({ ...baseOptions, installSummary: installed, fmtSummary: failed });
 
     const text = output();
     expect(text).toContain('Code was not formatted');
     expect(text).toContain('cd create-failure-demo && vp run');
     expect(text).not.toContain('Dependencies were not installed');
-    expect(process.exitCode).toBe(1);
+    expect(process.exitCode).toBeUndefined();
   });
 
   it('never lowers an exit code another step already raised', () => {

--- a/packages/cli/src/create/__tests__/utils.spec.ts
+++ b/packages/cli/src/create/__tests__/utils.spec.ts
@@ -12,6 +12,7 @@ import {
   getProjectDirFromPackageName,
   normalizeEditorOption,
   renameFiles,
+  resolveCreateCompletion,
   shouldConfigureEditorsForCreate,
 } from '../utils.js';
 
@@ -382,5 +383,60 @@ describe('renameFiles', () => {
     write('_foo', 'bar\n');
     renameFiles(projectDir);
     expect(read('_foo')).toBe('bar\n');
+  });
+});
+
+describe('resolveCreateCompletion', () => {
+  const installed = { durationMs: 1, exitCode: 0, status: 'installed' } as const;
+  const formatted = { durationMs: 1, exitCode: 0, status: 'formatted' } as const;
+  const failed = { durationMs: 1, exitCode: 1, status: 'failed' } as const;
+  const skipped = { durationMs: 0, status: 'skipped' } as const;
+
+  it('reports success and suggests running the project when both steps pass', () => {
+    expect(resolveCreateCompletion({ installSummary: installed, fmtSummary: formatted })).toEqual({
+      failures: [],
+      nextCommand: 'vp run',
+      exitCode: 0,
+    });
+  });
+
+  it('reports a failed install and suggests the recovery command', () => {
+    expect(resolveCreateCompletion({ installSummary: failed, fmtSummary: formatted })).toEqual({
+      failures: ['Dependencies were not installed'],
+      nextCommand: 'vp install',
+      exitCode: 1,
+    });
+  });
+
+  it('reports a failed format but still suggests running the project', () => {
+    expect(resolveCreateCompletion({ installSummary: installed, fmtSummary: failed })).toEqual({
+      failures: ['Code was not formatted'],
+      nextCommand: 'vp run',
+      exitCode: 1,
+    });
+  });
+
+  it('reports both failures in the order the steps ran', () => {
+    expect(resolveCreateCompletion({ installSummary: failed, fmtSummary: failed })).toEqual({
+      failures: ['Dependencies were not installed', 'Code was not formatted'],
+      nextCommand: 'vp install',
+      exitCode: 1,
+    });
+  });
+
+  it('does not treat a skipped install as a failure', () => {
+    expect(resolveCreateCompletion({ installSummary: skipped, fmtSummary: formatted })).toEqual({
+      failures: [],
+      nextCommand: 'vp run',
+      exitCode: 0,
+    });
+  });
+
+  it('does not treat a step that never ran as a failure', () => {
+    expect(resolveCreateCompletion({})).toEqual({
+      failures: [],
+      nextCommand: 'vp run',
+      exitCode: 0,
+    });
   });
 });

--- a/packages/cli/src/create/__tests__/utils.spec.ts
+++ b/packages/cli/src/create/__tests__/utils.spec.ts
@@ -408,11 +408,15 @@ describe('resolveCreateCompletion', () => {
     });
   });
 
-  it('reports a failed format but still suggests running the project', () => {
+  // A format failure leaves a complete, runnable project, so it is named in
+  // the summary but must not fail the command: scaffolding a `react-ts` or
+  // `vue-ts` template produces a `vite.config.ts` whose plugin import is not
+  // resolvable until dependencies land, and `vp fmt` fails there routinely.
+  it('reports a failed format without failing the command', () => {
     expect(resolveCreateCompletion({ installSummary: installed, fmtSummary: failed })).toEqual({
       failures: ['Code was not formatted'],
       nextCommand: 'vp run',
-      exitCode: 1,
+      exitCode: 0,
     });
   });
 

--- a/packages/cli/src/create/bin.ts
+++ b/packages/cli/src/create/bin.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { styleText } from 'node:util';
 
 import * as prompts from '@voidzero-dev/vite-plus-prompts';
 import mri from 'mri';
@@ -53,7 +52,7 @@ import {
   runViteInstall,
   selectPackageManager,
 } from '../utils/prompts.ts';
-import { accent, formatDuration, muted, log, printHeader, success } from '../utils/terminal.ts';
+import { accent, muted, log, printHeader, success } from '../utils/terminal.ts';
 import {
   detectWorkspace,
   updatePackageJsonWithDeps,
@@ -77,6 +76,7 @@ import {
 } from './prompts.ts';
 import { getRandomProjectName } from './random-name.ts';
 import { registerLocalTemplate } from './register-template.ts';
+import { showCreateSummary } from './summary.ts';
 import {
   executeBuiltinTemplate,
   executeBundledTemplate,
@@ -378,53 +378,11 @@ function formatTemplateName(templateName: string) {
   return `${frameworkName} + ${isTypeScript ? 'TypeScript' : 'JavaScript'}`;
 }
 
-function getNextCommand(projectDir: string, command: string) {
-  if (!projectDir || projectDir === '.') {
-    return command;
-  }
-  return `cd ${projectDir} && ${command}`;
-}
-
 function getCopilotSetupRoot(projectRoot: string, isExistingMonorepo: boolean) {
   if (!isExistingMonorepo) {
     return projectRoot;
   }
   return findGitRoot(projectRoot) ?? projectRoot;
-}
-
-function showCreateSummary(options: {
-  description?: string;
-  installSummary?: CommandRunSummary;
-  nextCommand: string;
-  packageManager: string;
-  packageManagerVersion: string;
-  projectDir: string;
-}) {
-  const {
-    description,
-    installSummary,
-    nextCommand,
-    packageManager,
-    packageManagerVersion,
-    projectDir,
-  } = options;
-
-  log(
-    `${styleText('magenta', '◇')} Scaffolded ${accent(projectDir)}${
-      description ? ` with ${description}` : ''
-    }`,
-  );
-  log(
-    `${styleText('gray', '•')} Node ${process.versions.node}  ${packageManager} ${packageManagerVersion}`,
-  );
-  if (installSummary?.status === 'installed') {
-    log(
-      `${styleText('green', '✓')} Dependencies installed in ${formatDuration(
-        installSummary.durationMs,
-      )}`,
-    );
-  }
-  log(`${styleText('blue', '→')} Next: ${accent(nextCommand)}`);
 }
 
 async function main() {
@@ -1107,12 +1065,14 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
     });
     await handleIgnoredBuilds(fullPath, fullPath, installSummary);
     updateCreateProgress('Formatting code');
-    await runViteFmt(fullPath, options.interactive, undefined, { silent: compactOutput });
+    const monorepoFmtSummary = await runViteFmt(fullPath, options.interactive, undefined, {
+      silent: compactOutput,
+    });
     clearCreateProgress();
     showCreateSummary({
       description: describeScaffold(selectedTemplateName, selectedTemplateArgs),
       installSummary,
-      nextCommand: getNextCommand(projectDir, 'vp run'),
+      fmtSummary: monorepoFmtSummary,
       packageManager: workspaceInfo.packageManager,
       packageManagerVersion: workspaceInfo.downloadPackageManager.version,
       projectDir,
@@ -1260,6 +1220,7 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
     detectTsupProject(fullPath).hasDependency;
 
   let installSummary: CommandRunSummary | undefined;
+  let fmtSummary: CommandRunSummary | undefined;
 
   // For templates that ship ESLint/Prettier, install template deps first so
   // `@oxlint/migrate` can resolve eslint.config.js's plugin imports, then
@@ -1403,7 +1364,7 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
     const fmtPaths = registeredConfigPath
       ? [projectDir, path.relative(workspaceInfo.rootDir, registeredConfigPath)]
       : [projectDir];
-    await runViteFmt(workspaceInfo.rootDir, options.interactive, fmtPaths, {
+    fmtSummary = await runViteFmt(workspaceInfo.rootDir, options.interactive, fmtPaths, {
       silent: compactOutput,
     });
     // No git setup here: `resolveGitInit` always returns false inside an
@@ -1445,14 +1406,16 @@ Use \`vp create --list\` to list all available templates, or run \`vp create --h
     });
     await handleIgnoredBuilds(fullPath, fullPath, installSummary);
     updateCreateProgress('Formatting code');
-    await runViteFmt(fullPath, options.interactive, undefined, { silent: compactOutput });
+    fmtSummary = await runViteFmt(fullPath, options.interactive, undefined, {
+      silent: compactOutput,
+    });
   }
 
   clearCreateProgress();
   showCreateSummary({
     description: describeScaffold(selectedTemplateName, selectedTemplateArgs),
     installSummary,
-    nextCommand: getNextCommand(projectDir, 'vp run'),
+    fmtSummary,
     packageManager: workspaceInfo.packageManager,
     packageManagerVersion: workspaceInfo.downloadPackageManager.version,
     projectDir,

--- a/packages/cli/src/create/summary.ts
+++ b/packages/cli/src/create/summary.ts
@@ -1,0 +1,70 @@
+import { styleText } from 'node:util';
+
+import type { CommandRunSummary } from '../utils/prompts.ts';
+import { accent, formatDuration, log } from '../utils/terminal.ts';
+import { resolveCreateCompletion } from './utils.ts';
+
+export function getNextCommand(projectDir: string, command: string) {
+  if (!projectDir || projectDir === '.') {
+    return command;
+  }
+  return `cd ${projectDir} && ${command}`;
+}
+
+/**
+ * Report how `vp create` finished.
+ *
+ * Scaffolding, installing and formatting are separate steps, and the last two
+ * can fail after the project directory exists. The summary therefore states
+ * which steps failed, suggests the command that has to succeed first, and
+ * raises the exit code so a script or CI job sees the failure.
+ */
+export function showCreateSummary(options: {
+  description?: string;
+  installSummary?: CommandRunSummary;
+  fmtSummary?: CommandRunSummary;
+  packageManager: string;
+  packageManagerVersion: string;
+  projectDir: string;
+}) {
+  const {
+    description,
+    installSummary,
+    fmtSummary,
+    packageManager,
+    packageManagerVersion,
+    projectDir,
+  } = options;
+
+  const completion = resolveCreateCompletion({ installSummary, fmtSummary });
+
+  log(
+    `${styleText('magenta', '◇')} Scaffolded ${accent(projectDir)}${
+      description ? ` with ${description}` : ''
+    }`,
+  );
+  log(
+    `${styleText('gray', '•')} Node ${process.versions.node}  ${packageManager} ${packageManagerVersion}`,
+  );
+  if (installSummary?.status === 'installed') {
+    log(
+      `${styleText('green', '✓')} Dependencies installed in ${formatDuration(
+        installSummary.durationMs,
+      )}`,
+    );
+  }
+  // The scaffold itself succeeded, so the directory is still reported as
+  // created — but a failed install or format must not be summarized as a
+  // project that is ready to run.
+  for (const failure of completion.failures) {
+    log(`${styleText('red', '✗')} ${failure}`);
+  }
+  log(
+    `${styleText('blue', '→')} Next: ${accent(getNextCommand(projectDir, completion.nextCommand))}`,
+  );
+  // Only ever raise the exit code: `handleIgnoredBuilds` may already have set
+  // it for a gated build that failed to run.
+  if (completion.exitCode !== 0) {
+    process.exitCode = completion.exitCode;
+  }
+}

--- a/packages/cli/src/create/utils.ts
+++ b/packages/cli/src/create/utils.ts
@@ -12,7 +12,7 @@ export interface CreateCompletion {
   failures: string[];
   /** Command worth suggesting next: recovery when the project is not usable. */
   nextCommand: string;
-  /** Non-zero when a step of the requested operation failed. */
+  /** Non-zero when the scaffolded project cannot be run as it stands. */
   exitCode: number;
 }
 
@@ -26,6 +26,14 @@ export interface CreateCompletion {
  * apart instead of reporting success for both.
  *
  * A skipped step (`VP_SKIP_INSTALL`) is not a failure — nothing was attempted.
+ *
+ * Only a failed install changes the exit code. Formatting runs against a
+ * project whose dependencies may not be resolvable yet — scaffolding a
+ * `react-ts` or `vue-ts` template leaves a `vite.config.ts` importing a plugin
+ * that is not installed, so `vp fmt` cannot load the config and fails on a
+ * project that is otherwise complete. Reporting that as a failed command would
+ * break every such `vp create` in CI, so it is named in the summary and left
+ * out of the exit code.
  */
 export function resolveCreateCompletion(options: {
   installSummary?: CommandRunSummary;
@@ -48,7 +56,7 @@ export function resolveCreateCompletion(options: {
     // the step that has to succeed first. A format failure leaves a runnable
     // project, so it does not change the suggestion.
     nextCommand: installFailed ? 'vp install' : 'vp run',
-    exitCode: failures.length > 0 ? 1 : 0,
+    exitCode: installFailed ? 1 : 0,
   };
 }
 

--- a/packages/cli/src/create/utils.ts
+++ b/packages/cli/src/create/utils.ts
@@ -4,7 +4,53 @@ import path from 'node:path';
 import validateNpmPackageName from 'validate-npm-package-name';
 
 import { editJsonFile } from '../utils/json.ts';
+import type { CommandRunSummary } from '../utils/prompts.ts';
 import { getRandomProjectName } from './random-name.ts';
+
+export interface CreateCompletion {
+  /** One line per step that failed, in the order the steps ran. */
+  failures: string[];
+  /** Command worth suggesting next: recovery when the project is not usable. */
+  nextCommand: string;
+  /** Non-zero when a step of the requested operation failed. */
+  exitCode: number;
+}
+
+/**
+ * Decide what `vp create` should report once scaffolding is done.
+ *
+ * The template files are written before dependencies are installed and the
+ * result is formatted, so those later steps can fail while the project
+ * directory already exists. "Files were generated" and "the project is ready
+ * to run" are different states, and the completion summary has to tell them
+ * apart instead of reporting success for both.
+ *
+ * A skipped step (`VP_SKIP_INSTALL`) is not a failure — nothing was attempted.
+ */
+export function resolveCreateCompletion(options: {
+  installSummary?: CommandRunSummary;
+  fmtSummary?: CommandRunSummary;
+}): CreateCompletion {
+  const installFailed = options.installSummary?.status === 'failed';
+  const fmtFailed = options.fmtSummary?.status === 'failed';
+
+  const failures: string[] = [];
+  if (installFailed) {
+    failures.push('Dependencies were not installed');
+  }
+  if (fmtFailed) {
+    failures.push('Code was not formatted');
+  }
+
+  return {
+    failures,
+    // Without `node_modules` the suggested `vp run` cannot work, so point at
+    // the step that has to succeed first. A format failure leaves a runnable
+    // project, so it does not change the suggestion.
+    nextCommand: installFailed ? 'vp install' : 'vp run',
+    exitCode: failures.length > 0 ? 1 : 0,
+  };
+}
 
 export type CreateEditorOption = string | false | undefined;
 type ParsedCreateEditorOption = CreateEditorOption | CreateEditorOption[];


### PR DESCRIPTION
Closes #2453

## Problem

`vp create` writes the template files first, then installs dependencies and formats the result. Those last two steps can fail after the project directory already exists — and when they did, the completion summary reported the run as a success anyway.

Reproduced with the issue's recipe against this branch's base (`c4dcb15`), using the built local CLI:

```
$ env -u VP_SKIP_INSTALL VP_CLI_BIN=/usr/bin/false \
    vp create vite:application --no-interactive --no-hooks --no-git \
    --directory create-failure-demo
You may need to run "vp install" manually in .../create-failure-demo
You may need to run "vp fmt" manually in .../create-failure-demo
◇ Scaffolded create-failure-demo with Vite application
• Node 22.22.2  pnpm 11.23.0
→ Next: cd create-failure-demo && vp run
=== EXIT CODE: 0 ===
node_modules missing
```

Three success signals — `Scaffolded`, `Next: vp run`, exit `0` — for a project that cannot run. The earlier "you may need to…" lines are easy to lose above a long install log, and a CI job reading only the exit code records the operation as successful.

## Changes

- `resolveCreateCompletion` (in `create/utils.ts`) turns the install and format results into: which steps failed, which command is worth suggesting next, and whether the exit code should be non-zero.
- `showCreateSummary` names each failed step, points `Next:` at `vp install` when dependencies are missing (the suggested `vp run` cannot work without them), and raises `process.exitCode`.
- The format result was previously discarded at all three `runViteFmt` call sites; it is now threaded through alongside the install result.

Same input on this branch:

```
◇ Scaffolded create-failure-demo with Vite application
• Node 22.22.2  pnpm 11.23.0
✗ Dependencies were not installed
✗ Code was not formatted
→ Next: cd create-failure-demo && vp install
=== EXIT CODE: 1 ===
```

The directory is still reported as scaffolded — as the issue notes, that part is true and is not the confusing bit.

Three behaviours deliberately preserved:

- **A skipped install is not a failure.** `VP_SKIP_INSTALL` returns `status: 'skipped'`; only `'failed'` counts.
- **The exit code is only ever raised, never lowered.** `handleIgnoredBuilds` already sets `process.exitCode = 1` for a gated build that failed under `--approve-builds`, and this must not clear it.
- **Only a failed install fails the command.** See below.

The success path is unchanged, byte for byte — no new line is printed and `Next:` still reads `vp run`.

## A format failure is reported but does not fail the command

The first revision of this PR exited non-zero for a format-only failure too, and flagged that as a call for you to make. **CI answered it**, so I have taken the exit-`0` variant rather than leave it open.

The PTY snapshot suite failed on `create_framework_shim_vue` and `new_create_vite`, on all three platforms. Both scaffold a template whose generated `vite.config.ts` imports a plugin that is not installed at the moment `vp fmt` runs:

```
vite.config.ts (2:16) [UNRESOLVED_IMPORT] Could not resolve '@vitejs/plugin-vue' in vite.config.ts
error: Failed to resolve vite config: ... Cannot find package '@vitejs/plugin-vue'
You may need to run "vp fmt" manually in <workspace>/vite-plus-application
◇ Scaffolded vite-plus-application with Vue + TypeScript
✗ Code was not formatted
→ Next: cd vite-plus-application && vp run
```

That project is complete and runnable; only formatting was skipped. Those two cases declare the `vp create` step as `snapshot = false`, so they recorded nothing until the step started exiting `1` — which is exactly the point: **a routine `vp create` of a `react-ts` or `vue-ts` template would have started failing every CI job that runs it.**

So `resolveCreateCompletion` now returns `exitCode: installFailed ? 1 : 0`. A format failure is still named in the summary (`✗ Code was not formatted`) — silently dropping it is what #2453 is about — and `Next:` still points at `vp run`, because the project runs. Only a missing `node_modules` makes the command itself fail.

Happy to scope the non-zero exit to `--no-interactive` runs as well, mirroring the existing `handleIgnoredBuilds` condition, if you would prefer that.

## A note on the small refactor

`showCreateSummary` and `getNextCommand` moved from `create/bin.ts` to a new `create/summary.ts`, unchanged apart from the fix. `bin.ts` runs `main()` on import, so nothing in it can be unit-tested; moving these two functions is what let the regression test assert on the real summary output and exit code rather than only on the decision helper. Happy to drop the move if you would rather keep them in `bin.ts`.

## Testing

New `create/__tests__/summary.spec.ts` covers the summary output and exit code; six cases added to `create/__tests__/utils.spec.ts` cover the decision helper. Two of them now assert that a format-only failure is reported *and* leaves the exit code alone, so the snapshot regression above cannot come back silently.

Verified in both directions. With `exitCode` restored to the previous `failures.length > 0 ? 1 : 0` (and the tests kept), exactly the two guarding tests fail — `2 failed | 53 passed`:

```
× reports a failed format without failing the command
  AssertionError: expected { …(3) } to deeply equal { …(3) }
× still suggests running the project and succeeds when only formatting failed
  AssertionError: expected 1 to be undefined
```

With the change applied, `55 passed`.

Checks actually run on the latest commit:

- `vitest run packages/cli/src/create/__tests__/{summary,utils}.spec.ts` — 55 passed, and the both-directions result above.
- `oxlint@1.79.0 -D correctness -D perf -D suspicious` on all four files — exit 0.
- `oxfmt@0.64.0 --check` with this repo's `fmt` block from `vite.config.ts` — all four files correctly formatted. (Run without `-c` it reports issues on untouched files too, so the repo config is the meaningful check.)
- `git diff --check` — clean.

Earlier revision, still valid for the parts it covers: `vitest run` (full unit suite) — 1034 passed, 1 skipped, with 7 pre-existing `packages/prompts` snapshot failures confirmed identical on a clean tree; `tsgo -b tsconfig.json` — error set byte-identical to a clean tree.

**Correcting the previous description:** it said no `create` snapshot exercises a failing install or format, so I would not expect snapshot churn, and that I could not confirm it by running the suite. The first half was wrong — no fixture *records* such a failure, but two fixtures *produce* one, and they surface it through the exit code rather than through recorded output. CI caught what I could not run locally.

The PTY snapshot suite still cannot run in my environment, so the fix above is verified by unit tests and by root-causing both recorded diffs, not by a local suite run.

## AI assistance

Claude Opus 5 wrote the implementation, the tests, the reproductions, and this description. The change is agent-authored and has not had a separate human review. Every result quoted above is from an actual run, not an estimate.