### PR TITLE
test: keep release snapshots independent of published versions

### DIFF
--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_pack_tsdown_023/snapshots.toml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_pack_tsdown_023/snapshots.toml
@@ -84,6 +84,7 @@ steps = [
 [[case]]
 name = "migration_pack_tsdown_023_no_external"
 vp = "global"
+local-registry = true
 comment = "Migrate noExternal patterns, references, and callbacks and confirm the dependency remains bundled."
 steps = [
   { argv = ["vpt", "cp", "no-external.config.txt", "vite.config.ts"], snapshot = false },

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_stale_vitest_alias_startup/pnpm-workspace.yaml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_stale_vitest_alias_startup/pnpm-workspace.yaml
@@ -2,8 +2,8 @@ packages:
   - .
 
 catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@0.3.0
-  vite-plus: 0.3.0
+  vite: npm:@voidzero-dev/vite-plus-core@__VITE_PLUS_VERSION__
+  vite-plus: __VITE_PLUS_VERSION__
   vitest: npm:@voidzero-dev/vite-plus-test@0.1.24
 
 overrides:

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_stale_vitest_alias_startup/setup-local.mjs
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_stale_vitest_alias_startup/setup-local.mjs
@@ -9,6 +9,11 @@ const localPackageDir = path.join('node_modules', 'vite-plus');
 fs.mkdirSync('node_modules', { recursive: true });
 fs.cpSync(sourcePackageDir, localPackageDir, { recursive: true, dereference: true });
 
+// Keep Vite+ current so the fixture tests only the stale Vitest alias.
+const { version } = JSON.parse(fs.readFileSync(path.join(sourcePackageDir, 'package.json'), 'utf8'));
+const workspaceConfig = fs.readFileSync('pnpm-workspace.yaml', 'utf8');
+fs.writeFileSync('pnpm-workspace.yaml', workspaceConfig.replaceAll('__VITE_PLUS_VERSION__', version));
+
 const fakeVitestDir = path.join('node_modules', 'vitest');
 fs.mkdirSync(fakeVitestDir, { recursive: true });
 fs.writeFileSync(
@@ -28,6 +33,6 @@ fs.writeFileSync(
   "throw new Error('stale Vitest alias was loaded before command dispatch');\n",
 );
 
-// This file only prepares node_modules. Remove the staged copy so migration's
-// source-import pass measures the project fixture rather than its test harness.
+// Remove the staged copy so migration's source-import pass measures the
+// project fixture rather than its test harness.
 fs.rmSync(new URL(import.meta.url));

--- a/packages/tools/src/local-npm-registry.ts
+++ b/packages/tools/src/local-npm-registry.ts
@@ -523,7 +523,8 @@ const server = createServer(async (req, res) => {
 
 // Registry env for every package manager, each of which reads its own
 // spelling: npm and bun honor NPM_CONFIG_REGISTRY, pnpm >= 10.6 only reads
-// PNPM_CONFIG_* (older pnpm read the lowercase npm_config_* form), and Yarn
+// PNPM_CONFIG_* (pnpm 11.0 requires lowercase pnpm_config_*; older pnpm
+// read the lowercase npm_config_* form), and Yarn
 // Berry only reads YARN_-prefixed settings and refuses plain-http registries
 // unless the host is whitelisted.
 //
@@ -549,6 +550,7 @@ function buildRegistryEnv(registry: string): Record<string, string> {
     NPM_CONFIG_REGISTRY: registry,
     npm_config_registry: registry,
     PNPM_CONFIG_REGISTRY: registry,
+    pnpm_config_registry: registry,
     YARN_NPM_REGISTRY_SERVER: registry,
     YARN_UNSAFE_HTTP_WHITELIST: '127.0.0.1',
     NO_PROXY: noProxy,


### PR DESCRIPTION
Use `pnpm_config_registry` so `pnpm@11.0.0` resolves the packed checkout during create snapshots. Enable the local registry for the pack fixture's install step.

Seed the stale Vitest fixture with the checkout version to keep its output stable after a release bump.

All four affected snapshot cases pass locally.
