### PR TITLE
fix(deps): keep automatic Vitest upgrades on v4

### DIFF
--- a/.github/scripts/__tests__/upgrade-deps-utils.spec.ts
+++ b/.github/scripts/__tests__/upgrade-deps-utils.spec.ts
@@ -1,0 +1,18 @@
+/// <reference types="node" />
+
+import { expect, test } from 'vitest';
+
+import { findLatestStableVersionForMajor } from '../upgrade-deps-utils.ts';
+
+test('selects the highest stable version from the supported major', () => {
+  expect(
+    findLatestStableVersionForMajor(
+      ['3.2.4', '4.1.11', '5.0.0', '4.10.0', '4.11.0-beta.1', '4.2.12'],
+      4,
+    ),
+  ).toBe('4.10.0');
+});
+
+test('returns undefined when the supported major has no stable release', () => {
+  expect(findLatestStableVersionForMajor(['4.2.0-beta.1', '5.0.0'], 4)).toBeUndefined();
+});

--- a/.github/scripts/upgrade-deps-utils.ts
+++ b/.github/scripts/upgrade-deps-utils.ts
@@ -1,0 +1,42 @@
+const STABLE_VERSION_RE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+type ParsedVersion = {
+  major: number;
+  minor: number;
+  patch: number;
+  version: string;
+};
+
+function parseStableVersion(version: string): ParsedVersion | undefined {
+  const match = STABLE_VERSION_RE.exec(version);
+  if (!match) {
+    return undefined;
+  }
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    version,
+  };
+}
+
+function isNewer(candidate: ParsedVersion, current: ParsedVersion): boolean {
+  return (
+    candidate.minor > current.minor ||
+    (candidate.minor === current.minor && candidate.patch > current.patch)
+  );
+}
+
+export function findLatestStableVersionForMajor(
+  versions: Iterable<string>,
+  major: number,
+): string | undefined {
+  let latest: ParsedVersion | undefined;
+  for (const version of versions) {
+    const parsed = parseStableVersion(version);
+    if (parsed?.major === major && (!latest || isNewer(parsed, latest))) {
+      latest = parsed;
+    }
+  }
+  return latest?.version;
+}

--- a/.github/scripts/upgrade-deps.ts
+++ b/.github/scripts/upgrade-deps.ts
@@ -1,6 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { findLatestStableVersionForMajor } from './upgrade-deps-utils.ts';
+
 const ROOT = process.cwd();
 const META_DIR = process.env.UPGRADE_DEPS_META_DIR;
 
@@ -29,6 +31,10 @@ type LatestTagOptions = {
 type NpmLatestResponse = {
   version?: unknown;
   dependencies?: Record<string, string>;
+};
+
+type NpmPackumentResponse = {
+  versions?: Record<string, unknown>;
 };
 
 type UpstreamVersions = {
@@ -64,6 +70,9 @@ type PnpmWorkspaceEntry = {
 };
 
 const STABLE_SEMVER_TAG_RE = /^v?\d+\.\d+\.\d+$/;
+// Vitest major upgrades can change the bundled API, export shims, and CLI
+// behavior. Advance this only after Vite+ has adapted to the new major.
+const SUPPORTED_VITEST_MAJOR = 4;
 
 const isFullSha = (s: string): boolean => /^[0-9a-f]{40}$/.test(s);
 
@@ -144,6 +153,23 @@ async function getLatestNpmVersion(packageName: string): Promise<string> {
     throw new Error(`Invalid npm response for ${packageName}: missing version field`);
   }
   return data.version;
+}
+
+async function getLatestNpmVersionForMajor(packageName: string, major: number): Promise<string> {
+  const res = await fetch(`https://registry.npmjs.org/${packageName}`, {
+    headers: { accept: 'application/vnd.npm.install-v1+json' },
+  });
+  if (!res.ok) {
+    throw new Error(
+      `Failed to fetch npm metadata for ${packageName}: ${res.status} ${res.statusText}`,
+    );
+  }
+  const data = (await res.json()) as NpmPackumentResponse;
+  const version = findLatestStableVersionForMajor(Object.keys(data.versions ?? {}), major);
+  if (!version) {
+    throw new Error(`No stable ${major}.x version found for ${packageName}`);
+  }
+  return version;
 }
 
 // Read a dependency range from the latest published version of `packageName`,
@@ -554,7 +580,7 @@ const [
   oxcParserVersion,
   oxcTransformVersion,
 ] = await Promise.all([
-  getLatestNpmVersion('vitest'),
+  getLatestNpmVersionForMajor('vitest', SUPPORTED_VITEST_MAJOR),
   getLatestNpmVersion('tsdown'),
   getLatestNpmVersion('tsdown-migrate'),
   // Mirror exactly what the bundled @tsdown/css depends on.

--- a/.github/workflows/upgrade-deps.yml
+++ b/.github/workflows/upgrade-deps.yml
@@ -89,21 +89,24 @@ jobs:
           show_full_output: 'true'
           prompt: |
             Your goal: after the daily upstream-dependency upgrade, bring the project back
-            to a fully green state. The upgrade script has bumped every dep to the latest
-            version, the `Sync remote and build` step has attempted to merge the rolldown
-            and vite catalogs into the workspace, and the `build-upstream` action has
-            attempted a build — your job is to diagnose and fix every error that surfaced,
-            then prove the fix is complete by running a final validation pass.
+            to a fully green state. The upgrade script has bumped every dep to its latest
+            supported version, the `Sync remote and build` step has attempted to merge the
+            rolldown and vite catalogs into the workspace, and the `build-upstream` action
+            has attempted a build — your job is to diagnose and fix every error that
+            surfaced, then prove the fix is complete by running a final validation pass.
 
             ### Background
             - Upgrade script: `./.github/scripts/upgrade-deps.ts`
+            - Vitest is intentionally capped at the latest stable `4.x` release until
+              Vite+ adapts to a newer major. Do not remove or bypass that cap.
             - Sync-remote tool: `pnpm tool sync-remote` (source in
               `packages/tools/src/sync-remote-deps.ts`) — clones rolldown/vite into the
               working tree, merges their pnpm-workspace catalogs into the root
               `pnpm-workspace.yaml`, and syncs the root `Cargo.toml` oxc crate
               versions to match `rolldown/Cargo.toml`.
             - Build-upstream action: `./.github/actions/build-upstream/action.yml`
-            - Package manager: `pnpm`. Do NOT downgrade any dep — we want the latest.
+            - Package manager: `pnpm`. Do not downgrade a dependency selected by the
+              upgrade script. Use the latest version that its compatibility policy allows.
 
             ### Outcomes from earlier steps (both ran with continue-on-error)
             - Sync remote and build: ${{ steps.build.outcome }}


### PR DESCRIPTION
The dependency upgrade workflow now selects the newest stable `vitest` release in the supported `4.x` major. It does not select `vitest@5` until the integration supports that major.

The workflow also tells its repair agent to keep the version cap. Unit tests cover stable version ordering, prerelease exclusion, and missing stable releases.