### PR TITLE
test(snapshots): pin pnpm in create build approval fixtures

### DIFF
--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/create_approve_builds_migrate_pnpm11/package.json
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/create_approve_builds_migrate_pnpm11/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "create-approve-builds-migrate-pnpm11",
+  "private": true,
+  "packageManager": "pnpm@11.0.0"
+}

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/create_approve_builds_pnpm11/package.json
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/create_approve_builds_pnpm11/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "create-approve-builds-pnpm11",
+  "private": true,
+  "packageManager": "pnpm@11.0.0"
+}


### PR DESCRIPTION
The pnpm 11 create build-approval snapshots fail on main because `approve-builds` now emits extra output. These fixtures do not pin a package manager, so `vp create` resolves the latest pnpm release.

Pin both fixtures to pnpm 11.0.0, matching the existing pnpm 11 `approve-builds` fixture. The original snapshots pass unchanged.

🤖 Generated with Codex
