### PR TITLE
feat(installer): separate Node and package-manager preferences

### DIFF
--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_self_setup/snapshots.toml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_self_setup/snapshots.toml
@@ -54,6 +54,18 @@ steps = [
 ]
 
 [[case]]
+name = "command_self_setup_combined_default"
+vp = "global"
+skip-platforms = ["windows"]
+steps = [
+  { argv = ["vpt", "mkdir", "-p", "external", "home"], snapshot = false },
+  { argv = ["vpt", "cp", "$VP_HOME/bin/vp", "external/vp"], snapshot = false },
+  { argv = ["vpt", "chmod", "+x", "external/vp"], snapshot = false },
+  { argv = ["./external/vp"], tty = false, envs = [["VP_HOME", "${workspace}/home"], ["VP_SKIP_DEPS_INSTALL", "1"], ["VP_VERSION", "combined-default"], ["VP_SELF_SETUP_NO_MODIFY_PATH", "1"], ["CI", "true"], ["VP_PNPM_MANAGER", "no"]], comment = "Without an explicit Node override, automatic setup still enables both; a family override takes precedence", snapshot = false },
+  ["vpt", "print-file", "home/config.json"],
+]
+
+[[case]]
 name = "command_self_setup_package_manager_choices"
 vp = "global"
 skip-platforms = ["windows"]

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_self_setup/snapshots.toml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_self_setup/snapshots.toml
@@ -97,3 +97,28 @@ steps = [
   ["vpt", "stat-file", "user/.bashrc", "--assert", "dir"],
   { argv = ["./home/bin/vp", "--help"], envs = [["VP_HOME", "${workspace}/home"]], comment = "The installed CLI accepts commands after the warning", snapshot = false },
 ]
+
+[[case]]
+name = "command_self_setup_mixed_shim_refresh"
+vp = "global"
+skip-platforms = ["windows"]
+env = { VP_SKIP_DEPS_INSTALL = "1", VP_SELF_SETUP_NO_MODIFY_PATH = "1" }
+steps = [
+  { argv = ["vpt", "mkdir", "-p", "external", "home/bin", "other/bin"], snapshot = false },
+  { argv = ["vpt", "cp", "$VP_HOME/bin/vp", "external/vp"], snapshot = false },
+  { argv = ["vpt", "chmod", "+x", "external/vp"], snapshot = false },
+  { argv = ["vpt", "write-file", "home/bin/node", "existing-node"], snapshot = false },
+  { argv = ["vpt", "write-file", "home/bin/npm", "existing-npm"], snapshot = false },
+  { argv = ["vpt", "write-file", "home/bin/pnpm", "existing-pnpm"], snapshot = false },
+  { argv = ["vpt", "write-file", "home/bin/pnpx", "existing-pnpx"], snapshot = false },
+  { argv = ["./external/vp"], tty = false, envs = [["VP_HOME", "${workspace}/home"], ["VP_VERSION", "mixed-shims"], ["VP_NODE_MANAGER", "no"], ["VP_PM_MANAGER", "no"], ["VP_PNPM_MANAGER", "yes"]], comment = "Managing pnpm replaces its existing commands while preserving system-first Node and npm", snapshot = false },
+  ["vpt", "print-file", "home/bin/node"],
+  ["vpt", "print-file", "home/bin/npm"],
+  ["vpt", "stat-file", "home/bin/pnpm", "--assert", "symlink"],
+  ["vpt", "stat-file", "home/bin/pnpx", "--assert", "symlink"],
+  { argv = ["vpt", "write-file", "other/bin/node", "existing-node"], snapshot = false },
+  { argv = ["vpt", "write-file", "other/bin/npm", "existing-npm"], snapshot = false },
+  { argv = ["./external/vp"], tty = false, envs = [["VP_HOME", "${workspace}/other"], ["VP_VERSION", "mixed-shims"], ["VP_NODE_MANAGER", "yes"], ["VP_PM_MANAGER", "no"]], comment = "Managing Node preserves an existing system-first npm command", snapshot = false },
+  ["vpt", "stat-file", "other/bin/node", "--assert", "symlink"],
+  ["vpt", "print-file", "other/bin/npm"],
+]

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_self_setup/snapshots.toml
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_self_setup/snapshots.toml
@@ -54,6 +54,23 @@ steps = [
 ]
 
 [[case]]
