### PR TITLE
fix(create): reject non-semver versions in org-template manifests

### DIFF
--- a/packages/cli/src/create/__tests__/org-manifest.spec.ts
+++ b/packages/cli/src/create/__tests__/org-manifest.spec.ts
@@ -509,4 +509,46 @@ describe('readOrgManifest', () => {
       /version "9\.9\.9" not found/,
     );
   });
+
+  it.each([['../../outside-write'], ['..'], ['.'], ['not-a-version']])(
+    'rejects a non-semver dist-tags.latest target: %s',
+    async (version) => {
+      // A registry can point `latest` at a non-semver string; the resolved
+      // version becomes a cache path component, so such a value must be
+      // rejected even when the packument is otherwise self-consistent.
+      const body = packument([
+        { name: 'web', description: 'v1', template: '@your-org/template-web' },
+      ]);
+      (body as { 'dist-tags': Record<string, string> })['dist-tags'].latest = version;
+      (body as { versions: Record<string, unknown> }).versions[version] = {
+        version,
+        dist: { tarball: TARBALL_URL, integrity: 'sha512-fake' },
+        createConfig: {
+          templates: [{ name: 'web', description: 'v1', template: '@your-org/template-web' }],
+        },
+      };
+      mockFetchJson(body);
+      await expect(readOrgManifest('@your-org')).rejects.toThrow(OrgManifestSchemaError);
+      await expect(readOrgManifest('@your-org')).rejects.toThrow(/invalid version/);
+    },
+  );
+
+  it('rejects a pinned version whose dist-tag target is not a semantic version', async () => {
+    // `vp create @scope@1.2.3` consults `dist-tags['1.2.3']` before the
+    // literal `versions['1.2.3']` entry, so a registry that defines a tag
+    // with that name can substitute a different target string.
+    const body = packument([
+      { name: 'web', description: 'v1', template: '@your-org/template-web' },
+    ]);
+    (body as { 'dist-tags': Record<string, string> })['dist-tags']['1.2.3'] = '../../outside-write';
+    (body as { versions: Record<string, unknown> }).versions['../../outside-write'] = {
+      version: '../../outside-write',
+      dist: { tarball: TARBALL_URL, integrity: 'sha512-fake' },
+      createConfig: {
+        templates: [{ name: 'web', description: 'v1', template: '@your-org/template-web' }],
+      },
+    };
+    mockFetchJson(body);
+    await expect(readOrgManifest('@your-org', '1.2.3')).rejects.toThrow(/invalid version/);
+  });
 });

--- a/packages/cli/src/create/__tests__/org-manifest.spec.ts
+++ b/packages/cli/src/create/__tests__/org-manifest.spec.ts
@@ -510,45 +510,29 @@ describe('readOrgManifest', () => {
     );
   });
 
