### PR TITLE
chore(error): remove unused error variants

### DIFF
--- a/crates/vp_error/src/lib.rs
+++ b/crates/vp_error/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::allow_attributes, clippy::disallowed_types)]
 
-use std::{ffi::OsString, path::Path, sync::Arc};
+use std::{path::Path, sync::Arc};
 
 use thiserror::Error;
 use vt_path::{AbsolutePath, AbsolutePathBuf, relative::FromPathError};
@@ -24,17 +24,6 @@ pub enum Error {
     #[error(transparent)]
     Serde(#[from] serde_json::Error),
 
-    #[error("Env value is not valid unicode: {key} = {value:?}")]
-    EnvValueIsNotValidUnicode { key: Str, value: OsString },
-
-    #[cfg(unix)]
-    #[error("Unsupported file type: {0:?}")]
-    UnsupportedFileType(nix::dir::Type),
-
-    #[cfg(windows)]
-    #[error("Unsupported file type: {0:?}")]
-    UnsupportedFileType(std::fs::FileType),
-
     #[error(transparent)]
     Utf8Error(#[from] bstr::Utf8Error),
 
@@ -44,27 +33,6 @@ pub enum Error {
 
     #[error(transparent)]
     WorkspaceError(#[from] vt_workspace::Error),
-
-    #[error("Lint failed, reason: {reason}")]
-    LintFailed { status: Str, reason: Str },
-
-    #[error("Fmt failed")]
-    FmtFailed { status: Str, reason: Str },
-
-    #[error("Vite failed")]
-    Vite { status: Str, reason: Str },
-
-    #[error("Test failed")]
-    TestFailed { status: Str, reason: Str },
-
-    #[error("Lib failed")]
-    LibFailed { status: Str, reason: Str },
-
-    #[error("Doc failed, reason: {reason}")]
-    DocFailed { status: Str, reason: Str },
-
-    #[error("Resolve universal vite config failed")]
-    ResolveUniversalViteConfigFailed { status: Str, reason: Str },
 
     #[error("The path ({}) is not a valid relative path because: {reason}", .path.display())]
     InvalidRelativePath { path: Box<Path>, reason: FromPathError },


### PR DESCRIPTION
Remove stale `vp_error::Error` variants that have no constructors or match sites. Current command failures propagate through exit statuses or generic resolver errors, so these variants no longer represent reachable errors.