+name = "command_self_setup_package_manager_choices"
+vp = "global"
+skip-platforms = ["windows"]
+env = { VP_SKIP_DEPS_INSTALL = "1", VP_SELF_SETUP_NO_MODIFY_PATH = "1", VP_NODE_MANAGER = "no" }
+steps = [
+  { argv = ["vpt", "mkdir", "-p", "external", "home"], snapshot = false },
+  { argv = ["vpt", "cp", "$VP_HOME/bin/vp", "external/vp"], snapshot = false },
+  { argv = ["vpt", "chmod", "+x", "external/vp"], snapshot = false },
+  { argv = ["./external/vp"], tty = false, envs = [["VP_HOME", "${workspace}/home"], ["VP_VERSION", "pm-default"], ["VP_PM_MANAGER", "yes"], ["VP_PNPM_MANAGER", "no"], ["VP_YARN_MANAGER", "no"]], comment = "Package-manager choices are independent of Node; pnpm and Yarn override the group default", snapshot = false },
+  ["vpt", "print-file", "home/config.json"],
+  { argv = ["./external/vp"], tty = false, envs = [["VP_HOME", "${workspace}/home"], ["VP_VERSION", "pm-overrides"], ["VP_PM_MANAGER", "no"], ["VP_NPM_MANAGER", "yes"], ["VP_BUN_MANAGER", "yes"]], comment = "npm and Bun can opt into management while the other families prefer system tools", snapshot = false },
+  ["vpt", "print-file", "home/config.json"],
+  { argv = ["./external/vp"], tty = false, envs = [["VP_HOME", "${workspace}/home"], ["VP_VERSION", "pm-preserved"], ["VP_NODE_MANAGER", "yes"]], comment = "Changing only Node management preserves all saved package-manager choices", snapshot = false },
+  ["vpt", "print-file", "home/config.json"],
+]
+
+[[case]]
 name = "command_self_setup_shell_warning"
 vp = "global"
 skip-platforms = ["windows"]

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_self_setup/snapshots/command_self_setup_bootstrap_options.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_self_setup/snapshots/command_self_setup_bootstrap_options.md
@@ -28,13 +28,7 @@ home/current/bin/.vp-setup-complete: file
 
 ```
 {
-  "nodeShimMode": "system_first",
-  "packageManagerShimModes": {
-    "bun": "system_first",
-    "npm": "system_first",
-    "pnpm": "system_first",
-    "yarn": "system_first"
-  }
+  "nodeShimMode": "system_first"
 }
 ```
 

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_self_setup/snapshots/command_self_setup_combined_default.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_self_setup/snapshots/command_self_setup_combined_default.md
@@ -1,0 +1,28 @@
+# command_self_setup_combined_default
+
+## `vpt mkdir -p external home`
+
+
+## `vpt cp $VP_HOME/bin/vp external/vp`
+
+
+## `vpt chmod +x external/vp`
+
+
+## `VP_HOME=${workspace}/home VP_SKIP_DEPS_INSTALL=1 VP_VERSION=combined-default VP_SELF_SETUP_NO_MODIFY_PATH=1 CI=true VP_PNPM_MANAGER=no ./external/vp`
+
+Without an explicit Node override, automatic setup still enables both; a family override takes precedence
+
+
+## `vpt print-file home/config.json`
+
+```
+{
+  "packageManagerShimModes": {
+    "bun": "managed",
+    "npm": "managed",
+    "pnpm": "system_first",
+    "yarn": "managed"
+  }
+}
+```

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_self_setup/snapshots/command_self_setup_mixed_shim_refresh.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_self_setup/snapshots/command_self_setup_mixed_shim_refresh.md
@@ -1,0 +1,74 @@
+# command_self_setup_mixed_shim_refresh
+
+## `vpt mkdir -p external home/bin other/bin`
+
+
+## `vpt cp $VP_HOME/bin/vp external/vp`
+
+
+## `vpt chmod +x external/vp`
+
+
+## `vpt write-file home/bin/node existing-node`
+
+
+## `vpt write-file home/bin/npm existing-npm`
+
+
+## `vpt write-file home/bin/pnpm existing-pnpm`
+
+
+## `vpt write-file home/bin/pnpx existing-pnpx`
+
+
+## `VP_HOME=${workspace}/home VP_VERSION=mixed-shims VP_NODE_MANAGER=no VP_PM_MANAGER=no VP_PNPM_MANAGER=yes ./external/vp`
+
+Managing pnpm replaces its existing commands while preserving system-first Node and npm
+
+
+## `vpt print-file home/bin/node`
+
+```
+existing-node
+```
+
+## `vpt print-file home/bin/npm`
+
+```
+existing-npm
+```
+
+## `vpt stat-file home/bin/pnpm --assert symlink`
+
+```
+home/bin/pnpm: symlink
+```
+
+## `vpt stat-file home/bin/pnpx --assert symlink`
+
+```
+home/bin/pnpx: symlink
+```
+
+## `vpt write-file other/bin/node existing-node`
+
+
+## `vpt write-file other/bin/npm existing-npm`
+
+
+## `VP_HOME=${workspace}/other VP_VERSION=mixed-shims VP_NODE_MANAGER=yes VP_PM_MANAGER=no ./external/vp`
+
+Managing Node preserves an existing system-first npm command
+
+
+## `vpt stat-file other/bin/node --assert symlink`
+
+```
+other/bin/node: symlink
+```
+
+## `vpt print-file other/bin/npm`
+
+```
+existing-npm
+```

