### PR TITLE
docs: fix Zed Oxc configuration

### DIFF
--- a/docs/guide/ide-integration.md
+++ b/docs/guide/ide-integration.md
@@ -82,10 +82,22 @@ You can also manually set up the Zed config:
     "JavaScript": {
       "format_on_save": "on",
       "prettier": { "allowed": false },
-      "formatter": [{ "language_server": { "name": "oxfmt" } }],
-      "code_action": "source.fixAll.oxc"
+      "formatter": [
+        { "language_server": { "name": "oxfmt" } },
+        { "code_action": "source.fixAll.oxc" }
+    ]
+    },
+    "JSX": {
+      "format_on_save": "on",
+      "prettier": { "allowed": false },
+      "formatter": [{ "language_server": { "name": "oxfmt" } }]
     },
     "TypeScript": {
+      "format_on_save": "on",
+      "prettier": { "allowed": false },
+      "formatter": [{ "language_server": { "name": "oxfmt" } }]
+    },
+    "TSX": {
       "format_on_save": "on",
       "prettier": { "allowed": false },
       "formatter": [{ "language_server": { "name": "oxfmt" } }]

--- a/docs/guide/ide-integration.md
+++ b/docs/guide/ide-integration.md
@@ -85,7 +85,7 @@ You can also manually set up the Zed config:
       "formatter": [
         { "language_server": { "name": "oxfmt" } },
         { "code_action": "source.fixAll.oxc" }
-    ]
+      ]
     },
     "JSX": {
       "format_on_save": "on",

--- a/packages/cli/src/utils/editor.ts
+++ b/packages/cli/src/utils/editor.ts
@@ -87,9 +87,11 @@ const ZED_SETTINGS = {
       {
         format_on_save: 'on',
         prettier: { allowed: false },
-        formatter: [{ language_server: { name: 'oxfmt' } }],
-        // Only the JavaScript entry runs the oxc fix-all code action on save
-        ...(language === 'JavaScript' ? { code_action: 'source.fixAll.oxc' } : {}),
+        formatter: [
+          { language_server: { name: 'oxfmt' } },
+          // Only the JavaScript entry runs the oxc fix-all code action on save.
+          ...(language === 'JavaScript' ? [{ code_action: 'source.fixAll.oxc' }] : []),
+        ],
       },
     ]),
   ),


### PR DESCRIPTION
Fix the Zed configuration example so source.fixAll.oxc is configured as a formatter code action instead of an invalid language-level setting. The Oxc Zed example configuration is doing it the same way: [oxc-project/oxc-zed example configuration](https://github.com/oxc-project/oxc-zed/blob/main/examples/both/.zed/settings.json?utm_source=chatgpt.com)

Also add JSX and TSX, since Zed treats them as separate languages and the TypeScript/JavaScript formatter settings don't apply to them. This tripped me up while setting up the integration just now, since my TSX files were still being formatted with the default settings.