### PR TITLE
test(ecosystem): add Solid 2 coverage

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -418,6 +418,15 @@ jobs:
               vp run build && vp run build:demos
               vp run lint
               vp run test:unit
+          - name: solid-vite-plugin
+            node-version: 24
+            # The next branch's Vite 8 example uses Solid 2 and @solidjs/vite-plugin.
+            directory: examples/vite-8
+            command: |
+              # Build the workspace plugin before vp run loads the example configs.
+              (cd ../.. && vp exec rollup -c)
+              vp run build
+              vp run test
         exclude:
           # frm-stack uses Docker (testcontainers) which doesn't work the same way on Windows
           - os: namespace-profile-windows-4c-8g

--- a/ecosystem-ci/repo.json
+++ b/ecosystem-ci/repo.json
@@ -159,5 +159,11 @@
     "branch": "main",
     "hash": "f434577e6bb2010b321653cb132a57bda18764fa",
     "forceFreshMigration": true
+  },
+  "solid-vite-plugin": {
+    "repository": "https://github.com/solidjs/solid-vite-plugin.git",
+    "branch": "next",
+    "hash": "5b6612bb8d5c51777dce9564f5dc48aabbdf848f",
+    "playwright": true
   }
 }


### PR DESCRIPTION
Add the Solid 2 example from `solidjs/solid-vite-plugin` to ecosystem CI. Pin the repository to `5b6612bb8d5c51777dce9564f5dc48aabbdf848f` on `next`.

The job builds the workspace plugin before `vp run` loads the example configurations. It then builds the example and runs its Chromium tests on Linux and Windows.

Related: [Solid 2 support discussion](https://github.com/voidzero-dev/vite-plus/discussions/2629#discussioncomment-18394431).