--- a/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_self_setup/snapshots/command_self_setup_package_manager_choices.md
+++ b/crates/vp_cli_snapshots/tests/cli_snapshots/fixtures/command_self_setup/snapshots/command_self_setup_package_manager_choices.md
@@ -1,0 +1,66 @@
+# command_self_setup_package_manager_choices
+
+## `vpt mkdir -p external home`
+
+
+## `vpt cp $VP_HOME/bin/vp external/vp`
+
+
+## `vpt chmod +x external/vp`
+
+
+## `VP_HOME=${workspace}/home VP_VERSION=pm-default VP_PM_MANAGER=yes VP_PNPM_MANAGER=no VP_YARN_MANAGER=no ./external/vp`
+
+Package-manager choices are independent of Node; pnpm and Yarn override the group default
+
+
+## `vpt print-file home/config.json`
+
+```
+{
+  "nodeShimMode": "system_first",
+  "packageManagerShimModes": {
+    "bun": "managed",
+    "npm": "managed",
+    "pnpm": "system_first",
+    "yarn": "system_first"
+  }
+}
+```
+
+## `VP_HOME=${workspace}/home VP_VERSION=pm-overrides VP_PM_MANAGER=no VP_NPM_MANAGER=yes VP_BUN_MANAGER=yes ./external/vp`
+
+npm and Bun can opt into management while the other families prefer system tools
+
+
+## `vpt print-file home/config.json`
+
+```
+{
+  "nodeShimMode": "system_first",
+  "packageManagerShimModes": {
+    "bun": "managed",
+    "npm": "managed",
+    "pnpm": "system_first",
+    "yarn": "system_first"
+  }
+}
+```
+
+## `VP_HOME=${workspace}/home VP_VERSION=pm-preserved VP_NODE_MANAGER=yes ./external/vp`
+
+Changing only Node management preserves all saved package-manager choices
+
+
+## `vpt print-file home/config.json`
+
+```
+{
+  "packageManagerShimModes": {
+    "bun": "managed",
+    "npm": "managed",
+    "pnpm": "system_first",
+    "yarn": "system_first"
+  }
+}
+```

