### PR TITLE
fix(pm): disable Yarn update notifications

### DIFF
--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/yarn_update_notifier/.yarnrc
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/yarn_update_notifier/.yarnrc
@@ -1,0 +1,1 @@
+disable-self-update-check false

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/yarn_update_notifier/.yarnrc.yml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/yarn_update_notifier/.yarnrc.yml
@@ -1,0 +1,1 @@
+enableTelemetry: true

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/yarn_update_notifier/package.json
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/yarn_update_notifier/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "yarn-update-notifier",
+  "version": "1.0.0",
+  "private": true,
+  "packageManager": "yarn@1.22.22"
+}

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/yarn_update_notifier/snapshots.toml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/yarn_update_notifier/snapshots.toml
@@ -1,0 +1,41 @@
+[[case]]
+name = "yarn1_update_notifier"
+vp = "global"
+env = { NODE_OPTIONS = "--no-deprecation" }
+comment = "Managed Yarn Classic disables self-update checks even when the project enables them."
+steps = [
+  ["vp", "pm", "config", "get", "disable-self-update-check"],
+  ["vp", "install"],
+]
+
+[[case]]
+name = "yarn2_update_notifier_compatibility"
+vp = "global"
+comment = "Yarn 2 commands work without unsupported update settings."
+steps = [
+  { argv = ["vpt", "json-edit", "package.json", "packageManager", "yarn@2.4.2"], snapshot = false },
+  ["vp", "pm", "config", "get", "enableTelemetry"],
+  ["vp", "install"],
+]
+
+[[case]]
+name = "yarn3_update_notifier_compatibility"
+vp = "global"
+comment = "Yarn 3 commands work without unsupported update settings."
+steps = [
+  { argv = ["vpt", "json-edit", "package.json", "packageManager", "yarn@3.8.7"], snapshot = false },
+  ["vp", "pm", "config", "get", "enableTelemetry"],
+  ["vp", "install"],
+]
+
+[[case]]
+name = "yarn4_update_notifier"
+vp = "global"
+comment = "Managed Yarn 4 disables daily tips, including version notices, without changing telemetry."
+steps = [
+  { argv = ["vpt", "json-edit", "package.json", "packageManager", "yarn@4.12.0"], snapshot = false },
+  { argv = ["vpt", "write-file", ".yarnrc.yml", "enableTelemetry: true\nenableTips: true\n"], snapshot = false },
+  ["vp", "pm", "config", "get", "enableTips"],
+  ["vp", "pm", "config", "get", "enableTelemetry"],
+  ["vp", "install"],
+]

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/yarn_update_notifier/snapshots/yarn1_update_notifier.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/yarn_update_notifier/snapshots/yarn1_update_notifier.md
@@ -1,0 +1,26 @@
+# yarn1_update_notifier
+
+Managed Yarn Classic disables self-update checks even when the project enables them.
+
+## `vp pm config get disable-self-update-check`
+
+```
+true
+```
+
+## `vp install`
+
+```
+VITE+ - The Unified Toolchain for the Web
+
+yarn install <version>
+info No lockfile found.
+[1/4] Resolving packages...
+[2/4] Fetching packages...
+[3/4] Linking dependencies...
+[4/4] Building fresh packages...
+
+success Saved lockfile.
+
+Done in <duration>.
+```

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/yarn_update_notifier/snapshots/yarn2_update_notifier_compatibility.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/yarn_update_notifier/snapshots/yarn2_update_notifier_compatibility.md
@@ -1,0 +1,26 @@
+# yarn2_update_notifier_compatibility
+
+Yarn 2 commands work without unsupported update settings.
+
+## `vpt json-edit package.json packageManager yarn@2.4.2`
+
+
+## `vp pm config get enableTelemetry`
+
+```
+true
+```
+
+## `vp install`
+
+```
+VITE+ - The Unified Toolchain for the Web
+
+➤ YN0000: ┌ Resolution step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Fetch step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Link step
+➤ YN0000: └ Completed
+➤ YN0000: Done in <duration> <duration>
+```

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/yarn_update_notifier/snapshots/yarn3_update_notifier_compatibility.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/yarn_update_notifier/snapshots/yarn3_update_notifier_compatibility.md
@@ -1,0 +1,26 @@
+# yarn3_update_notifier_compatibility
+
+Yarn 3 commands work without unsupported update settings.
+
+## `vpt json-edit package.json packageManager yarn@3.8.7`
+
+
+## `vp pm config get enableTelemetry`
+
+```
+true
+```
+
+## `vp install`
+
+```
+VITE+ - The Unified Toolchain for the Web
+
+➤ YN0000: ┌ Resolution step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Fetch step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Link step
+➤ YN0000: └ Completed
+➤ YN0000: Done in <duration> <duration>
+```

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/yarn_update_notifier/snapshots/yarn4_update_notifier.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/yarn_update_notifier/snapshots/yarn4_update_notifier.md
@@ -1,0 +1,38 @@
+# yarn4_update_notifier
+
+Managed Yarn 4 disables daily tips, including version notices, without changing telemetry.
+
+## `vpt json-edit package.json packageManager yarn@4.12.0`
+
+
+## `vpt write-file .yarnrc.yml 'enableTelemetry: true
+enableTips: true
+'`
+
+
+## `vp pm config get enableTips`
+
+```
+false
+```
+
+## `vp pm config get enableTelemetry`
+
+```
+true
+```
+
+## `vp install`
+
+```
+VITE+ - The Unified Toolchain for the Web
+
+➤ YN0000: · Yarn <version>
+➤ YN0000: ┌ Resolution step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Fetch step
+➤ YN0000: └ Completed
+➤ YN0000: ┌ Link step
+➤ YN0000: └ Completed
+➤ YN0000: · Done in <duration> <duration>
+```

