### PR TITLE
chore(ci): isolate preview workflow concurrency

### DIFF
--- a/.github/workflows/publish-preview-register.yml
+++ b/.github/workflows/publish-preview-register.yml
@@ -1,4 +1,5 @@
 name: Register preview build
+run-name: 'Register preview: ${{ github.event.workflow_run.head_branch }} (build #${{ github.event.workflow_run.run_number }}: ${{ github.event.workflow_run.conclusion }})'
 
 # PUBLISHING WORKFLOW. Takes the artifact built by "Publish preview build",
 # publishes it to the registry bridge, and comments on the PR. It is the only
@@ -47,8 +48,9 @@ env:
   IMAGE: ghcr.io/voidzero-dev/vite-plus
 
 concurrency:
-  # Keyed on the built commit, so a re-label or re-run coalesces.
-  group: register-preview-${{ github.event.workflow_run.head_sha }}
+  # Successful builds share a commit group so a re-label or re-run coalesces.
+  # Other completions must not replace a pending publish in that group.
+  group: register-preview-${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_sha || github.event.workflow_run.id }}
   # NOT cancel-in-progress. Cancelling a publish part-way is what left the
   # bridge with a packument/tarball mismatch on 2026-07-02; the action registers
   # the ref last precisely so an interrupted run stays invisible, and cancelling

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -1,4 +1,5 @@
 name: Publish preview build
+run-name: 'Preview PR #${{ github.event.pull_request.number }}: ${{ github.event.label.name }}'
 
 # BUILD WORKFLOW. Builds a labeled PR and packs its packages into a workflow
 # artifact. It holds no secrets and no OIDC permission, so it is safe to run
@@ -28,7 +29,8 @@ on:
     types: [labeled]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Unrelated labels must not cancel a preview build for the same PR.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.label.name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Adding an unrelated PR label can cancel an active preview build because all label events use the same concurrency group. Group builds by label so only another `preview-build` event can cancel a preview build.

`Register preview build` now gives unsuccessful builds separate concurrency groups. These runs cannot replace a pending publish for a successful build.

Run titles show the label or the upstream branch, build number, and result. Label events still create skipped runs.

Local checks passed: `actionlint`, `vp fmt --check`, and `git diff --check`.
