### PR TITLE
chore(deps): remove duplicate tempfile dev dependencies

### DIFF
--- a/crates/vp_global_cli/Cargo.toml
+++ b/crates/vp_global_cli/Cargo.toml
@@ -50,7 +50,6 @@ uuid = { workspace = true, features = ["v4"] }
 [dev-dependencies]
 serial_test = { workspace = true }
 temp-env = { workspace = true }
-tempfile = { workspace = true }
 vp_shared = { workspace = true, features = ["test-utils"] }
 
 [lints]

--- a/crates/vp_js_runtime/Cargo.toml
+++ b/crates/vp_js_runtime/Cargo.toml
@@ -36,7 +36,6 @@ reqwest = { workspace = true, features = ["stream", "rustls-no-provider"] }
 
 [dev-dependencies]
 httpmock = { workspace = true }
-tempfile = { workspace = true }
 vp_shared = { workspace = true, features = ["test-utils"] }
 
 [lints]


### PR DESCRIPTION
Each crate now has a single `tempfile` dependency declaration. The existing normal dependencies cover both production and test targets, so dependency resolution and behavior remain unchanged.