### PR TITLE
feat(env): support bun as a devEngines runtime

### DIFF
--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/shim_dev_engines_runtime_bun/package.json
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/shim_dev_engines_runtime_bun/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "shim-dev-engines-runtime-bun",
+  "version": "1.0.0",
+  "private": true,
+  "devEngines": {
+    "packageManager": { "name": "pnpm", "version": "10.11.0", "onFail": "download" },
+    "runtime": [
+      { "name": "bun", "version": "1.3.11", "onFail": "warn" },
+      { "name": "node", "version": "24.5.0", "onFail": "warn" }
+    ]
+  }
+}

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/shim_dev_engines_runtime_bun/snapshots.toml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/shim_dev_engines_runtime_bun/snapshots.toml
@@ -1,0 +1,10 @@
+# pnpm as package manager with bun and node as runtimes, all via devEngines
+[[case]]
+name = "shim_dev_engines_runtime_bun"
+vp = "global"
+steps = [
+  { argv = ["vp", "install", "-g", "pnpm"], snapshot = false },
+  { argv = ["bun", "--version"], comment = "bun resolves from the devEngines.runtime bun entry", continue-on-failure = true },
+  { argv = ["node", "-v"], comment = "node resolves from the devEngines.runtime node entry", continue-on-failure = true },
+  { argv = ["pnpm", "-v"], comment = "pnpm resolves from devEngines.packageManager", continue-on-failure = true },
+]

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/shim_dev_engines_runtime_bun/snapshots/shim_dev_engines_runtime_bun.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/shim_dev_engines_runtime_bun/snapshots/shim_dev_engines_runtime_bun.md
@@ -1,0 +1,28 @@
+# shim_dev_engines_runtime_bun
+
+## `vp install -g pnpm`
+
+
+## `bun --version`
+
+bun resolves from the devEngines.runtime bun entry
+
+```
+1.3.11
+```
+
+## `node -v`
+
+node resolves from the devEngines.runtime node entry
+
+```
+<version>
+```
+
+## `pnpm -v`
+
+pnpm resolves from devEngines.packageManager
+
+```
+10.11.0
+```

--- a/crates/vp_global_cli/src/commands/env/doctor.rs
+++ b/crates/vp_global_cli/src/commands/env/doctor.rs
@@ -818,10 +818,11 @@ async fn collect_dev_engines_findings(
         }
     }
 