--- a/crates/vp_global_cli/src/commands/env/setup.rs
+++ b/crates/vp_global_cli/src/commands/env/setup.rs
@@ -55,13 +55,13 @@ impl EnvShell {
 
 /// Execute the setup command.
 pub async fn execute(refresh: bool, env_only: bool) -> Result<ExitStatus, Error> {
-    execute_for_binary(&std::env::current_exe()?, refresh, refresh, env_only).await
+    execute_for_binary(&std::env::current_exe()?, |_| refresh, refresh, env_only).await
 }
 
 // Self-setup must create shims for the deployed binary, not the temporary download.
 pub(crate) async fn execute_for_binary(
     current_exe: &std::path::Path,
-    refresh: bool,
+    refresh: impl Fn(&str) -> bool,
     refresh_entrypoints: bool,
     env_only: bool,
 ) -> Result<ExitStatus, Error> {
@@ -90,9 +90,7 @@ pub(crate) async fn execute_for_binary(
     // Ensure bin directory exists
     tokio::fs::create_dir_all(bin_dir).await?;
 
-    if refresh {
-        cleanup_legacy_package_manager_installs(&bin_dir).await;
-    }
+    cleanup_legacy_package_manager_installs(&bin_dir, &refresh).await;
 
     #[cfg(windows)]
     tokio::fs::write(bin_dir.join("vp-use.cmd"), vp_use_cmd_content(&config)).await?;
@@ -106,7 +104,7 @@ pub(crate) async fn execute_for_binary(
 
     for tool in crate::shim::DEFAULT_SHIM_TOOLS {
         let refresh_tool =
-            if matches!(*tool, "vpx" | "vpr") { refresh_entrypoints } else { refresh };
+            if matches!(*tool, "vpx" | "vpr") { refresh_entrypoints } else { refresh(tool) };
         let result = create_shim(current_exe, bin_dir, tool, refresh_tool).await?;
         if result {
             created.push(*tool);
@@ -131,7 +129,7 @@ pub(crate) async fn execute_for_binary(
     }
 
     #[cfg(windows)]
-    if refresh {
+    if refresh("node") {
         if let Err(e) = refresh_package_shims(current_exe, bin_dir).await {
             tracing::warn!("Failed to refresh package shims: {}", e);
         }
@@ -139,7 +137,7 @@ pub(crate) async fn execute_for_binary(
 
     // Best-effort cleanup of .old files from rename-before-copy on Windows
     #[cfg(windows)]
-    if refresh || refresh_entrypoints {
+    if refresh("node") || refresh_entrypoints {
         cleanup_old_files(bin_dir).await;
     }
 
@@ -152,7 +150,7 @@ pub(crate) async fn execute_for_binary(
         }
     }
 
-    if !skipped.is_empty() && !refresh {
+    if !skipped.is_empty() {
         if !created.is_empty() {
             output::raw("");
         }
@@ -172,8 +170,14 @@ pub(crate) async fn execute_for_binary(
 }
 
 /// Remove legacy managed installs left by versions that did not expose package-manager shims.
-async fn cleanup_legacy_package_manager_installs(bin_dir: &vt_path::AbsolutePath) {
+async fn cleanup_legacy_package_manager_installs(
+    bin_dir: &vt_path::AbsolutePath,
+    refresh: &impl Fn(&str) -> bool,
+) {
     for package_name in LEGACY_PACKAGE_MANAGER_PACKAGES {
+        if !refresh(package_name) {
+            continue;
+        }
         let has_metadata = match PackageMetadata::load(package_name).await {
             Ok(metadata) => metadata.is_some(),
             Err(error) => {
@@ -200,6 +204,10 @@ async fn cleanup_legacy_package_manager_installs(bin_dir: &vt_path::AbsolutePath
                 "Failed to remove legacy global package '{package_name}': {error}"
             ));
         }
+    }
+
+    if !refresh("corepack") {
+        return;
     }
 
     // Corepack is no longer exposed, so remove its old default shim even when no package metadata remains.
@@ -1816,7 +1824,7 @@ mod tests {
                         .await
                         .unwrap();
                 }
-                execute_for_binary(&std::env::current_exe().unwrap(), false, true, false)
+                execute_for_binary(&std::env::current_exe().unwrap(), |_| false, true, false)
                     .await
                     .unwrap();
                 let dirs = &vp_shared::EnvConfig::get().dirs;

--- a/crates/vp_global_cli/src/self_setup.rs
+++ b/crates/vp_global_cli/src/self_setup.rs
@@ -221,8 +221,9 @@ async fn run(source: &Path) -> Result<AbsolutePathBuf, Error> {
         if let Some(mode) = mode {
             settings.node_shim_mode = mode;
         }
-        // Family-specific choices override the group default; unset choices preserve saved preferences.
-        let default = manager_mode("VP_PM_MANAGER");
+        // The combined prompt still controls both; an explicit Node variable only controls Node.
+        let default = manager_mode("VP_PM_MANAGER")
+            .or_else(|| if manager_mode("VP_NODE_MANAGER").is_none() { mode } else { None });
         for (family, variable) in [
             (PackageManagerType::Npm, "VP_NPM_MANAGER"),
             (PackageManagerType::Pnpm, "VP_PNPM_MANAGER"),
@@ -339,7 +340,8 @@ fn node_manager() -> Result<NodeManager, Error> {
     if !exists && automatic {
         return Ok(NodeManager::Enable);
     }
-    let enable = confirm("Would you like Vite+ to manage your Node.js versions?", true)?;
+    let enable =
+        confirm("Would you like Vite+ to manage your Node.js and package-manager versions?", true)?;
     Ok(if enable { NodeManager::Enable } else { NodeManager::SystemFirst })
 }
 

--- a/crates/vp_global_cli/src/self_setup.rs
+++ b/crates/vp_global_cli/src/self_setup.rs
@@ -250,9 +250,17 @@ async fn run(source: &Path) -> Result<AbsolutePathBuf, Error> {
     // Declining management preserves regular files, but create_shim can still replace foreign Unix symlinks.
     // The default bin directory is private to Vite+, so we accept this limitation for custom shared directories
     // rather than add the complexity of reliably identifying which symlinks belong to Vite+.
-    let refresh = node_mode != Some(config::ShimMode::SystemFirst);
+    let settings = config::load_config().await?;
+    // Each managed tool replaces its own shim, independently of the Node preference.
+    let refresh = |tool: &str| {
+        let mode = PackageManagerType::from_tool(tool)
+            .map(|family| settings.package_manager_shim_mode_for(family))
+            .unwrap_or(settings.node_shim_mode);
+        mode != config::ShimMode::SystemFirst
+    };
     // Windows entrypoints must point at this installation even when Node management is declined.
-    setup::execute_for_binary(binary.as_path(), refresh, cfg!(windows) || refresh, false).await?;
+    setup::execute_for_binary(binary.as_path(), refresh, cfg!(windows) || refresh("node"), false)
+        .await?;
     if !in_place {
         let name = version_dir
             .as_path()

--- a/crates/vp_global_cli/src/self_setup.rs
+++ b/crates/vp_global_cli/src/self_setup.rs
@@ -5,6 +5,7 @@ mod shell;
 use std::{path::Path, process::ExitCode};
 
 use dialoguer::{Confirm, theme::ColorfulTheme};
+use vp_pm_cli::PackageManagerType;
 use vp_setup::{SELF_SETUP_MARKER, VP_BINARY_NAME, install};
 use vp_shared::{EnvConfig, env_vars, output};
 use vt_path::{AbsolutePath, AbsolutePathBuf};
@@ -215,9 +216,23 @@ async fn run(source: &Path) -> Result<AbsolutePathBuf, Error> {
         NodeManager::SystemFirst => Some(config::ShimMode::SystemFirst),
         NodeManager::Refresh => None,
     };
-    if let Some(mode) = mode {
+    if !in_place {
         let mut settings = config::load_config().await?;
-        settings.set_shim_modes(true, true, mode);
+        if let Some(mode) = mode {
+            settings.node_shim_mode = mode;
+        }
+        // Family-specific choices override the group default; unset choices preserve saved preferences.
+        let default = manager_mode("VP_PM_MANAGER");
+        for (family, variable) in [
+            (PackageManagerType::Npm, "VP_NPM_MANAGER"),
+            (PackageManagerType::Pnpm, "VP_PNPM_MANAGER"),
+            (PackageManagerType::Yarn, "VP_YARN_MANAGER"),
+            (PackageManagerType::Bun, "VP_BUN_MANAGER"),
+        ] {
+            if let Some(mode) = manager_mode(variable).or(default) {
+                settings.set_package_manager_shim_mode(family, mode);
+            }
+        }
         config::save_config(&settings).await?;
     }
 
@@ -290,6 +305,14 @@ enum NodeManager {
     Enable,
 }
 
+fn manager_mode(variable: &str) -> Option<config::ShimMode> {
+    match std::env::var(variable).as_deref() {
+        Ok("yes") => Some(config::ShimMode::Managed),
+        Ok("no") => Some(config::ShimMode::SystemFirst),
+        _ => None,
+    }
+}
+
 fn node_manager() -> Result<NodeManager, Error> {
     match std::env::var("VP_NODE_MANAGER").as_deref() {
         Ok("yes") => return Ok(NodeManager::Enable),
@@ -316,8 +339,7 @@ fn node_manager() -> Result<NodeManager, Error> {
     if !exists && automatic {
         return Ok(NodeManager::Enable);
     }
-    let enable =
-        confirm("Would you like Vite+ to manage your Node.js and package-manager versions?", true)?;
+    let enable = confirm("Would you like Vite+ to manage your Node.js versions?", true)?;
     Ok(if enable { NodeManager::Enable } else { NodeManager::SystemFirst })
 }
 

--- a/crates/vp_global_cli/src/self_setup.rs
+++ b/crates/vp_global_cli/src/self_setup.rs
@@ -120,7 +120,11 @@ async fn run(source: &Path) -> Result<AbsolutePathBuf, Error> {
         ));
     }
     let previous_install = previous_install()?;
-    let node_manager = if in_place { NodeManager::Refresh } else { node_manager()? };
+    let node_override = manager_mode("VP_NODE_MANAGER");
+    // A supplied Node choice skips the combined prompt; upgrades preserve all saved choices.
+    let default_mode =
+        if in_place || node_override.is_some() { None } else { management_default()? };
+    let node_mode = if in_place { None } else { node_override.or(default_mode) };
     let version = env!("CARGO_PKG_VERSION");
     let registry = std::env::var(env_vars::NPM_CONFIG_REGISTRY_UPPER)
         .or_else(|_| std::env::var(env_vars::NPM_CONFIG_REGISTRY))
@@ -211,26 +215,19 @@ async fn run(source: &Path) -> Result<AbsolutePathBuf, Error> {
             }
         }
     }
-    let mode = match node_manager {
-        NodeManager::Enable => Some(config::ShimMode::Managed),
-        NodeManager::SystemFirst => Some(config::ShimMode::SystemFirst),
-        NodeManager::Refresh => None,
-    };
     if !in_place {
         let mut settings = config::load_config().await?;
-        if let Some(mode) = mode {
+        if let Some(mode) = node_mode {
             settings.node_shim_mode = mode;
         }
-        // The combined prompt still controls both; an explicit Node variable only controls Node.
-        let default = manager_mode("VP_PM_MANAGER")
-            .or_else(|| if manager_mode("VP_NODE_MANAGER").is_none() { mode } else { None });
+        let pm_mode = manager_mode("VP_PM_MANAGER").or(default_mode);
         for (family, variable) in [
             (PackageManagerType::Npm, "VP_NPM_MANAGER"),
             (PackageManagerType::Pnpm, "VP_PNPM_MANAGER"),
             (PackageManagerType::Yarn, "VP_YARN_MANAGER"),
             (PackageManagerType::Bun, "VP_BUN_MANAGER"),
         ] {
-            if let Some(mode) = manager_mode(variable).or(default) {
+            if let Some(mode) = manager_mode(variable).or(pm_mode) {
                 settings.set_package_manager_shim_mode(family, mode);
             }
         }
@@ -253,7 +250,7 @@ async fn run(source: &Path) -> Result<AbsolutePathBuf, Error> {
     // Declining management preserves regular files, but create_shim can still replace foreign Unix symlinks.
     // The default bin directory is private to Vite+, so we accept this limitation for custom shared directories
     // rather than add the complexity of reliably identifying which symlinks belong to Vite+.
-    let refresh = node_manager != NodeManager::SystemFirst;
+    let refresh = node_mode != Some(config::ShimMode::SystemFirst);
     // Windows entrypoints must point at this installation even when Node management is declined.
     setup::execute_for_binary(binary.as_path(), refresh, cfg!(windows) || refresh, false).await?;
     if !in_place {
@@ -299,13 +296,6 @@ fn confirm(prompt: &str, default: bool) -> Result<bool, Error> {
         .map_err(|error| Error::Other(error.to_string().into()))
 }
 
-#[derive(PartialEq, Eq)]
-enum NodeManager {
-    SystemFirst,
-    Refresh,
-    Enable,
-}
-
 fn manager_mode(variable: &str) -> Option<config::ShimMode> {
     match std::env::var(variable).as_deref() {
         Ok("yes") => Some(config::ShimMode::Managed),
@@ -314,12 +304,7 @@ fn manager_mode(variable: &str) -> Option<config::ShimMode> {
     }
 }
 
-fn node_manager() -> Result<NodeManager, Error> {
-    match std::env::var("VP_NODE_MANAGER").as_deref() {
-        Ok("yes") => return Ok(NodeManager::Enable),
-        Ok("no") => return Ok(NodeManager::SystemFirst),
-        _ => {}
-    }
+fn management_default() -> Result<Option<config::ShimMode>, Error> {
     let dirs = &EnvConfig::get().dirs;
     let node = dirs.bin.join(setup::shim_filename("node"));
     let exists = std::fs::symlink_metadata(&node).is_ok();
@@ -331,18 +316,18 @@ fn node_manager() -> Result<NodeManager, Error> {
     let owned = exists && dirs.owns_windows_trampoline(node.as_path());
     if owned {
         // Refresh existing shims without undoing a user's `vp env off` preference.
-        return Ok(NodeManager::Refresh);
+        return Ok(None);
     }
     let automatic = ["CI", "CODESPACES", "REMOTE_CONTAINERS", "DEVPOD"]
         .iter()
         .any(|name| std::env::var_os(name).is_some())
         || find_on_path("node").is_none();
     if !exists && automatic {
-        return Ok(NodeManager::Enable);
+        return Ok(Some(config::ShimMode::Managed));
     }
     let enable =
         confirm("Would you like Vite+ to manage your Node.js and package-manager versions?", true)?;
-    Ok(if enable { NodeManager::Enable } else { NodeManager::SystemFirst })
+    Ok(Some(if enable { config::ShimMode::Managed } else { config::ShimMode::SystemFirst }))
 }
 
 // PATH discovery only offers cleanup after an explicit move; VpDirs remains the authority for the target.

--- a/crates/vp_installer/src/cli.rs
+++ b/crates/vp_installer/src/cli.rs
@@ -30,6 +30,10 @@ pub struct Options {
     #[arg(long = "no-node-manager")]
     pub no_node_manager: bool,
 
+    // A choice in the combined menu applies to both, independently of VP_NODE_MANAGER.
+    #[arg(skip)]
+    pub management_choice: bool,
+
     /// Do not modify the User PATH
     #[arg(long = "no-modify-path")]
     pub no_modify_path: bool,

--- a/crates/vp_installer/src/cli.rs
+++ b/crates/vp_installer/src/cli.rs
@@ -30,10 +30,6 @@ pub struct Options {
     #[arg(long = "no-node-manager")]
     pub no_node_manager: bool,
 
-    // A choice in the combined menu applies to both, independently of VP_NODE_MANAGER.
-    #[arg(skip)]
-    pub management_choice: bool,
-
     /// Do not modify the User PATH
     #[arg(long = "no-modify-path")]
     pub no_modify_path: bool,

--- a/crates/vp_installer/src/main.rs
+++ b/crates/vp_installer/src/main.rs
@@ -173,11 +173,11 @@ async fn do_install(opts: &cli::Options, dirs: &VpDirs) -> Result<(), Box<dyn st
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
-    // Forward the combined choice separately; explicit PM and family variables are inherited.
+    // The existing menu selects both; forward its PM default separately from a Node-only env override.
     let explicit_node = std::env::var("VP_NODE_MANAGER")
         .is_ok_and(|value| value.eq_ignore_ascii_case("yes") || value.eq_ignore_ascii_case("no"));
     let explicit_pm = matches!(std::env::var("VP_PM_MANAGER").as_deref(), Ok("yes" | "no"));
-    if !explicit_pm && (opts.management_choice || !explicit_node) {
+    if !explicit_pm && (!opts.yes || !explicit_node) {
         command.env("VP_PM_MANAGER", if opts.no_node_manager { "no" } else { "yes" });
     }
     if let Some(registry) = opts.registry.as_deref() {
@@ -427,10 +427,7 @@ fn show_customize_menu(opts: &mut cli::Options) {
                 let r = read_input("    npm registry URL (or empty for default): ");
                 opts.registry = if r.is_empty() { None } else { Some(r) };
             }
-            "3" => {
-                opts.no_node_manager = !opts.no_node_manager;
-                opts.management_choice = true;
-            }
+            "3" => opts.no_node_manager = !opts.no_node_manager,
             "4" => opts.no_modify_path = !opts.no_modify_path,
             _ => println!("  Invalid option."),
         }

--- a/crates/vp_installer/src/main.rs
+++ b/crates/vp_installer/src/main.rs
@@ -161,11 +161,16 @@ async fn do_install(opts: &cli::Options, dirs: &VpDirs) -> Result<(), Box<dyn st
     }
 
     // 3. The menu supplies setup choices; interactive runs may still need release-age consent.
+    let manager = if opts.no_node_manager { "no" } else { "yes" };
     let mut command = tokio::process::Command::new(binary.as_path());
     command
         .env_remove(vp_shared::env_vars::VP_SELF_SETUP_SUPPORT_CHECK)
         .env(vp_shared::env_vars::VP_SELF_SETUP_REPLACE_EXISTING, if opts.yes { "1" } else { "0" })
-        .env("VP_NODE_MANAGER", if opts.no_node_manager { "no" } else { "yes" })
+        .env("VP_NODE_MANAGER", manager)
+        .env(
+            "VP_PM_MANAGER",
+            std::env::var("VP_PM_MANAGER").unwrap_or_else(|_| manager.to_string()),
+        )
         .env(
             vp_shared::env_vars::VP_SELF_SETUP_NO_MODIFY_PATH,
             if opts.no_modify_path { "1" } else { "0" },
@@ -173,13 +178,6 @@ async fn do_install(opts: &cli::Options, dirs: &VpDirs) -> Result<(), Box<dyn st
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
-    // The existing menu selects both; forward its PM default separately from a Node-only env override.
-    let explicit_node = std::env::var("VP_NODE_MANAGER")
-        .is_ok_and(|value| value.eq_ignore_ascii_case("yes") || value.eq_ignore_ascii_case("no"));
-    let explicit_pm = matches!(std::env::var("VP_PM_MANAGER").as_deref(), Ok("yes" | "no"));
-    if !explicit_pm && (!opts.yes || !explicit_node) {
-        command.env("VP_PM_MANAGER", if opts.no_node_manager { "no" } else { "yes" });
-    }
     if let Some(registry) = opts.registry.as_deref() {
         command.env(vp_shared::env_vars::NPM_CONFIG_REGISTRY_UPPER, registry);
     }

--- a/crates/vp_installer/src/main.rs
+++ b/crates/vp_installer/src/main.rs
@@ -169,7 +169,10 @@ async fn do_install(opts: &cli::Options, dirs: &VpDirs) -> Result<(), Box<dyn st
         .env("VP_NODE_MANAGER", manager)
         .env(
             "VP_PM_MANAGER",
-            std::env::var("VP_PM_MANAGER").unwrap_or_else(|_| manager.to_string()),
+            std::env::var("VP_PM_MANAGER")
+                .ok()
+                .filter(|value| matches!(value.as_str(), "yes" | "no"))
+                .unwrap_or_else(|| manager.to_string()),
         )
         .env(
             vp_shared::env_vars::VP_SELF_SETUP_NO_MODIFY_PATH,

--- a/crates/vp_installer/src/main.rs
+++ b/crates/vp_installer/src/main.rs
@@ -173,6 +173,13 @@ async fn do_install(opts: &cli::Options, dirs: &VpDirs) -> Result<(), Box<dyn st
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
+    // Forward the combined choice separately; explicit PM and family variables are inherited.
+    let explicit_node = std::env::var("VP_NODE_MANAGER")
+        .is_ok_and(|value| value.eq_ignore_ascii_case("yes") || value.eq_ignore_ascii_case("no"));
+    let explicit_pm = matches!(std::env::var("VP_PM_MANAGER").as_deref(), Ok("yes" | "no"));
+    if !explicit_pm && (opts.management_choice || !explicit_node) {
+        command.env("VP_PM_MANAGER", if opts.no_node_manager { "no" } else { "yes" });
+    }
     if let Some(registry) = opts.registry.as_deref() {
         command.env(vp_shared::env_vars::NPM_CONFIG_REGISTRY_UPPER, registry);
     }
@@ -420,7 +427,10 @@ fn show_customize_menu(opts: &mut cli::Options) {
                 let r = read_input("    npm registry URL (or empty for default): ");
                 opts.registry = if r.is_empty() { None } else { Some(r) };
             }
-            "3" => opts.no_node_manager = !opts.no_node_manager,
+            "3" => {
+                opts.no_node_manager = !opts.no_node_manager;
+                opts.management_choice = true;
+            }
             "4" => opts.no_modify_path = !opts.no_modify_path,
             _ => println!("  Invalid option."),
         }

--- a/docs/guide/installer-env-vars.md
+++ b/docs/guide/installer-env-vars.md
@@ -99,8 +99,8 @@ These variables control the installer scripts and the standalone Windows install
 - **Values**: `yes` uses Vite+ management; `no` prefers system tools, with
   managed tools as a fallback when a system tool is unavailable.
 - **Default**: Unset. The installer's combined Node.js and package-manager
-  choice remains the default. When `VP_NODE_MANAGER` is explicitly set, it
-  only changes Node.js; existing package-manager preferences are preserved.
+  choice remains the default. With the script installers, setting only
+  `VP_NODE_MANAGER` preserves existing package-manager preferences.
 
 ### `VP_NPM_MANAGER` / `VP_PNPM_MANAGER` / `VP_YARN_MANAGER` / `VP_BUN_MANAGER`
 
@@ -118,8 +118,9 @@ These variables control the installer scripts and the standalone Windows install
 
 These management variables are installation choices, saved in Vite+'s config.
 The interactive prompt still controls both Node.js and package managers;
-explicit package-manager variables override that combined choice. The Windows
-installer forwards the same choices to the downloaded binary.
+explicit package-manager variables override that combined choice. The standalone
+`vp-setup` installer uses its existing combined option as the default for both
+variables, in interactive and silent installations alike.
 In-place upgrades preserve the saved choices. Unrecognized values are ignored.
 They select management behavior, not package-manager versions, and do not
 prevent the installer from creating shims. Older releases installed through

--- a/docs/guide/installer-env-vars.md
+++ b/docs/guide/installer-env-vars.md
@@ -81,7 +81,8 @@ These variables control the installer scripts and the standalone Windows install
 
 ### `VP_NODE_MANAGER`
 
-- **Purpose**: Control Node.js version manager setup during installation
+- **Purpose**: Control Node.js version manager setup during installation. This
+  does not change package-manager preferences.
 - **Values**: `yes` or `no`
 - **Default**: Auto-detected
 - **CLI equivalent**: `--no-node-manager` (inverted)
@@ -90,6 +91,34 @@ These variables control the installer scripts and the standalone Windows install
   # Skip Node.js manager setup in CI
   curl -fsSL https://vite.plus | VP_NODE_MANAGER=no bash
   ```
+
+### `VP_PM_MANAGER`
+
+- **Purpose**: Set the management preference for all four package-manager
+  families: npm, pnpm, Yarn, and Bun.
+- **Values**: `yes` uses Vite+ management; `no` prefers system tools, with
+  managed tools as a fallback when a system tool is unavailable.
+- **Default**: Unset. Existing preferences are preserved; on a fresh install,
+  each family follows the normal first-use selection.
+
+### `VP_NPM_MANAGER` / `VP_PNPM_MANAGER` / `VP_YARN_MANAGER` / `VP_BUN_MANAGER`
+
+- **Purpose**: Set the management preference for an individual package-manager
+  family. Each variable overrides `VP_PM_MANAGER` for that family.
+- **Values**: `yes` or `no`, with the same meaning as `VP_PM_MANAGER`.
+- **Default**: Unset (use `VP_PM_MANAGER`, or preserve the existing preference).
+- **Example**:
+
+  ```bash
+  # Keep system Node.js and package managers, but let Vite+ manage pnpm.
+  curl -fsSL https://vite.plus | VP_NODE_MANAGER=no VP_PM_MANAGER=no VP_PNPM_MANAGER=yes bash
+  ```
+
+These management variables are installation choices, saved in Vite+'s config.
+In-place upgrades preserve the saved choices. Unrecognized values are ignored.
+They select management behavior, not package-manager versions, and do not
+prevent the installer from creating shims. Older releases installed through
+the legacy installer retain their original behavior.
 
 ### `VP_PR_VERSION`
 

--- a/docs/guide/installer-env-vars.md
+++ b/docs/guide/installer-env-vars.md
@@ -81,8 +81,7 @@ These variables control the installer scripts and the standalone Windows install
 
 ### `VP_NODE_MANAGER`
 
-- **Purpose**: Control Node.js version manager setup during installation. This
-  does not change package-manager preferences.
+- **Purpose**: Control Node.js version manager setup during installation.
 - **Values**: `yes` or `no`
 - **Default**: Auto-detected
 - **CLI equivalent**: `--no-node-manager` (inverted)

--- a/docs/guide/installer-env-vars.md
+++ b/docs/guide/installer-env-vars.md
@@ -98,15 +98,17 @@ These variables control the installer scripts and the standalone Windows install
   families: npm, pnpm, Yarn, and Bun.
 - **Values**: `yes` uses Vite+ management; `no` prefers system tools, with
   managed tools as a fallback when a system tool is unavailable.
-- **Default**: Unset. Existing preferences are preserved; on a fresh install,
-  each family follows the normal first-use selection.
+- **Default**: Unset. The installer's combined Node.js and package-manager
+  choice remains the default. When `VP_NODE_MANAGER` is explicitly set, it
+  only changes Node.js; existing package-manager preferences are preserved.
 
 ### `VP_NPM_MANAGER` / `VP_PNPM_MANAGER` / `VP_YARN_MANAGER` / `VP_BUN_MANAGER`
 
 - **Purpose**: Set the management preference for an individual package-manager
   family. Each variable overrides `VP_PM_MANAGER` for that family.
 - **Values**: `yes` or `no`, with the same meaning as `VP_PM_MANAGER`.
-- **Default**: Unset (use `VP_PM_MANAGER`, or preserve the existing preference).
+- **Default**: Unset (use `VP_PM_MANAGER`, then the combined installer choice,
+  or preserve the existing preference).
 - **Example**:
 
   ```bash
@@ -115,6 +117,9 @@ These variables control the installer scripts and the standalone Windows install
   ```
 
 These management variables are installation choices, saved in Vite+'s config.
+The interactive prompt still controls both Node.js and package managers;
+explicit package-manager variables override that combined choice. The Windows
+installer forwards the same choices to the downloaded binary.
 In-place upgrades preserve the saved choices. Unrecognized values are ignored.
 They select management behavior, not package-manager versions, and do not
 prevent the installer from creating shims. Older releases installed through


### PR DESCRIPTION
The installer currently applies `VP_NODE_MANAGER` to both Node.js and every package manager. This PR limits that environment variable to Node.js while preserving the existing combined installation prompt and its behavior.

This PR adds `VP_PM_MANAGER` to set the preference for all package managers, with `VP_NPM_MANAGER`, `VP_PNPM_MANAGER`, `VP_YARN_MANAGER`, and `VP_BUN_MANAGER` overriding it for each family. `yes` selects Vite+ management; `no` selects system-first behavior. Explicit package-manager variables override the combined installer choice. With the script installers, a Node-only environment override preserves saved package-manager preferences. In-place upgrades keep existing settings.

The `vp_installer` crate keeps its existing options and forwards the resolved combined choice as both `VP_NODE_MANAGER` and the default for `VP_PM_MANAGER`. Explicit package-manager overrides are preserved. Interactive and silent installations use the same forwarding logic.

For example, `VP_NODE_MANAGER=no VP_PM_MANAGER=no VP_PNPM_MANAGER=yes` keeps Node.js and the other package managers system-first while letting Vite+ manage pnpm.

🤖 Generated with Codex
