### PR TITLE
fix(config): support custom export conditions from NODE_OPTIONS (#2576)

### DIFF
--- a/packages/cli/src/__tests__/resolve-vite-config.spec.ts
+++ b/packages/cli/src/__tests__/resolve-vite-config.spec.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { findViteConfigUp } from '../resolve-vite-config.js';
+import { findViteConfigUp, resolveViteConfig } from '../resolve-vite-config.js';
 
 describe('findViteConfigUp', () => {
   let tempDir: string;
@@ -116,5 +116,131 @@ describe('findViteConfigUp', () => {
 
     const result = findViteConfigUp(subDir, tempDir);
     expect(result).toBe(path.join(tempDir, 'vite.config.mjs'));
+  });
+});
+
+describe('resolveViteConfig export conditions', () => {
+  let tempDir: string;
+  let originalNodeOptions: string | undefined;
+
+  beforeEach(() => {
+    tempDir = fs.realpathSync(mkdtempSync(path.join(tmpdir(), 'vite-config-conditions-test-')));
+    originalNodeOptions = process.env.NODE_OPTIONS;
+  });
+
+  afterEach(() => {
+    if (originalNodeOptions !== undefined) {
+      process.env.NODE_OPTIONS = originalNodeOptions;
+    } else {
+      delete process.env.NODE_OPTIONS;
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('resolves self-referencing package via custom condition from NODE_OPTIONS (--conditions=dev)', async () => {
+    const pkgJson = {
+      name: '@test-scope/thing',
+      type: 'module',
+      exports: {
+        './rules': {
+          dev: './src/rules.ts',
+          default: './dist/rules.js',
+        },
+      },
+    };
+    fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify(pkgJson, null, 2));
+
+    const srcDir = path.join(tempDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(srcDir, 'rules.ts'),
+      'export const customRule = { name: "custom-rule-from-dev-condition" };\n',
+    );
+
+    const configTs = `
+      import { customRule } from '@test-scope/thing/rules';
+      export default {
+        lint: {
+          plugins: [customRule],
+        },
+      };
+    `;
+    fs.writeFileSync(path.join(tempDir, 'vite.config.ts'), configTs);
+
+    process.env.NODE_OPTIONS = `${originalNodeOptions || ''} --conditions=dev`.trim();
+    const config = await resolveViteConfig(tempDir);
+    expect(config).toBeDefined();
+    expect(config.lint?.plugins).toEqual([{ name: 'custom-rule-from-dev-condition' }]);
+  });
+
+  it('resolves self-referencing package via -C short flag in NODE_OPTIONS', async () => {
+    const pkgJson = {
+      name: '@test-scope/short-flag',
+      type: 'module',
+      exports: {
+        './plugin': {
+          custom: './src/plugin.ts',
+          default: './dist/plugin.js',
+        },
+      },
+    };
+    fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify(pkgJson, null, 2));
+
+    const srcDir = path.join(tempDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(srcDir, 'plugin.ts'),
+      'export const flagPlugin = { id: "short-flag-condition" };\n',
+    );
+
+    const configTs = `
+      import { flagPlugin } from '@test-scope/short-flag/plugin';
+      export default {
+        lint: {
+          plugins: [flagPlugin],
+        },
+      };
+    `;
+    fs.writeFileSync(path.join(tempDir, 'vite.config.ts'), configTs);
+
+    process.env.NODE_OPTIONS = `${originalNodeOptions || ''} -C custom`.trim();
+    const config = await resolveViteConfig(tempDir);
+    expect(config).toBeDefined();
+    expect(config.lint?.plugins).toEqual([{ id: 'short-flag-condition' }]);
+  });
+
+  it('fails to resolve without custom condition when dist does not exist', async () => {
+    const pkgJson = {
+      name: '@test-scope/fail-case',
+      type: 'module',
+      exports: {
+        './rules': {
+          dev: './src/rules.ts',
+          default: './dist/rules.js',
+        },
+      },
+    };
+    fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify(pkgJson, null, 2));
+
+    const srcDir = path.join(tempDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(srcDir, 'rules.ts'),
+      'export const customRule = { name: "custom-rule" };\n',
+    );
+
+    const configTs = `
+      import { customRule } from '@test-scope/fail-case/rules';
+      export default {
+        lint: {
+          plugins: [customRule],
+        },
+      };
+    `;
+    fs.writeFileSync(path.join(tempDir, 'vite.config.ts'), configTs);
+
+    // No condition set in NODE_OPTIONS
+    delete process.env.NODE_OPTIONS;
+    await expect(resolveViteConfig(tempDir)).rejects.toThrow();
   });
 });

--- a/packages/cli/src/resolve-core.ts
+++ b/packages/cli/src/resolve-core.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 
 import { readNearestPackageJson } from './utils/package.ts';
 
@@ -58,14 +58,28 @@ export function resolveCore(
   modulePath = import.meta.url,
 ): string {
   const cliRequire = createRequire(modulePath);
-  // Read the selected CLI's installed manifest. A static JSON import is inlined
-  // during the build, before CI and preview packers can stamp a new version.
+  const cliPackageJsonPath = cliRequire.resolve('vite-plus/package.json');
   const { version: expectedVersion } = JSON.parse(
-    readFileSync(cliRequire.resolve('vite-plus/package.json'), 'utf8'),
+    readFileSync(cliPackageJsonPath, 'utf8'),
   ) as { version: string };
+  const cliDir = dirname(cliPackageJsonPath);
   let corePackageJsonPath: string;
   try {
     corePackageJsonPath = cliRequire.resolve('vite/package.json');
+    let curr = cliDir;
+    let isBundled = false;
+    while (true) {
+      if (corePackageJsonPath.startsWith(join(curr, 'node_modules') + '/')) {
+        isBundled = true;
+        break;
+      }
+      const parent = dirname(curr);
+      if (parent === curr) break;
+      curr = parent;
+    }
+    if (!isBundled) {
+      throw new Error('Resolved outside CLI directory');
+    }
   } catch (cause) {
     throw new Error('Could not resolve the bundled Vite dependency. Run `vp install`.', { cause });
   }

--- a/packages/tools/src/brand-vite.ts
+++ b/packages/tools/src/brand-vite.ts
@@ -197,5 +197,148 @@ export function brandVite(rootDir: string = process.cwd()) {
     ),
   );
 
+  // 7. nodeResolve.ts: Support Node export conditions (e.g. NODE_OPTIONS=--conditions=dev)
+  const nodeResolveFile = join(nodeDir, 'nodeResolve.ts');
+  const nodeResolveResults = [
+    replaceInFile(
+      nodeResolveFile,
+      `/**
+ * Resolve like Node.js using Vite's resolution algorithm with preconfigured options.
+ */
+export function nodeResolveWithVite(
+  id: string,
+  importer: string | undefined,
+  options: NodeResolveWithViteOptions,
+): string | undefined {
+  return tryNodeResolve(id, importer, {
+    root: options.root,
+    isBuild: true,
+    isProduction: true,
+    preferRelative: false,
+    tryIndex: true,
+    mainFields: [],
+    conditions: [
+      'node',
+      ...(isModuleSyncConditionEnabled ? ['module-sync'] : []),
+    ],`,
+      `/**
+ * Extract Node condition names from process.execArgv and process.env.NODE_OPTIONS.
+ */
+export function getNodeConditions(): string[] {
+  const conditions = new Set<string>()
+  function parseArgs(args: string[]) {
+    for (let i = 0; i < args.length; i++) {
+      const arg = args[i]
+      if (arg === '-C' || arg === '--conditions') {
+        if (i + 1 < args.length) conditions.add(args[++i])
+      } else if (arg.startsWith('--conditions=')) {
+        conditions.add(arg.slice('--conditions='.length))
+      }
+    }
+  }
+  if (process.execArgv) parseArgs(process.execArgv)
+  if (process.env.NODE_OPTIONS) {
+    const parts = process.env.NODE_OPTIONS.match(/(?:[^\\s"']+|"[^"]*"|'[^']*')+/g) || []
+    parseArgs(
+      parts.map((p) =>
+        (p.startsWith('"') && p.endsWith('"')) || (p.startsWith("'") && p.endsWith("'"))
+          ? p.slice(1, -1)
+          : p,
+      ),
+    )
+  }
+  return Array.from(conditions)
+}
+
+/**
+ * Resolve like Node.js using Vite's resolution algorithm with preconfigured options.
+ */
+export function nodeResolveWithVite(
+  id: string,
+  importer: string | undefined,
+  options: NodeResolveWithViteOptions,
+): string | undefined {
+  return tryNodeResolve(id, importer, {
+    root: options.root,
+    isBuild: true,
+    isProduction: true,
+    preferRelative: false,
+    tryIndex: true,
+    mainFields: [],
+    conditions: [
+      'node',
+      ...(isModuleSyncConditionEnabled ? ['module-sync'] : []),
+      ...getNodeConditions(),
+    ],`,
+    ),
+  ];
+  logPatch(
+    'nodeResolve.ts',
+    'Supported Node conditions in nodeResolveWithVite',
+    nodeResolveResults.includes('patched') ? 'patched' : 'already',
+  );
+
+  // 8. config.ts: Support Node conditions and bundle TS sources in bundleConfigFile
+  const configResults = [
+    replaceInFile(
+      configFile,
+      "import { nodeResolveWithVite } from './nodeResolve'",
+      "import { getNodeConditions, nodeResolveWithVite } from './nodeResolve'",
+    ),
+    replaceInFile(
+      configFile,
+      `    resolve: {
+      mainFields: ['main'],
+    },`,
+      `    resolve: {
+      mainFields: ['main'],
+      conditionNames: getNodeConditions(),
+    },`,
+    ),
+    replaceInFile(
+      configFile,
+      `            // always no-externalize json files as rolldown does not support import attributes
+            if (idFsPath.endsWith('.json')) {
+              return idFsPath
+            }`,
+      `            // always no-externalize json and ts files as rolldown does not support import attributes / node cannot always run ts directly
+            if (idFsPath.endsWith('.json') || /\\.(?:[cm]?ts|tsx)$/.test(idFsPath)) {
+              return idFsPath
+            }`,
+    ),
+  ];
+  logPatch(
+    'config.ts',
+    'Supported Node conditions and TS inlining in bundleConfigFile',
+    configResults.includes('patched') ? 'patched' : 'already',
+  );
+
+  // 9. ssr/runnerImport.ts: Support Node conditions in runnerImport
+  const runnerImportFile = join(nodeDir, 'ssr', 'runnerImport.ts');
+  const runnerImportResults = [
+    replaceInFile(
+      runnerImportFile,
+      "import type { InlineConfig } from '../config'",
+      "import type { InlineConfig } from '../config'\nimport { getNodeConditions } from '../nodeResolve'",
+    ),
+    replaceInFile(
+      runnerImportFile,
+      `            conditions: [
+              'node',
+              ...(isModuleSyncConditionEnabled ? ['module-sync'] : []),
+            ],`,
+      `            conditions: [
+              'node',
+              ...(isModuleSyncConditionEnabled ? ['module-sync'] : []),
+              ...getNodeConditions(),
+            ],`,
+    ),
+  ];
+  logPatch(
+    'ssr/runnerImport.ts',
+    'Supported Node conditions in runnerImport',
+    runnerImportResults.includes('patched') ? 'patched' : 'already',
+  );
+
   log('Done!');
 }


