### PR TITLE
fix(prompts): replace deprecated tsdown option

### DIFF
--- a/packages/prompts/tsdown.config.ts
+++ b/packages/prompts/tsdown.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
-  inlineOnly: false,
+  deps: {
+    onlyBundle: false,
+  },
 });


### PR DESCRIPTION
Updates the prompts build config to use tsdown's supported dependency option. This removes the deprecation warning while continuing to suppress bundled-dependency warnings.


ref:
<img width="807" height="210" alt="Screenshot 2026-09-02 at 6 48 42 PM" src="https://github.com/user-attachments/assets/3632914a-852f-463e-b875-bdcd50082672" />


related PR: https://github.com/rolldown/tsdown/pull/1029