### PR TITLE
vp_js_runtime: add FreeBSD to the supported OS set

### DIFF
--- a/crates/vp_js_runtime/src/platform.rs
+++ b/crates/vp_js_runtime/src/platform.rs
@@ -13,6 +13,7 @@ pub enum Os {
     Linux,
     Darwin,
     Windows,
+    FreeBSD,
 }
 
 /// CPU architecture
@@ -59,10 +60,19 @@ impl Os {
         {
             Self::Windows
         }
-        #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+        #[cfg(target_os = "freebsd")]
+        {
+            Self::FreeBSD
+        }
+        #[cfg(not(any(
+            target_os = "linux",
+            target_os = "macos",
+            target_os = "windows",
+            target_os = "freebsd"
+        )))]
         {
             compile_error!(
-                "Unsupported operating system. vp_js_runtime only supports Linux, macOS, and Windows."
+                "Unsupported operating system. vp_js_runtime only supports Linux, macOS, Windows, and FreeBSD."
             )
         }
     }
@@ -74,6 +84,7 @@ impl fmt::Display for Os {
             Self::Linux => write!(f, "linux"),
             Self::Darwin => write!(f, "darwin"),
             Self::Windows => write!(f, "windows"),
+            Self::FreeBSD => write!(f, "freebsd"),
         }
     }
 }

--- a/crates/vp_js_runtime/src/providers/node.rs
+++ b/crates/vp_js_runtime/src/providers/node.rs
@@ -171,7 +171,7 @@ impl NodeProvider {
     const fn archive_format(platform: Platform) -> ArchiveFormat {
         match platform.os {
             Os::Windows => ArchiveFormat::Zip,
-            Os::Linux | Os::Darwin => ArchiveFormat::TarGz,
+            Os::Linux | Os::Darwin | Os::FreeBSD => ArchiveFormat::TarGz,
         }
     }
 
@@ -599,6 +599,7 @@ impl JsRuntimeProvider for NodeProvider {
             Os::Linux => "linux",
             Os::Darwin => "darwin",
             Os::Windows => "win",
+            Os::FreeBSD => "linux",
         };
         let arch = match platform.arch {
             crate::platform::Arch::X64 => "x64",
@@ -653,14 +654,14 @@ impl JsRuntimeProvider for NodeProvider {
     fn binary_relative_path(&self, platform: Platform) -> Str {
         match platform.os {
             Os::Windows => "node.exe".into(),
-            Os::Linux | Os::Darwin => "bin/node".into(),
+            Os::Linux | Os::Darwin | Os::FreeBSD => "bin/node".into(),
         }
     }
 
     fn bin_dir_relative_path(&self, platform: Platform) -> Str {
         match platform.os {
             Os::Windows => "".into(),
-            Os::Linux | Os::Darwin => "bin".into(),
+            Os::Linux | Os::Darwin | Os::FreeBSD => "bin".into(),
         }
     }
 


### PR DESCRIPTION
vp_js_runtime's Os enum only lists Linux, Darwin, and Windows, and Os::current() has a compile_error! for any other target.  FreeBSD is a legitimate target for the `vp` binary (the rest of the toolchain builds fine), so add a FreeBSD variant and route it through the same tar.gz + bin/node + bin/ conventions the other unix platforms use.

Note: managed Node.js currently has no official FreeBSD build, so `vp env` downloads on FreeBSD will 404 at runtime.  That is a distribution gap, not a code gap, and does not block the `vp` binary itself from compiling or running.  If/when Node.js publishes FreeBSD artifacts, only the platform_string() mapping in providers/node.rs needs to be updated (FreeBSD -> "freebsd" instead of "linux").

Fixes https://github.com/voidzero-dev/vite-plus/issues/2537