### PR TITLE
fix(pm): disable npm update notifications

### DIFF
--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/npm_update_notifier/.npmrc
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/npm_update_notifier/.npmrc
@@ -1,0 +1,3 @@
+update-notifier=true
+audit=false
+fund=false

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/npm_update_notifier/global-package/package.json
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/npm_update_notifier/global-package/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "global-update-notifier-test",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "postinstall": "node -e \"require('node:assert/strict').equal(process.env.npm_config_update_notifier, 'false')\""
+  }
+}

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/npm_update_notifier/package.json
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/npm_update_notifier/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "npm-update-notifier",
+  "version": "1.0.0",
+  "private": true,
+  "packageManager": "npm@11.13.0",
+  "scripts": {
+    "postinstall": "node -e \"console.log('npm_config_update_notifier=' + process.env.npm_config_update_notifier)\""
+  }
+}

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/npm_update_notifier/snapshots.toml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/npm_update_notifier/snapshots.toml
@@ -1,0 +1,24 @@
+[[case]]
+name = "npm11_update_notifier"
+vp = "global"
+comment = "Managed npm 11 commands disable update notifications even when the project enables them."
+steps = [
+  ["vp", "pm", "config", "get", "update-notifier"],
+  ["vp", "install"],
+]
+
+[[case]]
+name = "npm_global_update_notifier"
+vp = "global"
+comment = "Global installs disable npm update notifications in the child process."
+steps = [["vp", "install", "-g", "./global-package"]]
+
+[[case]]
+name = "npm12_update_notifier"
+vp = "global"
+comment = "Managed npm 12 commands disable update notifications even when the project enables them."
+steps = [
+  { argv = ["vpt", "json-edit", "package.json", "packageManager", "npm@12.0.2"], snapshot = false },
+  ["vp", "pm", "config", "get", "update-notifier"],
+  ["vp", "install"],
+]

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/npm_update_notifier/snapshots/npm11_update_notifier.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/npm_update_notifier/snapshots/npm11_update_notifier.md
@@ -1,0 +1,22 @@
+# npm11_update_notifier
+
+Managed npm 11 commands disable update notifications even when the project enables them.
+
+## `vp pm config get update-notifier`
+
+```
+false
+```
+
+## `vp install`
+
+```
+VITE+ - The Unified Toolchain for the Web
+
+> npm-update-notifier@1.0.0 postinstall
+> node -e "console.log('npm_config_update_notifier=' + process.env.npm_config_update_notifier)"
+
+npm_config_update_notifier=false
+
+up to date in <duration>
+```

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/npm_update_notifier/snapshots/npm12_update_notifier.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/npm_update_notifier/snapshots/npm12_update_notifier.md
@@ -1,0 +1,22 @@
+# npm12_update_notifier
+
+Managed npm 12 commands disable update notifications even when the project enables them.
+
+## `vpt json-edit package.json packageManager npm@12.0.2`
+
+
+## `vp pm config get update-notifier`
+
+```
+false
+```
+
+## `vp install`
+
+```
+VITE+ - The Unified Toolchain for the Web
+
+npm_config_update_notifier=false
+
+up to date in <duration>
+```

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/npm_update_notifier/snapshots/npm_global_update_notifier.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/npm_update_notifier/snapshots/npm_global_update_notifier.md
@@ -1,0 +1,12 @@
+# npm_global_update_notifier
+
+Global installs disable npm update notifications in the child process.
+
+## `vp install -g ./global-package`
+
+```
+VITE+ - The Unified Toolchain for the Web
+
+info: Installing 1 global package with Node.js <version>
+✓ Installed global-update-notifier-test 1.0.0
+```

