### PR TITLE
fix(pm): disable pnpm update notifications

### DIFF
--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/pnpm_update_notifier/package.json
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/pnpm_update_notifier/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "pnpm-update-notifier",
+  "version": "1.0.0",
+  "private": true,
+  "packageManager": "pnpm@11.25.0",
+  "scripts": {
+    "postinstall": "node -e \"console.log('PNPM_CONFIG_UPDATE_NOTIFIER=' + process.env.PNPM_CONFIG_UPDATE_NOTIFIER)\""
+  }
+}

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/pnpm_update_notifier/pnpm-workspace.yaml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/pnpm_update_notifier/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+updateNotifier: true

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/pnpm_update_notifier/snapshots.toml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/pnpm_update_notifier/snapshots.toml
@@ -1,0 +1,18 @@
+[[case]]
+name = "pnpm11_update_notifier"
+vp = "global"
+comment = "Managed pnpm 11 commands disable update notifications even when the project enables them."
+steps = [
+  ["vp", "pm", "config", "get", "updateNotifier"],
+  ["vp", "install"],
+]
+
+[[case]]
+name = "pnpm12_update_notifier"
+vp = "global"
+comment = "Managed pnpm 12 commands disable update notifications even when the project enables them."
+steps = [
+  { argv = ["vpt", "json-edit", "package.json", "packageManager", "pnpm@12.3.4"], snapshot = false },
+  ["vp", "pm", "config", "get", "updateNotifier"],
+  ["vp", "install"],
+]

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/pnpm_update_notifier/snapshots/pnpm11_update_notifier.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/pnpm_update_notifier/snapshots/pnpm11_update_notifier.md
@@ -1,0 +1,22 @@
+# pnpm11_update_notifier
+
+Managed pnpm 11 commands disable update notifications even when the project enables them.
+
+## `vp pm config get updateNotifier`
+
+```
+false
+```
+
+## `vp install`
+
+```
+VITE+ - The Unified Toolchain for the Web
+
+Already up to date
+. postinstall$ node -e "console.log('PNPM_CONFIG_UPDATE_NOTIFIER=' + process.env.PNPM_CONFIG_UPDATE_NOTIFIER)"
+│ PNPM_CONFIG_UPDATE_NOTIFIER=false
+└─ Done in <duration>
+
+Done in <duration> using pnpm <version>
+```

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/pnpm_update_notifier/snapshots/pnpm12_update_notifier.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/pnpm_update_notifier/snapshots/pnpm12_update_notifier.md
@@ -1,0 +1,25 @@
+# pnpm12_update_notifier
+
+Managed pnpm 12 commands disable update notifications even when the project enables them.
+
+## `vpt json-edit package.json packageManager pnpm@12.3.4`
+
+
+## `vp pm config get updateNotifier`
+
+```
+false
+```
+
+## `vp install`
+
+```
+VITE+ - The Unified Toolchain for the Web
+
+. postinstall$ node -e "console.log('PNPM_CONFIG_UPDATE_NOTIFIER=' + process.env.PNPM_CONFIG_UPDATE_NOTIFIER)"
+│ PNPM_CONFIG_UPDATE_NOTIFIER=false
+└─ Done in <duration>
+Already up to date
+
+Done in <duration> using pnpm <version>
+```

--- a/crates/vp_pm_cli/src/resolution/resolve.rs
+++ b/crates/vp_pm_cli/src/resolution/resolve.rs
@@ -60,6 +60,10 @@ where
         command
             .env
             .insert("PATH".to_string(), vp_shared::format_path_prepended(manager.get_bin_prefix()));
+        if manager.client == PackageManagerType::Pnpm {
+            // Vite+ manages pnpm, so its self-update notification is not useful here.
+            command.env.insert("PNPM_CONFIG_UPDATE_NOTIFIER".to_string(), "false".to_string());
+        }
     }
 
     Ok(resolution)
@@ -76,7 +80,7 @@ fn parse_version(manager: &PackageManager) -> Result<Version, Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::resolution::ApproveBuildsArgs;
+    use crate::resolution::{ApproveBuildsArgs, InstallArgs};
 
     fn package_manager(client: PackageManagerType, version: &str) -> PackageManager {
         let workspace_root = vt_path::current_dir().unwrap();
@@ -121,5 +125,28 @@ mod tests {
                 ..
             } if version == "latest"
         ));
+    }
+
+    #[test]
+    fn only_pnpm_installs_disable_update_notifications() {
+        for (client, version, expected) in [
+            (PackageManagerType::Pnpm, "11.25.0", Some("false")),
+            (PackageManagerType::Pnpm, "12.3.4", Some("false")),
+            (PackageManagerType::Npm, "11.0.0", None),
+            (PackageManagerType::Yarn, "4.0.0", None),
+            (PackageManagerType::Bun, "1.0.0", None),
+        ] {
+            let manager = package_manager(client, version);
+            let resolution = resolve_for_manager(&manager, InstallArgs::default()).unwrap();
+            let CommandResolution::Run(command) = resolution.outcome else {
+                panic!("expected install command");
+            };
+
+            assert_eq!(
+                command.env.get("PNPM_CONFIG_UPDATE_NOTIFIER").map(String::as_str),
+                expected,
+                "{client}@{version}"
+            );
+        }
     }
 }


### PR DESCRIPTION
`vp install` can show pnpm's update notice even though Vite+ manages the selected pnpm version. The shared package-manager resolver now sets `PNPM_CONFIG_UPDATE_NOTIFIER=false` for pnpm commands.

The tests cover pnpm `11.25.0` and `12.3.4`, including projects that set `updateNotifier: true`.

Before this change:

<img width="731" alt="pnpm upgrade notification shown during vp install" src="https://github.com/user-attachments/assets/8f197217-bbd9-48b4-9c43-7a232fd1e450" />