--- a/crates/vp_pm_cli/src/resolution/resolve.rs
+++ b/crates/vp_pm_cli/src/resolution/resolve.rs
@@ -60,9 +60,28 @@ where
         command
             .env
             .insert("PATH".to_string(), vp_shared::format_path_prepended(manager.get_bin_prefix()));
-        if manager.client == PackageManagerType::Pnpm {
-            // Vite+ manages pnpm, so its self-update notification is not useful here.
-            command.env.insert("PNPM_CONFIG_UPDATE_NOTIFIER".to_string(), "false".to_string());
+        match manager.client {
+            PackageManagerType::Pnpm => {
+                // Vite+ manages pnpm, so its self-update notification is not useful here.
+                command.env.insert("PNPM_CONFIG_UPDATE_NOTIFIER".to_string(), "false".to_string());
+            }
+            PackageManagerType::Yarn if command.program == "yarn" => {
+                match parse_version(manager)?.major {
+                    0 | 1 => {
+                        command.env.insert(
+                            "YARN_DISABLE_SELF_UPDATE_CHECK".to_string(),
+                            "true".to_string(),
+                        );
+                    }
+                    4.. => {
+                        // Yarn 4 includes version notices in its daily tips.
+                        command.env.insert("YARN_ENABLE_TIPS".to_string(), "false".to_string());
+                    }
+                    // Yarn 2 and 3 reject these settings and have no version notices.
+                    _ => {}
+                }
+            }
+            _ => {}
         }
     }
 
@@ -80,7 +99,7 @@ fn parse_version(manager: &PackageManager) -> Result<Version, Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::resolution::{ApproveBuildsArgs, InstallArgs};
+    use crate::resolution::{ApproveBuildsArgs, DlxArgs, InstallArgs};
 
     fn package_manager(client: PackageManagerType, version: &str) -> PackageManager {
         let workspace_root = vt_path::current_dir().unwrap();
@@ -125,6 +144,59 @@ mod tests {
                 ..
             } if version == "latest"
         ));
+    }
+
+    #[test]
+    fn yarn_update_settings_match_the_major_version() {
+        for (client, version, classic, tips) in [
+            (PackageManagerType::Yarn, "1.22.22", Some("true"), None),
+            (PackageManagerType::Yarn, "2.4.2", None, None),
+            (PackageManagerType::Yarn, "3.8.7", None, None),
+            (PackageManagerType::Yarn, "4.0.0", None, Some("false")),
+            (PackageManagerType::Yarn, "4.12.0", None, Some("false")),
+            (PackageManagerType::Npm, "11.13.0", None, None),
+            (PackageManagerType::Pnpm, "12.3.4", None, None),
+            (PackageManagerType::Bun, "1.0.0", None, None),
+        ] {
+            let manager = package_manager(client, version);
+            let resolution = resolve_for_manager(&manager, InstallArgs::default()).unwrap();
+            let CommandResolution::Run(command) = resolution.outcome else {
+                panic!("expected install command");
+            };
+
+            assert_eq!(
+                command.env.get("YARN_DISABLE_SELF_UPDATE_CHECK").map(String::as_str),
+                classic,
+                "{client}@{version}"
+            );
+            assert_eq!(
+                command.env.get("YARN_ENABLE_TIPS").map(String::as_str),
+                tips,
+                "{client}@{version}"
+            );
+            assert!(!command.env.contains_key("YARN_ENABLE_TELEMETRY"));
+        }
+    }
+
+    #[test]
+    fn yarn_classic_npx_fallback_uses_only_npm_update_settings() {
+        let manager = package_manager(PackageManagerType::Yarn, "1.22.22");
+        let resolution = resolve_for_manager(
+            &manager,
+            DlxArgs { args: vec!["create-vue".to_string()], ..Default::default() },
+        )
+        .unwrap();
+        let CommandResolution::Run(command) = resolution.outcome else {
+            panic!("expected npx command");
+        };
+
+        assert_eq!(command.program, "npx");
+        assert_eq!(
+            command.env.get("npm_config_update_notifier").map(String::as_str),
+            Some("false")
+        );
+        assert!(!command.env.contains_key("YARN_DISABLE_SELF_UPDATE_CHECK"));
+        assert!(!command.env.contains_key("YARN_ENABLE_TIPS"));
     }
 
     #[test]


### PR DESCRIPTION
`vp install` can show Yarn upgrade notices even though Vite+ manages the selected version.

The resolver sets `YARN_DISABLE_SELF_UPDATE_CHECK=true` for Yarn Classic and `YARN_ENABLE_TIPS=false` for Yarn `4` and later. This also hides daily tips. The telemetry setting stays unchanged.

Yarn `2` and `3` receive neither setting because they reject these options. Terminal tests cover Yarn `1.22.22`, `2.4.2`, `3.8.7`, and `4.12.0`.
