### PR TITLE
chore(rust): use the current unit_bindings lint name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rust-version = "1.92.0"
 [workspace.lints.rust]
 absolute_paths_not_starting_with_crate = "warn"
 non_ascii_idents = "warn"
-unit-bindings = "warn"
+unit_bindings = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)', 'cfg(coverage_nightly)'] }
 unsafe_op_in_unsafe_fn = "warn"
 unused_unsafe = "warn"


### PR DESCRIPTION
fix wrong typo:`unit-bindings` to `unit_bindings` (follows oxc-project lint rule)

ref: https://github.com/oxc-project/oxc/blob/d5d3c76cf6ba69c197c3030aa7a18d5bf9f4066c/Cargo.toml#L24