### PR TITLE
chore(core): remove unused Babel dependencies

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -119,9 +119,6 @@
   },
   "devDependencies": {
     "@ast-grep/napi": "^0.43.0",
-    "@babel/generator": "^7.28.5",
-    "@babel/parser": "^7.28.5",
-    "@babel/types": "^7.28.5",
     "@emnapi/core": "catalog:",
     "@emnapi/runtime": "catalog:",
     "@napi-rs/cli": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -523,15 +523,6 @@ importers:
       '@ast-grep/napi':
         specifier: ^0.43.0
         version: 0.43.0
-      '@babel/generator':
-        specifier: ^7.28.5
-        version: 7.29.8
-      '@babel/parser':
-        specifier: ^7.28.5
-        version: 7.29.8
-      '@babel/types':
-        specifier: ^7.28.5
-        version: 7.29.8
       '@emnapi/core':
         specifier: 'catalog:'
         version: 2.0.0-alpha.4


### PR DESCRIPTION
## Summary

Core no longer needs direct dependencies on `@babel/generator`, `@babel/parser`, or `@babel/types` because the current `rolldown-plugin-dts` uses `yuku-parser` and `yuku-codegen` instead.

These packages originally covered runtime requirements from `rolldown-plugin-dts` bundled into tsdown. They later moved to `devDependencies` when `build-cjs-deps.ts` began bundling those CJS dependencies into core's output.

This removes the leftover declarations without changing CJS bundling. Upstream Vite retains its own `@babel/parser` dependency, and other consumers retain their transitive Babel dependencies.

Related: #396