-  it.each([['../../outside-write'], ['..'], ['.'], ['not-a-version']])(
-    'rejects a non-semver dist-tags.latest target: %s',
-    async (version) => {
-      // A registry can point `latest` at a non-semver string; the resolved
-      // version becomes a cache path component, so such a value must be
-      // rejected even when the packument is otherwise self-consistent.
-      const body = packument([
-        { name: 'web', description: 'v1', template: '@your-org/template-web' },
-      ]);
-      (body as { 'dist-tags': Record<string, string> })['dist-tags'].latest = version;
-      (body as { versions: Record<string, unknown> }).versions[version] = {
-        version,
-        dist: { tarball: TARBALL_URL, integrity: 'sha512-fake' },
-        createConfig: {
-          templates: [{ name: 'web', description: 'v1', template: '@your-org/template-web' }],
-        },
-      };
-      mockFetchJson(body);
-      await expect(readOrgManifest('@your-org')).rejects.toThrow(OrgManifestSchemaError);
-      await expect(readOrgManifest('@your-org')).rejects.toThrow(/invalid version/);
-    },
-  );
-
-  it('rejects a pinned version whose dist-tag target is not a semantic version', async () => {
-    // `vp create @scope@1.2.3` consults `dist-tags['1.2.3']` before the
-    // literal `versions['1.2.3']` entry, so a registry that defines a tag
-    // with that name can substitute a different target string.
+  it.each([
+    ['latest', '../../outside-write'],
+    ['latest', '..'],
+    ['latest', '.'],
+    ['latest', 'not-a-version'],
+    // A tag named like a pinned version can also substitute an invalid target.
+    ['1.2.3', '../../outside-write'],
+  ])('rejects a non-semver dist-tags.%s target: %s', async (tag, version) => {
     const body = packument([
       { name: 'web', description: 'v1', template: '@your-org/template-web' },
     ]);
-    (body as { 'dist-tags': Record<string, string> })['dist-tags']['1.2.3'] = '../../outside-write';
-    (body as { versions: Record<string, unknown> }).versions['../../outside-write'] = {
-      version: '../../outside-write',
-      dist: { tarball: TARBALL_URL, integrity: 'sha512-fake' },
-      createConfig: {
-        templates: [{ name: 'web', description: 'v1', template: '@your-org/template-web' }],
+    // Keep matching metadata so only the version validation rejects it.
+    mockFetchJson({
+      ...body,
+      'dist-tags': { ...body['dist-tags'], [tag]: version },
+      versions: {
+        ...body.versions,
+        [version]: { ...body.versions['1.0.0'], version },
       },
-    };
-    mockFetchJson(body);
-    await expect(readOrgManifest('@your-org', '1.2.3')).rejects.toThrow(/invalid version/);
+    });
+    const requestedVersion = tag === 'latest' ? undefined : tag;
+    const manifest = readOrgManifest('@your-org', requestedVersion);
+    await expect(manifest).rejects.toThrow(OrgManifestSchemaError);
+    await expect(manifest).rejects.toThrow(/invalid version/);
   });
 });

--- a/packages/cli/src/create/__tests__/org-tarball.spec.ts
+++ b/packages/cli/src/create/__tests__/org-tarball.spec.ts
@@ -2,17 +2,22 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { OrgManifest } from '../org-manifest.js';
 import {
   cleanupStaleStagingDirs,
+  ensureOrgPackageExtracted,
   normalizeEntryName,
   parseEntryMode,
   resolveBundledPath,
   resolveExtractionDir,
   sanitizeHostForPath,
 } from '../org-tarball.js';
+
+const { mockGetVpDirs } = vi.hoisted(() => ({ mockGetVpDirs: vi.fn() }));
+
+vi.mock('../../../binding/index.js', () => ({ getVpDirs: mockGetVpDirs }));
 
 describe('resolveBundledPath', () => {
   const scratchDirs: string[] = [];
@@ -112,15 +117,38 @@ describe('resolveExtractionDir', () => {
     },
   );
 
-  // Escaping `<root>/<host>/<scope>/create` takes at least four `..` segments.
-  it.each(['../../../../outside', '../../../../../../outside-write', '/absolute'])(
-    'rejects a version that escapes the cache root: %s',
+  // Three `..` segments reach the cache root; four escape it.
+  it.each(['../../..', '../../../../outside', '../../../../../../outside-write', '/absolute'])(
+    'rejects a version that resolves to or outside the cache root: %s',
     (version) => {
       expect(() => resolveExtractionDir(cacheRoot, manifestFor(version))).toThrow(
         /escapes the cache root/,
       );
     },
   );
+});
+
+describe('ensureOrgPackageExtracted', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rejects the cache root before filesystem or network activity', async () => {
+    mockGetVpDirs.mockReturnValue({ cache: path.join(os.tmpdir(), 'vp-org-extraction-cache') });
+    const exists = vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    const mkdir = vi.spyOn(fs.promises, 'mkdir').mockResolvedValue(undefined);
+    const readdir = vi.spyOn(fs.promises, 'readdir').mockResolvedValue([]);
+    const fetch = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('unexpected download'));
+
+    await expect(ensureOrgPackageExtracted(manifestFor('../../..'))).rejects.toThrow(
+      /escapes the cache root/,
+    );
+
+    expect(exists).not.toHaveBeenCalled();
+    expect(mkdir).not.toHaveBeenCalled();
+    expect(readdir).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
 });
 
 describe('sanitizeHostForPath', () => {

--- a/packages/cli/src/create/__tests__/org-tarball.spec.ts
+++ b/packages/cli/src/create/__tests__/org-tarball.spec.ts
@@ -103,17 +103,17 @@ function manifestFor(version: string): OrgManifest {
 describe('resolveExtractionDir', () => {
   const cacheRoot = path.resolve(os.tmpdir(), 'vp-cache-root');
 
-  it('places a valid version beneath the cache root', () => {
-    expect(resolveExtractionDir(cacheRoot, manifestFor('1.0.0'))).toBe(
-      path.join(cacheRoot, 'registry.npmjs.org', '@your-org', 'create', '1.0.0'),
-    );
-  });
+  it.each(['1.0.0', '0.0.0', '1.2.3', '2.0.0-beta.1', '10.20.30+build.5'])(
+    'places version %s beneath the cache root',
+    (version) => {
+      expect(resolveExtractionDir(cacheRoot, manifestFor(version))).toBe(
+        path.join(cacheRoot, 'registry.npmjs.org', '@your-org', 'create', version),
+      );
+    },
+  );
 
-  // The version sits four levels below the cache root
-  // (`<root>/<host>/<scope>/create/<version>`), so leaving the root takes
-  // at least four `..` segments; shallower values stay inside the root
-  // and are rejected by the semver check in `readOrgManifest` instead.
-  it.each([['../../../../outside'], ['../../../../../../outside-write'], ['/absolute']])(
+  // Escaping `<root>/<host>/<scope>/create` takes at least four `..` segments.
+  it.each(['../../../../outside', '../../../../../../outside-write', '/absolute'])(
     'rejects a version that escapes the cache root: %s',
     (version) => {
       expect(() => resolveExtractionDir(cacheRoot, manifestFor(version))).toThrow(
@@ -121,13 +121,6 @@ describe('resolveExtractionDir', () => {
       );
     },
   );
-
-  it('keeps strict-semver versions inside the cache root', () => {
-    for (const version of ['0.0.0', '1.2.3', '2.0.0-beta.1', '10.20.30+build.5']) {
-      const dir = resolveExtractionDir(cacheRoot, manifestFor(version));
-      expect(dir.startsWith(`${cacheRoot}${path.sep}`)).toBe(true);
-    }
-  });
 });
 
 describe('sanitizeHostForPath', () => {

--- a/packages/cli/src/create/__tests__/org-tarball.spec.ts
+++ b/packages/cli/src/create/__tests__/org-tarball.spec.ts
@@ -4,11 +4,13 @@ import path from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
+import type { OrgManifest } from '../org-manifest.js';
 import {
   cleanupStaleStagingDirs,
   normalizeEntryName,
   parseEntryMode,
   resolveBundledPath,
+  resolveExtractionDir,
   sanitizeHostForPath,
 } from '../org-tarball.js';
 
@@ -85,6 +87,46 @@ describe('normalizeEntryName', () => {
   it('returns null for entries outside the `package/` root', () => {
     expect(normalizeEntryName('not-package/foo.ts')).toBeNull();
     expect(normalizeEntryName('node_modules/foo/package.json')).toBeNull();
+  });
+});
+
+function manifestFor(version: string): OrgManifest {
+  return {
+    scope: '@your-org',
+    packageName: '@your-org/create',
+    version,
+    tarballUrl: 'https://registry.npmjs.org/@your-org/create/-/create-1.0.0.tgz',
+    templates: [],
+  };
+}
+
+describe('resolveExtractionDir', () => {
+  const cacheRoot = path.resolve(os.tmpdir(), 'vp-cache-root');
+
+  it('places a valid version beneath the cache root', () => {
+    expect(resolveExtractionDir(cacheRoot, manifestFor('1.0.0'))).toBe(
+      path.join(cacheRoot, 'registry.npmjs.org', '@your-org', 'create', '1.0.0'),
+    );
+  });
+
+  // The version sits four levels below the cache root
+  // (`<root>/<host>/<scope>/create/<version>`), so leaving the root takes
+  // at least four `..` segments; shallower values stay inside the root
+  // and are rejected by the semver check in `readOrgManifest` instead.
+  it.each([['../../../../outside'], ['../../../../../../outside-write'], ['/absolute']])(
+    'rejects a version that escapes the cache root: %s',
+    (version) => {
+      expect(() => resolveExtractionDir(cacheRoot, manifestFor(version))).toThrow(
+        /escapes the cache root/,
+      );
+    },
+  );
+
+  it('keeps strict-semver versions inside the cache root', () => {
+    for (const version of ['0.0.0', '1.2.3', '2.0.0-beta.1', '10.20.30+build.5']) {
+      const dir = resolveExtractionDir(cacheRoot, manifestFor(version));
+      expect(dir.startsWith(`${cacheRoot}${path.sep}`)).toBe(true);
+    }
   });
 });
 

--- a/packages/cli/src/create/org-manifest.ts
+++ b/packages/cli/src/create/org-manifest.ts
@@ -1,5 +1,7 @@
 import path from 'node:path';
 
+import semver from 'semver';
+
 import { fetchNpmResource, getNpmRegistry } from '../utils/npm-config.ts';
 import { readPackageJsonFromTarball } from './org-tarball.ts';
 
@@ -332,6 +334,17 @@ export async function readOrgManifest(
     if (!resolvedVersion) {
       return null;
     }
+  }
+  // The registry controls both `dist-tags` and the `versions` map, so the
+  // resolved value is only as well-formed as the registry's metadata. The
+  // version later becomes a cache-path component (`resolveExtractionDir`),
+  // where `..` segments in a malformed value would place the extraction
+  // outside the cache root. Reject anything that is not a semantic version.
+  if (semver.valid(resolvedVersion) === null) {
+    throw new OrgManifestSchemaError(
+      `invalid version "${resolvedVersion}" (expected a semantic version)`,
+      packageName,
+    );
   }
   const meta = packument.versions?.[resolvedVersion];
   if (!meta) {

--- a/packages/cli/src/create/org-manifest.ts
+++ b/packages/cli/src/create/org-manifest.ts
@@ -335,11 +335,8 @@ export async function readOrgManifest(
       return null;
     }
   }
-  // The registry controls both `dist-tags` and the `versions` map, so the
-  // resolved value is only as well-formed as the registry's metadata. The
-  // version later becomes a cache-path component (`resolveExtractionDir`),
-  // where `..` segments in a malformed value would place the extraction
-  // outside the cache root. Reject anything that is not a semantic version.
+  // Registry versions become cache-path components, so reject malformed
+  // values even when the registry has matching version metadata.
   if (semver.valid(resolvedVersion) === null) {
     throw new OrgManifestSchemaError(
       `invalid version "${resolvedVersion}" (expected a semantic version)`,

--- a/packages/cli/src/create/org-tarball.ts
+++ b/packages/cli/src/create/org-tarball.ts
@@ -28,16 +28,32 @@ export function sanitizeHostForPath(host: string): string {
  * (via `.npmrc` scope mappings) don't share a cache slot. The registry
  * guarantees `manifest.tarballUrl` is a valid URL, so any parse failure
  * here is a real bug worth surfacing.
+ *
+ * The result must stay beneath `cacheRoot`. `readOrgManifest` already
+ * validates `manifest.version` as a semantic version; this containment
+ * check keeps the same invariant at the sink, so a malformed
+ * registry-controlled value (e.g. `..` segments) cannot place the
+ * extraction outside the cache, even through a future caller that
+ * skips validation.
  */
-function getExtractionDir(manifest: OrgManifest): string {
+export function resolveExtractionDir(cacheRoot: string, manifest: OrgManifest): string {
   const { host } = new URL(manifest.tarballUrl);
-  return path.join(
-    getCacheRoot(),
+  const resolvedRoot = path.resolve(cacheRoot);
+  const resolvedDir = path.resolve(
+    resolvedRoot,
     sanitizeHostForPath(host),
     manifest.scope,
     'create',
     manifest.version,
   );
+  if (resolvedDir !== resolvedRoot && !resolvedDir.startsWith(`${resolvedRoot}${path.sep}`)) {
+    throw new Error(`org template extraction path escapes the cache root: ${manifest.version}`);
+  }
+  return resolvedDir;
+}
+
+function getExtractionDir(manifest: OrgManifest): string {
+  return resolveExtractionDir(getCacheRoot(), manifest);
 }
 
 function parseIntegrity(integrity: string): { algorithm: string; expected: string } | null {

--- a/packages/cli/src/create/org-tarball.ts
+++ b/packages/cli/src/create/org-tarball.ts
@@ -29,8 +29,8 @@ export function sanitizeHostForPath(host: string): string {
  * guarantees `manifest.tarballUrl` is a valid URL, so any parse failure
  * here is a real bug worth surfacing.
  *
- * Check containment here as well, in case a caller skips the version
- * validation in `readOrgManifest`.
+ * Require a strict descendant of `cacheRoot` so sibling staging directories
+ * stay inside the cache, even if a caller skips `readOrgManifest` validation.
  */
 export function resolveExtractionDir(cacheRoot: string, manifest: OrgManifest): string {
   const { host } = new URL(manifest.tarballUrl);
@@ -42,7 +42,7 @@ export function resolveExtractionDir(cacheRoot: string, manifest: OrgManifest): 
     'create',
     manifest.version,
   );
-  if (resolvedDir !== resolvedRoot && !resolvedDir.startsWith(`${resolvedRoot}${path.sep}`)) {
+  if (!resolvedDir.startsWith(`${resolvedRoot}${path.sep}`)) {
     throw new Error(`org template extraction path escapes the cache root: ${manifest.version}`);
   }
   return resolvedDir;

--- a/packages/cli/src/create/org-tarball.ts
+++ b/packages/cli/src/create/org-tarball.ts
@@ -29,12 +29,8 @@ export function sanitizeHostForPath(host: string): string {
  * guarantees `manifest.tarballUrl` is a valid URL, so any parse failure
  * here is a real bug worth surfacing.
  *
- * The result must stay beneath `cacheRoot`. `readOrgManifest` already
- * validates `manifest.version` as a semantic version; this containment
- * check keeps the same invariant at the sink, so a malformed
- * registry-controlled value (e.g. `..` segments) cannot place the
- * extraction outside the cache, even through a future caller that
- * skips validation.
+ * Check containment here as well, in case a caller skips the version
+ * validation in `readOrgManifest`.
  */
 export function resolveExtractionDir(cacheRoot: string, manifest: OrgManifest): string {
   const { host } = new URL(manifest.tarballUrl);
@@ -50,10 +46,6 @@ export function resolveExtractionDir(cacheRoot: string, manifest: OrgManifest): 
     throw new Error(`org template extraction path escapes the cache root: ${manifest.version}`);
   }
   return resolvedDir;
-}
-
-function getExtractionDir(manifest: OrgManifest): string {
-  return resolveExtractionDir(getCacheRoot(), manifest);
 }
 
 function parseIntegrity(integrity: string): { algorithm: string; expected: string } | null {
@@ -311,7 +303,7 @@ export async function cleanupStaleStagingDirs(destDir: string): Promise<void> {
  * cleans up and returns the existing directory.
  */
 export async function ensureOrgPackageExtracted(manifest: OrgManifest): Promise<string> {
-  const extractedRoot = getExtractionDir(manifest);
+  const extractedRoot = resolveExtractionDir(getCacheRoot(), manifest);
   if (fs.existsSync(path.join(extractedRoot, 'package.json'))) {
     return extractedRoot;
   }


### PR DESCRIPTION
Malformed registry versions can place org-template files outside the cache root. `readOrgManifest()` now rejects versions that fail `semver.valid()`, including targets from `dist-tags.latest` and tags that match a requested version.

`resolveExtractionDir()` also checks that the extraction path stays within the cache root. Tests cover invalid versions, path traversal, and valid versions with prerelease or build metadata.
