### PR TITLE
test(migrate): reproduce toolchain downgrades in existing projects

### DIFF
--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_downgrades_newer_toolchain_pnpm/check-downgrade.mjs
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_downgrades_newer_toolchain_pnpm/check-downgrade.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
+import cliPkg from 'vite-plus/package.json' with { type: 'json' };
+import { versions } from 'vite-plus/versions';
+
+const require = createRequire(import.meta.url);
+const cliRequire = createRequire(require.resolve('vite-plus/package.json'));
+const before = JSON.parse(readFileSync('package.before.json', 'utf8')).devDependencies;
+const after = JSON.parse(readFileSync('package.json', 'utf8')).devDependencies;
+const workspace = readFileSync('pnpm-workspace.yaml', 'utf8');
+
+assert(workspace.includes(`  vite: npm:@voidzero-dev/vite-plus-core@${cliPkg.version}\n`));
+assert(workspace.includes(`  vite-plus: ${cliPkg.version}\n`));
+assert(workspace.includes(`  vitest: ${versions.vitest}\n`));
+assert(workspace.includes(`  "@vitest/browser-playwright": ${versions.vitest}\n`));
+assert.equal(after['vite-plus'], 'catalog:');
+assert.equal(after['@vitest/browser'], undefined);
+
+for (const name of ['vite', 'vitest', '@vitest/browser', '@vitest/browser-playwright']) {
+  const previous = before[name].replace(/^\^/, '');
+  const bundled = versions[name === 'vite' ? 'vite' : 'vitest'];
+  // All versions in this fixture are stable releases. Keep the fixture newer
+  // than the bundle so a future version bump cannot hide a lost reproduction.
+  assert(bundled.localeCompare(previous, 'en', { numeric: true }) < 0, `${name} must downgrade`);
+  if (name === 'vite') {
+    assert.equal(require(`${name}/package.json`).name, '@voidzero-dev/vite-plus-core');
+    assert.equal(require(`${name}/package.json`).version, cliPkg.version);
+  } else {
+    const resolve = name === '@vitest/browser' ? cliRequire : require;
+    assert.equal(resolve(`${name}/package.json`).version, bundled);
+  }
+  if (name !== '@vitest/browser') {
+    assert.equal(after[name], 'catalog:');
+  }
+  console.log(`${name}: downgraded to the running CLI's bundled version`);
+}

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_downgrades_newer_toolchain_pnpm/package.json
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_downgrades_newer_toolchain_pnpm/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "migration-downgrades-newer-toolchain-pnpm",
+  "private": true,
+  "devDependencies": {
+    "@vitest/browser": "^4.1.12",
+    "@vitest/browser-playwright": "^4.1.12",
+    "vite": "^8.2.3",
+    "vite-plus": "^0.3.1",
+    "vitest": "4.1.12"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": "10.33.0",
+      "onFail": "download"
+    }
+  }
+}

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_downgrades_newer_toolchain_pnpm/pnpm-workspace.yaml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_downgrades_newer_toolchain_pnpm/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - .

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_downgrades_newer_toolchain_pnpm/snapshots.toml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_downgrades_newer_toolchain_pnpm/snapshots.toml
@@ -1,0 +1,14 @@
+[[case]]
+name = "migration_downgrades_newer_toolchain_pnpm"
+vp = "local"
+local-registry = true
+unset-env = ["VP_SKIP_INSTALL"]
+comment = "Reproduce #2662: an existing Vite+ project has Vite and Vitest versions newer than the running CLI's bundled versions."
+steps = [
+  { argv = ["vpt", "cp", "package.json", "package.before.json"], snapshot = false },
+  { argv = ["vpt", "write-file", "node_modules/vite/package.json", "{\"name\":\"vite\",\"version\":\"8.2.3\"}"], snapshot = false },
+  { argv = ["vp", "migrate", "--no-interactive", "--no-hooks", "--no-agent", "--no-editor"], comment = "migration reports success without warning that the toolchain was downgraded" },
+  { argv = ["vpt", "print-file", "package.json"], comment = "managed dependencies now resolve through the rewritten catalog" },
+  { argv = ["vpt", "print-file", "pnpm-workspace.yaml"], comment = "the catalog records the running CLI's toolchain pins" },
+  { argv = ["node", "check-downgrade.mjs"], comment = "assert the installed versions are lower even though snapshots redact the bundled versions" },
+]

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_downgrades_newer_toolchain_pnpm/snapshots/migration_downgrades_newer_toolchain_pnpm.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_downgrades_newer_toolchain_pnpm/snapshots/migration_downgrades_newer_toolchain_pnpm.md
@@ -1,0 +1,90 @@
+# migration_downgrades_newer_toolchain_pnpm
+
+Reproduce #2662: an existing Vite+ project has Vite and Vitest versions newer than the running CLI's bundled versions.
+
+## `vpt cp package.json package.before.json`
+
+
+## `vpt write-file node_modules/vite/package.json '{"name":"vite","version":"8.2.3"}'`
+
+
+## `vp migrate --no-interactive --no-hooks --no-agent --no-editor`
+
+migration reports success without warning that the toolchain was downgraded
+
+```
+VITE+ - The Unified Toolchain for the Web
+
+Formatting code...
+
+Code formatted
+◇ Updated . to Vite+ <version>
+• Node <version>  pnpm <version>
+• Dependencies:
+    vite                        8.2.3  → <version>
+    vitest                      4.1.12 → <version>
+    @vitest/browser             4.1.12 → <version>
+    @vitest/browser-playwright  4.1.12 → <version>
+✓ Dependencies installed in <duration>
+• Package manager settings configured
+```
+
+## `vpt print-file package.json`
+
+managed dependencies now resolve through the rewritten catalog
+
+```
+{
+  "name": "migration-downgrades-newer-toolchain-pnpm",
+  "private": true,
+  "devDependencies": {
+    "@vitest/browser-playwright": "catalog:",
+    "playwright": "*",
+    "vite": "catalog:",
+    "vite-plus": "catalog:",
+    "vitest": "catalog:"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": "<version>",
+      "onFail": "download"
+    }
+  }
+}
+```
+
+## `vpt print-file pnpm-workspace.yaml`
+
+the catalog records the running CLI's toolchain pins
+
+```
+packages:
+  - .
+catalog:
+  vite: npm:@voidzero-dev/vite-plus-core@<version>
+  vitest: <version>
+  vite-plus: <version>
+  "@vitest/browser-playwright": <version>
+overrides:
+  vite@*: "catalog:"
+  vitest@*: "catalog:"
+peerDependencyRules:
+  allowAny:
+    - vite
+    - vitest
+  allowedVersions:
+    vite: "*"
+    vitest: "*"
+```
+
+## `node check-downgrade.mjs`
+
+assert the installed versions are lower even though snapshots redact the bundled versions
+
+```
+vite: downgraded to the running CLI's bundled version
+vitest: downgraded to the running CLI's bundled version
+@vitest/browser: downgraded to the running CLI's bundled version
+@vitest/browser-playwright: downgraded to the running CLI's bundled version
+```

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_downgrades_newer_toolchain_pnpm/vite.config.ts
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/migration_downgrades_newer_toolchain_pnpm/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite-plus';
+import { playwright } from 'vite-plus/test/browser-playwright';
+
+export default defineConfig({
+  test: {
+    browser: {
+      enabled: true,
+      provider: playwright(),
+    },
+  },
+});


### PR DESCRIPTION
`vp migrate` can downgrade newer toolchain dependencies in an existing Vite+ project and report success without a warning.

This draft adds a `pnpm` snapshot test for #2662. The test installs dependencies through the local registry and checks the catalog entries and installed versions. It records the current behavior without a fix.

The snapshot test passed in record and compare modes.