-    // Runtimes Vite+ does not manage (informational)
+    // Runtimes Vite+ does not manage (informational); bun is managed through
+    // the package-manager store, resolved by the bun/bunx shims.
     if let Some(field) = runtime_field {
         for entry in field.entries() {
-            if entry.name != "node" {
+            if !matches!(entry.name.as_str(), "node" | "bun") {
                 findings.push(DevEnginesFinding::note(
                     "Runtime",
                     format!(
@@ -1272,6 +1273,19 @@ mod tests {
             "got: {}",
             findings[0].message
         );
+    }
+
+    #[tokio::test]
+    async fn test_dev_engines_findings_bun_runtime_is_managed() {
+        // bun is managed as a runtime (resolved by the bun/bunx shims via the
+        // package-manager store), so it must not get the "not managed" note.
+        let findings = dev_engines_findings_for(
+            &[("package.json", r#"{"devEngines":{"runtime":{"name":"bun","version":"1.3.11"}}}"#)],
+            None,
+        )
+        .await;
+
+        assert!(findings.is_empty(), "findings: {:?}", messages(&findings));
     }
 
     #[tokio::test]

--- a/crates/vp_global_cli/src/commands/env/setup.rs
+++ b/crates/vp_global_cli/src/commands/env/setup.rs
@@ -45,8 +45,12 @@ impl EnvShell {
     }
 }
 
-/// Tools to create shims for (node, npm, npx, corepack, vpx, vpr)
-pub(crate) const SHIM_TOOLS: &[&str] = &["node", "npm", "npx", "corepack", "vpx", "vpr"];
+/// Tools to create shims for (node, npm, npx, corepack, bun, bunx, vpx, vpr).
+///
+/// `bun`/`bunx` are default shims so a `devEngines.runtime` bun pin works
+/// without bun being the package manager (see `shim::dispatch`).
+pub(crate) const SHIM_TOOLS: &[&str] =
+    &["node", "npm", "npx", "corepack", "bun", "bunx", "vpx", "vpr"];
 
 /// Execute the setup command.
 pub async fn execute(refresh: bool, env_only: bool) -> Result<ExitStatus, Error> {
@@ -84,7 +88,7 @@ pub async fn execute(refresh: bool, env_only: bool) -> Result<ExitStatus, Error>
     // Create wrapper script in bin/
     setup_vp_wrapper(&current_exe, bin_dir, refresh).await?;
 
-    // Create shims for node, npm, npx, corepack
+    // Create the default shims (see SHIM_TOOLS)
     let mut created = Vec::new();
     let mut skipped = Vec::new();
 

--- a/crates/vp_global_cli/src/commands/env/which.rs
+++ b/crates/vp_global_cli/src/commands/env/which.rs
@@ -11,8 +11,8 @@ use std::process::ExitStatus;
 use chrono::Local;
 use owo_colors::OwoColorize;
 use vp_pm_cli::{
-    PackageManagerType, package_manager_bin_path, package_manager_install_dir,
-    resolve_package_manager_from_package_json,
+    package_manager_bin_path, package_manager_install_dir,
+    resolve_package_manager_tool_from_package_json,
 };
 use vp_shared::output;
 use vt_path::{AbsolutePath, AbsolutePathBuf};
@@ -149,15 +149,10 @@ async fn execute_package_manager_tool(
     cwd: &AbsolutePath,
     tool: &str,
 ) -> Result<Option<ExitStatus>, Error> {
-    let Some(expected_type) = PackageManagerType::from_tool(tool) else {
+    let Some(resolution) = resolve_package_manager_tool_from_package_json(cwd, tool)? else {
         return Ok(None);
     };
-    let Some(resolution) = resolve_package_manager_from_package_json(cwd)? else {
-        return Ok(None);
-    };
-    if resolution.package_manager_type != expected_type {
-        return Ok(None);
-    }
+    let expected_type = resolution.package_manager_type;
 
     let Some(install_dir) = package_manager_install_dir(expected_type, &resolution.version) else {
         return Ok(None);

--- a/crates/vp_global_cli/src/commands/global/install.rs
+++ b/crates/vp_global_cli/src/commands/global/install.rs
@@ -112,12 +112,16 @@ pub(crate) fn is_protected_shim(bin_name: &str, ignore_case: bool) -> bool {
     CORE_SHIMS.contains(&bin_name) || crate::commands::env::setup::SHIM_TOOLS.contains(&bin_name)
 }
 
-/// Check if a package can own a bin name. A protected shim cannot belong to a
-/// package, except for the `corepack` bin from the `corepack` package. This
-/// exception lets an explicit `vp install -g corepack` have priority. No other
-/// package can get `BinConfig` ownership of a declared `corepack` bin.
+/// Whether a package may own a bin name. Protected shim names never belong
+/// to packages, except that the `corepack` and `bun` packages may own their
+/// own bins (`corepack`; `bun`/`bunx`), so an explicit `vp install -g` of
+/// them wins the shim's resolution order. The exemption is scoped to the
+/// package name; any other package declaring one of these bins must not take
+/// BinConfig ownership.
 pub(crate) fn package_may_own_bin(package_name: &str, bin_name: &str) -> bool {
-    !is_protected_shim(bin_name, true) || (bin_name == "corepack" && package_name == "corepack")
+    !is_protected_shim(bin_name, true)
+        || (bin_name == "corepack" && package_name == "corepack")
+        || (matches!(bin_name, "bun" | "bunx") && package_name == "bun")
 }
 
 /// Options for [`install`].
@@ -1356,6 +1360,12 @@ mod tests {
         assert!(package_may_own_bin("corepack", "corepack"));
         assert!(!package_may_own_bin("some-package", "corepack"));
         assert!(!package_may_own_bin("@scope/corepack", "corepack"));
+
+        // Same scoping for the bun package and its bun/bunx bins
+        assert!(package_may_own_bin("bun", "bun"));
+        assert!(package_may_own_bin("bun", "bunx"));
+        assert!(!package_may_own_bin("some-package", "bunx"));
+        assert!(!package_may_own_bin("bun", "corepack"));
 
         // Other protected shims never belong to packages
         assert!(!package_may_own_bin("corepack", "npm"));

--- a/crates/vp_global_cli/src/shim/dispatch.rs
+++ b/crates/vp_global_cli/src/shim/dispatch.rs
@@ -6,7 +6,7 @@
 //! 3. Tool execution (core tools and package binaries)
 
 use vp_pm_cli::{
-    PackageManagerType, ensure_package_manager_bin, resolve_package_manager_from_package_json,
+    PackageManagerType, ensure_package_manager_bin, resolve_package_manager_tool_from_package_json,
 };
 use vp_shared::{PrependOptions, env_vars, output, prepend_to_path_env};
 use vt_path::{AbsolutePath, AbsolutePathBuf, current_dir};
@@ -663,30 +663,19 @@ fn resolve_npm_prefix(
     get_npm_global_prefix(npm_path, node_dir)
 }
 
-/// Resolve a matching package-manager binary from the current project's explicit
-/// `packageManager` field.
-///
-/// The match is intentionally strict to avoid translating commands: `npm` only uses
-/// `npm@...`, `pnpm` only uses `pnpm@...`, etc.
+/// Resolve the managed package-manager binary the current project declares
+/// for `tool` (see `resolve_package_manager_tool_from_package_json` for the
+/// sources and the strict family match), downloading it when needed.
 async fn resolve_matching_package_manager_tool(
     cwd: &AbsolutePath,
     tool: &str,
 ) -> Result<Option<AbsolutePathBuf>, Error> {
-    let Some(expected_type) = PackageManagerType::from_tool(tool) else {
+    let Some(resolution) = resolve_package_manager_tool_from_package_json(cwd, tool)? else {
         return Ok(None);
     };
-
-    let Some(resolution) = resolve_package_manager_from_package_json(cwd)? else {
-        return Ok(None);
-    };
-
-    if resolution.package_manager_type != expected_type {
-        return Ok(None);
-    }
-
-    let bin_name = expected_type.bin_name_for_tool(tool);
+    let bin_name = resolution.package_manager_type.bin_name_for_tool(tool);
     let bin_path = ensure_package_manager_bin(
-        expected_type,
+        resolution.package_manager_type,
         &resolution.version,
         resolution.hash.as_deref(),
         bin_name,
@@ -998,8 +987,23 @@ async fn dispatch_package_binary(tool: &str, args: &[String]) -> i32 {
     let package_metadata = match find_package_for_binary(tool).await {
         Ok(Some(metadata)) => metadata,
         Ok(None) => {
-            eprintln!("vp: Binary '{tool}' not found in any installed package");
-            eprintln!("vp: Run 'vp install -g <package>' to install");
+            // The bun/bunx shims exist by default, even when nothing
+            // configures bun: with no project pin and no globally installed
+            // package, fall back to the system binary.
+            if let Some(family) = PackageManagerType::from_tool(tool) {
+                if let Some(system_path) = find_system_tool(tool) {
+                    return exec::exec_tool(&system_path, args);
+                }
+                eprintln!(
+                    "vp: '{tool}' is not configured for this project and no system {family} was found"
+                );
+                eprintln!(
+                    "vp: Declare {family} in package.json (packageManager, devEngines.packageManager, or devEngines.runtime for bun), or run 'vp install -g {family}'"
+                );
+            } else {
+                eprintln!("vp: Binary '{tool}' not found in any installed package");
+                eprintln!("vp: Run 'vp install -g <package>' to install");
+            }
             return 1;
         }
         Err(e) => {

--- a/crates/vp_pm_cli/src/lib.rs
+++ b/crates/vp_pm_cli/src/lib.rs
@@ -25,7 +25,7 @@ pub use package_manager::{
     PackageManager, PackageManagerBuilder, PackageManagerResolution, PackageManagerSource,
     PackageManagerType, download_package_manager, ensure_package_manager_bin,
     get_package_manager_type_and_version, package_manager_bin_path, package_manager_install_dir,
-    resolve_package_manager_from_package_json,
+    resolve_package_manager_from_package_json, resolve_package_manager_tool_from_package_json,
 };
 pub use request::HttpClient;
 pub use resolution::{

--- a/crates/vp_pm_cli/src/package_manager.rs
+++ b/crates/vp_pm_cli/src/package_manager.rs
@@ -384,15 +384,8 @@ pub fn resolve_package_manager_from_package_json(
     };
     // An absent version means any version satisfies (devEngines spec)
     let version_req = version_req.unwrap_or_else(|| "*".into());
-    let version = if Version::parse(&version_req).is_ok() {
-        version_req
-    } else if let Ok(range) = node_semver::Range::parse(version_req.as_str())
-        && let Some(cached) = find_cached_package_manager_version(package_manager_type, &range)?
-    {
-        cached
-    } else {
-        version_req
-    };
+    let version = find_installed_package_manager_version(package_manager_type, &version_req)?
+        .unwrap_or(version_req);
 
     let package_json_path = workspace_root.path.join("package.json");
     Ok(Some(PackageManagerResolution {
@@ -403,6 +396,62 @@ pub fn resolve_package_manager_from_package_json(
         source_path: package_json_path.to_absolute_path_buf(),
         project_root: workspace_root.path.to_absolute_path_buf(),
     }))
+}
+
+/// Resolve the project-declared source for a package-manager *tool*
+/// (`pnpm`, `bunx`, ...): [`resolve_package_manager_from_package_json`] when
+/// it names the tool's family (strict, so commands are never translated),
+/// then — for bun only — a `devEngines.runtime` bun entry, since bun can be
+/// pinned as a runtime independently of the package manager
+/// (rfcs/dev-engines.md).
+pub fn resolve_package_manager_tool_from_package_json(
+    cwd: impl AsRef<AbsolutePath>,
+    tool: &str,
+) -> Result<Option<PackageManagerResolution>, Error> {
+    let Some(expected_type) = PackageManagerType::from_tool(tool) else {
+        return Ok(None);
+    };
+    if let Some(resolution) = resolve_package_manager_from_package_json(cwd.as_ref())?
+        && resolution.package_manager_type == expected_type
+    {
+        return Ok(Some(resolution));
+    }
+    if expected_type != PackageManagerType::Bun {
+        return Ok(None);
+    }
+    resolve_bun_runtime_from_dev_engines(cwd.as_ref())
+}
+
+/// Bun declared as a runtime in `devEngines.runtime`: the same binary as the
+/// bun package manager, so it resolves into the managed package-manager store.
+/// Walks up from `cwd` like Node.js runtime resolution (package-manager
+/// detection is anchored at the workspace root instead).
+fn resolve_bun_runtime_from_dev_engines(
+    cwd: &AbsolutePath,
+) -> Result<Option<PackageManagerResolution>, Error> {
+    let mut dir = Some(cwd);
+    while let Some(current) = dir {
+        let package_json_path = current.join("package.json");
+        if let Some(runtime) = read_dev_engines(&package_json_path).and_then(|d| d.runtime)
+            && let Some(entry) = runtime.find_by_name("bun")
+        {
+            // An absent version means any version satisfies (devEngines spec)
+            let version_req = entry.version.clone().unwrap_or_else(|| "*".into());
+            let version =
+                find_installed_package_manager_version(PackageManagerType::Bun, &version_req)?
+                    .unwrap_or(version_req);
+            return Ok(Some(PackageManagerResolution {
+                package_manager_type: PackageManagerType::Bun,
+                version,
+                hash: None,
+                source: "devEngines.runtime".into(),
+                source_path: package_json_path,
+                project_root: current.to_absolute_path_buf(),
+            }));
+        }
+        dir = current.parent();
+    }
+    Ok(None)
 }
 
 /// Return the managed install directory for a package manager version.
@@ -456,11 +505,15 @@ fn get_package_manager_from_package_json(
 fn read_dev_engines_package_manager(
     workspace_root: &WorkspaceRoot,
 ) -> Option<vp_shared::DevEngineField> {
-    let package_json_path = workspace_root.path.join("package.json");
-    let file = open_exists_file(&package_json_path).ok()??;
-    // Lenient: a package.json we cannot parse here is reported by other paths
+    read_dev_engines(&workspace_root.path.join("package.json"))?.package_manager
+}
+
+/// Read `devEngines` from a package.json. Lenient: a missing or unparsable
+/// file yields `None`; such files are reported by other paths.
+fn read_dev_engines(package_json_path: &AbsolutePath) -> Option<vp_shared::DevEngines> {
+    let file = open_exists_file(package_json_path).ok()??;
     let pkg: vp_shared::PackageJson = serde_json::from_reader(BufReader::new(&file)).ok()?;
-    pkg.dev_engines.and_then(|dev_engines| dev_engines.package_manager)
+    pkg.dev_engines
 }
 
 /// Resolve the package manager from `devEngines.packageManager` in package.json.
@@ -806,6 +859,31 @@ fn find_cached_package_manager_version(
         best = Some(version);
     }
     Ok(best.map(|version| Str::from(version.to_string())))
+}
+
+/// Find an already-downloaded version satisfying `version_req` (an exact
+/// version or a semver range; `"*"` means any version).
+///
+/// Non-mutating and offline: returns `None` when no complete install
+/// satisfies the requirement (or when the requirement is not parseable),
+/// leaving resolution to [`download_package_manager`].
+fn find_installed_package_manager_version(
+    package_manager_type: PackageManagerType,
+    version_req: &str,
+) -> Result<Option<Str>, Error> {
+    if Version::parse(version_req).is_ok() {
+        let Some(install_dir) = package_manager_install_dir(package_manager_type, version_req)
+        else {
+            return Ok(None);
+        };
+        let bin_name = package_manager_type.to_string();
+        let complete = is_package_manager_install_complete(&install_dir, &bin_name)?;
+        return Ok(complete.then(|| version_req.into()));
+    }
+    let Ok(range) = node_semver::Range::parse(version_req) else {
+        return Ok(None);
+    };
+    find_cached_package_manager_version(package_manager_type, &range)
 }
 
 /// Resolve a semver range (e.g. from `devEngines.packageManager`) to an exact
@@ -2121,6 +2199,110 @@ mod tests {
         assert!(resolution.hash.is_none());
         assert_eq!(resolution.source.as_str(), "packageManager");
         assert_eq!(resolution.project_root, temp_dir_path);
+    }
+
+    #[test]
+    fn test_resolve_package_manager_tool_bun_from_dev_engines_runtime() {
+        // Mixed mode: pnpm is the package manager, bun and node are runtimes.
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        create_package_json(
+            &temp_dir_path,
+            r#"{
+                "packageManager": "pnpm@10.11.0",
+                "devEngines": {
+                    "runtime": [
+                        {"name": "bun", "version": "1.3.11", "onFail": "warn"},
+                        {"name": "node", "version": "24.5.0", "onFail": "warn"}
+                    ]
+                }
+            }"#,
+        );
+
+        for tool in ["bun", "bunx"] {
+            let resolution = resolve_package_manager_tool_from_package_json(&temp_dir_path, tool)
+                .unwrap()
+                .unwrap_or_else(|| panic!("{tool} should resolve from devEngines.runtime"));
+            assert_eq!(resolution.package_manager_type, PackageManagerType::Bun);
+            assert_eq!(resolution.version.as_str(), "1.3.11");
+            assert_eq!(resolution.source.as_str(), "devEngines.runtime");
+            assert_eq!(resolution.source_path, temp_dir_path.join("package.json"));
+            assert_eq!(resolution.project_root, temp_dir_path);
+        }
+
+        // pnpm keeps resolving from the package-manager field
+        let pnpm = resolve_package_manager_tool_from_package_json(&temp_dir_path, "pnpm")
+            .unwrap()
+            .unwrap();
+        assert_eq!(pnpm.package_manager_type, PackageManagerType::Pnpm);
+        assert_eq!(pnpm.version.as_str(), "10.11.0");
+        assert_eq!(pnpm.source.as_str(), "packageManager");
+
+        // no command translation: other families do not match the pnpm pin
+        assert!(
+            resolve_package_manager_tool_from_package_json(&temp_dir_path, "yarn")
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            resolve_package_manager_tool_from_package_json(&temp_dir_path, "npm")
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_resolve_package_manager_tool_bun_runtime_walks_up() {
+        let temp_dir = create_temp_dir();
+        let root = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        create_package_json(
+            &root,
+            r#"{"devEngines": {"runtime": {"name": "bun", "version": "1.3.11"}}}"#,
+        );
+        let nested = root.join("packages/app");
+        fs::create_dir_all(&nested).unwrap();
+        create_package_json(&nested, r#"{"name": "app"}"#);
+
+        let resolution =
+            resolve_package_manager_tool_from_package_json(&nested, "bun").unwrap().unwrap();
+        assert_eq!(resolution.version.as_str(), "1.3.11");
+        assert_eq!(resolution.source_path, root.join("package.json"));
+        assert_eq!(resolution.project_root, root);
+    }
+
+    #[test]
+    fn test_resolve_package_manager_tool_bun_package_manager_source_wins() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        create_package_json(
+            &temp_dir_path,
+            r#"{
+                "packageManager": "bun@1.3.10",
+                "devEngines": {"runtime": {"name": "bun", "version": "1.3.11"}}
+            }"#,
+        );
+
+        let resolution =
+            resolve_package_manager_tool_from_package_json(&temp_dir_path, "bun").unwrap().unwrap();
+        assert_eq!(resolution.version.as_str(), "1.3.10");
+        assert_eq!(resolution.source.as_str(), "packageManager");
+    }
+
+    #[test]
+    fn test_resolve_package_manager_tool_bun_runtime_absent_version_means_any() {
+        let temp_dir = create_temp_dir();
+        let temp_dir_path = AbsolutePathBuf::new(temp_dir.path().to_path_buf()).unwrap();
+        create_package_json(&temp_dir_path, r#"{"devEngines": {"runtime": {"name": "bun"}}}"#);
+
+        // Isolate VP_HOME so no already-downloaded bun satisfies `*`.
+        let resolution =
+            EnvConfig::with_vars([(env_vars::VP_HOME, temp_dir_path.as_path())], |_| {
+                resolve_package_manager_tool_from_package_json(&temp_dir_path, "bun")
+            })
+            .unwrap()
+            .unwrap();
+        assert_eq!(resolution.version.as_str(), "*");
+        assert_eq!(resolution.source.as_str(), "devEngines.runtime");
     }
 
     #[test]

--- a/docs/guide/env.md
+++ b/docs/guide/env.md
@@ -21,6 +21,22 @@ latest LTS.
 
 When a project declares `packageManager` (or `devEngines.packageManager`) in `package.json`, matching package-manager shims also use that package-manager version. For example, `packageManager: "npm@10.9.4"` makes both `npm` and `npx` run through npm 10.9.4. Alias pairs follow the installed package-manager shims: `npm`/`npx`, `pnpm`/`pnpx`, `yarn`/`yarnpkg`, and `bun`/`bunx`. Vite+ does not translate mismatched commands, so a project pinned to `pnpm` still lets `npm` fall back to the npm that comes with the resolved Node.js runtime.
 
+When bun is not the project's package manager, it can still be pinned as a _runtime_ in `devEngines.runtime` (alongside node). The `bun`/`bunx` shims resolve that entry — walking up parent directories like Node.js resolution — and download the declared bun version. (If a package-manager source names bun, that pin governs the `bun` binary instead.) This makes mixed setups work, where e.g. pnpm handles installs while bun runs scripts:
+
+```json
+{
+  "packageManager": "pnpm@10.11.0",
+  "devEngines": {
+    "runtime": [
+      { "name": "bun", "version": "1.3.13", "onFail": "warn" },
+      { "name": "node", "version": "24", "onFail": "warn" }
+    ]
+  }
+}
+```
+
+With this configuration, `pnpm`, `bun`, and `node` each resolve to their declared version. `vp env setup` creates the `bun`/`bunx` shims by default, so no per-machine bun install is needed; when a project declares no bun at all, they fall back to a globally installed bun (`vp install -g bun`) and then to the system bun.
+
 A fresh install uses the split platform layout by default. On Unix, Vite+
 stores managed runtimes and related files in `~/.local/share/vite-plus`. It
 stores executables in the Vite+-owned `~/.local/share/vite-plus/bin` directory.
@@ -120,7 +136,7 @@ use this file to select the Node.js version.
 
 ```bash
 # Setup
-vp env setup                  # Create shims for node, npm, npx, corepack
+vp env setup                  # Create shims for node, npm, npx, corepack, bun
 vp env on                     # Use Vite+ managed Node.js
 vp env print                  # Print shell snippet for this session
 

--- a/rfcs/dev-engines.md
+++ b/rfcs/dev-engines.md
@@ -144,7 +144,8 @@ The walk-up algorithm is unchanged: at each directory, sources are checked in th
 #### 2.2 Array form and non-node runtimes
 
 - Entries are evaluated in array order; the first entry with `name == "node"` is used (matches spec "first acceptable option" for the runtimes Vite+ manages).
-- Entries for runtimes Vite+ does not manage (`deno`, `bun`, ...) are skipped for resolution. `vp env doctor` lists them as informational notes ("declared runtime `deno` is not managed by Vite+").
+- A `bun` entry is also managed: the `bun`/`bunx` shims resolve it (walking up like Node.js resolution) and download the declared bun version into the managed package-manager store, since bun the runtime and bun the package manager are the same binary. Package-manager sources (`packageManager`, `devEngines.packageManager`) win over the runtime entry when both name bun. This makes mixed setups work, e.g. `packageManager: "pnpm@..."` plus `devEngines.runtime` entries for bun and node.
+- Entries for runtimes Vite+ does not manage (`deno`, ...) are skipped for resolution. `vp env doctor` lists them as informational notes ("declared runtime `deno` is not managed by Vite+").
 - If no `node` entry exists, the chain falls through to `engines.node`.
 
 #### 2.3 `onFail` semantics
@@ -370,7 +371,7 @@ A small shared Rust helper (in `vp_shared`) will own "edit one field in package.
 
 ## Non-Goals
 
-- Managing non-Node runtimes (`deno`, `bun` as a runtime) via `devEngines.runtime`.
+- Managing runtimes other than node and bun via `devEngines.runtime`.
 - Validating `devEngines.os` / `cpu` / `libc`.
 - Acting as a general enforcement layer for arbitrary package manager names beyond pnpm / yarn / npm / bun.
 - Changing session-override behavior (`vp env use`, `VP_NODE_VERSION`).


### PR DESCRIPTION
We have a repo that uses `bun` for running scripts and somethings along with node in parallel since we aim to support both runtimes, we use `pnpm` as the package manager. So I have attempted to write something like this in package.json
```json
  "devEngines": {
    "packageManager": { "name": "pnpm", "version": "10.20.0", "onFail": "download" },
    "runtime": [
      { "name": "bun", "version": "1.3.13", "onFail": "download" },
      { "name": "node", "version": "24.5.0", "onFail": "download" }
    ]
  }
```
this resolves `pnpm` as the package manager, and `node` version as runtime, but doesn't put the correct `bun` version on `PATH`. I expected this since Vite+ says it doesn't want to manage runtimes, but still allows to use `bun` as package manager. I asked in Voidzero discord and @TheAlexLichter confirmed too.
I still want to migrate our repo to Vite+, so I took a stab at this with help of Claude Fable 5, and the implementation came out at 350 lines, the mechanism for managing/downloading `bun` already exists, only the dev engines had to be hooked up. This doesn't mean Vite+ does everything through bun, it only makes it so the correct version of `bun` is available in path and the scripts in package.json and invoking bun from the shell downloads and uses correct bun version.
<img width="1634" height="1410" alt="Screenshot 2026-08-26 at 14-51-11" src="https://github.com/user-attachments/assets/54a397c5-a8cf-4920-9260-d720704d0ba1" />

I have cleaned up the code and opened this PR on suggestion of @TheAlexLichter so we can have a discussion on this, the behaviour in this PR is what I exactly need. I can tweak how its implemented based on feedback.

Discord Thread https://discord.com/channels/1475973262193459293/1540305126269521941