--- a/crates/vp_global_cli/src/commands/global/install.rs
+++ b/crates/vp_global_cli/src/commands/global/install.rs
@@ -554,6 +554,7 @@ async fn install_one(
     let output = Command::new(npm_path.as_path())
         .args(["install", "-g", "--no-fund", &package_spec])
         .env("npm_config_prefix", install_dir.as_path())
+        .env("npm_config_update_notifier", "false")
         .env("PATH", format_path_prepended(node_bin_dir.as_path()))
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/crates/vp_pm_cli/src/resolution/command.rs
+++ b/crates/vp_pm_cli/src/resolution/command.rs
@@ -17,12 +17,13 @@ pub(crate) struct ResolvedCommand {
 
 impl ResolvedCommand {
     pub(crate) fn new(program: impl Into<String>) -> Self {
-        Self {
-            program: program.into(),
-            args: Vec::new(),
-            env: BTreeMap::new(),
-            pre_run: Vec::new(),
+        let program = program.into();
+        let mut env = BTreeMap::new();
+        if matches!(program.as_str(), "npm" | "npx") {
+            // Include npm/npx fallbacks: Vite+ manages their versions too.
+            env.insert("npm_config_update_notifier".to_string(), "false".to_string());
         }
+        Self { program, args: Vec::new(), env, pre_run: Vec::new() }
     }
 }
 

--- a/crates/vp_pm_cli/src/resolution/commands/dlx.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/dlx.rs
@@ -391,6 +391,10 @@ mod tests {
         assert_eq!(command.program, "npx");
         assert_eq!(command.args, vec!["--yes", "create-vue", "my-app"]);
         assert_eq!(resolution.diagnostics[0].kind, DiagnosticKind::FallbackCommand);
+        assert_eq!(
+            command.env.get("npm_config_update_notifier").map(String::as_str),
+            Some("false")
+        );
     }
 
     #[test]
@@ -401,7 +405,10 @@ mod tests {
         assert_eq!(command.program, "npx");
         assert_eq!(command.args, vec!["--yes", "create-vue", "my-app"]);
         assert!(resolution.diagnostics.is_empty());
-        assert!(command.env.is_empty());
+        assert_eq!(
+            command.env.get("npm_config_update_notifier").map(String::as_str),
+            Some("false")
+        );
     }
 
     #[test]

--- a/crates/vp_pm_cli/src/resolution/commands/whoami.rs
+++ b/crates/vp_pm_cli/src/resolution/commands/whoami.rs
@@ -99,6 +99,10 @@ mod tests {
 
         assert_eq!(command.program, "npm");
         assert_eq!(command.args, vec!["whoami"]);
+        assert_eq!(
+            command.env.get("npm_config_update_notifier").map(String::as_str),
+            Some("false")
+        );
     }
 
     #[test]

--- a/crates/vp_pm_cli/src/resolution/resolve.rs
+++ b/crates/vp_pm_cli/src/resolution/resolve.rs
@@ -128,6 +128,30 @@ mod tests {
     }
 
     #[test]
+    fn only_npm_installs_disable_npm_update_notifications() {
+        for (client, version, expected) in [
+            (PackageManagerType::Npm, "11.13.0", Some("false")),
+            (PackageManagerType::Npm, "12.0.2", Some("false")),
+            (PackageManagerType::Npm, "latest", Some("false")),
+            (PackageManagerType::Pnpm, "12.3.4", None),
+            (PackageManagerType::Yarn, "4.0.0", None),
+            (PackageManagerType::Bun, "1.0.0", None),
+        ] {
+            let manager = package_manager(client, version);
+            let resolution = resolve_for_manager(&manager, InstallArgs::default()).unwrap();
+            let CommandResolution::Run(command) = resolution.outcome else {
+                panic!("expected install command");
+            };
+
+            assert_eq!(
+                command.env.get("npm_config_update_notifier").map(String::as_str),
+                expected,
+                "{client}@{version}"
+            );
+        }
+    }
+
+    #[test]
     fn only_pnpm_installs_disable_update_notifications() {
         for (client, version, expected) in [
             (PackageManagerType::Pnpm, "11.25.0", Some("false")),


### PR DESCRIPTION
`vp install` can show an npm upgrade notice even though Vite+ manages the npm version.

The command builder now sets `npm_config_update_notifier=false` for `npm` and `npx`, including fallback commands. Global installs set the same variable.

Tests cover npm `11.13.0` and `12.0.2`, project settings, fallback commands, and global installs.