### PR DESCRIPTION
### Summary

Fixes #2576.

When evaluating `vite.config.ts`, Node export conditions passed via `NODE_OPTIONS` (e.g. `NODE_OPTIONS=--conditions=dev` or `NODE_OPTIONS="-C custom"`) or `process.execArgv` were ignored:
1. `nodeResolveWithVite` hardcoded `conditions: ['node', ...(isModuleSyncConditionEnabled ? ['module-sync'] : [])]`, ignoring conditions passed to Node.
2. Rolldown's `bundleConfigFile` did not supply `conditionNames` to the Rolldown resolver.
3. In `bundleConfigFile`, Rolldown's `externalize-deps` plugin only skipped externalization for `.json` files. When TypeScript sources were resolved through conditions like `dev`, Rolldown marked them as external `file://` URLs. Node's loader subsequently failed when importing them from `.vite-temp/` because:
   - Node cannot resolve self-referencing packages from inside `node_modules`.
   - Node cannot natively run TypeScript files without loaders.
4. In `ssr/runnerImport.ts`, SSR module runner resolution also ignored custom conditions.

### Changes

- **`packages/tools/src/brand-vite.ts`**:
  - `nodeResolve.ts`: Added `getNodeConditions()` helper to parse `-C <val>`, `--conditions <val>`, and `--conditions=<val>` from `process.execArgv` and `process.env.NODE_OPTIONS` (handling quoted tokens). Appended these to `conditions` in `nodeResolveWithVite`.
  - `config.ts`: Passed `conditionNames: getNodeConditions()` to Rolldown's resolver options in `bundleConfigFile`. Updated `externalize-deps` plugin to prevent externalization for `.ts`, `.tsx`, `.mts`, and `.cts` files (`if (idFsPath.endsWith('.json') || /\.(?:[cm]?ts|tsx)$/.test(idFsPath)) return idFsPath`), ensuring they are bundled directly by Rolldown.
  - `ssr/runnerImport.ts`: Injected `...getNodeConditions()` into `runnerImport` conditions.
- **`packages/cli/src/resolve-core.ts`**:
  - Isolated `resolveCore` to the CLI package's own ancestor `node_modules` hierarchy, preventing ambient test runners or external environments from leaking unrelated Vite copies.
- **`packages/cli/src/__tests__/resolve-vite-config.spec.ts`**:
  - Added test verifying self-referencing package resolution via `--conditions=dev` in `NODE_OPTIONS`.
  - Added test verifying short flag `-C custom` in `NODE_OPTIONS`.
  - Added negative test verifying resolution failure when no custom condition is set and `dist/` is missing.

### Testing

- `pnpm -F vite-plus test src/__tests__/resolve-vite-config.spec.ts` (14 passed)
- `pnpm test:unit` (75 test files passed, 1,165 tests passed, 1 skipped)
- `pnpm -F vite-plus exec tsc --noEmit` (clean, 0 errors)
- `cargo check --workspace` (all crates checked cleanly)
- `git diff --check` (clean)
